### PR TITLE
Fixed the way ANSI sequences are constructed

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -678,6 +678,7 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 	u_int	attr = gc->attr;
 	u_int	lastattr = lastgc->attr;
 	char	tmp[64];
+	int	attrchanged = 0;
 
 	struct {
 		u_int	mask;
@@ -699,27 +700,31 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 		if (!(attr & attrs[i].mask) && (lastattr & attrs[i].mask)) {
 			s[n++] = 0;
 			lastattr &= GRID_ATTR_CHARSET;
+			attrchanged = 1;
 			break;
 		}
 	}
 	/* For each attribute that is newly set, add its code. */
 	for (i = 0; i < nitems(attrs); i++) {
 		if ((attr & attrs[i].mask) && !(lastattr & attrs[i].mask))
+		{
 			s[n++] = attrs[i].code;
+			attrchanged = 1;
+		}
 	}
 
-	/* If the foreground colour changed, append its parameters. */
+	/* If the foreground colour or the attributes changed, append the colour's parameters. */
 	nnewc = grid_string_cells_fg(gc, newc);
 	noldc = grid_string_cells_fg(lastgc, oldc);
-	if (nnewc != noldc || memcmp(newc, oldc, nnewc * sizeof newc[0]) != 0) {
+	if (nnewc != noldc || memcmp(newc, oldc, nnewc * sizeof newc[0]) != 0 || attrchanged == 1) {
 		for (i = 0; i < nnewc; i++)
 			s[n++] = newc[i];
 	}
 
-	/* If the background colour changed, append its parameters. */
+	/* If the background colour or the attributes changed, append the colour's parameters. */
 	nnewc = grid_string_cells_bg(gc, newc);
 	noldc = grid_string_cells_bg(lastgc, oldc);
-	if (nnewc != noldc || memcmp(newc, oldc, nnewc * sizeof newc[0]) != 0) {
+	if (nnewc != noldc || memcmp(newc, oldc, nnewc * sizeof newc[0]) != 0 || attrchanged == 1) {
 		for (i = 0; i < nnewc; i++)
 			s[n++] = newc[i];
 	}


### PR DESCRIPTION
ANSI sequences are now OK when changing attributes/colors.

Before
======

Server:
![server-master](https://cloud.githubusercontent.com/assets/3536628/25381586/a43f7d50-29b4-11e7-86f9-e92c9561d0f5.png)
Captured buffer:
![client-master](https://cloud.githubusercontent.com/assets/3536628/25381587/a4450e1e-29b4-11e7-83ac-de60cddade71.png)

After
=====

Server:
![server-kibos1er](https://cloud.githubusercontent.com/assets/3536628/25381584/a43effb0-29b4-11e7-8bd5-8e6f38ea9931.png)
Captured buffer:
![client-kibos1er](https://cloud.githubusercontent.com/assets/3536628/25381585/a43f3d40-29b4-11e7-8fb6-bd025b465011.png)
