### PR TITLE
Fix compilation warning

### DIFF
--- a/compat/getopt.c
+++ b/compat/getopt.c
@@ -94,7 +94,7 @@ BSDgetopt(int nargc, char *const *nargv, const char *ostr)
 	}
 	else {					/* need an argument */
 		if (*place)			/* no white space */
-			BSDoptarg = place;
+			BSDoptarg = (char *)place;
 		else if (nargc <= ++BSDoptind) {	/* no arg */
 			place = EMSG;
 			if (*ostr == ':')


### PR DESCRIPTION
Please see warning below:

```
gcc -DPACKAGE_NAME=\"tmux\" -DPACKAGE_TARNAME=\"tmux\" -DPACKAGE_VERSION=\"2.1\" -DPACKAGE_STRING=\"tmux\ 2.1\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"tmux\" -DVERSION=\"2.1\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_CURSES_H=1 -DHAVE_DIRENT_H=1 -DHAVE_FCNTL_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_NCURSES_H=1 -DHAVE_PATHS_H=1 -DHAVE_PTY_H=1 -DHAVE_STDINT_H=1 -DHAVE_SYS_DIR_H=1 -DHAVE_TERM_H=1 -DHAVE_DIRFD=1 -DHAVE_FLOCK=1 -DHAVE_SYSCONF=1 -DHAVE_CFMAKERAW=1 -DHAVE_B64_NTOP=1 -DHAVE_FORKPTY=1 -DHAVE_DAEMON=1 -DHAVE_SETENV=1 -DHAVE_ASPRINTF=1 -DHAVE_STRCASESTR=1 -DHAVE_STRSEP=1 -DHAVE_CFMAKERAW=1 -DHAVE_OPENAT=1 -DHAVE_DECL_OPTARG=1 -DHAVE_DECL_OPTIND=1 -DHAVE_DECL_OPTRESET=0 -DHAVE_BSD_TYPES=1 -DHAVE___PROGNAME=1 -DHAVE_PROC_PID=1  -I.   -DTMUX_CONF="\"/etc/tmux.conf\"" -DDEBUG -iquote.    -D_GNU_SOURCE -std=gnu99 -O2 -g -Wno-long-long -Wall -W -Wnested-externs -Wformat=2 -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wwrite-strings -Wshadow -Wpointer-arith -Wsign-compare -Wundef -Wbad-function-cast -Winline -Wcast-align -Wdeclaration-after-statement -Wno-pointer-sign  -MT compat/getopt.o -MD -MP -MF $depbase.Tpo -c -o compat/getopt.o compat/getopt.c &&\
mv -f $depbase.Tpo $depbase.Po
compat/getopt.c: In function ‘BSDgetopt’:
compat/getopt.c:97:14: warning: assignment discards ‘const’ qualifier from pointer target type
    BSDoptarg = place;
              ^
```