### PR TITLE
Add no resize argument (-n) for tmux attach

### DIFF
--- a/cmd-attach-session.c
+++ b/cmd-attach-session.c
@@ -36,8 +36,8 @@ const struct cmd_entry cmd_attach_session_entry = {
 	.name = "attach-session",
 	.alias = "attach",
 
-	.args = { "c:dErt:", 0, 0 },
-	.usage = "[-dEr] [-c working-directory] " CMD_TARGET_SESSION_USAGE,
+	.args = { "c:dErnt:", 0, 0 },
+	.usage = "[-dErn] [-c working-directory] " CMD_TARGET_SESSION_USAGE,
 
 	.tflag = CMD_SESSION_WITHPANE,
 
@@ -47,7 +47,7 @@ const struct cmd_entry cmd_attach_session_entry = {
 
 enum cmd_retval
 cmd_attach_session(struct cmd_q *cmdq, int dflag, int rflag, const char *cflag,
-    int Eflag)
+    int Eflag, int nrflag)
 {
 	struct session		*s = cmdq->state.tflag.s;
 	struct client		*c = cmdq->client, *c_loop;
@@ -119,6 +119,9 @@ cmd_attach_session(struct cmd_q *cmdq, int dflag, int rflag, const char *cflag,
 		if (rflag)
 			c->flags |= CLIENT_READONLY;
 
+		if (nrflag)
+			c->flags |= CLIENT_NORESIZE;
+
 		if (dflag) {
 			TAILQ_FOREACH(c_loop, &clients, entry) {
 				if (c_loop->session != s || c == c_loop)
@@ -160,5 +163,5 @@ cmd_attach_session_exec(struct cmd *self, struct cmd_q *cmdq)
 	struct args	*args = self->args;
 
 	return (cmd_attach_session(cmdq, args_has(args, 'd'),
-	    args_has(args, 'r'), args_get(args, 'c'), args_has(args, 'E')));
+	    args_has(args, 'r'), args_get(args, 'c'), args_has(args, 'E'), args_has(args, 'n')));
 }

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -111,7 +111,7 @@ cmd_new_session_exec(struct cmd *self, struct cmd_q *cmdq)
 				cmd_find_from_session(&cmdq->state.tflag, as);
 				return (cmd_attach_session(cmdq,
 				    args_has(args, 'D'), 0, NULL,
-				    args_has(args, 'E')));
+				    args_has(args, 'E'), 0));
 			}
 			cmdq_error(cmdq, "duplicate session: %s", newname);
 			return (CMD_RETURN_ERROR);

--- a/resize.c
+++ b/resize.c
@@ -58,7 +58,7 @@ recalculate_sizes(void)
 		s->attached = 0;
 		ssx = ssy = UINT_MAX;
 		TAILQ_FOREACH(c, &clients, entry) {
-			if (c->flags & CLIENT_SUSPENDED)
+			if (c->flags & (CLIENT_SUSPENDED | CLIENT_NORESIZE))
 				continue;
 			if (c->session == s) {
 				if (c->tty.sx < ssx)

--- a/tmux.h
+++ b/tmux.h
@@ -1275,6 +1275,7 @@ struct client {
 #define CLIENT_256COLOURS 0x20000
 #define CLIENT_IDENTIFIED 0x40000
 #define CLIENT_STATUSFORCE 0x80000
+#define CLIENT_NORESIZE 0x100000
 	int		 flags;
 	struct key_table *keytable;
 
@@ -1836,7 +1837,7 @@ extern const struct cmd_entry *cmd_table[];
 
 /* cmd-attach-session.c */
 enum cmd_retval	 cmd_attach_session(struct cmd_q *, int, int, const char *,
-    int);
+    int, int);
 
 /* cmd-list.c */
 struct cmd_list	*cmd_list_parse(int, char **, const char *, u_int, char **);


### PR DESCRIPTION
`tmux attach -n` for attaching a client that has no effect on the screen resize.

It's mainly useful in cases where the client is a read-only client and it shouldn't affect the main user.

I thought it is useful when I wrote this https://github.com/mie00/tmux-guest to find that it's annoying when someone with a smaller screen try to attach to your sessions in read-only mode.