### PR TITLE
Add binary clock

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -36,7 +36,7 @@ const char *options_table_mode_keys_list[] = {
 	"emacs", "vi", NULL
 };
 const char *options_table_clock_mode_style_list[] = {
-	"12", "24", NULL
+	"12", "24", "binary", NULL
 };
 const char *options_table_status_keys_list[] = {
 	"emacs", "vi", NULL


### PR DESCRIPTION
Add the possibility to choose 'binary' as style in clock-mode-style.

Now the question is why ?

Let's imagine this patch is upstream,
peoples will get the possibility to read binary far more often than they usually do,
they will become familiar with binary algorithm,
Developers will get habit to use bit-mask, once they have learn how to manipulate binary,
they will get curious about low level stuff,
they will use programming language that allow to manipulate bit-mask easily, like C.

But if they don't learn how to manipulate bit-mask, developers will stop learning C because it's too complex for them, they will go java, OS will be create in java, kernel will be in Java,
the world will use java, and java logo is coffee, so the world will drink coffee.
What will happen with then ?
Tea market will drop, coffee grow up, and do you think nations like Brazil produce enough coffee for all china ?
No china will obviously invade Brazil to have more coffee,
and from this a new world war will happen.

So voilà, as a humanist I can't let the world be destroy and decide to save it,
let's introduce a binary clock in Tmux and save the world with it !

Thanks.

Signed-off-by: Matthias Gatto <uso.cosmo.ray@gmail.com>