### PR TITLE
Add xmalloc.h and new merged example file to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,8 @@ CLEANFILES = tmux.1.mdoc tmux.1.man
 
 # Distribution tarball options.
 EXTRA_DIST = \
-	CHANGES FAQ README TODO COPYING examples compat/*.[ch] \
-	array.h compat.h tmux.h osdep-*.c mdoc2man.awk tmux.1
+	CHANGES FAQ README TODO COPYING example_tmux.conf compat/*.[ch] \
+	array.h compat.h tmux.h osdep-*.c xmalloc.h mdoc2man.awk tmux.1
 dist-hook:
 	make clean
 	grep "^#found_debug=" configure


### PR DESCRIPTION
make dist fails because it tries to include the old examples directory,
so use the merged example file instead.

Also include xmalloc.h which is required to build.