### PR TITLE
Fix default socket on noacl cygwin root

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -133,7 +133,11 @@ make_label(const char *label)
 		errno = ENOTDIR;
 		goto fail;
 	}
+#ifdef __CYGWIN__
+	if (sb.st_uid != uid) {
+#else
 	if (sb.st_uid != uid || (sb.st_mode & S_IRWXO) != 0) {
+#endif
 		errno = EACCES;
 		goto fail;
 	}


### PR DESCRIPTION
With cygwin noacl root, permissions are just weird and tmux
fails to create default socket even when it can (and stuff
works if it does).