### PR TITLE
Fix fill in code to store boolean flags in the .flag member.

### DIFF
--- a/tty-term.c
+++ b/tty-term.c
@@ -454,7 +454,7 @@ tty_term_find(char *name, int fd, char **cause)
 			if (n == -1)
 				break;
 			code->type = TTYCODE_FLAG;
-			code->value.number = n;
+			code->value.flag = n;
 			break;
 		}
 	}


### PR DESCRIPTION
@nicm I bumped into this while hacking the terminal-overrides code... It's doesn't really cause a bug but I think it should still be fixed. Thanks!