### PR TITLE
Support for the escape sequences of the Terminology shell

### DIFF
--- a/input.c
+++ b/input.c
@@ -441,7 +441,7 @@ const struct input_state input_state_utf8_one = {
 
 /* terminology_escape state definition. */
 const struct input_state input_state_terminology_escape = {
-	"utf8_one",
+	"terminology_escape",
 	NULL, input_exit_terminology_escape,
 	input_state_terminology_escape_table
 };


### PR DESCRIPTION
These changes make sure the escape sequences used by Terminology (https://github.com/billiob/terminology) are passed through tmux in raw form, so the terminal emulators graphical extensions can be used. It does not address the problem that Terminology does not know about the separate scrollback buffer of tmux, though, the demo programs issued by Terminology (tyls, etc.) will produce strange effects, but if the sequences are used in own programs/scripts, it works like a charm...