### PR TITLE
Fix the cygwin tmux always creates new windows in HOME directory

### DIFF
--- a/window.c
+++ b/window.c
@@ -943,9 +943,9 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
 			fatal("execl failed");
 		}
 		if (ptr != NULL && *(ptr + 1) != '\0')
-			xasprintf(&argv0, "-%s", ptr + 1);
+			xasprintf(&argv0, "%s", ptr + 1);
 		else
-			xasprintf(&argv0, "-%s", wp->shell);
+			xasprintf(&argv0, "%s", wp->shell);
 		execl(wp->shell, argv0, (char *)NULL);
 		fatal("execl failed");
 	}


### PR DESCRIPTION
Verify the issue by using the command
```shell
$tmux new-session -s test -n test -c "/usr/bin"
```
in the cygwin environment, the '-c' option never work, the new window always go to the HOME directory. 

The issue is caused by the extra `-` added to the `argv0` in lines:
```c
xasprintf(&argv0, "-%s", ptr + 1);
```
and
```c
xasprintf(&argv0, "-%s", wp->shell);
```
The issue is only happen in the cygwin tmux, the macos and linux is ok for using the wrong `argv0`, Just wondering why the extra `-` is needed, is it a typo?