### PR TITLE
Support compilation on Solaris 11.3

### DIFF
--- a/osdep-sunos.c
+++ b/osdep-sunos.c
@@ -17,6 +17,7 @@
  */
 
 #include <sys/types.h>
+#include <sys/param.h>
 #include <sys/stat.h>
 
 #include <event.h>

--- a/server.c
+++ b/server.c
@@ -34,6 +34,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef ACCESSPERMS
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO) 
+#endif
+
 #include "tmux.h"
 
 /*

--- a/window.c
+++ b/window.c
@@ -30,6 +30,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifndef FIONREAD
+#include <sys/filio.h>
+#endif
+
 #include "tmux.h"
 
 /*


### PR DESCRIPTION
Note: Still fails with default build order (autoreconf -if && ./configure
&& make) due to linking against -lncurses. Instead linking against
-lcurses works properly.

I haven't figured out how to convince configure to use -lcurses instead of -lncurses