### PR TITLE
New 'monitor-activity-ignore-delay' option added

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -222,6 +222,9 @@ alerts_check_activity(struct window *w)
 {
 	struct winlink	*wl;
 	struct session	*s;
+	struct timeval	now;
+	struct timeval	tv;
+	u_int			delayms;
 
 	if (~w->flags & WINDOW_ACTIVITY)
 		return (0);
@@ -231,11 +234,19 @@ alerts_check_activity(struct window *w)
 	TAILQ_FOREACH(wl, &w->winlinks, wentry)
 		wl->session->flags &= ~SESSION_ALERTED;
 
+	gettimeofday(&now, NULL);
+
 	TAILQ_FOREACH(wl, &w->winlinks, wentry) {
 		if (wl->flags & WINLINK_ACTIVITY)
 			continue;
 		s = wl->session;
 		if (s->curw == wl)
+			continue;
+
+		timersub(&now, &wl->window->background_time, &tv);
+		delayms = options_get_number(wl->window->options, "monitor-activity-ignore-delay");
+
+		if ((tv.tv_sec * 1000) + (tv.tv_usec / 1000) < delayms)
 			continue;
 
 		wl->flags |= WINLINK_ACTIVITY;

--- a/options-table.c
+++ b/options-table.c
@@ -627,6 +627,14 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "monitor-activity-ignore-delay",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .minimum = 0,
+	  .maximum = INT_MAX,
+	  .default_num = 0
+	},
+
 	{ .name = "monitor-silence",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/session.c
+++ b/session.c
@@ -539,6 +539,9 @@ session_set_current(struct session *s, struct winlink *wl)
 	if (wl == s->curw)
 		return (1);
 
+	if ((s->curw != NULL) && (s->curw->window != NULL))
+		gettimeofday(&s->curw->window->background_time, NULL);
+
 	winlink_stack_remove(&s->lastw, wl);
 	winlink_stack_push(&s->lastw, s->curw);
 	s->curw = wl;

--- a/tmux.1
+++ b/tmux.1
@@ -3035,6 +3035,15 @@ option.
 Monitor for activity in the window.
 Windows with activity are highlighted in the status line.
 .Pp
+.It Xo Ic monitor-activity-ignore-delay
+.Op Ic interval
+.Xc
+When
+.Ic monitor-activity
+is enabled, activity that happens within the first
+.Ic interval
+milliseconds will be ignored.
+.Pp
 .It Xo Ic monitor-silence
 .Op Ic interval
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -803,6 +803,7 @@ struct window {
 
 	struct event	 alerts_timer;
 
+	struct timeval	 background_time;
 	struct timeval	 activity_time;
 
 	struct window_pane *active;

--- a/window.c
+++ b/window.c
@@ -311,6 +311,9 @@ window_create(u_int sx, u_int sy)
 	TAILQ_INIT(&w->panes);
 	w->active = NULL;
 
+	w->background_time.tv_sec = 0;
+	w->background_time.tv_usec = 0;
+
 	w->lastlayout = -1;
 	w->layout_root = NULL;
 


### PR DESCRIPTION
This is a pull request for a feature I found I needed for a particular use case, but I also understand that almost no one else might find it useful, so please feel free to ignore this pull request if you find this new functionality to be too obscure :)

A new parameter ("**monitor-activity-ignore-delay**") has been created that accepts a value (in milliseconds) and activity that takes place in a background window **before** the specified time (since the window changed from being the active one to its current background state) is ignored.

For example, let's say we set this value to "2000" (ie. "2 seconds") and we have a window that prints "hello" every 5 seconds. Under these conditions, if we change to another window on "second 1" after a "hello" is printed, the original window will be marked with the "activity flag" in 4 seconds (as expected). **However**, if we change to another window on "second 4" after "hello" is printed, the original window will be marked with the "activity flag" in **6 seconds** (1+5) instead of in 1 second (because there is a 2 seconds "ignore window")

Now let me explain why I needed this (in case it helps me convince you to accept this PR, hehe): I am using a vim mapping that calls a vimscript function which ends up invoking "tmux new-window". The thing is that it looks like vim, **after** executing this command (ie. after tmux changes to a new window) still writes a few extra characters to the terminal (they seem to be control sequences to reposition the cursor on the screen) which tmux rightfully detects as "new activity".
This means that **every time** I create a new tmux window from vim, the vim window is immediately marked with the "new activity" flag.
Thanks to the new parameter that this PR introduces, if I set it to, say, 100 ms, the problem disappears.