### PR TITLE
Add missing wchar.h header when enable-utf8proc(HAVE_UTF8PROC)

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -22,6 +22,7 @@
 
 #include <limits.h>
 #include <stdio.h>
+#include <wchar.h>
 
 #ifndef __GNUC__
 #define __attribute__(a)


### PR DESCRIPTION
Fix compile error when `--enable-utf8proc`.
The `utf8proc_{wcwidth,mbtowc,wctomb}` functions uses `wchar_t` type as its argument, but `wchar.h` header was not included.