### PR TITLE
for 'choose-tree' add windows sorting by activity time

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1384,6 +1384,10 @@ If
 .Fl w
 is given, will show windows.
 .Pp
+If
+.Fl a
+is given, windows will be sorted by last activity time (descending order).
+.Pp
 By default, the tree is collapsed and sessions must be expanded to windows
 with the right arrow key.
 The


### PR DESCRIPTION
Tmux lacks a very convenient feature of GNU screen — the ability to sort windows by activity time (windowlist -m). So I made this tiny patch to implement such feature.