### PR TITLE
Status fix

### DIFF
--- a/status.c
+++ b/status.c
@@ -547,7 +547,7 @@ status_message_set(struct client *c, const char *fmt, ...)
 	struct message_entry	*msg, *msg1;
 	va_list			 ap;
 	int			 delay;
-	u_int			 first, limit;
+	u_int			 limit;
 
 	limit = options_get_number(global_options, "message-limit");
 
@@ -564,10 +564,9 @@ status_message_set(struct client *c, const char *fmt, ...)
 	msg->msg = xstrdup(c->message_string);
 	TAILQ_INSERT_TAIL(&c->message_log, msg, entry);
 
-	first = c->message_next - limit;
 	TAILQ_FOREACH_SAFE(msg, &c->message_log, entry, msg1) {
-		if (msg->msg_num >= first)
-			continue;
+		if (msg->msg_num + limit >= c->message_next)
+			break;
 		free(msg->msg);
 		TAILQ_REMOVE(&c->message_log, msg, entry);
 		free(msg);


### PR DESCRIPTION
Two commits:

> Fix message log appends

> The following has been improved:
> 1) Previous code had "u_int first" which is incorrect as
>    "first = c->message_next - limit" would result in negative values,
>    resulting in dropping the first `limit` messages.
> 2) Avoid to traverse the entire list of message to prune messages.
> 3) Extracted it into a global function as it can be useful for other part of
>    tmux (and tmate).

and

> Guard against NULL c->session in status_message_set()