### PR TITLE
Add wrap-select-pane option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -892,6 +892,12 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "default"
 	},
 
+	{ .name = "wrap-select-pane",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_num = 1
+	},
+
 	{ .name = "wrap-search",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/window.c
+++ b/window.c
@@ -1233,7 +1233,7 @@ window_pane_find_up(struct window_pane *wp)
 	size = 0;
 
 	edge = wp->yoff;
-	if (edge == 0)
+	if (options_get_number(global_options, "wrap-select-pane") && edge == 0)
 		edge = wp->window->sy + 1;
 
 	left = wp->xoff;
@@ -1279,7 +1279,7 @@ window_pane_find_down(struct window_pane *wp)
 	size = 0;
 
 	edge = wp->yoff + wp->sy + 1;
-	if (edge >= wp->window->sy)
+	if (options_get_number(global_options, "wrap-select-pane") && edge >= wp->window->sy)
 		edge = 0;
 
 	left = wp->xoff;
@@ -1325,7 +1325,7 @@ window_pane_find_left(struct window_pane *wp)
 	size = 0;
 
 	edge = wp->xoff;
-	if (edge == 0)
+	if (options_get_number(global_options, "wrap-select-pane") && edge == 0)
 		edge = wp->window->sx + 1;
 
 	top = wp->yoff;
@@ -1371,7 +1371,7 @@ window_pane_find_right(struct window_pane *wp)
 	size = 0;
 
 	edge = wp->xoff + wp->sx + 1;
-	if (edge >= wp->window->sx)
+	if (options_get_number(global_options, "wrap-select-pane") && edge >= wp->window->sx)
 		edge = 0;
 
 	top = wp->yoff;


### PR DESCRIPTION
I've found select-pane wrapping around edges of the terminal to be error prone for my workflow. It looks like others have the same pain (hence https://github.com/dalejung/tmux-select-pane-no-wrap).

Would you consider merging this option to disable it, so that those who don't want this functionality don't have to patch it with a janky shell script?