### PR TITLE
Look for ncurses with pkg-config and falls back to AC_SEARCH_LIBS (total patch)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,15 +143,32 @@ if test "x$found_libevent" = xno; then
 	AC_MSG_ERROR("libevent not found")
 fi
 
-# Look for curses.
-AC_SEARCH_LIBS(
-	setupterm,
-	[terminfo curses ncurses tinfo],
-	found_curses=yes,
-	found_curses=no
+# Look for ncurses
+PKG_CHECK_MODULES(
+        LIBNCURSES,
+        ncurses,
+        [
+                CPPFLAGS="$LIBNCURSES_CFLAGS $CPPFLAGS"
+                LIBS="$LIBNCURSES_LIBS $LIBS"
+                found_curses=yes
+        ],
+        [
+                AC_SEARCH_LIBS(
+                        setupterm,
+                        [terminfo curses tinfo],
+                        found_curses=yes,
+                        found_curses=no
+                )
+                AC_SEARCH_LIBS(
+                        addch,
+                        [ncurses],
+                        found_curses=yes,
+                        found_curses=no
+                )
+        ]
 )
 if test "x$found_curses" = xno; then
-	AC_MSG_ERROR("curses not found")
+        AC_MSG_ERROR("curses not found")
 fi
 
 # Look for utempter.


### PR DESCRIPTION
ncurses.h may be needed by tty-term.c.
This patch should do the following:
 1) pkg-config search for ncurses
 2) if it was not found by pkg-config it searchs functions into
    librairies with AC_SEARCH_LIBS to confirm that they really exists:
    2.1) it searches setupterm function into terminfo curses tinfo libraries and
    2.2) then it searches addch function into ncurses.

On my system, without libncurses-dev installed this generates an error.
Previously it didn't because AC_SEARCH_LIBS did found setupterm into tinfo
and returned true.