### PR TITLE
Update README file for installing from version control

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ To get and build the latest from version control:
 	$ git clone https://github.com/tmux/tmux.git
 	$ cd tmux
 	$ sh autogen.sh
-	$ ./configure && make
+	$ ./configure && make install
 
 For more information see http://git-scm.com. Patches should be sent by email to
 the mailing list at tmux-users@googlegroups.com.


### PR DESCRIPTION
Instructions to get/build the latest from version control don't actually install tmux, but just build it. I ran the autogen and then ./configure && make and tmux wasn't installed.

So changed line to `./configure && make install` so that it's parallel to the instructions for building from a release tarball.