### PR TITLE
fixed compilation bug introduced with commit 2b0bc9f1c5f546e822009c231a1bb0e1a2d6711a

### DIFF
--- a/cmd-show-options.c
+++ b/cmd-show-options.c
@@ -20,7 +20,12 @@
 
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef HAVE_VIS
 #include <vis.h>
+#else
+#include "compat/vis.h"
+#endif
 
 #include "tmux.h"
 


### PR DESCRIPTION
This patch enables the compatibility mode for VIS and solves a compilation error arising in the latest version.

Error solved:
```
cmd-show-options.c:23:17: fatal error: vis.h: No such file or directory
compilation terminated.
Makefile:876: recipe for target 'cmd-show-options.o' failed
make: *** [cmd-show-options.o] Error 1
```

