### PR TITLE
Cache commands executed with #() and default to 1 for status-interval

### DIFF
--- a/format.c
+++ b/format.c
@@ -219,6 +219,7 @@ format_job_get(struct format_tree *ft, const char *cmd)
 {
 	struct format_job	fj0, *fj;
 	time_t			t;
+	int			ct;
 
 	fj0.cmd = cmd;
 	if ((fj = RB_FIND(format_job_tree, &format_jobs, &fj0)) == NULL) {
@@ -230,8 +231,13 @@ format_job_get(struct format_tree *ft, const char *cmd)
 		RB_INSERT(format_job_tree, &format_jobs, fj);
 	}
 
+	if (ft->s)
+	    ct = options_get_number(&ft->s->options, "command-cache-time");
+	else
+	    ct = 1;
+
 	t = time(NULL);
-	if (fj->job == NULL && ((ft->flags & FORMAT_FORCE) || fj->last != t)) {
+	if (fj->job == NULL && ((ft->flags & FORMAT_FORCE) || fj->last + ct <= t)) {
 		fj->job = job_run(fj->cmd, NULL, -1, format_job_callback,
 		    NULL, fj);
 		if (fj->job == NULL) {

--- a/options-table.c
+++ b/options-table.c
@@ -141,6 +141,13 @@ const struct options_table_entry session_options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "command-cache-time",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .minimum = 0,
+	  .maximum = INT_MAX,
+	  .default_num = 15
+	},
+
 	{ .name = "default-command",
 	  .type = OPTIONS_TABLE_STRING,
 	  .default_str = ""
@@ -324,7 +331,7 @@ const struct options_table_entry session_options_table[] = {
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .minimum = 0,
 	  .maximum = INT_MAX,
-	  .default_num = 15
+	  .default_num = 1
 	},
 
 	{ .name = "status-justify",

--- a/tmux.1
+++ b/tmux.1
@@ -2509,6 +2509,11 @@ means bells in the current window are ignored but not those in other windows.
 .Xc
 If on, ring the terminal bell when an alert
 occurs.
+.It Xo Ic command-cache-time Ar time
+.Xc
+Set the time in seconds how long commands executed with
+.Ql #()
+will be cached (default 15).
 .It Ic default-command Ar shell-command
 Set the command used for new windows (if not specified when the window is
 created) to
@@ -2731,7 +2736,7 @@ Show or hide the status line.
 Update the status bar every
 .Ar interval
 seconds.
-By default, updates will occur every 15 seconds.
+By default, updates will occur every second.
 A setting of zero disables redrawing at interval.
 .It Xo Ic status-justify
 .Op Ic left | centre | right
@@ -3339,7 +3344,10 @@ When constructing formats,
 .Nm
 does not wait for
 .Ql #()
-commands to finish; instead, the previous result from running the same command is used,
+commands to finish, neither does it re-execute them if
+.Ic command-cache-time
+seconds have not been passed since the last run;
+instead, the previous result from running the same command is used,
 or a placeholder if the command has not been run before.
 Commands are executed with the
 .Nm


### PR DESCRIPTION
As of 379400cfa69f8df9ac13b070c60d5f8a282ddf6e, commands have been run
every second when the status bar is being redrawn (on every event loop).

This commit introduces a ‘command-cache-time’ setting that controls the
caching time of #() commands and reduces status-interval to 1, so clocks
are redrawn in time and not only when the event loop happens to be
executed.