### PR TITLE
compat: don't re-define program_invocation_short_name

### DIFF
--- a/compat/getprogname.c
+++ b/compat/getprogname.c
@@ -19,11 +19,10 @@
 #include "compat.h"
 
 #if defined(HAVE_PROGRAM_INVOCATION_SHORT_NAME)
+#include <errno.h>
 const char *
 getprogname(void)
 {
-	extern char	*program_invocation_short_name;
-
 	return (program_invocation_short_name);
 }
 #elif defined(HAVE___PROGNAME)


### PR DESCRIPTION
program_invocation_short_name is defined in errno.h, and its definition
can differ between the various C libraries: glibc defines it as:
    extern char *program_invocation_short_name;

while uClibc defines it as:
    extern const char *program_invocation_short_name;

So there is not simple solution to know the prototype.

But since it is defined in errno.h, there is no reason to try and define
it ourselves; let's just trust what the header provides.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>