### PR TITLE
Allow selection to be independent from cursor.

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -258,6 +258,8 @@ screen_set_selection(struct screen *s, u_int sx, u_int sy,
 
 	memcpy(&sel->cell, gc, sizeof sel->cell);
 	sel->flag = 1;
+	sel->hidden = 0;
+
 	sel->rectflag = rectflag;
 
 	sel->sx = sx; sel->sy = sy;
@@ -271,8 +273,19 @@ screen_clear_selection(struct screen *s)
 	struct screen_sel	*sel = &s->sel;
 
 	sel->flag = 0;
+	sel->hidden = 0;
 	sel->lineflag = LINE_SEL_NONE;
 }
+
+/* Hide selection. */
+void
+screen_hide_selection(struct screen *s)
+{
+	struct screen_sel	*sel = &s->sel;
+
+	sel->hidden = 1;
+}
+
 
 /* Check if cell in selection. */
 int
@@ -281,7 +294,7 @@ screen_check_selection(struct screen *s, u_int px, u_int py)
 	struct screen_sel	*sel = &s->sel;
 	u_int			 xx;
 
-	if (!sel->flag)
+	if (!sel->flag || sel->hidden)
 		return (0);
 
 	if (sel->rectflag) {
@@ -377,7 +390,7 @@ void
 screen_select_cell(struct screen *s, struct grid_cell *dst,
     const struct grid_cell *src)
 {
-	if (!s->sel.flag)
+	if (!s->sel.flag || s->sel.hidden)
 		return;
 
 	memcpy(dst, &s->sel.cell, sizeof *dst);

--- a/tmux.h
+++ b/tmux.h
@@ -683,6 +683,8 @@ LIST_HEAD(joblist, job);
 /* Screen selection. */
 struct screen_sel {
 	int		 flag;
+	int		 hidden;
+
 	int		 rectflag;
 	enum {
 		LINE_SEL_NONE,
@@ -2057,6 +2059,7 @@ void	 screen_resize(struct screen *, u_int, u_int, int);
 void	 screen_set_selection(struct screen *,
 	     u_int, u_int, u_int, u_int, u_int, struct grid_cell *);
 void	 screen_clear_selection(struct screen *);
+void	 screen_hide_selection(struct screen *);
 int	 screen_check_selection(struct screen *, u_int, u_int);
 void	 screen_select_cell(struct screen *, struct grid_cell *,
 	     const struct grid_cell *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -62,6 +62,8 @@ static void	window_copy_search_down(struct window_pane *, const char *,
 static void	window_copy_goto_line(struct window_pane *, const char *);
 static void	window_copy_update_cursor(struct window_pane *, u_int, u_int);
 static void	window_copy_start_selection(struct window_pane *);
+static enum relative_position	window_copy_adjust_selection(struct window_pane *wp,
+		    u_int *selx, u_int *sely)
 static int	window_copy_update_selection(struct window_pane *, int);
 static void    *window_copy_get_selection(struct window_pane *, size_t *);
 static void	window_copy_copy_buffer(struct window_pane *, const char *,
@@ -100,6 +102,14 @@ static void	window_copy_scroll_down(struct window_pane *, u_int);
 static void	window_copy_rectangle_toggle(struct window_pane *);
 static void	window_copy_move_mouse(struct mouse_event *);
 static void	window_copy_drag_update(struct client *, struct mouse_event *);
+static void	window_copy_synchronize_cursor(struct window_pane *wp);
+
+/* Used by window_copy_adjust_selection */
+enum relative_position {
+	RELATIVE_POSITION_ABOVE,
+	RELATIVE_POSITION_ON_SCREEN,
+	RELATIVE_POSITION_BELOW,
+};
 
 const struct window_mode window_copy_mode = {
 	.init = window_copy_init,
@@ -141,10 +151,19 @@ struct window_copy_mode_data {
 	struct screen	*backing;
 	int		 backing_written; /* backing display started */
 
-	u_int		 oy;
+	u_int		 oy; /* number of lines scrolled up */
 
-	u_int		 selx;
+	u_int		 selx; /* beginning of selection */
 	u_int		 sely;
+
+	u_int		 endselx; /* end of selection */
+	u_int		 endsely;
+
+	enum {
+			CURSORDRAG_NONE, /* selection is independent of cursor */
+			CURSORDRAG_ENDSEL, /* endselx,endsely is synchronized with cursor */
+			CURSORDRAG_SEL, /* selx,sely is synchronized with cursor */
+	} cursordrag;
 
 	int		 rectflag;	/* in rectangle copy mode? */
 	int		 scroll_exit;	/* exit on scroll to end? */
@@ -172,6 +191,8 @@ window_copy_init(struct window_pane *wp)
 	data->oy = 0;
 	data->cx = 0;
 	data->cy = 0;
+
+	data->cursordrag = CURSORDRAG_NONE;
 
 	data->lastcx = 0;
 	data->lastsx = 0;
@@ -513,6 +534,9 @@ window_copy_command(struct window_pane *wp, struct client *c, struct session *s,
 				window_copy_start_selection(wp);
 				window_copy_redraw_screen(wp);
 			}
+		}
+		if (strcmp(command, "stop-dragging-selection") == 0) {
+			data->cursordrag = CURSORDRAG_NONE;
 		}
 		if (strcmp(command, "bottom-line") == 0) {
 			data->cx = 0;
@@ -1151,6 +1175,30 @@ window_copy_redraw_screen(struct window_pane *wp)
 }
 
 static void
+window_copy_synchronize_cursor(struct window_pane *wp)
+{
+	struct window_copy_mode_data	*data = wp->modedata;
+	u_int				xx, yy;
+
+	xx = data->cx;
+	yy = screen_hsize(data->backing) + data->cy - data->oy;
+
+	switch (data->cursordrag) {
+		case CURSORDRAG_ENDSEL:
+			data->endselx = xx;
+			data->endsely = yy;
+		break;
+		case CURSORDRAG_SEL:
+			data->selx = xx;
+			data->sely = yy;
+		break;
+		case CURSORDRAG_NONE:
+			/* no-op */
+		break;
+	}
+}
+
+static void
 window_copy_update_cursor(struct window_pane *wp, u_int cx, u_int cy)
 {
 	struct window_copy_mode_data	*data = wp->modedata;
@@ -1180,8 +1228,54 @@ window_copy_start_selection(struct window_pane *wp)
 	data->selx = data->cx;
 	data->sely = screen_hsize(data->backing) + data->cy - data->oy;
 
+	data->endselx = data->selx;
+	data->endsely = data->sely;
+
+	data->cursordrag = CURSORDRAG_ENDSEL;
+
 	s->sel.flag = 1;
 	window_copy_update_selection(wp, 1);
+}
+
+enum relative_position {
+	RELATIVE_POSITION_ABOVE,
+	RELATIVE_POSITION_ON_SCREEN,
+	RELATIVE_POSITION_BELOW,
+};
+
+static enum relative_position
+window_copy_adjust_selection(struct window_pane *wp, u_int *selx, u_int *sely)
+{
+	struct window_copy_mode_data	*data = wp->modedata;
+	struct screen			*s = &data->screen;
+	u_int 			sx, sy, ty;
+	enum relative_position	 relpos;
+
+	sx = *selx;
+	sy = *sely;
+	relpos = RELATIVE_POSITION_ON_SCREEN;
+
+	/* Find top of screen. */
+	ty = screen_hsize(data->backing) - data->oy;
+
+	if (sy < ty) {
+		relpos = RELATIVE_POSITION_ABOVE;
+		if (!data->rectflag)
+			sx = 0;
+		sy = 0;
+	} else if (sy > ty + screen_size_y(s) - 1) {
+		relpos = RELATIVE_POSITION_BELOW;
+		if (!data->rectflag)
+			sx = screen_size_x(s) - 1;
+		sy = screen_size_y(s) - 1;
+	} else {
+		sy -= ty;
+	}
+	sy = screen_hsize(s) + sy;
+
+	*selx = sx;
+	*sely = sy;
+	return relpos;
 }
 
 static int
@@ -1191,34 +1285,35 @@ window_copy_update_selection(struct window_pane *wp, int may_redraw)
 	struct screen			*s = &data->screen;
 	struct options			*oo = wp->window->options;
 	struct grid_cell		 gc;
-	u_int				 sx, sy, ty, cy;
+	u_int				 sx, sy, ty, cy, endsx, endsy;
+	enum relative_position	 startrelpos, endrelpos;
 
 	if (!s->sel.flag && s->sel.lineflag == LINE_SEL_NONE)
 		return (0);
 
-	/* Set colours. */
-	style_apply(&gc, oo, "mode-style");
-
-	/* Find top of screen. */
-	ty = screen_hsize(data->backing) - data->oy;
+	window_copy_synchronize_cursor(wp);
 
 	/* Adjust the selection. */
 	sx = data->selx;
 	sy = data->sely;
-	if (sy < ty) {					/* above screen */
-		if (!data->rectflag)
-			sx = 0;
-		sy = 0;
-	} else if (sy > ty + screen_size_y(s) - 1) {	/* below screen */
-		if (!data->rectflag)
-			sx = screen_size_x(s) - 1;
-		sy = screen_size_y(s) - 1;
-	} else
-		sy -= ty;
-	sy = screen_hsize(s) + sy;
+	startrelpos = window_copy_adjust_selection(wp, &sx, &sy);
+
+	/* Adjust the end of selection. */
+	endsx = data->endselx;
+	endsy = data->endsely;
+	endrelpos = window_copy_adjust_selection(wp, &endsx, &endsy);
+
+	/* Selection is outside of the current screen */
+	if (startrelpos == endrelpos && startrelpos != RELATIVE_POSITION_ON_SCREEN) {
+		screen_hide_selection(s);
+		return (0);
+	}
+
+	/* Set colours. */
+	style_apply(&gc, oo, "mode-style");
 
 	screen_set_selection(s,
-	    sx, sy, data->cx, screen_hsize(s) + data->cy, data->rectflag, &gc);
+	    sx, sy, endsx, endsy, data->rectflag, &gc);
 
 	if (data->rectflag && may_redraw) {
 		/*
@@ -1261,8 +1356,8 @@ window_copy_get_selection(struct window_pane *wp, size_t *len)
 	 */
 
 	/* Find start and end. */
-	xx = data->cx;
-	yy = screen_hsize(data->backing) + data->cy - data->oy;
+	xx = data->endselx;
+	yy = data->endsely;
 	if (yy < data->sely || (yy == data->sely && xx < data->selx)) {
 		sx = xx; sy = yy;
 		ex = data->selx; ey = data->sely;
@@ -1500,6 +1595,8 @@ window_copy_clear_selection(struct window_pane *wp)
 
 	screen_clear_selection(&data->screen);
 
+	data->cursordrag = CURSORDRAG_NONE;
+
 	py = screen_hsize(data->backing) + data->cy - data->oy;
 	px = window_copy_find_length(wp, py);
 	if (data->cx > px)
@@ -1640,26 +1737,40 @@ window_copy_other_end(struct window_pane *wp)
 	else if (s->sel.lineflag == LINE_SEL_RIGHT_LEFT)
 		s->sel.lineflag = LINE_SEL_LEFT_RIGHT;
 
-	selx = data->selx;
-	sely = data->sely;
+	switch (data->cursordrag) {
+		case CURSORDRAG_NONE:
+		case CURSORDRAG_SEL:
+			data->cursordrag = CURSORDRAG_ENDSEL;
+		break;
+		case CURSORDRAG_ENDSEL:
+			data->cursordrag = CURSORDRAG_SEL;
+		break;
+	}
+
+	selx = data->endselx;
+	sely = data->endsely;
+	if (data->cursordrag == CURSORDRAG_SEL) {
+		selx = data->selx;
+		sely = data->sely;
+	}
+
 	cx = data->cx;
 	cy = data->cy;
 	yy = screen_hsize(data->backing) + data->cy - data->oy;
 
-	data->selx = cx;
-	data->sely = yy;
 	data->cx = selx;
 
 	hsize = screen_hsize(data->backing);
-	if (sely < hsize - data->oy) {
+	if (sely < hsize - data->oy) { /* above */
 		data->oy = hsize - sely;
 		data->cy = 0;
-	} else if (sely > hsize - data->oy + screen_size_y(s)) {
+	} else if (sely > hsize - data->oy + screen_size_y(s)) { /* below */
 		data->oy = hsize - sely + screen_size_y(s) - 1;
 		data->cy = screen_size_y(s) - 1;
 	} else
 		data->cy = cy + sely - yy;
 
+	window_copy_update_selection(wp, 1);
 	window_copy_redraw_screen(wp);
 }
 


### PR DESCRIPTION
Add endselx, endsely fields to window copy data - now we use them
instead of current cursor position.
If the cursor is moved and dragtype is not CURSORDRAG_NONE,
then corresponding selx,sely (or endselx,endsely) will be moved with cursor.
Add "stop-dragging-selection" command to copy mode.