### PR TITLE
Autoconfigure pledge().

### DIFF
--- a/client.c
+++ b/client.c
@@ -287,7 +287,7 @@ client_main(struct event_base *base, int argc, char **argv, int flags,
 	if ((ttynam = ttyname(STDIN_FILENO)) == NULL)
 		ttynam = "";
 
-#ifdef __OpenBSD__
+#ifdef HAVE_PLEDGE
 	/*
 	 * Drop privileges for client. "proc exec" is needed for -c and for
 	 * locking (which uses system(3)).
@@ -548,7 +548,7 @@ client_dispatch_wait(struct imsg *imsg, const char *shellcmd)
 	struct msg_stdout_data	 stdoutdata;
 	struct msg_stderr_data	 stderrdata;
 	int			 retval;
-#ifdef __OpenBSD__
+#ifdef HAVE_PLEDGE
 	static int		 pledge_applied;
 
 	/*

--- a/configure.ac
+++ b/configure.ac
@@ -126,6 +126,7 @@ AC_CHECK_FUNCS(
 		prctl \
 		sysconf \
 		cfmakeraw \
+		pledge \
 	]
 )
 

--- a/server.c
+++ b/server.c
@@ -148,7 +148,7 @@ server_start(struct event_base *base, int lockfd, char *lockfile)
 	if (log_get_level() > 3)
 		tty_create_log();
 
-#ifdef __OpenBSD__
+#ifdef HAVE_PLEDGE
 	if (pledge("stdio rpath wpath cpath fattr unix getpw recvfd proc exec "
 	    "tty ps", NULL) != 0)
 		fatal("pledge failed");

--- a/tmux.c
+++ b/tmux.c
@@ -258,7 +258,7 @@ main(int argc, char **argv)
 	if (shellcmd != NULL && argc != 0)
 		usage();
 
-#ifdef __OpenBSD__
+#ifdef HAVE_PLEDGE
 	if (pledge("stdio rpath wpath cpath flock fattr unix getpw sendfd "
 	    "recvfd proc exec tty ps", NULL) != 0)
 		err(1, "pledge");


### PR DESCRIPTION
On older versions of OpenBSD, `pledge()` does not exist.  Use Autoconf to detect it.
