### PR TITLE
cmd-bind-key.c: fix argument count check for `bind -t` case

### DIFF
--- a/cmd-bind-key.c
+++ b/cmd-bind-key.c
@@ -54,7 +54,7 @@ cmd_bind_key_exec(struct cmd *self, struct cmd_q *cmdq)
 	const char	*tablename;
 
 	if (args_has(args, 't')) {
-		if (args->argc != 2 && args->argc != 3) {
+		if (args->argc < 3) {
 			cmdq_error(cmdq, "not enough arguments");
 			return (CMD_RETURN_ERROR);
 		}


### PR DESCRIPTION
`bind-key` may accept multiple arguments as commands like this:

    bind-key -t vi-copy WheelUpPane scroll-up \; scroll-up \; scroll-up

Fixes issue #400.