### PR TITLE
Remove getopt.h include

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -22,7 +22,6 @@
 #include <errno.h>
 #include <event.h>
 #include <fcntl.h>
-#include <getopt.h>
 #include <langinfo.h>
 #include <locale.h>
 #include <pwd.h>


### PR DESCRIPTION
'getopt()' is provided by `<unistd.h>`.  Including `<getop.h>` is not
necessary unless `getopt_long()` or `getopt_long_only()` are needed,
which are GNU extensions.

This allows compilation for non-GNU platforms (e.g., AIX).