### PR TITLE
Don't stop dragging selection if mouse wheel is scrolled.

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -421,7 +421,7 @@ have_event:
 		m->wp = -1;
 
 	/* Stop dragging if needed. */
-	if (type != DRAG && c->tty.mouse_drag_flag) {
+	if (type != DRAG && type != WHEEL && c->tty.mouse_drag_flag) {
 		if (c->tty.mouse_drag_release != NULL)
 			c->tty.mouse_drag_release(c, m);
 

--- a/server-client.c
+++ b/server-client.c
@@ -326,7 +326,7 @@ server_client_check_mouse(struct client *c)
 		type = WHEEL;
 		x = m->x, y = m->y, b = m->b;
 		log_debug("wheel at %u,%u", x, y);
-	} else if (MOUSE_BUTTONS(m->b) == 3) {
+	} else if (MOUSE_RELEASE(m->b)) {
 		type = UP;
 		x = m->x, y = m->y, b = m->lb;
 		log_debug("up at %u,%u", x, y);
@@ -733,11 +733,12 @@ server_client_handle_key(struct client *c, key_code key)
 	if (key == KEYC_MOUSE) {
 		if (c->flags & CLIENT_READONLY)
 			return;
+		m->valid = 1;
+
 		key = server_client_check_mouse(c);
 		if (key == KEYC_UNKNOWN)
 			return;
 
-		m->valid = 1;
 		m->key = key;
 
 		if (!options_get_number(s->options, "mouse"))


### PR DESCRIPTION
How to reproduce: enable mouse mode, click somehwere and start dragging a selection. Then scroll up with a wheel. Now selection doesn't react on mouse move, though in rxvt/termite you would expect it to follow the mouse.

The m->valid part is about pressing page up while dragging mouse.

I'm not quite sure about the m->valid. It seems that no one uses m->key when m->valid is 0,  maybe you know the actual meaning of this variable?
