### PR TITLE
Don't pull cleared (not scrolled) history back into view.

### DIFF
--- a/grid-view.c
+++ b/grid-view.c
@@ -67,6 +67,8 @@ grid_view_clear_history(struct grid *gd)
 		grid_collect_history(gd);
 		grid_scroll_history(gd);
 	}
+
+	gd->hscrolled = 0;
 }
 
 /* Clear area. */

--- a/screen-write.c
+++ b/screen-write.c
@@ -1016,7 +1016,7 @@ screen_write_clearhistory(struct screen_write_ctx *ctx)
 	struct grid	*gd = s->grid;
 
 	grid_move_lines(gd, 0, gd->hsize, gd->sy);
-	gd->hsize = 0;
+	gd->hscrolled = gd->hsize = 0;
 }
 
 /* Write cell data. */

--- a/screen.c
+++ b/screen.c
@@ -177,8 +177,9 @@ screen_resize_y(struct screen *s, u_int sy)
 	 * If the height is decreasing, delete lines from the bottom until
 	 * hitting the cursor, then push lines from the top into the history.
 	 *
-	 * When increasing, pull as many lines as possible from the history to
-	 * the top, then fill the remaining with blanks at the bottom.
+	 * When increasing, pull as many lines as possible from scrolled history
+	 * (not explicitely cleared from view) to the top, then fill the remaining
+	 * with blanks at the bottom.
 	 */
 
 	/* Size decreasing. */
@@ -200,9 +201,10 @@ screen_resize_y(struct screen *s, u_int sy)
 		 * lines from the top.
 		 */
 		available = s->cy;
-		if (gd->flags & GRID_HISTORY)
+		if (gd->flags & GRID_HISTORY) {
+			gd->hscrolled += needed;
 			gd->hsize += needed;
-		else if (needed > 0 && available > 0) {
+		} else if (needed > 0 && available > 0) {
 			if (available > needed)
 				available = needed;
 			grid_view_delete_lines(gd, 0, available);
@@ -219,13 +221,14 @@ screen_resize_y(struct screen *s, u_int sy)
 		needed = sy - oldy;
 
 		/*
-		 * Try to pull as much as possible out of the history, if is
+		 * Try to pull as much as possible out of scrolled history, if is
 		 * is enabled.
 		 */
-		available = gd->hsize;
+		available = gd->hscrolled;
 		if (gd->flags & GRID_HISTORY && available > 0) {
 			if (available > needed)
 				available = needed;
+			gd->hscrolled -= available;
 			gd->hsize -= available;
 			s->cy += available;
 		} else

--- a/tmux.h
+++ b/tmux.h
@@ -693,6 +693,7 @@ struct grid {
 	u_int			 sx;
 	u_int			 sy;
 
+	u_int			 hscrolled;
 	u_int			 hsize;
 	u_int			 hlimit;
 


### PR DESCRIPTION
- It's intuitive to see the cursor position as being relative to the
  top of the pane. Pulling lines down unexpectedly changes the cursor
  position.
- Certain third party tools will use a temporary pane for the user to
  make a selection. The rapid opening and closing of a helper pane
  unexpectedly changes the state of the original pane.
  See demonstration video here:
      https://github.com/junegunn/fzf/issues/201