### PR TITLE
cmd-find.c: follow ppids for current window

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -1815,6 +1815,7 @@ int		 cmd_find_target(struct cmd_find_state *,
 		     struct cmd_find_state *, struct cmd_q *, const char *,
 		     enum cmd_find_type, int);
 struct client	*cmd_find_client(struct cmd_q *, const char *, int);
+pid_t		 cmd_find_ppid(pid_t);
 void		 cmd_find_clear_state(struct cmd_find_state *, struct cmd_q *,
 		     int);
 int		 cmd_find_valid_state(struct cmd_find_state *);
@@ -2169,6 +2170,7 @@ u_int		 window_count_panes(struct window *);
 void		 window_destroy_panes(struct window *);
 struct window_pane *window_pane_find_by_id_str(const char *);
 struct window_pane *window_pane_find_by_id(u_int);
+struct window_pane *window_pane_find_by_pid(pid_t);
 struct window_pane *window_pane_create(struct window *, u_int, u_int, u_int);
 void		 window_pane_destroy(struct window_pane *);
 int		 window_pane_spawn(struct window_pane *, int, char **,

--- a/window.c
+++ b/window.c
@@ -732,6 +732,19 @@ window_pane_find_by_id(u_int id)
 }
 
 struct window_pane *
+window_pane_find_by_pid(pid_t pid)
+{
+	struct window_pane *wp;
+
+	RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
+		if (wp->pid == pid) {
+			return (wp);
+		}
+	}
+	return (NULL);
+}
+
+struct window_pane *
 window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 {
 	struct window_pane	*wp;


### PR DESCRIPTION
Before, a command like

    tmux rename-window foo

would rename *current* window, not the window where `tmux rename-window
foo` originated from.

This behavior can be easily reproduced: run a delayed `rename-window`:

    +-----------------------------+         +-----------------------------+
    |$ (sleep 1 &&                |         |$                            |
    |   tmux rename-window xxx) & |         |                             |
    |  tmux next-window           |  ---->  |                             |
    |                             |         |                             |
    |[0] 0:bash* 1:bash-          |         |[0] 0:bash- 1:xxx*           |
    +-----------------------------+         +-----------------------------+

Even though `rename-window` was issued from window 0,
window 1 was renamed.

This is especially obvious if you run a command that took a while, then
renamed the window:

    tmux rename-window foo
    ssh foo
    tmux set-window-option automatic-rename on

When the `ssh` command exits hours later, it sets automatic renaming on
whichever window I happened to be selected on. Annoying!

The fix is to walk up the process tree until we find the client's
pane. Then, we rename that window (or do whatever we were going to do).
Just like commands within a session will use that session by default,
all commands from within a pane will use that pane by default.

Now, that same command does this:

    +-----------------------------+         +-----------------------------+
    |$ (sleep 1 &&                |         |$                            |
    |   tmux rename-window xxx) & |         |                             |
    |  tmux next-window           |  ---->  |                             |
    |                             |         |                             |
    |[0] 0:bash* 1:bash-          |         |[0] 0:xxx- 1:bash*           |
    +-----------------------------+         +-----------------------------+