### PR TITLE
New window and split window in the current folder by default

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -93,6 +93,9 @@ cmd_split_window_exec(struct cmd *self, struct cmd_q *cmdq)
 		format_defaults(ft, cmdq->state.c, s, NULL, NULL);
 		to_free = cwd = format_expand(ft, args_get(args, 'c'));
 		format_free(ft);
+        } else if ((cwd = osdep_get_cwd(wp->fd)) ||
+		   (cwd = osdep_get_cwd(s->curw->window->active->fd))) {
+		/* */
 	} else if (cmdq->client != NULL && cmdq->client->session == NULL)
 		cwd = cmdq->client->cwd;
 	else


### PR DESCRIPTION
Hi,

I'm missing the tmux feature to open new windows and panes in the current directory.
Here's a patch to bring it back.

Many OS distros are still shipped with that old version 1.8 when tmux did that.
As I can see, when people try newer tmux, they get surprized about not having new windows in the current folder.

I know I can just add `-c` to the key bindings but still, currently there's no solution how to run a custom command in the current directory.