### PR TITLE
Fix powerline on Unicode 9-compliant terminals

### DIFF
--- a/compat/utf8proc.c
+++ b/compat/utf8proc.c
@@ -33,10 +33,6 @@ utf8proc_wcwidth(wchar_t wc)
 		 */
 		return (1);
 	}
-	if (cat == UTF8PROC_CATEGORY_SO) {
-		/* Symbols, like emoji, should always use width 1. */
-		return (1);
-	}
 	return (utf8proc_charwidth(wc));
 }
 


### PR DESCRIPTION
Powerline uses [the WATCH character](https://github.com/powerline/powerline/blob/fd54f63/powerline/config_files/themes/powerline.json#L41) (U+231A) when displaying current time. In [Unicode 8.0.0](http://www.unicode.org/Public/8.0.0/ucd/EastAsianWidth.txt), it's NEUTRAL:
```
2313..231F;N     # So    [13] SEGMENT..BOTTOM RIGHT CORNER
```
However, [Unicode 9.0.0](http://www.unicode.org/Public/UNIDATA/EastAsianWidth.txt) changed it to WIDE:
```
2313..2319;N     # So     [7] SEGMENT..TURNED NOT SIGN
231A..231B;W     # So     [2] WATCH..HOURGLASS
231C..231F;N     # So     [4] TOP LEFT CORNER..BOTTOM RIGHT CORNER
```
This breaks Unicode 9-compliant terminal emulators, including [Gnome/VTE3](https://bugzilla.gnome.org/show_bug.cgi?id=771591) (the core component of gnome-terminal and xfce4-terminal) and [QTerminal](https://github.com/lxde/qterminal/issues/260). If an user is on Fedora Rawhide, which has [patched glibc for Unicode 9.0.0 support](http://pkgs.fedoraproject.org/cgit/rpms/glibc.git/commit/?id=5c031d86de2393daa5181ad5ccdbca52c5eb3554), terminals use ```wcwidth()``` will be affected, too. I suggest to remove the assumption "Symbols, like emoji, should always use width 1." so that tmux works fine with those terminal emulators.

/cc @joshuarubin I didn't find any description about the assumption regarding UTF8PROC_CATEGORY_SO. Does values from ```utf8proc_charwidth()``` break something? (#524)