### PR TITLE
Initialize modeprefix with 1, otherwise first send-keys will be a no-op

### DIFF
--- a/window.c
+++ b/window.c
@@ -769,6 +769,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	wp->event = NULL;
 
 	wp->mode = NULL;
+	wp->modeprefix = 1;
 
 	wp->layout_cell = NULL;
 


### PR DESCRIPTION
reproduce: launch tmux, select something with mouse and press page up - the first one will be a no-op because modeprefix is 0 (and modeprefix is a synonym to sendkeys -N argument)