### PR TITLE
tmux.c: TMPDIR for tmux sockets

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -143,7 +143,7 @@ session created, and continues to process the rest of the configuration file.
 .It Fl L Ar socket-name
 .Nm
 stores the server socket in a directory under
-.Ev TMUX_TMPDIR
+.Ev TMPDIR
 or
 .Pa /tmp
 if it is unset.

--- a/tmux.c
+++ b/tmux.c
@@ -118,7 +118,7 @@ make_label(const char *label)
 
 	uid = getuid();
 
-	if ((s = getenv("TMUX_TMPDIR")) != NULL && *s != '\0')
+	if ((s = getenv("TMPDIR")) != NULL && *s != '\0')
 		xasprintf(&base, "%s/tmux-%u", s, uid);
 	else
 		xasprintf(&base, "%s/tmux-%u", _PATH_TMP, uid);


### PR DESCRIPTION
After consulting the documentation, I saw that TMUX_TMPDIR was used to
prefix tmux sockets. This was a surprise, since I have TMPDIR set in my
environment. Curious, I consulted the git history. Quoting 3034a71488ce:

    Over the years, I have seen $TMPDIR set up worse than /tmp many
    times, and don't know how this practice infected other parts of the
    system.

As it is standard, return to using TMPDIR to store tmux sockets. Per the
standard, TMPDIR is "a directory made available for programs that need a
place to create temporary files". [IEEE Std 1003.1-2008, Sec 8.3]

Fixes: 3034a71488ce ("Let's see if anyone screams...")
Signed-off-by: Joe Konno <joe.konno@intel.com>