### PR TITLE
Enable support for 24-bit tmux color options and clean up color code

### DIFF
--- a/colour.c
+++ b/colour.c
@@ -68,7 +68,7 @@ colour_rgbto256(u_char r, u_char g, u_char b)
 	/* If we have hit the colour exactly, return early. */
 	if (cr == r && cg == g && cb == b)
 		return ((16 + (36 * qr) + (6 * qg) + qb) |
-		    COLOUR_FLAG_256COLOURS);
+		    COLOUR_FLAG_256);
 
 	/* Work out the closest grey (average of RGB). */
 	grey_avg = (r + g + b) / 3;
@@ -84,7 +84,7 @@ colour_rgbto256(u_char r, u_char g, u_char b)
 		idx = 232 + grey_idx;
 	else
 		idx = 16 + (36 * qr) + (6 * qg) + qb;
-	return (idx | COLOUR_FLAG_256COLOURS);
+	return (idx | COLOUR_FLAG_256);
 }
 
 /* Convert colour to a string. */
@@ -92,14 +92,15 @@ const char *
 colour_tostring(int c)
 {
 	static char	s[32];
+	u_char		r, g, b;
 
-	if (c & COLOUR_FLAG_24BITCOLOUR) {
-		xsnprintf(s, sizeof s, "#%02X%02X%02X", (c >> 16) & 0xFF,
-		    (c >> 8) & 0xFF, c & 0xFF);
+	if (c & COLOUR_FLAG_RGB) {
+		colour_24bittorgb(c, &r, &g, &b);
+		xsnprintf(s, sizeof s, "#%02X%02X%02X", r, g, b);
 		return (s);
 	}
 
-	if (c & COLOUR_FLAG_256COLOURS) {
+	if (c & COLOUR_FLAG_256) {
 		xsnprintf(s, sizeof s, "colour%d", c & 0xFF);
 		return (s);
 	}
@@ -161,12 +162,7 @@ colour_fromstring(const char *s)
 		len = strlen(s);
 		if (len == 7)
 			n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
-		else if (len == 4) {
-			n = sscanf(s + 1, "%1hhx%1hhx%1hhx", &r, &g, &b);
-			r *= 0x11;
-			g *= 0x11;
-			b *= 0x11;
-		} else
+		else
 			return (-1);
 		if (n != 3)
 			return (-1);
@@ -177,7 +173,7 @@ colour_fromstring(const char *s)
 		n = strtonum(s + (sizeof "colour") - 1, 0, 255, &errstr);
 		if (errstr != NULL)
 			return (-1);
-		return (n | COLOUR_FLAG_256COLOURS);
+		return (n | COLOUR_FLAG_256);
 	}
 
 	if (strcasecmp(s, "black") == 0 || strcmp(s, "0") == 0)
@@ -248,7 +244,7 @@ colour_rgbto24bit(u_char r, u_char g, u_char b)
 {
 	return ((((u_int) ((r) & 0xFF)) << 16) |
 		(((u_int) ((g) & 0xFF)) << 8) |
-		(((u_int) ((b) & 0xFF))) | COLOUR_FLAG_24BITCOLOUR);
+		(((u_int) ((b) & 0xFF))) | COLOUR_FLAG_RGB);
 }
 
 void

--- a/colour.c
+++ b/colour.c
@@ -150,7 +150,6 @@ colour_fromstring(const char *s)
 {
 	const char	*errstr;
 	const char	*cp;
-	int		 len;
 	int		 n;
 	u_char		 r, g, b;
 
@@ -159,8 +158,7 @@ colour_fromstring(const char *s)
 			;
 		if (*cp != '\0')
 			return (-1);
-		len = strlen(s);
-		if (len == 7)
+		if (strlen(s) == 7)
 			n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
 		else
 			return (-1);

--- a/colour.c
+++ b/colour.c
@@ -158,7 +158,7 @@ colour_fromstring(const char *s)
 			;
 		if (*cp != '\0')
 			return (-1);
-                n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
+		n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
 		if (n != 3)
 			return (-1);
 		return (colour_rgbto24bit(r, g, b));

--- a/colour.c
+++ b/colour.c
@@ -153,15 +153,12 @@ colour_fromstring(const char *s)
 	int		 n;
 	u_char		 r, g, b;
 
-	if (*s == '#') {
+	if (*s == '#' && strlen(s) == 7) {
 		for (cp = s + 1; isxdigit((u_char) *cp); cp++)
 			;
 		if (*cp != '\0')
 			return (-1);
-		if (strlen(s) == 7)
-			n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
-		else
-			return (-1);
+                n = sscanf(s + 1, "%2hhx%2hhx%2hhx", &r, &g, &b);
 		if (n != 3)
 			return (-1);
 		return (colour_rgbto24bit(r, g, b));

--- a/grid.c
+++ b/grid.c
@@ -270,7 +270,7 @@ grid_get_cell(struct grid *gd, u_int px, u_int py, struct grid_cell *gc)
 		return;
 	}
 
-	gc->flags = gce->flags & ~GRID_FLAG_EXTENDED;
+	gc->flags = gce->flags & ~(GRID_FLAG_FG256|GRID_FLAG_BG256);
 	gc->attr = gce->data.attr;
 	gc->fg = gce->data.fg;
 	if (gce->flags & GRID_FLAG_FG256)
@@ -319,7 +319,7 @@ grid_set_cell(struct grid *gd, u_int px, u_int py, const struct grid_cell *gc)
 		return;
 	}
 
-	gce->flags = gc->flags & ~GRID_FLAG_EXTENDED;
+	gce->flags = gc->flags;
 	gce->data.attr = gc->attr;
 	gce->data.fg = gc->fg & 0xFF;
 	if (gc->fg & COLOUR_FLAG_256)

--- a/grid.c
+++ b/grid.c
@@ -461,7 +461,7 @@ grid_string_cells_fg(const struct grid_cell *gc, int *values)
 	if (gc->fg & COLOUR_FLAG_256) {
 		values[n++] = 38;
 		values[n++] = 5;
-		values[n++] = gc->fg;
+		values[n++] = gc->fg & 0xFF;
 	} else if (gc->fg & COLOUR_FLAG_RGB) {
 		values[n++] = 38;
 		values[n++] = 2;
@@ -510,7 +510,7 @@ grid_string_cells_bg(const struct grid_cell *gc, int *values)
 	if (gc->bg & COLOUR_FLAG_256) {
 		values[n++] = 48;
 		values[n++] = 5;
-		values[n++] = gc->bg;
+		values[n++] = gc->bg & 0xFF;
 	} else if (gc->bg & COLOUR_FLAG_RGB) {
 		values[n++] = 48;
 		values[n++] = 2;

--- a/input.c
+++ b/input.c
@@ -1635,9 +1635,9 @@ input_csi_dispatch_sgr_256(struct input_ctx *ictx, int fgbg, u_int *i)
 		}
 	} else {
 		if (fgbg == 38) {
-			gc->fg = c | COLOUR_FLAG_256COLOURS;
+			gc->fg = c | COLOUR_FLAG_256;
 		} else if (fgbg == 48) {
-			gc->bg = c | COLOUR_FLAG_256COLOURS;
+			gc->bg = c | COLOUR_FLAG_256;
 		}
 	}
 }

--- a/input.c
+++ b/input.c
@@ -1629,21 +1629,15 @@ input_csi_dispatch_sgr_256(struct input_ctx *ictx, int fgbg, u_int *i)
 	c = input_get(ictx, *i, 0, -1);
 	if (c == -1) {
 		if (fgbg == 38) {
-			gc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
 			gc->fg = 8;
 		} else if (fgbg == 48) {
-			gc->flags &= ~(GRID_FLAG_BG256|GRID_FLAG_BGRGB);
 			gc->bg = 8;
 		}
 	} else {
 		if (fgbg == 38) {
-			gc->flags |= GRID_FLAG_FG256;
-			gc->flags &= ~GRID_FLAG_FGRGB;
-			gc->fg = c;
+			gc->fg = c | COLOUR_FLAG_256COLOURS;
 		} else if (fgbg == 48) {
-			gc->flags |= GRID_FLAG_BG256;
-			gc->flags &= ~GRID_FLAG_BGRGB;
-			gc->bg = c;
+			gc->bg = c | COLOUR_FLAG_256COLOURS;
 		}
 	}
 }
