### PR TITLE
Allow control mode clients to connect without resizing windows

### DIFF
--- a/resize.c
+++ b/resize.c
@@ -58,6 +58,8 @@ recalculate_sizes(void)
 		s->attached = 0;
 		ssx = ssy = UINT_MAX;
 		TAILQ_FOREACH(c, &clients, entry) {
+			if (c->flags & CLIENT_CONTROL) 
+			        continue;
 			if (c->flags & CLIENT_SUSPENDED)
 				continue;
 			if (c->session == s) {


### PR DESCRIPTION
@msaffer and I were experimenting with control mode and were surprised to find that connecting to an existing session in control mode caused a window resize to the default terminal size of 80x24. This patch skips resizing for clients with the `CLIENT_CONTROL` flag set. 