### PR TITLE
Added support for two (top and bottom) status bars...

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -139,15 +139,15 @@ cmd_resize_pane_mouse_update(struct client *c, struct mouse_event *m)
 	}
 
 	y = m->y;
-	if (m->statusat == 0 && y > 0)
-		y--;
-	else if (m->statusat > 0 && y >= (u_int)m->statusat)
-		y = m->statusat - 1;
+    if (m->anyatzero && y > 0)
+        y--;
+    if (m->anyonlast && y >= m->auxstatusat + m->statusat)
+        y = m->auxstatusat + m->statusat - 1;
 	ly = m->ly;
-	if (m->statusat == 0 && ly > 0)
-		ly--;
-	else if (m->statusat > 0 && ly >= (u_int)m->statusat)
-		ly = m->statusat - 1;
+    if (m->anyatzero && y > 0)
+        ly--;
+    if (m->anyonlast && ly >= m->auxstatusat + m->statusat)
+        ly = m->auxstatusat + m->statusat - 1;
 
 	found = 0;
 	TAILQ_FOREACH(wp, &wl->window->panes, entry) {

--- a/cmd.c
+++ b/cmd.c
@@ -591,10 +591,10 @@ cmd_mouse_at(struct window_pane *wp, struct mouse_event *m, u_int *xp,
 		y = m->y;
 	}
 
-	if (m->statusat == 0 && y > 0)
-		y--;
-	else if (m->statusat > 0 && y >= (u_int)m->statusat)
-		y = m->statusat - 1;
+    if (m->anyatzero && y > 0)
+        y--;
+    if (m->anyonlast && y >= m->auxstatusat + m->statusat)
+        y = m->auxstatusat + m->statusat - 1;
 
 	if (x < wp->xoff || x >= wp->xoff + wp->sx)
 		return (-1);

--- a/options-table.c
+++ b/options-table.c
@@ -334,6 +334,140 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "#S:#I:#W - \"#T\" #{session_alerts}"
 	},
 
+	{ .name = "aux-status",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0
+	},
+
+	{ .name = "aux-status-attr",
+	  .type = OPTIONS_TABLE_ATTRIBUTES,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0,
+	  .style = "aux-status-style"
+	},
+
+	{ .name = "aux-status-bg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 2,
+	  .style = "aux-status-style"
+	},
+
+	{ .name = "aux-status-fg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0,
+	  .style = "aux-status-style"
+	},
+
+    /* aux status interval is the same as the main status interval */
+
+	{ .name = "aux-status-justify",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_status_justify_list,
+	  .default_num = 0
+	},
+
+    /* aux-status-keys is he same as the main status keys */
+
+	{ .name = "aux-status-left",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  /* .default_str = "this is the left" */
+	  .default_str = ""
+	},
+
+	{ .name = "aux-status-left-attr",
+	  .type = OPTIONS_TABLE_ATTRIBUTES,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0,
+	  .style = "aux-status-left-style"
+	},
+
+	{ .name = "aux-status-left-bg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 8,
+	  .style = "aux-status-left-style"
+	},
+
+	{ .name = "aux-status-left-fg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 8,
+	  .style = "aux-status-left-style"
+	},
+
+	{ .name = "aux-status-left-length",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 0,
+	  .maximum = SHRT_MAX,
+	  .default_num = 10
+	},
+
+	{ .name = "aux-status-left-style",
+	  .type = OPTIONS_TABLE_STYLE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "default"
+	},
+
+	{ .name = "aux-status-position",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_status_position_list,
+	  .default_num = 0
+	},
+
+	{ .name = "aux-status-right",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "[#H]"
+	},
+
+	{ .name = "aux-status-right-attr",
+	  .type = OPTIONS_TABLE_ATTRIBUTES,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0,
+	  .style = "aux-status-right-style"
+	},
+
+	{ .name = "aux-status-right-bg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 8,
+	  .style = "aux-status-right-style"
+	},
+
+	{ .name = "aux-status-right-fg",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 8,
+	  .style = "aux-status-right-style"
+	},
+
+	{ .name = "aux-status-right-length",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 0,
+	  .maximum = SHRT_MAX,
+	  .default_num = 40
+	},
+
+	{ .name = "aux-status-right-style",
+	  .type = OPTIONS_TABLE_STYLE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "default"
+	},
+
+	{ .name = "aux-status-style",
+	  .type = OPTIONS_TABLE_STYLE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "bg=green,fg=black"
+	},
+
 	{ .name = "status",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/server-client.c
+++ b/server-client.c
@@ -914,7 +914,7 @@ server_client_check_redraw(struct client *c)
 		else if (c->prompt_string != NULL)
 			redraw = status_prompt_redraw(c);
 		else{
-			aux_status_redraw(c);
+			redraw = aux_status_redraw(c);
 			redraw = status_redraw(c);
         }
 		if (!redraw)

--- a/tmux.h
+++ b/tmux.h
@@ -1084,6 +1084,9 @@ struct mouse_event {
 
 	key_code	key;
 	int		statusat;
+	int		auxstatusat;
+	int		anyatzero;
+	int		anyonlast;
 
 	u_int		x;
 	u_int		y;
@@ -1246,6 +1249,7 @@ struct client {
 
 	struct event	 status_timer;
 	struct screen	 status;
+	struct screen	 aux_status;
 
 #define CLIENT_TERMINAL 0x1
 #define CLIENT_LOGIN 0x2
@@ -1941,8 +1945,12 @@ void	 server_unzoom_window(struct window *);
 void	 status_timer_start(struct client *);
 void	 status_timer_start_all(void);
 int	 status_at_line(struct client *);
+int	 aux_status_at_line(struct client *);
+int	 any_status_at_zero(struct client *);
+int	 any_status_on_last(struct client *);
 struct window *status_get_window_at(struct client *, u_int);
 int	 status_redraw(struct client *);
+int	 aux_status_redraw(struct client *);
 void printflike(2, 3) status_message_set(struct client *, const char *, ...);
 void	 status_message_clear(struct client *);
 int	 status_message_redraw(struct client *);

--- a/tty.c
+++ b/tty.c
@@ -812,7 +812,7 @@ tty_write(void (*cmdfn)(struct tty *, const struct tty_ctx *),
 
 		ctx->xoff = wp->xoff;
 		ctx->yoff = wp->yoff;
-		if (status_at_line(c) == 0)
+		if (any_status_at_zero(c))
 			ctx->yoff++;
 
 		cmdfn(&c->tty, ctx);


### PR DESCRIPTION
It works great for me. The only things that need to be done (unless I'm missing something) is configuration constraints (can't have the main bar and the aux bar in the same position) and documentation on the new feature.

Basically, the new bar, `aux-status`, is just like the main bar except all of it's configuration options are prefaced with `aux`. Also, it doesn't contain any of the information about the windows (like the main bar).

To make things more concrete, this is an excerpt from my `.tmux.conf`
```
set-option -g aux-status-left-length 100
set-option -g aux-status-right-length 100
set -g aux-status-style "bg=#989acc, fg=#fda878"

set-option -g status-position bottom
set-option -g aux-status-position top

set -g aux-status on
```