### PR TITLE
Minor change to fix building tmux on Oracle Solaris 11.x

### DIFF
--- a/tty-term.c
+++ b/tty-term.c
@@ -21,12 +21,19 @@
 #if defined(HAVE_CURSES_H)
 #include <curses.h>
 #elif defined(HAVE_NCURSES_H)
+#ifdef __sun
+#include <ncurses/ncurses.h>
+#endif /* __sun */
 #include <ncurses.h>
 #endif
 #include <fnmatch.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef __sun
+#include <ncurses/term.h>
+#else
 #include <term.h>
+#endif
 
 #include "tmux.h"
 


### PR DESCRIPTION
The ncurses headers are located in a nested dir:
$ pkg contents library/ncurses | egrep "(ncurses\.h|term\.h)"
usr/include/ncurses/ncurses.h
usr/include/ncurses/term.h
(It's required to build libevent2 prior to building tmux2, as official repos provide libevent1.4 only)