### PR TITLE
server_client_create: initialize FD to -1

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -95,6 +95,7 @@ server_client_create(int fd)
 
 	environ_init(&c->environ);
 
+	c->fd = -1;
 	c->cwd = -1;
 
 	c->cmdq = cmdq_new(c);


### PR DESCRIPTION
Without this, if a client fails to call MSG_IDENTIFY_STDIN, on client
disconnect FD 0 will be closed, eventually leading to corruption.