### PR TITLE
Don't require space after ;

### DIFF
--- a/TODO
+++ b/TODO
@@ -9,7 +9,6 @@
           config file as-is
 
 - make command sequences more usable
-	* don't require space after ;
 	* options for error handling: && and ||?
 
 - options bits and pieces:

--- a/cmd-string.c
+++ b/cmd-string.c
@@ -83,6 +83,23 @@ cmd_string_parse(const char *s, struct cmd_list **cmdlist, const char *file,
 	for (;;) {
 		ch = cmd_string_getc(s, &p);
 		switch (ch) {
+        case ';':
+            if (buf != NULL) {
+                buf = xrealloc(buf, len + 2);
+                buf[len++] = ch;
+                buf[len] = '\0';
+
+                argv = xreallocarray(argv, argc + 1,
+                    sizeof *argv);
+                argv[argc++] = buf;
+
+                buf = NULL;
+                len = 0;
+            } else {
+                buf = xrealloc(buf, len + 1);
+                buf[len++] = ch;
+            }
+            break;
 		case '\'':
 			if ((t = cmd_string_string(s, &p, '\'', 0)) == NULL)
 				goto error;

--- a/cmd-string.c
+++ b/cmd-string.c
@@ -84,21 +84,16 @@ cmd_string_parse(const char *s, struct cmd_list **cmdlist, const char *file,
 		ch = cmd_string_getc(s, &p);
 		switch (ch) {
         case ';':
-            if (buf != NULL) {
-                buf = xrealloc(buf, len + 2);
-                buf[len++] = ch;
-                buf[len] = '\0';
+            buf = xrealloc(buf, len + 2);
+            buf[len++] = ch;
+            buf[len] = '\0';
 
-                argv = xreallocarray(argv, argc + 1,
-                    sizeof *argv);
-                argv[argc++] = buf;
+            argv = xreallocarray(argv, argc + 1,
+                sizeof *argv);
+            argv[argc++] = buf;
 
-                buf = NULL;
-                len = 0;
-            } else {
-                buf = xrealloc(buf, len + 1);
-                buf[len++] = ch;
-            }
+            buf = NULL;
+            len = 0;
             break;
 		case '\'':
 			if ((t = cmd_string_string(s, &p, '\'', 0)) == NULL)


### PR DESCRIPTION
When parsing a command string, treat ';' as a delimiter between commands rather than relying on whitespace as a delimiter. This allows commands of the form \<command\>;\<command\> and \<command\> ;\<command\>