### PR TITLE
Add option to use double-line characters for pane borders

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -50,6 +50,9 @@ const char *options_table_status_position_list[] = {
 const char *options_table_bell_action_list[] = {
 	"none", "any", "current", "other", NULL
 };
+const char *options_pane_border_linestyle_list[] = {
+	"single", "double", NULL
+};
 
 /* Server options. */
 const struct options_table_entry server_options_table[] = {
@@ -611,6 +614,12 @@ const struct options_table_entry window_options_table[] = {
 	  .type = OPTIONS_TABLE_COLOUR,
 	  .default_num = 8,
 	  .style = "pane-border-style"
+	},
+
+	{ .name = "pane-border-linestyle",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .choices = options_pane_border_linestyle_list,
+	  .default_num = 0,
 	},
 
 	{ .name = "pane-border-style",

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -282,10 +282,29 @@ screen_redraw_draw_borders(struct client *c, int status, u_int top)
 	struct grid_cell	 m_active_gc, active_gc, m_other_gc, other_gc;
 	struct grid_cell	 msg_gc;
 	u_int		 	 i, j, type, msgx = 0, msgy = 0;
-	int			 active, small, flags;
+	int			 active, small, flags, utf8flag, pane_border_linestyle;
 	char			 msg[256];
 	const char		*tmp;
 	size_t			 msglen = 0;
+
+	struct utf8_data cell_borders[] = {
+		{ .data = {226, 149, 0}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 145}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 144}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 148}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 151}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 154}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 157}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 166}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 169}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 160}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 163}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 172}, .size = 3, .width = 1 },
+		{ .data = {226, 149, 0}, .size = 3, .width = 1 },
+	};
+
+	utf8flag = options_get_number(oo, "utf8");
+	pane_border_linestyle = options_get_number(oo, "pane-border-linestyle");
 
 	small = (tty->sy - status + top > w->sy) || (tty->sx > w->sx);
 	if (small) {
@@ -343,7 +362,11 @@ screen_redraw_draw_borders(struct client *c, int status, u_int top)
 			else
 				tty_attributes(tty, &other_gc, NULL);
 			tty_cursor(tty, i, top + j);
-			tty_putc(tty, CELL_BORDERS[type]);
+			if (pane_border_linestyle == 0 || !utf8flag) {
+				tty_putc(tty, CELL_BORDERS[type]);
+			} else {
+				tty_putn(tty, cell_borders[type].data, 3, 1);
+			}
 		}
 	}
 

--- a/tmux.1
+++ b/tmux.1
@@ -3068,6 +3068,11 @@ Like
 .Ic base-index ,
 but set the starting index for pane numbers.
 .Pp
+.It Xo Ic pane-border-linestyle
+.Op Ic single | double
+.Xc
+Use single line or double line characters to draw pane borders.  UTF8 must be enabled for double to work.  Default is single.
+.Pp
 .It Ic pane-border-style Ar style
 Set the pane border style for panes aside from the active pane.
 For how to specify


### PR DESCRIPTION
Single line pane borders sometime appear a bit thin.