### PR TITLE
Add new format 'pane_current_path_basename'

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -3391,6 +3391,7 @@ The following variables are available, where appropriate:
 .It Li "pane_bottom" Ta "" Ta "Bottom of pane"
 .It Li "pane_current_command" Ta "" Ta "Current command if available"
 .It Li "pane_current_path" Ta "" Ta "Current path if available"
+.It Li "pane_current_path_basename" Ta "" Ta "Basename of current path if available"
 .It Li "pane_dead" Ta "" Ta "1 if pane is dead"
 .It Li "pane_dead_status" Ta "" Ta "Exit status of process in dead pane"
 .It Li "pane_height" Ta "" Ta "Height of pane"


### PR DESCRIPTION
This adds a new format option `pane_current_path_basename` to make `$(basename $(pwd))` available for use, typical usage is in `automatic-rename-format`.

The background: I wanted a way to put both cwd and current command in the auto window title but `pane_current_path` would be too long in most cases.  I know I can print a `\033k` escape sequence to set window title automatically (e.g via the `PROMPT_COMMAND` env for bash) but it does not support display current command.

Now this new format makes the work, for example I can auto rename window title to a fairly short and meaningful string:

```
set -g automatic-rename on
set -g automatic-rename-format \
    '#I#{?pane_in_mode,[tmux],[#{pane_current_path_basename}] #{pane_current_command}}#F'
```

![image](https://cloud.githubusercontent.com/assets/1407119/10711038/74fcbcdc-7aa2-11e5-8dbc-96d139855fc3.png)