@@ -1669,17 +1663,9 @@ input_csi_dispatch_sgr_rgb(struct input_ctx *ictx, int fgbg, u_int *i)
 		return;
 
 	if (fgbg == 38) {
-		gc->flags &= ~GRID_FLAG_FG256;
-		gc->flags |= GRID_FLAG_FGRGB;
-		gc->fg_rgb.r = r;
-		gc->fg_rgb.g = g;
-		gc->fg_rgb.b = b;
+		gc->fg = colour_rgbto24bit(r, g, b);
 	} else if (fgbg == 48) {
-		gc->flags &= ~GRID_FLAG_BG256;
-		gc->flags |= GRID_FLAG_BGRGB;
-		gc->bg_rgb.r = r;
-		gc->bg_rgb.g = g;
-		gc->bg_rgb.b = b;
+		gc->bg = colour_rgbto24bit(r, g, b);
 	}
 }
 
@@ -1761,11 +1747,9 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 		case 35:
 		case 36:
 		case 37:
-			gc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
 			gc->fg = n - 30;
 			break;
 		case 39:
-			gc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
 			gc->fg = 8;
 			break;
 		case 40:
@@ -1776,11 +1760,9 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 		case 45:
 		case 46:
 		case 47:
-			gc->flags &= ~(GRID_FLAG_BG256|GRID_FLAG_BGRGB);
 			gc->bg = n - 40;
 			break;
 		case 49:
-			gc->flags &= ~(GRID_FLAG_BG256|GRID_FLAG_BGRGB);
 			gc->bg = 8;
 			break;
 		case 90:
@@ -1791,7 +1773,6 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 		case 95:
 		case 96:
 		case 97:
-			gc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
 			gc->fg = n;
 			break;
 		case 100:
@@ -1802,7 +1783,6 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 		case 105:
 		case 106:
 		case 107:
-			gc->flags &= ~(GRID_FLAG_BG256|GRID_FLAG_BGRGB);
 			gc->bg = n - 10;
 			break;
 		}

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -552,9 +552,9 @@ screen_redraw_draw_number(struct client *c, struct window_pane *wp, u_int top)
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
 	if (w->active == wp)
-		colour_set_bg(&gc, active_colour);
+		gc.bg = active_colour;
 	else
