### PR TITLE
Fix changing directions in linewise copy mode

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -2038,7 +2038,7 @@ window_copy_cursor_down(struct window_pane *wp, int scroll_only)
 		data->lastsx = ox;
 	}
 
-	if (s->sel.lineflag == LINE_SEL_RIGHT_LEFT && oy == data->sely)
+	if (s->sel.lineflag == LINE_SEL_RIGHT_LEFT && oy == data->endsely)
 		window_copy_other_end(wp);
 
 	data->cx = data->lastcx;


### PR DESCRIPTION
Since commit 7e6c2cb23868, if I enter copy mode with select-line, move
the cursor up a few lines, then move the cursor down, the selection
grows from the bottom instead of shrinking from the top. This fixes
that condition.