### PR TITLE
Fix if-shell not expanding all current formats

### DIFF
--- a/cmd-if-shell.c
+++ b/cmd-if-shell.c
@@ -81,7 +81,7 @@ cmd_if_shell_exec(struct cmd *self, struct cmd_q *cmdq)
 		cwd = NULL;
 
 	ft = format_create(cmdq, 0);
-	format_defaults(ft, NULL, s, wl, wp);
+	format_defaults(ft, cmdq->state.c, s, wl, wp);
 	shellcmd = format_expand(ft, args->argv[0]);
 	format_free(ft);
 


### PR DESCRIPTION
Title says it all. `if-shell` wasn't expanding all formats, such as one pertaining to panes. Passing the format state to `format_defaults()` fixes the problem. Nothing fancy here. :grinning: 