-		colour_set_bg(&gc, colour);
+		gc.bg = colour;
 	tty_attributes(tty, &gc, wp);
 	for (ptr = buf; *ptr != '\0'; ptr++) {
 		if (*ptr < '0' || *ptr > '9')
@@ -579,9 +579,9 @@ screen_redraw_draw_number(struct client *c, struct window_pane *wp, u_int top)
 draw_text:
 	memcpy(&gc, &grid_default_cell, sizeof gc);
 	if (w->active == wp)
-		colour_set_fg(&gc, active_colour);
+		gc.fg = active_colour;
 	else
-		colour_set_fg(&gc, colour);
+		gc.fg = colour;
 	tty_attributes(tty, &gc, wp);
 	tty_puts(tty, buf);
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -34,7 +34,7 @@ static int	screen_write_combine(struct screen_write_ctx *,
 		    const struct utf8_data *);
 
 static const struct grid_cell screen_write_pad_cell = {
-	GRID_FLAG_PADDING, 0, { .fg = 8 }, { .bg = 8 }, { { 0 }, 0, 0, 0 }
+	GRID_FLAG_PADDING, 0, 8, 8, { { 0 }, 0, 0, 0 }
 };
 
 /* Initialise writing with a window. */
@@ -1031,10 +1031,6 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 		tmp_gc.attr = tmp_gc.attr & ~GRID_ATTR_CHARSET;
 		tmp_gc.attr |= gc->attr & GRID_ATTR_CHARSET;
 		tmp_gc.flags = gc->flags;
-		tmp_gc.flags &= ~(GRID_FLAG_FGRGB|GRID_FLAG_BGRGB);
-		tmp_gc.flags &= ~(GRID_FLAG_FG256|GRID_FLAG_BG256);
-		tmp_gc.flags |= s->sel.cell.flags &
-		    (GRID_FLAG_FG256|GRID_FLAG_BG256);
 		ttyctx.cell = &tmp_gc;
 		tty_write(tty_cmd_cell, &ttyctx);
 	} else if (!skip) {

--- a/style.c
+++ b/style.c
@@ -33,7 +33,8 @@ style_parse(const struct grid_cell *defgc, struct grid_cell *gc,
 	char			tmp[32];
 	int			val;
 	size_t			end;
-	u_char			fg, bg, attr, flags;
+	int			fg, bg;
+	u_char			attr, flags;
 
 	if (*in == '\0')
 		return (0);
@@ -56,37 +57,21 @@ style_parse(const struct grid_cell *defgc, struct grid_cell *gc,
 			fg = defgc->fg;
 			bg = defgc->bg;
 			attr = defgc->attr;
-			flags &= ~(GRID_FLAG_FG256|GRID_FLAG_BG256);
-			flags |=
-			    defgc->flags & (GRID_FLAG_FG256|GRID_FLAG_BG256);
+			flags = defgc->flags;
 		} else if (end > 3 && strncasecmp(tmp + 1, "g=", 2) == 0) {
 			if ((val = colour_fromstring(tmp + 3)) == -1)
 				goto error;
 			if (*in == 'f' || *in == 'F') {
 				if (val != 8) {
-					if (val & 0x100) {
-						flags |= GRID_FLAG_FG256;
-						val &= ~0x100;
-					} else
-						flags &= ~GRID_FLAG_FG256;
 					fg = val;
 				} else {
 					fg = defgc->fg;
-					flags &= ~GRID_FLAG_FG256;
-					flags |= defgc->flags & GRID_FLAG_FG256;
 				}
 			} else if (*in == 'b' || *in == 'B') {
 				if (val != 8) {
-					if (val & 0x100) {
-						flags |= GRID_FLAG_BG256;
-						val &= ~0x100;
-					} else
-						flags &= ~GRID_FLAG_BG256;
 					bg = val;
 				} else {
 					bg = defgc->bg;
-					flags &= ~GRID_FLAG_BG256;
-					flags |= defgc->flags & GRID_FLAG_BG256;
 				}
 			} else
 				goto error;
@@ -120,27 +105,19 @@ error:
 const char *
 style_tostring(struct grid_cell *gc)
 {
-	int		 c, off = 0, comma = 0;
+	int		 off = 0, comma = 0;
 	static char	 s[256];
 
 	*s = '\0';
 
-	if (gc->fg != 8 || gc->flags & GRID_FLAG_FG256) {
-		if (gc->flags & GRID_FLAG_FG256)
-			c = gc->fg | 0x100;
-		else
-			c = gc->fg;
-		off += xsnprintf(s, sizeof s, "fg=%s", colour_tostring(c));
+	if (gc->fg != 8) {
+		off += xsnprintf(s, sizeof s, "fg=%s", colour_tostring(gc->fg));
 		comma = 1;
 	}
 
-	if (gc->bg != 8 || gc->flags & GRID_FLAG_BG256) {
-		if (gc->flags & GRID_FLAG_BG256)
-			c = gc->bg | 0x100;
-		else
-			c = gc->bg;
+	if (gc->bg != 8) {
 		off += xsnprintf(s + off, sizeof s - off, "%sbg=%s",
-		    comma ? "," : "", colour_tostring(c));
+		    comma ? "," : "", colour_tostring(gc->bg));
 		comma = 1;
 	}
 
@@ -177,9 +154,9 @@ style_update_new(struct options *oo, const char *name, const char *newname)
 	value = o->num;
 
 	if (strstr(name, "-bg") != NULL)
-		colour_set_bg(gc, value);
+		gc->bg = value;
 	else if (strstr(name, "-fg") != NULL)
-		colour_set_fg(gc, value);
+		gc->fg = value;
 	else if (strstr(name, "-attr") != NULL)
 		gc->attr = value;
 }
@@ -189,23 +166,15 @@ void
 style_update_old(struct options *oo, const char *name, struct grid_cell *gc)
 {
 	char	newname[128];
-	int	c, size;
+	int	size;
 
 	size = strrchr(name, '-') - name;
 
-	if (gc->flags & GRID_FLAG_BG256)
-		c = gc->bg | 0x100;
-	else
-		c = gc->bg;
 	xsnprintf(newname, sizeof newname, "%.*s-bg", size, name);
-	options_set_number(oo, newname, c);
+	options_set_number(oo, newname, gc->bg);
 
-	if (gc->flags & GRID_FLAG_FG256)
-		c = gc->fg | 0x100;
-	else
-		c = gc->fg;
 	xsnprintf(newname, sizeof newname, "%.*s-fg", size, name);
-	options_set_number(oo, newname, c);
+	options_set_number(oo, newname, gc->fg);
 
 	xsnprintf(newname, sizeof newname, "%.*s-attr", size, name);
 	options_set_number(oo, newname, gc->attr);
@@ -219,14 +188,8 @@ style_apply(struct grid_cell *gc, struct options *oo, const char *name)
 
 	memcpy(gc, &grid_default_cell, sizeof *gc);
 	gcp = options_get_style(oo, name);
-	if (gcp->flags & GRID_FLAG_FG256)
-		colour_set_fg(gc, gcp->fg | 0x100);
-	else
-		colour_set_fg(gc, gcp->fg);
-	if (gcp->flags & GRID_FLAG_BG256)
-		colour_set_bg(gc, gcp->bg | 0x100);
-	else
-		colour_set_bg(gc, gcp->bg);
+	gc->fg = gcp->fg;
+	gc->bg = gcp->bg;
 	gc->attr |= gcp->attr;
 }
 
@@ -237,17 +200,11 @@ style_apply_update(struct grid_cell *gc, struct options *oo, const char *name)
 	struct grid_cell	*gcp;
 
 	gcp = options_get_style(oo, name);
-	if (gcp->fg != 8 || gcp->flags & GRID_FLAG_FG256) {
-		if (gcp->flags & GRID_FLAG_FG256)
-			colour_set_fg(gc, gcp->fg | 0x100);
-		else
-			colour_set_fg(gc, gcp->fg);
+	if (gcp->fg != 8) {
+		gc->fg = gcp->fg;
 	}
-	if (gcp->bg != 8 || gcp->flags & GRID_FLAG_BG256) {
-		if (gcp->flags & GRID_FLAG_BG256)
-			colour_set_bg(gc, gcp->bg | 0x100);
-		else
-			colour_set_bg(gc, gcp->bg);
+	if (gcp->bg != 8) {
+		gc->bg = gcp->bg;
 	}
 	if (gcp->attr != 0)
 		gc->attr |= gcp->attr;

--- a/tmux.h
+++ b/tmux.h
@@ -628,8 +628,8 @@ enum utf8_state {
 };
 
 /* Colour flags. */
-#define COLOUR_FLAG_256COLOURS 0x01000000
-#define COLOUR_FLAG_24BITCOLOUR 0x02000000
+#define COLOUR_FLAG_256 0x01000000
+#define COLOUR_FLAG_RGB 0x02000000
 
 /* Grid attributes. */
 #define GRID_ATTR_BRIGHT 0x1
@@ -642,9 +642,11 @@ enum utf8_state {
 #define GRID_ATTR_CHARSET 0x80	/* alternative character set */
 
 /* Grid flags. */
-#define GRID_FLAG_PADDING 0x1
-#define GRID_FLAG_EXTENDED 0x2
-#define GRID_FLAG_SELECTED 0x4
+#define GRID_FLAG_FG256 0x1
+#define GRID_FLAG_BG256 0x2
+#define GRID_FLAG_PADDING 0x4
+#define GRID_FLAG_EXTENDED 0x8
+#define GRID_FLAG_SELECTED 0x10
 
 /* Grid line flags. */
 #define GRID_LINE_WRAPPED 0x1
@@ -664,8 +666,8 @@ struct grid_cell_entry {
 		u_int		offset;
 		struct {
 			u_char	attr;
-			u_int	fg;
-			u_int	bg;
+			u_char	fg;
+			u_char	bg;
 			u_char	data;
 		} data;
 	};

--- a/tmux.h
+++ b/tmux.h
@@ -627,6 +627,10 @@ enum utf8_state {
 	UTF8_ERROR
 };
 
+/* Colour flags. */
+#define COLOUR_FLAG_256COLOURS 0x01000000
+#define COLOUR_FLAG_24BITCOLOUR 0x02000000
+
 /* Grid attributes. */
 #define GRID_ATTR_BRIGHT 0x1
 #define GRID_ATTR_DIM 0x2
@@ -638,36 +642,19 @@ enum utf8_state {
 #define GRID_ATTR_CHARSET 0x80	/* alternative character set */
 
 /* Grid flags. */
-#define GRID_FLAG_FG256 0x1
-#define GRID_FLAG_BG256 0x2
-#define GRID_FLAG_PADDING 0x4
-#define GRID_FLAG_EXTENDED 0x8
-#define GRID_FLAG_FGRGB 0x10
-#define GRID_FLAG_BGRGB 0x20
-#define GRID_FLAG_SELECTED 0x40
+#define GRID_FLAG_PADDING 0x1
+#define GRID_FLAG_EXTENDED 0x2
+#define GRID_FLAG_SELECTED 0x4
 
 /* Grid line flags. */
 #define GRID_LINE_WRAPPED 0x1
-
-/* Grid cell RGB colours. */
-struct grid_cell_rgb {
-	u_char	r;
-	u_char	g;
-	u_char	b;
-};
 
 /* Grid cell data. */
 struct grid_cell {
 	u_char			flags;
 	u_char			attr;
-	union {
-		u_char		fg;
-		struct grid_cell_rgb	fg_rgb;
-	};
-	union {
-		u_char		bg;
-		struct grid_cell_rgb	bg_rgb;
-	};
+	u_int			fg;
+	u_int			bg;
 	struct utf8_data	data;
 
 };
@@ -677,8 +664,8 @@ struct grid_cell_entry {
 		u_int		offset;
 		struct {
 			u_char	attr;
-			u_char	fg;
-			u_char	bg;
+			u_int	fg;
+			u_int	bg;
 			u_char	data;
 		} data;
 	};
@@ -1982,12 +1969,12 @@ char	*xterm_keys_lookup(key_code);
 int	 xterm_keys_find(const char *, size_t, size_t *, key_code *);
 
 /* colour.c */
-int	 colour_find_rgb(u_char, u_char, u_char);
-void	 colour_set_fg(struct grid_cell *, int);
-void	 colour_set_bg(struct grid_cell *, int);
+int	 colour_rgbto256(u_char, u_char, u_char);
 const char *colour_tostring(int);
-int	 colour_fromstring(const char *);
+int	 colour_fromstring(const char *s);
 u_char	 colour_256to16(u_char);
+int	 colour_rgbto24bit(u_char, u_char, u_char);
+void	 colour_24bittorgb(int, u_char *, u_char *, u_char *);
 
 /* attributes.c */
 const char *attributes_tostring(u_char);

--- a/tty.c
+++ b/tty.c
@@ -1495,7 +1495,7 @@ tty_check_fg(struct tty *tty, struct grid_cell *gc)
 	u_int	colours;
 
 	/* Is this a 24-bit colour? */
-        if (gc->fg & COLOUR_FLAG_24BITCOLOUR) {
+        if (gc->fg & COLOUR_FLAG_RGB) {
 		/* Not a 24-bit terminal? Translate to 256-colour palette. */
 		if (!tty_term_flag(tty->term, TTYC_TC)) {
 			colour_24bittorgb(gc->fg, &r, &g, &b);
@@ -1507,7 +1507,7 @@ tty_check_fg(struct tty *tty, struct grid_cell *gc)
 	colours = tty_term_number(tty->term, TTYC_COLORS);
 
 	/* Is this a 256-colour colour? */
-        if (gc->fg & COLOUR_FLAG_256COLOURS) {
+        if (gc->fg & COLOUR_FLAG_256) {
 		/* And not a 256 colour mode? */
 		if (!(tty->term->flags & TERM_256COLOURS) &&
 		    !(tty->term_flags & TERM_256COLOURS)) {
@@ -1538,7 +1538,7 @@ tty_check_bg(struct tty *tty, struct grid_cell *gc)
 	u_int	colours;
 
 	/* Is this a 24-bit colour? */
-        if (gc->bg & COLOUR_FLAG_24BITCOLOUR) {
+        if (gc->bg & COLOUR_FLAG_RGB) {
 		/* Not a 24-bit terminal? Translate to 256-colour palette. */
 		if (!tty_term_flag(tty->term, TTYC_TC)) {
 			colour_24bittorgb(gc->bg, &r, &g, &b);
@@ -1550,7 +1550,7 @@ tty_check_bg(struct tty *tty, struct grid_cell *gc)
 	colours = tty_term_number(tty->term, TTYC_COLORS);
 
 	/* Is this a 256-colour colour? */
-        if (gc->bg & COLOUR_FLAG_256COLOURS) {
+        if (gc->bg & COLOUR_FLAG_256) {
 		/*
 		 * And not a 256 colour mode? Translate to 16-colour
 		 * palette. Bold background doesn't exist portably, so just
@@ -1580,8 +1580,8 @@ tty_colours_fg(struct tty *tty, const struct grid_cell *gc)
 	char			 s[32];
 
 	/* Is this a 24-bit or 256-colour colour? */
-	if (gc->fg & COLOUR_FLAG_24BITCOLOUR ||
-	    gc->fg & COLOUR_FLAG_256COLOURS) {
+	if (gc->fg & COLOUR_FLAG_RGB ||
+	    gc->fg & COLOUR_FLAG_256) {
 		if (tty_try_colour(tty, gc->fg, "38") == 0)
 			goto save_fg;
 		/* Should not get here, already converted in tty_check_fg. */
@@ -1610,8 +1610,8 @@ tty_colours_bg(struct tty *tty, const struct grid_cell *gc)
 	char			 s[32];
 
 	/* Is this a 24-bit or 256-colour colour? */
-	if (gc->bg & COLOUR_FLAG_24BITCOLOUR ||
-	    gc->bg & COLOUR_FLAG_256COLOURS) {
+	if (gc->bg & COLOUR_FLAG_RGB ||
+	    gc->bg & COLOUR_FLAG_256) {
 		if (tty_try_colour(tty, gc->bg, "48") == 0)
 			goto save_bg;
 		/* Should not get here, already converted in tty_check_bg. */
@@ -1639,7 +1639,7 @@ tty_try_colour(struct tty *tty, int colour, const char *type)
 	u_char	r, g, b;
 	char	s[32];
 
-	if (colour & COLOUR_FLAG_256COLOURS) {
+	if (colour & COLOUR_FLAG_256) {
 		colour &= 0xFF;
 		/*
 		 * If the user has specified -2 to the client, setaf and setab
@@ -1670,7 +1670,7 @@ tty_try_colour(struct tty *tty, int colour, const char *type)
 		    (u_char) colour);
 		tty_puts(tty, s);
 		return (0);
-	} else if (colour & COLOUR_FLAG_24BITCOLOUR) {
+	} else if (colour & COLOUR_FLAG_RGB) {
 		colour &= 0xFFFFFF;
 		if (!tty_term_flag(tty->term, TTYC_TC))
 			return (-1);

--- a/tty.c
+++ b/tty.c
@@ -36,17 +36,12 @@ static int tty_log_fd = -1;
 void	tty_read_callback(struct bufferevent *, void *);
 void	tty_error_callback(struct bufferevent *, short, void *);
 
-static int tty_same_fg(const struct grid_cell *, const struct grid_cell *);
-static int tty_same_bg(const struct grid_cell *, const struct grid_cell *);
 static int tty_same_colours(const struct grid_cell *, const struct grid_cell *);
-static int tty_is_fg(const struct grid_cell *, int);
-static int tty_is_bg(const struct grid_cell *, int);
 
 static int tty_client_ready(struct client *, struct window_pane *);
 
 void	tty_set_italics(struct tty *);
-int	tty_try_256(struct tty *, u_char, const char *);
-int	tty_try_rgb(struct tty *, const struct grid_cell_rgb *, const char *);
+int	tty_try_colour(struct tty *, int, const char *);
 
 void	tty_colours(struct tty *, const struct grid_cell *);
 void	tty_check_fg(struct tty *, struct grid_cell *);
@@ -71,71 +66,9 @@ void	tty_default_colours(struct grid_cell *, const struct window_pane *);
 	((ctx)->xoff == 0 && screen_size_x((ctx)->wp->screen) >= (tty)->sx)
 
 static int
-tty_same_fg(const struct grid_cell *gc1, const struct grid_cell *gc2)
-{
-	int	flags1, flags2;
-
-	flags1 = (gc1->flags & (GRID_FLAG_FG256|GRID_FLAG_FGRGB));
-	flags2 = (gc2->flags & (GRID_FLAG_FG256|GRID_FLAG_FGRGB));
-
-	if (flags1 != flags2)
-	    return (0);
-
-	if (flags1 & GRID_FLAG_FGRGB) {
-		if (gc1->fg_rgb.r != gc2->fg_rgb.r)
-			return (0);
-		if (gc1->fg_rgb.g != gc2->fg_rgb.g)
-			return (0);
-		if (gc1->fg_rgb.b != gc2->fg_rgb.b)
-			return (0);
-		return (1);
-	}
-	return (gc1->fg == gc2->fg);
-}
-
-static int
-tty_same_bg(const struct grid_cell *gc1, const struct grid_cell *gc2)
-{
-	int	flags1, flags2;
-
-	flags1 = (gc1->flags & (GRID_FLAG_BG256|GRID_FLAG_BGRGB));
-	flags2 = (gc2->flags & (GRID_FLAG_BG256|GRID_FLAG_BGRGB));
-
-	if (flags1 != flags2)
-	    return (0);
-
-	if (flags1 & GRID_FLAG_BGRGB) {
-		if (gc1->bg_rgb.r != gc2->bg_rgb.r)
-			return (0);
-		if (gc1->bg_rgb.g != gc2->bg_rgb.g)
-			return (0);
-		if (gc1->bg_rgb.b != gc2->bg_rgb.b)
-			return (0);
-		return (1);
-	}
-	return (gc1->bg == gc2->bg);
-}
-
-static int
 tty_same_colours(const struct grid_cell *gc1, const struct grid_cell *gc2)
 {
-	return (tty_same_fg(gc1, gc2) && tty_same_bg(gc1, gc2));
-}
-
-static int
-tty_is_fg(const struct grid_cell *gc, int c)
-{
-	if (gc->flags & (GRID_FLAG_FG256|GRID_FLAG_FGRGB))
-		return (0);
-	return (gc->fg == c);
-}
-
-static int
-tty_is_bg(const struct grid_cell *gc, int c)
-{
-	if (gc->flags & (GRID_FLAG_BG256|GRID_FLAG_BGRGB))
-		return (0);
-	return (gc->bg == c);
+	return (gc1->fg == gc2->fg && gc1->bg == gc2->bg);
 }
 
 void
@@ -679,7 +612,7 @@ tty_fake_bce(const struct tty *tty, const struct window_pane *wp)
 	if (wp != NULL)
 		tty_default_colours(&gc, wp);
 
-	if (gc.bg == 8 && !(gc.flags & GRID_FLAG_BG256))
+	if (gc.bg == 8)
 		return (0);
 	return (!tty_term_flag(tty->term, TTYC_BCE));
 }
@@ -754,11 +687,6 @@ tty_draw_line(struct tty *tty, const struct window_pane *wp,
 
 	for (i = 0; i < sx; i++) {
 		grid_view_get_cell(s->grid, i, py, &gc);
-		if (screen_check_selection(s, i, py)) {
-			gc.flags &= ~(GRID_FLAG_FG256|GRID_FLAG_BG256);
-			gc.flags |= s->sel.cell.flags &
-			    (GRID_FLAG_FG256|GRID_FLAG_BG256);
-		}
 		tty_cell(tty, &gc, wp);
 	}
 
@@ -1507,7 +1435,7 @@ void
 tty_colours(struct tty *tty, const struct grid_cell *gc)
 {
 	struct grid_cell	*tc = &tty->cell;
-	int			 have_ax, fg_default, bg_default;
+	int			 have_ax;
 
 	/* No changes? Nothing is necessary. */
 	if (tty_same_colours(gc, tc))
@@ -1519,9 +1447,7 @@ tty_colours(struct tty *tty, const struct grid_cell *gc)
 	 * case if only one is default need to fall onward to set the other
 	 * colour.
 	 */
-	fg_default = tty_is_fg(gc, 8);
-	bg_default = tty_is_bg(gc, 8);
-	if (fg_default || bg_default) {
+	if (gc->fg == 8 || gc->bg == 8) {
 		/*
 		 * If don't have AX but do have op, send sgr0 (op can't
 		 * actually be used because it is sometimes the same as sgr0
@@ -1533,50 +1459,47 @@ tty_colours(struct tty *tty, const struct grid_cell *gc)
 		if (!have_ax && tty_term_has(tty->term, TTYC_OP))
 			tty_reset(tty);
 		else {
-			if (fg_default && !tty_is_fg(tc, 8)) {
+			if (gc->fg == 8 && tc->fg != 8) {
 				if (have_ax)
 					tty_puts(tty, "\033[39m");
-				else if (!tty_is_fg(tc, 7))
+				else if (tc->fg != 7)
 					tty_putcode1(tty, TTYC_SETAF, 7);
 				tc->fg = 8;
-				tc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
 			}
-			if (bg_default && !tty_is_bg(tc, 8)) {
+			if (gc->bg == 8 && tc->bg != 8) {
 				if (have_ax)
 					tty_puts(tty, "\033[49m");
-				else if (!tty_is_bg(tc, 0))
+				else if (tc->bg != 0)
 					tty_putcode1(tty, TTYC_SETAB, 0);
 				tc->bg = 8;
-				tc->flags &= ~(GRID_FLAG_BG256|GRID_FLAG_BGRGB);
 			}
 		}
 	}
 
 	/* Set the foreground colour. */
-	if (!fg_default && !tty_same_fg(gc, tc))
+	if (gc->fg != 8 && gc->fg != tc->fg)
 		tty_colours_fg(tty, gc);
 
 	/*
 	 * Set the background colour. This must come after the foreground as
 	 * tty_colour_fg() can call tty_reset().
 	 */
-	if (!bg_default && !tty_same_bg(gc, tc))
+	if (gc->bg != 8 && gc->bg != tc->bg)
 		tty_colours_bg(tty, gc);
 }
 
 void
 tty_check_fg(struct tty *tty, struct grid_cell *gc)
 {
-	struct grid_cell_rgb	*rgb = &gc->fg_rgb;
-	u_int			 colours;
+	u_char	r, g, b;
+	u_int	colours;
 
 	/* Is this a 24-bit colour? */
-	if (gc->flags & GRID_FLAG_FGRGB) {
+        if (gc->fg & COLOUR_FLAG_24BITCOLOUR) {
 		/* Not a 24-bit terminal? Translate to 256-colour palette. */
 		if (!tty_term_flag(tty->term, TTYC_TC)) {
-			gc->flags &= ~GRID_FLAG_FGRGB;
-			gc->flags |= GRID_FLAG_FG256;
-			gc->fg = colour_find_rgb(rgb->r, rgb->g, rgb->b);
+			colour_24bittorgb(gc->fg, &r, &g, &b);
+			gc->fg = colour_rgbto256(r, g, b);
 		}
 		else
 			return;
@@ -1584,7 +1507,7 @@ tty_check_fg(struct tty *tty, struct grid_cell *gc)
 	colours = tty_term_number(tty->term, TTYC_COLORS);
 
 	/* Is this a 256-colour colour? */
-	if (gc->flags & GRID_FLAG_FG256) {
+        if (gc->fg & COLOUR_FLAG_256COLOURS) {
 		/* And not a 256 colour mode? */
 		if (!(tty->term->flags & TERM_256COLOURS) &&
 		    !(tty->term_flags & TERM_256COLOURS)) {
@@ -1597,7 +1520,6 @@ tty_check_fg(struct tty *tty, struct grid_cell *gc)
 					gc->attr |= GRID_ATTR_BRIGHT;
 			} else
 				gc->attr &= ~GRID_ATTR_BRIGHT;
-			gc->flags &= ~GRID_FLAG_FG256;
 		}
 		return;
 	}
@@ -1612,16 +1534,15 @@ tty_check_fg(struct tty *tty, struct grid_cell *gc)
 void
 tty_check_bg(struct tty *tty, struct grid_cell *gc)
 {
-	struct grid_cell_rgb	*rgb = &gc->bg_rgb;
-	u_int			 colours;
+	u_char	r, g, b;
+	u_int	colours;
 
 	/* Is this a 24-bit colour? */
-	if (gc->flags & GRID_FLAG_BGRGB) {
+        if (gc->bg & COLOUR_FLAG_24BITCOLOUR) {
 		/* Not a 24-bit terminal? Translate to 256-colour palette. */
 		if (!tty_term_flag(tty->term, TTYC_TC)) {
-			gc->flags &= ~GRID_FLAG_BGRGB;
-			gc->flags |= GRID_FLAG_BG256;
-			gc->bg = colour_find_rgb(rgb->r, rgb->g, rgb->b);
+			colour_24bittorgb(gc->bg, &r, &g, &b);
+			gc->bg = colour_rgbto256(r, g, b);
 		}
 		else
 			return;
@@ -1629,7 +1550,7 @@ tty_check_bg(struct tty *tty, struct grid_cell *gc)
 	colours = tty_term_number(tty->term, TTYC_COLORS);
 
 	/* Is this a 256-colour colour? */
-	if (gc->flags & GRID_FLAG_BG256) {
+        if (gc->bg & COLOUR_FLAG_256COLOURS) {
 		/*
 		 * And not a 256 colour mode? Translate to 16-colour
 		 * palette. Bold background doesn't exist portably, so just
@@ -1643,7 +1564,6 @@ tty_check_bg(struct tty *tty, struct grid_cell *gc)
 				if (colours >= 16)
 					gc->fg += 90;
 			}
-			gc->flags &= ~GRID_FLAG_BG256;
 		}
 		return;
 	}
@@ -1657,139 +1577,112 @@ void
 tty_colours_fg(struct tty *tty, const struct grid_cell *gc)
 {
 	struct grid_cell	*tc = &tty->cell;
-	u_char			 fg = gc->fg;
 	char			 s[32];
 
-	tc->flags &= ~(GRID_FLAG_FG256|GRID_FLAG_FGRGB);
-
-	/* Is this a 24-bit colour? */
-	if (gc->flags & GRID_FLAG_FGRGB) {
-		if (tty_try_rgb(tty, &gc->fg_rgb, "38") == 0)
-			goto save_fg;
-		/* Should not get here, already converted in tty_check_fg. */
-		return;
-	}
-
-	/* Is this a 256-colour colour? */
-	if (gc->flags & GRID_FLAG_FG256) {
-		if (tty_try_256(tty, fg, "38") == 0)
+	/* Is this a 24-bit or 256-colour colour? */
+	if (gc->fg & COLOUR_FLAG_24BITCOLOUR ||
+	    gc->fg & COLOUR_FLAG_256COLOURS) {
+		if (tty_try_colour(tty, gc->fg, "38") == 0)
 			goto save_fg;
 		/* Should not get here, already converted in tty_check_fg. */
 		return;
 	}
 
 	/* Is this an aixterm bright colour? */
-	if (fg >= 90 && fg <= 97) {
-		xsnprintf(s, sizeof s, "\033[%dm", fg);
+	if (gc->fg >= 90 && gc->fg <= 97) {
+		xsnprintf(s, sizeof s, "\033[%dm", gc->fg);
 		tty_puts(tty, s);
 		goto save_fg;
 	}
 
 	/* Otherwise set the foreground colour. */
-	tty_putcode1(tty, TTYC_SETAF, fg);
+	tty_putcode1(tty, TTYC_SETAF, gc->fg);
 
 save_fg:
 	/* Save the new values in the terminal current cell. */
-	if (gc->flags & GRID_FLAG_FGRGB)
-		memcpy(&tc->fg_rgb, &gc->fg_rgb, sizeof tc->fg_rgb);
-	else
-		tc->fg = fg;
-	tc->flags &= ~(GRID_FLAG_FGRGB|GRID_FLAG_FG256);
-	tc->flags |= (gc->flags & (GRID_FLAG_FG256|GRID_FLAG_FGRGB));
+	tc->fg = gc->fg;
 }
 
 void
 tty_colours_bg(struct tty *tty, const struct grid_cell *gc)
 {
 	struct grid_cell	*tc = &tty->cell;
-	u_char			 bg = gc->bg;
 	char			 s[32];
 
-	/* Is this a 24-bit colour? */
-	if (gc->flags & GRID_FLAG_BGRGB) {
-		if (tty_try_rgb(tty, &gc->bg_rgb, "48") == 0)
-			goto save_bg;
-		/* Should not get here, already converted in tty_check_bg. */
-		return;
-	}
-
-	/* Is this a 256-colour colour? */
-	if (gc->flags & GRID_FLAG_BG256) {
-		if (tty_try_256(tty, bg, "48") == 0)
+	/* Is this a 24-bit or 256-colour colour? */
+	if (gc->bg & COLOUR_FLAG_24BITCOLOUR ||
+	    gc->bg & COLOUR_FLAG_256COLOURS) {
+		if (tty_try_colour(tty, gc->bg, "48") == 0)
 			goto save_bg;
 		/* Should not get here, already converted in tty_check_bg. */
 		return;
 	}
 
 	/* Is this an aixterm bright colour? */
-	if (bg >= 90 && bg <= 97) {
-		xsnprintf(s, sizeof s, "\033[%dm", bg + 10);
+	if (gc->bg >= 90 && gc->bg <= 97) {
+		xsnprintf(s, sizeof s, "\033[%dm", gc->bg + 10);
 		tty_puts(tty, s);
 		goto save_bg;
 	}
 
 	/* Otherwise set the background colour. */
-	tty_putcode1(tty, TTYC_SETAB, bg);
+	tty_putcode1(tty, TTYC_SETAB, gc->bg);
 
 save_bg:
 	/* Save the new values in the terminal current cell. */
-	if (gc->flags & GRID_FLAG_BGRGB)
-		memcpy(&tc->bg_rgb, &gc->bg_rgb, sizeof tc->bg_rgb);
-	else
-		tc->bg = bg;
-	tc->flags &= ~(GRID_FLAG_BGRGB|GRID_FLAG_BG256);
-	tc->flags |= (gc->flags & (GRID_FLAG_BG256|GRID_FLAG_BGRGB));
+	tc->bg = gc->bg;
 }
 
 int
-tty_try_256(struct tty *tty, u_char colour, const char *type)
+tty_try_colour(struct tty *tty, int colour, const char *type)
 {
+	u_char	r, g, b;
 	char	s[32];
 
-	/*
-	 * If the user has specified -2 to the client, setaf and setab may not
-	 * work (or they may not want to use them), so send the usual sequence.
-	 */
-	if (tty->term_flags & TERM_256COLOURS)
-		goto fallback;
+	if (colour & COLOUR_FLAG_256COLOURS) {
+		colour &= 0xFF;
+		/*
+		 * If the user has specified -2 to the client, setaf and setab
+		 * may not work (or they may not want to use them), so send the
+		 * usual sequence.
+		 */
+		if (tty->term_flags & TERM_256COLOURS)
+			goto fallback_256;
 
-	/*
-	 * If the terminfo entry has 256 colours and setaf and setab exist,
-	 * assume that they work correctly.
-	 */
-	if (tty->term->flags & TERM_256COLOURS) {
-		if (*type == '3') {
-			if (!tty_term_has(tty->term, TTYC_SETAF))
-				goto fallback;
-			tty_putcode1(tty, TTYC_SETAF, colour);
-		} else {
-			if (!tty_term_has(tty->term, TTYC_SETAB))
-				goto fallback;
-			tty_putcode1(tty, TTYC_SETAB, colour);
+		/*
+		 * If the terminfo entry has 256 colours and setaf and setab
+		 * exist, assume that they work correctly.
+		 */
+		if (tty->term->flags & TERM_256COLOURS) {
+			if (*type == '3') {
+				if (!tty_term_has(tty->term, TTYC_SETAF))
+					goto fallback_256;
+				tty_putcode1(tty, TTYC_SETAF, colour);
+			} else {
+				if (!tty_term_has(tty->term, TTYC_SETAB))
+					goto fallback_256;
+				tty_putcode1(tty, TTYC_SETAB, colour);
+			}
+			return (0);
 		}
+	fallback_256:
+		xsnprintf(s, sizeof s, "\033[%s;5;%hhum", type,
+		    (u_char) colour);
+		tty_puts(tty, s);
+		return (0);
+	} else if (colour & COLOUR_FLAG_24BITCOLOUR) {
+		colour &= 0xFFFFFF;
+		if (!tty_term_flag(tty->term, TTYC_TC))
+			return (-1);
+
+		colour_24bittorgb(colour, &r, &g, &b);
+		xsnprintf(s, sizeof s, "\033[%s;2;%hhu;%hhu;%hhum", type,
+		    r, g, b);
+		tty_puts(tty, s);
 		return (0);
 	}
 
 	return (-1);
-
-fallback:
-	xsnprintf(s, sizeof s, "\033[%s;5;%hhum", type, colour);
-	tty_puts(tty, s);
-	return (0);
-}
-
-int
-tty_try_rgb(struct tty *tty, const struct grid_cell_rgb *rgb, const char *type)
-{
-	char	s[32];
-
-	if (!tty_term_flag(tty->term, TTYC_TC))
-		return (-1);
-
-	xsnprintf(s, sizeof s, "\033[%s;2;%hhu;%hhu;%hhum", type, rgb->r,
-	    rgb->g, rgb->b);
-	tty_puts(tty, s);
-	return (0);
 }
 
 void
@@ -1811,31 +1704,23 @@ tty_default_colours(struct grid_cell *gc, const struct window_pane *wp)
 	}
 	pgc = &wp->colgc;
 
-	if (gc->fg == 8 && !(gc->flags & GRID_FLAG_FG256)) {
-		if (pgc->fg != 8 || (pgc->flags & GRID_FLAG_FG256)) {
+	if (gc->fg == 8) {
+		if (pgc->fg != 8) {
 			gc->fg = pgc->fg;
-			gc->flags |= (pgc->flags & GRID_FLAG_FG256);
-		} else if (wp == w->active &&
-		    (agc->fg != 8 || (agc->flags & GRID_FLAG_FG256))) {
+		} else if (wp == w->active && agc->fg != 8) {
 			gc->fg = agc->fg;
-			gc->flags |= (agc->flags & GRID_FLAG_FG256);
 		} else {
 			gc->fg = wgc->fg;
-			gc->flags |= (wgc->flags & GRID_FLAG_FG256);
 		}
 	}
 
-	if (gc->bg == 8 && !(gc->flags & GRID_FLAG_BG256)) {
-		if (pgc->bg != 8 || (pgc->flags & GRID_FLAG_BG256)) {
+	if (gc->bg == 8) {
+		if (pgc->bg != 8) {
 			gc->bg = pgc->bg;
-			gc->flags |= (pgc->flags & GRID_FLAG_BG256);
-		} else if (wp == w->active &&
-		    (agc->bg != 8 || (agc->flags & GRID_FLAG_BG256))) {
+		} else if (wp == w->active && agc->bg != 8) {
 			gc->bg = agc->bg;
-			gc->flags |= (agc->flags & GRID_FLAG_BG256);
 		} else {
 			gc->bg = wgc->bg;
-			gc->flags |= (wgc->flags & GRID_FLAG_BG256);
 		}
 	}
 }

--- a/window-clock.c
+++ b/window-clock.c
@@ -230,7 +230,7 @@ window_clock_draw_screen(struct window_pane *wp)
 			screen_write_cursormove(&ctx, x, y);
 
 			memcpy(&gc, &grid_default_cell, sizeof gc);
-			colour_set_fg(&gc, colour);
+			gc.fg = colour;
 			screen_write_puts(&ctx, &gc, "%s", tim);
 		}
 
@@ -242,7 +242,7 @@ window_clock_draw_screen(struct window_pane *wp)
 	y = (screen_size_y(s) / 2) - 3;
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
-	colour_set_bg(&gc, colour);
+	gc.bg = colour;
 	for (ptr = tim; *ptr != '\0'; ptr++) {
 		if (*ptr >= '0' && *ptr <= '9')
 			idx = *ptr - '0';


### PR DESCRIPTION
* Enable support for 24-bit colors for `tmux` options. Before this change, `tmux` options are limited to 256 colors even when running in a terminal that supports 24-bit color.
* Clean up color code. Before this change, color information for a cell was divided between its flags (indicating what color model was used: regular, 256 color, or 24-bit color) and its foreground/background value (which itself was a union of an 8-bit value or a struct with separate red/green/blue values). With this change, all color information is stored in a single 32-bit value, with the higher 8 bits indicating the color model and the lower 24 bits indicating value.