### PR TITLE
Added #include <stdarg.h> without which these files will not compile.

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/cfg.c
+++ b/cfg.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -20,6 +20,7 @@
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include <time.h>
 

--- a/control.c
+++ b/control.c
@@ -21,6 +21,7 @@
 
 #include <event.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 #include <time.h>
 

--- a/environ.c
+++ b/environ.c
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include <stdlib.h>
+#include <stdarg.h>
 #include <string.h>
 
 #include "tmux.h"


### PR DESCRIPTION
I don't know what version of compiler tmux is typically compiled with, but on my system it complains about va_args, etc, not being defined. This patch allows it to compile by including the relevant header.