### PR TITLE
tmux load-buffer in tmux 2.2+ hangs on epoll_wait()

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -337,5 +337,5 @@ main(int argc, char **argv)
 	free(label);
 
 	/* Pass control to the client. */
-	exit(client_main(event_init(), argc, argv, flags, shellcmd));
+	exit(client_main(osdep_event_init(), argc, argv, flags, shellcmd));
 }


### PR DESCRIPTION
Hello,

When I run `tmux load-buffer` from Vim 7.4 as shown below, I observe that `tmux load-buffer` emits the following warning and then hangs on `epoll_wait()`.  This happens under tmux 2.2 as well as the latest git version at commit 2377092a70db3327cbeb07328ea8422d0395edc4.

```
[warn] Epoll ADD(1) on fd 0 failed.  Old events were 0; read change was 1 (add); write change was 0 (none): Operation not permitted
```

Thanks for your consideration.

### Steps to reproduce the bug

Run the following command in Vim 7.4:

```vim
:silent call system('tmux load-buffer -', 'hello world')
```

Observe that Vim is now hung, waiting for the `tmux load-buffer` process to return.  In another shell, inspect the `tmux load-buffer` process and observe that it's hung on the `epoll_wait()` system call:

```sh
$ pgrep -f 'tmux load-buffer' | xargs ps
  PID TTY      STAT   TIME COMMAND
18162 pts/45   S+     0:00 /bin/sh -c (tmux load-buffer -) < /tmp/v35eeBB/30 >/tmp/v35eeBB/31 2>&1
18163 pts/45   S+     0:00 tmux load-buffer -

$ head /tmp/v35eeBB/30 /tmp/v35eeBB/31
==> /tmp/v35eeBB/30 <==
hello world
==> /tmp/v35eeBB/31 <==
[warn] Epoll ADD(1) on fd 0 failed.  Old events were 0; read change was 1 (add); write change was 0 (none): Operation not permitted

$ sudo strace -p 18163
strace: Process 18163 attached
epoll_wait(3, ^Cstrace: Process 18163 detached
 <detached ...>

$ lsof -p 18163
COMMAND   PID  USER   FD      TYPE             DEVICE SIZE/OFF    NODE NAME
tmux    18163 sunny  cwd       DIR              254,1     4096 1058241 /home/sunny/.vim/bundle/tmux/slimux
tmux    18163 sunny  rtd       DIR              254,1     4096       2 /
tmux    18163 sunny  txt       REG              254,1  2826784 3145980 /home/sunny/app/tmux/bin/tmux
tmux    18163 sunny  mem       REG              254,1   911240 6821736 /usr/lib/libpthread-2.23.so
tmux    18163 sunny  mem       REG              254,1 10143400 6821709 /usr/lib/libc-2.23.so
tmux    18163 sunny  mem       REG              254,1   387248 6821714 /usr/lib/libresolv-2.23.so
tmux    18163 sunny  mem       REG              254,1   293336 6829834 /usr/lib/libevent-2.0.so.5.1.9
tmux    18163 sunny  mem       REG              254,1   465768 6821783 /usr/lib/libncursesw.so.6.0
tmux    18163 sunny  mem       REG              254,1    31984 6821708 /usr/lib/libutil-2.23.so
tmux    18163 sunny  mem       REG              254,1   886464 6821734 /usr/lib/ld-2.23.so
tmux    18163 sunny  mem       REG              254,1  1668976 6951965 /usr/lib/locale/locale-archive
tmux    18163 sunny    0r      REG               0,34       11   98230 /tmp/v35eeBB/30
tmux    18163 sunny    1w      REG               0,34      132   98231 /tmp/v35eeBB/31
tmux    18163 sunny    2w      REG               0,34      132   98231 /tmp/v35eeBB/31
tmux    18163 sunny    3u  a_inode               0,11        0    7216 [eventpoll]
tmux    18163 sunny    4u     unix 0xffff88007a4b0780      0t0   98232 type=STREAM
tmux    18163 sunny    5u     unix 0xffff88007a4b3480      0t0   98233 type=STREAM
tmux    18163 sunny    6u     unix 0xffff88007a4b1e00      0t0   98234 type=STREAM

$ kill 18163
```

Finally, kill the `tmux load-buffer` process to stop Vim from hanging. :cry: 