### PR TITLE
Default key binding for RectangleToggle: v -> Ctrl-v

### DIFF
--- a/mode-key.c
+++ b/mode-key.c
@@ -335,7 +335,7 @@ const struct mode_key_entry mode_key_vi_copy[] = {
 	{ 'o',			    0, MODEKEYCOPY_OTHEREND },
 	{ 't',			    0, MODEKEYCOPY_JUMPTO },
 	{ 'q',			    0, MODEKEYCOPY_CANCEL },
-	{ 'v',			    0, MODEKEYCOPY_RECTANGLETOGGLE },
+	{ '\026' /* C-v */,	    0, MODEKEYCOPY_RECTANGLETOGGLE },
 	{ 'w',			    0, MODEKEYCOPY_NEXTWORD },
 	{ '{',			    0, MODEKEYCOPY_PREVIOUSPARAGRAPH },
 	{ '}',			    0, MODEKEYCOPY_NEXTPARAGRAPH },


### PR DESCRIPTION
Many aspects of vi-copy mimic VIM's visual mode. To select a rectangular section of the text in VIM (visual-block-mode) one uses Ctrl-v. It therefore makes sense to use the same key binding in tmux.