### PR TITLE
Add full-size window split feature

### DIFF
--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -124,7 +124,7 @@ join_pane(struct cmd *self, struct cmd_q *cmdq, int not_same_window)
 		else
 			size = (dst_wp->sx * percentage) / 100;
 	}
-	lc = layout_split_pane(dst_wp, type, size, args_has(args, 'b'));
+	lc = layout_split_pane(dst_wp, type, size, args_has(args, 'b'), 0);
 	if (lc == NULL) {
 		cmdq_error(cmdq, "create pane failed: pane too small");
 		return (CMD_RETURN_ERROR);

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -38,8 +38,8 @@ const struct cmd_entry cmd_split_window_entry = {
 	.name = "split-window",
 	.alias = "splitw",
 
-	.args = { "bc:dF:l:hp:Pt:v", 0, -1 },
-	.usage = "[-bdhvP] [-c start-directory] [-F format] "
+	.args = { "bc:dfF:l:hp:Pt:v", 0, -1 },
+	.usage = "[-bdfhvP] [-c start-directory] [-F format] "
 		 "[-p percentage|-l size] " CMD_TARGET_PANE_USAGE " [command]",
 
 	.tflag = CMD_PANE,
@@ -130,7 +130,8 @@ cmd_split_window_exec(struct cmd *self, struct cmd_q *cmdq)
 	if (*shell == '\0' || areshell(shell))
 		shell = _PATH_BSHELL;
 
-	lc = layout_split_pane(wp, type, size, args_has(args, 'b'));
+	lc = layout_split_pane(wp, type, size, args_has(args, 'b'),
+	    args_has(args, 'f'));
 	if (lc == NULL) {
 		cause = xstrdup("pane too small");
 		goto error;

--- a/tmux.1
+++ b/tmux.1
@@ -2015,6 +2015,13 @@ The
 .Fl b
 option causes the new pane to be created to the left of or above
 .Ar target-pane .
+The
+.Fl f
+option creates a new pane spanning the full window height (with
+.Fl h )
+or full window width (with
+.Fl v ) ,
+instead of splitting the active pane.
 All other options have the same meaning as for the
 .Ic new-window
 command.

--- a/tmux.h
+++ b/tmux.h
@@ -2206,7 +2206,7 @@ void		 layout_resize_pane_to(struct window_pane *, enum layout_type,
 		     u_int);
 void		 layout_assign_pane(struct layout_cell *, struct window_pane *);
 struct layout_cell *layout_split_pane(struct window_pane *, enum layout_type,
-		     int, int);
+		     int, int, int);
 void		 layout_close_pane(struct window_pane *);
 
 /* layout-custom.c */


### PR DESCRIPTION
This adds a new argument (`-f`) to the `split-window` command which causes
the new pane to be created spanning the full window height (with `-h`) or
full window width (with `-v`) instead of splitting the active pane.

When creating a new full-size split, all existing panes are resized
proportionally to fit within the reduced window space. The command fails
if there is not sufficient space available in the window.

To illustrate, `split-window -h` on the following layout (with pane 1
active) produces:

```
    +---------+      +----+----+
    | 1       |      | 1  | 3  |
    +---------+  ->  +----+----+
    | 2       |      | 2       |
    +---------+      +---------+
```

With this feature, `split-window -h -f` on the same layout produces:

```
    +---------+      +----+----+
    | 1       |      | 1  | 3  |
    +---------+  ->  +----+    |
    | 2       |      | 2  |    |
    +---------+      +---------+
```

----

These types of full-size splits can be created in vim (using `:topleft` or `:botright`), and I wrote this to add the same type of feature to tmux. I can create full-size splits using \<Prefix\>\[hjkl\] (vim-style direction keys) with the following tmux config:

```
bind h split-window -h -f -b
bind j split-window -v -f
bind k split-window -v -f -b
bind l split-window -h -f
```

This is my first time writing any code for tmux. I'm happy to answer questions or receive feedback.