### PR TITLE
reverting key table changes.

### DIFF
--- a/cmd-attach-session.c
+++ b/cmd-attach-session.c
@@ -98,6 +98,7 @@ cmd_attach_session(struct cmdq_item *item, int dflag, int rflag,
 			environ_update(s->options, c->environ, s->environ);
 
 		c->session = s;
+		server_client_set_key_table(c, NULL);
 		status_timer_start(c);
 		notify_client("client-session-changed", c);
 		session_update_activity(s, NULL);

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -277,6 +277,7 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 		} else if (c->session != NULL)
 			c->last_session = c->session;
 		c->session = s;
+		server_client_set_key_table(c, NULL);
 		status_timer_start(c);
 		notify_client("client-session-changed", c);
 		session_update_activity(s, NULL);

--- a/cmd-switch-client.c
+++ b/cmd-switch-client.c
@@ -108,6 +108,7 @@ cmd_switch_client_exec(struct cmd *self, struct cmdq_item *item)
 	if (c->session != NULL && c->session != s)
 		c->last_session = c->session;
 	c->session = s;
+	server_client_set_key_table(c, NULL);
 	status_timer_start(c);
 	session_update_activity(s, NULL);
 	gettimeofday(&s->last_attached_time, NULL);


### PR DESCRIPTION
Without clearing key tables for session switch, some configuration may lead to
undesired behavior after switching -- prefix indicator is on while not behaving
like prefix has been pressed, and one key event will be consumed silently.

Configuration that can reproduce such problematic behavior is in https://github.com/amosbird/tmuxconfig