### PR TITLE
find: rename relative left/right to avoid ambiguity

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -103,8 +103,8 @@ const char *cmd_find_pane_table[][2] = {
 	{ "{bottom-right}", "bottom-right" },
 	{ "{up}", "{up}" },
 	{ "{down}", "{down}" },
-	{ "{left}", "{left}" },
-	{ "{right}", "{right}" },
+	{ "{rleft}", "{left}" },
+	{ "{rright}", "{right}" },
 	{ NULL, NULL }
 };
 

--- a/tmux.1
+++ b/tmux.1
@@ -502,8 +502,8 @@ The following special tokens are available for the pane index:
 .It Li "{bottom-right}" Ta "" Ta "The bottom-right pane"
 .It Li "{up}" Ta "" Ta "The pane above the active pane"
 .It Li "{down}" Ta "" Ta "The pane below the active pane"
-.It Li "{left}" Ta "" Ta "The pane to the left of the active pane"
-.It Li "{right}" Ta "" Ta "The pane to the right of the active pane"
+.It Li "{rleft}" Ta "" Ta "The pane to the left of the active pane"
+.It Li "{rright}" Ta "" Ta "The pane to the right of the active pane"
 .El
 .Pp
 The tokens


### PR DESCRIPTION
---
Feel free to use something more descriptive than `r` as well when applying (or I can respin).