### PR TITLE
Add missing GRID_FLAG_{BG,FG}RGB so that RGB style strings behave properly

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -305,14 +305,19 @@ grid_get_cell(struct grid *gd, u_int px, u_int py, struct grid_cell *gc)
 		return;
 	}
 
-	gc->flags = gce->flags & ~(GRID_FLAG_FG256|GRID_FLAG_BG256);
+	gc->flags = gce->flags &
+		~(GRID_FLAG_FG256|GRID_FLAG_BG256|GRID_FLAG_FGRGB|GRID_FLAG_BGRGB);
 	gc->attr = gce->data.attr;
 	gc->fg = gce->data.fg;
 	if (gce->flags & GRID_FLAG_FG256)
 		gc->fg |= COLOUR_FLAG_256;
+	if (gce->flags & GRID_FLAG_FGRGB)
+		gc->fg |= COLOUR_FLAG_RGB;
 	gc->bg = gce->data.bg;
 	if (gce->flags & GRID_FLAG_BG256)
 		gc->bg |= COLOUR_FLAG_256;
+	if (gce->flags & GRID_FLAG_BGRGB)
+		gc->bg |= COLOUR_FLAG_RGB;
 	utf8_set(&gc->data, gce->data.data);
 }
 
@@ -364,9 +369,13 @@ grid_set_cell(struct grid *gd, u_int px, u_int py, const struct grid_cell *gc)
 	gce->data.fg = gc->fg & 0xff;
 	if (gc->fg & COLOUR_FLAG_256)
 		gce->flags |= GRID_FLAG_FG256;
+	if (gc->fg & COLOUR_FLAG_RGB)
+		gce->flags |= GRID_FLAG_FGRGB;
 	gce->data.bg = gc->bg & 0xff;
 	if (gc->bg & COLOUR_FLAG_256)
 		gce->flags |= GRID_FLAG_BG256;
+	if (gc->bg & COLOUR_FLAG_RGB)
+		gce->flags |= GRID_FLAG_BGRGB;
 	gce->data.data = gc->data.data[0];
 }
 

--- a/tmux.h
+++ b/tmux.h
@@ -577,6 +577,8 @@ enum utf8_state {
 #define GRID_FLAG_PADDING 0x4
 #define GRID_FLAG_EXTENDED 0x8
 #define GRID_FLAG_SELECTED 0x10
+#define GRID_FLAG_FGRGB 0x20
+#define GRID_FLAG_BGRGB 0x40
 
 /* Grid line flags. */
 #define GRID_LINE_WRAPPED 0x1


### PR DESCRIPTION
This fixes an issue I noticed where #rrggbb colors are downgrading to 256 colors, even on a true color terminal. Adding these two flags seems to work just fine for me. Thanks!


Test case:
tmux set -g status-left '#[bg=#000000] #[bg=#100000] #[bg=#200000] #[bg=#300000] #[bg=#400000] #[bg=#500000] #[bg=#600000] #[bg=#700000] #[bg=#800000] #[bg=#900000]'

Good result: 10 shades of red
Bad result: 3 shades