### PR TITLE
Add new terminal-aliases server option

### DIFF
--- a/examples/tmux.vim
+++ b/examples/tmux.vim
@@ -217,6 +217,7 @@ syn keyword tmuxOptsSet
 	\ status-right-length
 	\ status-utf8
 	\ staus-right-style
+	\ terminal-aliases
 	\ terminal-overrides
 	\ update-environment
 	\ visual-activity

--- a/options-table.c
+++ b/options-table.c
@@ -104,6 +104,11 @@ const struct options_table_entry server_options_table[] = {
 	  .default_num = 1
 	},
 
+	{ .name = "terminal-aliases",
+	  .type = OPTIONS_TABLE_STRING,
+	  .default_str = NULL
+	},
+
 	{ .name = "terminal-overrides",
 	  .type = OPTIONS_TABLE_STRING,
 	  .default_str = "*256col*:colors=256"

--- a/tmux.1
+++ b/tmux.1
@@ -2440,6 +2440,20 @@ disallowedWindowOps: 20,21,SetXprop
 Or changing this property from the
 .Xr xterm 1
 interactive menu when required.
+.It Ic terminal-aliases Ar string
+Contains a list of entries which override terminal descriptions.
+.Ar string
+is a comma-separated list of items each a colon-separated pair of a
+terminal type pattern (matched using
+.Xr fnmatch 3 )
+and the name of the target terminal to use in its place.
+.Pp
+For example, to force 256 colours support on terminals that use
+.Ev TERM=xterm ,
+use:
+.Bd -literal -offset indent
+"xterm:xterm-256color"
+.Ed
 .It Ic terminal-overrides Ar string
 Contains a list of entries which override terminal descriptions read using
 .Xr terminfo 5 .


### PR DESCRIPTION
Fixes: #120

Well, in a way, it's still a workaround, but I think it's a more elegant way to enable 256 color support in `TERM=xterm`.

Thanks!
Filipe

@nicm @ThomasAdam

The original commit description follows:

The option adds a mapping between terminal settings in $TERM variable and the actual terminfo entry to use.

It can be more effective than terminal-overrides for tasks such as enabling 256 colour support, since that usually requires setting more than a single terminfo variable to the correct values.

For instance, until tmux 1.8 this recipe used to work to enable 256 colour support on xterm:

```
  set -g terminal-overrides "xterm:colors=256"
```

However, commit f2e54e1e2ff5a1 started using "setaf" and "setab" terminfo settings, which are insufficient in "xterm" to set 256 colours. It is possible to override those, but if the goal is to enable support for 256 colours, it is more effective to do so by instructing tmux to just use the full "xterm-256color" terminfo entry directly, which can now be achieved using:

```
  set -g terminal-aliases "xterm:xterm-256color"
```

Of course, ideally the $TERM setting should be correct to specify "xterm-256color" if that support is available, but unfortunately some terminal emulators are limited (for instance, xfce4-terminal uses termcap which has only a basic set of entries these days) and there are number of systems misconfigured to set TERM=xterm or similar from global configuration files such as /etc/profile, which often makes it more convenient to just override settings in tmux configuration (same as was already done, to quite an extent, by terminal-overrides, anyways.)

Tested on xfce4-terminal, using the "xterm:xterm-256color" mapping, confirming that vim syntax highlighting with 256 colour support was available inside the freshly started tmux session. Man page updated and tested locally.
