### PR TITLE
Add bottom-border option

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -197,6 +197,8 @@ cmd_new_session_exec(struct cmd *self, struct cmd_q *cmdq)
 	}
 	if (sy > 0 && options_get_number(global_s_options, "status"))
 		sy--;
+	if (sy > 0 && options_get_number(&global_s_options, "bottom-border"))
+		sy--;
 	if (sx == 0)
 		sx = 1;
 	if (sy == 0)

--- a/options-table.c
+++ b/options-table.c
@@ -150,6 +150,11 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "bottom-border",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .default_num = 0
+	},
+
 	{ .name = "default-command",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/resize.c
+++ b/resize.c
@@ -78,6 +78,9 @@ recalculate_sizes(void)
 		}
 		s->flags &= ~SESSION_UNATTACHED;
 
+		if (options_get_number(&s->options, "bottom-border") && ssy > 0)
+			ssy--;
+
 		if (has_status && ssy == 0)
 			ssy = 1;
 


### PR DESCRIPTION
This patch allows to specify the `bottom-border` option to display a (just esthetic) bottom border line between the status bar and the window panes.

This is without the `bottom-border` option:

![2015-12-24-120703_884x604_scrot](https://cloud.githubusercontent.com/assets/79197/11994471/f15b34fc-aa36-11e5-9e2f-1b4e7e61942d.png)

and this is with:

![2015-12-24-120723_884x604_scrot](https://cloud.githubusercontent.com/assets/79197/11994473/f49f54f4-aa36-11e5-9ac0-023ba2c2e024.png)
