### PR TITLE
Fix the UTF-8 detection on non-GNU systems

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -271,15 +271,9 @@ main(int argc, char **argv)
 	if (getenv("TMUX") != NULL)
 		flags |= CLIENT_UTF8;
 	else {
-		s = getenv("LC_ALL");
-		if (s == NULL || *s == '\0')
-			s = getenv("LC_CTYPE");
-		if (s == NULL || *s == '\0')
-			s = getenv("LANG");
-		if (s == NULL || *s == '\0')
-			s = "";
-		if (strcasestr(s, "UTF-8") != NULL ||
-		    strcasestr(s, "UTF8") != NULL)
+		s = nl_langinfo(CODESET);
+		if(strcasecmp(s, "UTF-8") != 0 ||
+		   strcasecmp(s, "UTF8") != 0)
 			flags |= CLIENT_UTF8;
 	}
 


### PR DESCRIPTION
Not all systems have locale environment variables set; so the `CLIENT_UTF8` flag can be unset on a such UTF-8 configured system.

This commit fixes that by, instead calling of `getenv()`, calling `nl_langinfo(CODESET)`; which, according to the man,
> returns a string which is - *the name of the character encoding used in the selected locale, such as "UTF-8"* - in the program's current global locale.

after the locale has been set at the top of the `main()`.