### PR TITLE
Regular expression support for capture-pane

### DIFF
--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -100,7 +100,7 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	const struct grid_line	*gl;
 	struct grid_cell	*gc = NULL;
 	int			 n, with_codes, error, escape_c0, join_lines;
-	u_int			 i, k, sx, top, bottom, tmp;
+	u_int			 i, sx, top, bottom, tmp;
 	char			*cause, *buf, *line, *subset;
 	const char		*Sflag, *Eflag, *regex;
 	size_t			 linelen;

--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -193,13 +193,7 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 		if (regex && regexec(&reg, line, only_matching ? 1 : 0, match, 0))
 			continue;
 
-		if (!regex || !only_matching) {
-			buf = cmd_capture_pane_append(buf, len, line, linelen);
-
-			gl = grid_peek_line(gd, i);
-			if (!join_lines || !(gl->flags & GRID_LINE_WRAPPED))
-				buf[(*len)++] = '\n';
-		} else if (only_matching) {
+		if (only_matching) {
 			subset = line;
 			do {
 				linelen = match[0].rm_eo - match[0].rm_so;
@@ -208,6 +202,11 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 				buf[(*len)++] = '\n';
 				subset += match[0].rm_eo;
 			} while (!regexec(&reg, subset, 1, match, REG_NOTBOL));
+		} else {
+			buf = cmd_capture_pane_append(buf, len, line, linelen);
+			gl = grid_peek_line(gd, i);
+			if (!join_lines || !(gl->flags & GRID_LINE_WRAPPED))
+				buf[(*len)++] = '\n';
 		}
 
 		free(line);

--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -165,7 +165,7 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	join_lines = args_has(args, 'J');
 
 	if (join_lines && only_matching) {
-		cmdq_error(cmdq, "cannot use -o with -J");
+		cmdq_error(item, "cannot use -o with -J");
 		return (NULL);
 	} else if ((regex = args_get(args, 'r'))) {
 		if (args_has(args, 'i')) {
@@ -173,11 +173,11 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 		}
 		if ((error = regcomp(&reg, regex, regex_flags))) {
 			// TODO: Return stringified error message
-			cmdq_error(cmdq, "unable to compile regular expression");
+			cmdq_error(item, "unable to compile regular expression");
 			return (NULL);
 		}
 	} else if (only_matching) {
-		cmdq_error(cmdq, "cannot use -o without -r");
+		cmdq_error(item, "cannot use -o without -r");
 		return (NULL);
 	}
 

--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -108,6 +108,7 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	int			 regex_flags = REG_EXTENDED,
 				 only_matching = args_has(args, 'o');
 	regmatch_t		 match[1];
+	char			 regex_error[512];
 
 	sx = screen_size_x(&wp->base);
 	if (args_has(args, 'a')) {
@@ -172,8 +173,10 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 			regex_flags |= REG_ICASE;
 		}
 		if ((error = regcomp(&reg, regex, regex_flags))) {
-			// TODO: Return stringified error message
-			cmdq_error(item, "unable to compile regular expression");
+			regerror(error, &reg, regex_error, sizeof(regex_error));
+			cmdq_error(item,
+			    "unable to compile regular expression: %s",
+			    regex_error);
 			return (NULL);
 		}
 	} else if (only_matching) {

--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 
+#include <regex.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -39,9 +40,9 @@ const struct cmd_entry cmd_capture_pane_entry = {
 	.name = "capture-pane",
 	.alias = "capturep",
 
-	.args = { "ab:CeE:JpPqS:t:", 0, 0 },
-	.usage = "[-aCeJpPq] " CMD_BUFFER_USAGE " [-E end-line] "
-		 "[-S start-line]" CMD_TARGET_PANE_USAGE,
+	.args = { "ab:CeE:iJopPr:qS:t:", 0, 0 },
+	.usage = "[-aCeJiopPq] " CMD_BUFFER_USAGE " [-E end-line] "
+		 "[-S start-line] " "[-r REGEX]" CMD_TARGET_PANE_USAGE,
 
 	.tflag = CMD_PANE,
 
@@ -98,11 +99,15 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	struct grid		*gd;
 	const struct grid_line	*gl;
 	struct grid_cell	*gc = NULL;
-	int			 n, with_codes, escape_c0, join_lines;
-	u_int			 i, sx, top, bottom, tmp;
-	char			*cause, *buf, *line;
-	const char		*Sflag, *Eflag;
+	int			 n, with_codes, error, escape_c0, join_lines;
+	u_int			 i, k, sx, top, bottom, tmp;
+	char			*cause, *buf, *line, *subset;
+	const char		*Sflag, *Eflag, *regex;
 	size_t			 linelen;
+	regex_t			 reg;
+	int			 regex_flags = REG_EXTENDED,
+				 only_matching = args_has(args, 'o');
+	regmatch_t		 match[1];
 
 	sx = screen_size_x(&wp->base);
 	if (args_has(args, 'a')) {
@@ -159,20 +164,55 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	escape_c0 = args_has(args, 'C');
 	join_lines = args_has(args, 'J');
 
+	if (join_lines && only_matching) {
+		cmdq_error(cmdq, "cannot use -o with -J");
+		return (NULL);
+	} else if ((regex = args_get(args, 'r'))) {
+		if (args_has(args, 'i')) {
+			regex_flags |= REG_ICASE;
+		}
+		if ((error = regcomp(&reg, regex, regex_flags))) {
+			// TODO: Return stringified error message
+			cmdq_error(cmdq, "unable to compile regular expression");
+			return (NULL);
+		}
+	} else if (only_matching) {
+		cmdq_error(cmdq, "cannot use -o without -r");
+		return (NULL);
+	}
+
 	buf = NULL;
 	for (i = top; i <= bottom; i++) {
 		line = grid_string_cells(gd, 0, i, sx, &gc, with_codes,
 		    escape_c0, !join_lines);
 		linelen = strlen(line);
 
-		buf = cmd_capture_pane_append(buf, len, line, linelen);
+		if (regex && regexec(&reg, line, only_matching ? 1 : 0, match, 0))
+			continue;
 
-		gl = grid_peek_line(gd, i);
-		if (!join_lines || !(gl->flags & GRID_LINE_WRAPPED))
-			buf[(*len)++] = '\n';
+		if (!regex || !only_matching) {
+			buf = cmd_capture_pane_append(buf, len, line, linelen);
+
+			gl = grid_peek_line(gd, i);
+			if (!join_lines || !(gl->flags & GRID_LINE_WRAPPED))
+				buf[(*len)++] = '\n';
+		} else if (only_matching) {
+			subset = line;
+			do {
+				linelen = match[0].rm_eo - match[0].rm_so;
+				buf = cmd_capture_pane_append(buf, len,
+				   subset + match[0].rm_so, linelen);
+				buf[(*len)++] = '\n';
+				subset += match[0].rm_eo;
+			} while (!regexec(&reg, subset, 1, match, REG_NOTBOL));
+		}
 
 		free(line);
 	}
+
+	if (regex)
+		regfree(&reg);
+
 	return (buf);
 }
 

--- a/tmux.1
+++ b/tmux.1
@@ -1252,9 +1252,10 @@ By default, it uses the format
 but a different format may be specified with
 .Fl F .
 .It Xo Ic capture-pane
-.Op Fl aepPqCJ
+.Op Fl aeiopPqCJ
 .Op Fl b Ar buffer-name
 .Op Fl E Ar end-line
+.Op Fl r Ar regex
 .Op Fl S Ar start-line
 .Op Fl t Ar target-pane
 .Xc
@@ -1275,6 +1276,16 @@ If
 .Fl e
 is given, the output includes escape sequences for text and background
 attributes.
+If
+.Fl r
+is given, the output will only include lines matching the given extended regular
+expression. The regular expression is case-sensitive unless
+.Fl i
+is given. Using
+.Fl o
+with
+.Fl r
+will cause only the matching parts of the text to be printed.
 .Fl C
 also escapes non-printable characters as octal \exxx.
 .Fl J


### PR DESCRIPTION
I have modified capture-pane to implement regular expression support. This is useful when searching for lines of text in scrollback buffers that have a lot of data in them but only a small subset of the data is of interest to the user. I'm not comfortable with autconf, so I have not made any changes to it. If you would like to merge this change, I would be happy to update the build system (if necessary) if you can provide some general guidance.