### PR TITLE
New window option 'utmp-inhibit'.

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -710,6 +710,12 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "utmp-inhibit",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_num = 0
+	},
+
 	{ .name = "window-active-style",
 	  .type = OPTIONS_TABLE_STYLE,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/server-fn.c
+++ b/server-fn.c
@@ -302,7 +302,8 @@ server_destroy_pane(struct window_pane *wp, int hooks)
 	old_fd = wp->fd;
 	if (wp->fd != -1) {
 #ifdef HAVE_UTEMPTER
-		utempter_remove_record(wp->fd);
+		if (!options_get_number(wp->window->options, "utmp-inhibit"))
+				utempter_remove_record(wp->fd);
 #endif
 		bufferevent_free(wp->event);
 		close(wp->fd);

--- a/tmux.1
+++ b/tmux.1
@@ -3091,6 +3091,11 @@ command.
 Duplicate input to any pane to all other panes in the same window (only
 for panes that are not in any special mode).
 .Pp
+.It Xo Ic utmp-inhibit
+.Op Ic on | off
+.Xc
+Prevents writing utmp records for the window. Default is off.
+.Pp
 .It Ic window-active-style Ar style
 Set the style for the window's active pane.
 For how to specify

--- a/window.c
+++ b/window.c
@@ -782,7 +782,8 @@ window_pane_destroy(struct window_pane *wp)
 
 	if (wp->fd != -1) {
 #ifdef HAVE_UTEMPTER
-		utempter_remove_record(wp->fd);
+		if (!options_get_number(wp->window->options, "utmp-inhibit"))
+				utempter_remove_record(wp->fd);
 #endif
 		bufferevent_free(wp->event);
 		close(wp->fd);
@@ -914,9 +915,11 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
 	}
 
 #ifdef HAVE_UTEMPTER
-	xsnprintf(s, sizeof s, "tmux(%lu).%%%u", (long) getpid(), wp->id);
-	utempter_add_record(wp->fd, s);
-	kill(getpid(), SIGCHLD);
+	if (!options_get_number(wp->window->options, "utmp-inhibit")) {
+		xsnprintf(s, sizeof s, "tmux(%lu).%%%u", (long) getpid(), wp->id);
+		utempter_add_record(wp->fd, s);
+		kill(getpid(), SIGCHLD);
+	}
 #endif
 
 	setblocking(wp->fd, 0);


### PR DESCRIPTION
This allows the user to opt out of having utmp entries written for
each pane. Can help prevent clobbering of utmp records on busy shell
servers.