### PR TITLE
Make -N work as repeat count in non-mode

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -2219,7 +2219,7 @@ the
 .Sx WINDOWS AND PANES
 section.
 .Fl N
-specifies a repeat count to a copy mode command.
+specifies a repeat count (acts as a prefix for a copy mode command).
 .It Xo Ic send-prefix
 .Op Fl 2
 .Op Fl t Ar target-pane


### PR DESCRIPTION
Tries to solve #671 
e.g.
`bind-key -n C-o send -N 50 Up`
will result in Up being sent 50 times