### PR TITLE
Fix typo: right-up should be right-of

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -104,7 +104,7 @@ const char *cmd_find_pane_table[][2] = {
 	{ "{up-of}", "{up}" },
 	{ "{down-of}", "{down}" },
 	{ "{left-of}", "{left}" },
-	{ "{right-up}", "{right}" },
+	{ "{right-of}", "{right}" },
 	{ NULL, NULL }
 };
 


### PR DESCRIPTION
Fix a typo from commit 13b7fd82c12ff2a0812d2b378a49011c12028796.