### PR TITLE
Prefer more columns for tiled layouts

### DIFF
--- a/layout-set.c
+++ b/layout-set.c
@@ -480,9 +480,9 @@ layout_set_tiled(struct window *w)
 	/* How many rows and columns are wanted? */
 	rows = columns = 1;
 	while (rows * columns < n) {
-		rows++;
+		columns++;
 		if (rows * columns < n)
-			columns++;
+			rows++;
 	}
 
 	/* What width and height should they be? */


### PR DESCRIPTION
Most screens are wider than they are taller, so we change the tiled
layouts to prefer having more columns that rows. For example, with 6
windows, this change gives 2 rows and 3 columns, while the old code
would have 3 rows and 2 columns.

Resolves https://github.com/tmux/tmux/issues/161