### PR TITLE
Enhance osdep_get_name() on NetBSD

### DIFF
--- a/osdep-netbsd.c
+++ b/osdep-netbsd.c
@@ -85,13 +85,14 @@ osdep_get_name(int fd, __unused char *tty)
 	mib[1] = KERN_PROC2;
 	mib[2] = KERN_PROC_PGRP;
 	mib[4] = sizeof (*buf);
-	mib[5] = 0;
 
 retry:
+	mib[5] = 0;
+
 	if (sysctl(mib, __arraycount(mib), NULL, &len, NULL, 0) == -1)
 		return (NULL);
 
-	if ((newbuf = realloc(buf, len * sizeof (*buf))) == NULL)
+	if ((newbuf = realloc(buf, len)) == NULL)
 		goto error;
 	buf = newbuf;
 


### PR DESCRIPTION
Follow the cannonical solution to reset mib[5] for KERN_PROC2 calls to 0 to
retrieve the number of bytes required to allocate.

Don't overallocate buf, len is already in bytes.