### PR TITLE
freeing out variable before its reassignment.

### DIFF
--- a/status.c
+++ b/status.c
@@ -1554,6 +1554,7 @@ status_prompt_complete(struct session *session, const char *s)
 		out = status_prompt_complete_prefix(list, size);
 	if (out != NULL) {
 		xasprintf(&tmp, "-%c%s%s", copy[1], out, colon);
+		free(out);
 		out = tmp;
 	}
 

--- a/utf8.c
+++ b/utf8.c
@@ -68,7 +68,8 @@ utf8_open(struct utf8_data *ud, u_char ch)
 		ud->size = 4;
 	else
 		return (UTF8_ERROR);
-	utf8_append(ud, ch);
+	if (utf8_append(ud, ch) == UTF8_ERROR)
+		return (UTF8_ERROR);
 	return (UTF8_MORE);
 }
 


### PR DESCRIPTION
controlling eventually 'optimistic' utf8_append return.