### PR TITLE
add window name to break-pane

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -34,8 +34,8 @@ const struct cmd_entry cmd_break_pane_entry = {
 	.name = "break-pane",
 	.alias = "breakp",
 
-	.args = { "dPF:s:t:", 0, 0 },
-	.usage = "[-dP] [-F format] [-s src-pane] [-t dst-window]",
+	.args = { "dPF:n:s:t:", 0, 0 },
+	.usage = "[-dP] [-F format] [-n window-name] [-s src-pane] [-t dst-window]",
 
 	.sflag = CMD_PANE,
 	.tflag = CMD_WINDOW_INDEX,
@@ -78,9 +78,16 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	w = wp->window = window_create(dst_s->sx, dst_s->sy);
 	TAILQ_INSERT_HEAD(&w->panes, wp, entry);
 	w->active = wp;
-	name = default_window_name(w);
-	window_set_name(w, name);
-	free(name);
+
+	if ((name = (char *)args_get(args, 'n')) == NULL) {
+		name = default_window_name(w);
+		window_set_name(w, name);
+		free(name);
+	} else {
+		window_set_name(w, name);
+		options_set_number(w->options, "automatic-rename", 0);
+	}
+
 	layout_init(w, wp);
 	wp->flags |= PANE_CHANGED;
 

--- a/tmux.1
+++ b/tmux.1
@@ -1262,6 +1262,7 @@ Commands related to windows and panes are as follows:
 .It Xo Ic break-pane
 .Op Fl dP
 .Op Fl F Ar format
+.Op Fl n Ar window-name
 .Op Fl s Ar src-pane
 .Op Fl t Ar dst-window
 .Xc


### PR DESCRIPTION
Surprised that the break-pane command didn't give a way to name the window that gets created.  Not 100% positive this is the "right" way to do things, but it appears to work in my limited testing.