### PR TITLE
configure: check for ncursesw as well

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,18 @@ PKG_CHECK_MODULES(
 	found_ncurses=no
 )
 if test "x$found_ncurses" = xno; then
+PKG_CHECK_MODULES(
+	LIBNCURSES,
+	ncursesw,
+	[
+		CPPFLAGS="$LIBNCURSES_CFLAGS $CPPFLAGS"
+		LIBS="$LIBNCURSES_LIBS $LIBS"
+		found_ncurses=yes
+	],
+	found_ncurses=no
+)
+fi
+if test "x$found_ncurses" = xno; then
 	# pkg-config didn't work, try ncurses.
 	AC_CHECK_LIB(
 		ncurses,
@@ -184,9 +196,11 @@ if test "x$found_ncurses" = xno; then
 		ncurses.h,
 		,
 		found_ncurses=no)
+	if test "x$found_ncurses" = xyes; then
+		LIBS="$LIBS -lncurses"
+	fi
 fi
 if test "x$found_ncurses" = xyes; then
-	LIBS="$LIBS -lncurses"
 	AC_DEFINE(HAVE_NCURSES_H)
 else
 	# No ncurses, try curses.


### PR DESCRIPTION
This makes tmux build on systems which only have _ncursesw_, which is ncurses with wide character support (built with `--enable-widec`). There may be room for improvement, but for now both ncurses and ncursesw are detected via pkgconfig reliably.