### PR TITLE
Add set-clipboard-cmd option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -113,6 +113,12 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 1
 	},
 
+	{ .name = "set-clipboard-cmd",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_str = ""
+	},
+
 	{ .name = "terminal-overrides",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/tmux.1
+++ b/tmux.1
@@ -2444,6 +2444,8 @@ disallowedWindowOps: 20,21,SetXprop
 Or changing this property from the
 .Xr xterm 1
 interactive menu when required.
+.It Ic set-clipboard-cmd Ar string
+Command to pipe the selection into when copying
 .It Ic terminal-overrides Ar string
 Contains a list of entries which override terminal descriptions read using
 .Xr terminfo 5 .


### PR DESCRIPTION
This configuration parameter allows a user to automatically pipe the selection to xclip or whatever tool they fancy for managing their clipboard.

https://github.com/matthiasvegh/dotfiles/blob/master/home/.tmux.conf#L6-L7 shows example usage of this. This works well even through Putty if X forwarding is on. (ie.: windows clipboard is kept in sync with the selected text).