### PR TITLE
window-copy: remove unused ox variable

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -423,10 +423,9 @@ void
 window_copy_previous_paragraph(struct window_pane *wp)
 {
 	struct window_copy_mode_data	*data = wp->modedata;
-	u_int				 ox, oy;
+	u_int				 oy;
 
 	oy = screen_hsize(data->backing) + data->cy - data->oy;
-	ox = window_copy_find_length(wp, oy);
 
 	while (oy > 0 && window_copy_find_length(wp, oy) == 0)
 		oy--;


### PR DESCRIPTION
---
Doesn't look like it's supposed to be used.