### PR TITLE
Add -f flag to list of flags split-window takes.

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1955,7 +1955,7 @@ is given and the selected window is already the current window,
 the command behaves like
 .Ic last-window .
 .It Xo Ic split-window
-.Op Fl bdhvP
+.Op Fl bdfhvP
 .Op Fl c Ar start-directory
 .Oo Fl l
 .Ar size |


### PR DESCRIPTION
Recent pull request (https://github.com/tmux/tmux/pull/505) added this flag, but the flag was not listed in the man page as one the command takes. The flag is documented, just missing from the list.
