### PR TITLE
Simple handling of OSC 52 clipboard sharing

### DIFF
--- a/input.c
+++ b/input.c
@@ -22,6 +22,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <resolv.h> 
+
 #include "tmux.h"
 
 /*
@@ -106,6 +108,7 @@ static void	input_set_state(struct window_pane *,
 static void	input_reset_cell(struct input_ctx *);
 
 static void	input_osc_4(struct window_pane *, const char *);
+static void	input_osc_52(struct window_pane *, const char *);
 static void	input_osc_104(struct window_pane *, const char *);
 
 /* Transition entry/exit handlers. */
@@ -1862,6 +1865,9 @@ input_exit_osc(struct input_ctx *ictx)
 	case 4:
 		input_osc_4(ictx->wp, p);
 		break;
+	case 52:
+		input_osc_52(ictx->wp, p);
+		break;
 	case 12:
 		if (*p != '?') /* ? is colour request */
 			screen_set_cursor_colour(ictx->ctx.s, p);
@@ -2009,6 +2015,40 @@ input_osc_4(struct window_pane *wp, const char *p)
 bad:
 	log_debug("bad OSC 4: %s", p);
 	free(copy);
+}
+
+/* Handle the OSC 52 sequence for setting the tmux top clipboard.  Ignores all X-related multi-buffer information*/
+static void
+input_osc_52(struct window_pane *wp, const char *p)
+{
+	char		*end;
+	u_char		*out;
+	size_t		l;
+	int		outl;
+	struct screen_write_ctx	ctx;
+
+	if ((end = strchr(p, ';')) == NULL)
+		return;
+	end++;
+
+	if (*end == '\0')
+		return;
+	
+	l = (strlen(end) / 4) * 3;
+
+	out = xmalloc(l + 1);
+	outl = b64_pton(end, out, l);
+	
+	if (outl != -1) {
+		if (options_get_number(global_options, "set-clipboard")) {
+			screen_write_start(&ctx, wp, NULL);
+			screen_write_setselection(&ctx, out, outl);
+			screen_write_stop(&ctx);
+		}
+		paste_add(out, outl);
+	}
+	else
+		free(out);
 }
 
 /* Handle the OSC 104 sequence for unsetting (multiple) palette entries. */


### PR DESCRIPTION
A much simpler and stripped-down no-nonsense implementation of OSC 52 clipboard sharing.  

Please note that in order to get this to actually work, I did have to recompile my TERMINFO db and add the line:
`Ms=\E]52;%p1%s;%p2%s\007,`

I was unable to get it to work with terminal overrides in the tmux configuration.