### PR TITLE
Looks for ncurses with pkg_config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,10 +155,16 @@ PKG_CHECK_MODULES(
         [
 		AC_SEARCH_LIBS(
 			setupterm,
-			[terminfo curses ncurses tinfo],
+			[terminfo curses tinfo],
 			found_curses=yes,
 			found_curses=no
 		)
+		AC_SEARCH_LIBS(
+                        addch,
+                        [ncurses],
+                        found_curses=yes,
+                        found_curses=no
+                )
 	]
 )
 if test "x$found_curses" = xno; then

--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,20 @@ if test "x$found_libevent" = xno; then
 	AC_MSG_ERROR("libevent not found")
 fi
 
+# Look for ncurses
+PKG_CHECK_MODULES(
+        LIBNCURSES,
+        ncurses,
+        [
+                CPPFLAGS="$LIBNCURSES_CFLAGS $CPPFLAGS"
+                LIBS="$LIBNCURSES_LIBS $LIBS"
+                found_libncurses=yes
+        ]
+)
+if test "x$found_libncurses" = xno; then
+        AC_MSG_ERROR("libncurses not found")
+fi
+
 # Look for curses.
 AC_SEARCH_LIBS(
 	setupterm,

--- a/configure.ac
+++ b/configure.ac
@@ -150,19 +150,16 @@ PKG_CHECK_MODULES(
         [
                 CPPFLAGS="$LIBNCURSES_CFLAGS $CPPFLAGS"
                 LIBS="$LIBNCURSES_LIBS $LIBS"
-                found_libncurses=yes
-        ]
-)
-if test "x$found_libncurses" = xno; then
-        AC_MSG_ERROR("libncurses not found")
-fi
-
-# Look for curses.
-AC_SEARCH_LIBS(
-	setupterm,
-	[terminfo curses ncurses tinfo],
-	found_curses=yes,
-	found_curses=no
+                found_curses=yes
+        ],
+        [
+		AC_SEARCH_LIBS(
+			setupterm,
+			[terminfo curses ncurses tinfo],
+			found_curses=yes,
+			found_curses=no
+		)
+	]
 )
 if test "x$found_curses" = xno; then
 	AC_MSG_ERROR("curses not found")


### PR DESCRIPTION
On my fresh installed debian jessie 8.2 ncurses.h is not installed and configure script did said nothing. The compilation aborted with message "unable to found ncurses.h". That patch corrects this.