### PR TITLE
new-session: check that the client has a cwd

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -142,7 +142,7 @@ cmd_new_session_exec(struct cmd *self, struct cmd_q *cmdq)
 		format_defaults(ft, c, NULL, NULL, NULL);
 		to_free = cwd = format_expand(ft, args_get(args, 'c'));
 		format_free(ft);
-	} else if (c != NULL && c->session == NULL)
+	} else if (c != NULL && c->session == NULL && c->cwd)
 		cwd = c->cwd;
 	else
 		cwd = ".";


### PR DESCRIPTION
This turns into a NULL dereference in session_create where it is
xstrdup'd.

---
Seen when attaching to an existing server and creating a new session through SSH. Was unable to bisect it down to 01defc9f4965bb174e1d1295754d5a8695683054 which started the crash. It is not clean to revert of of `master`, so I don't know what about it is the problem. It might be the `window_pane_create` hunk?