### PR TITLE
Make man page to show the right value

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -3199,7 +3199,7 @@ will generate
 .Xr xterm 1 -style
 function key sequences; these have a number included to indicate modifiers such
 as Shift, Alt or Ctrl.
-The default is off.
+The default is on.
 .El
 .It Xo Ic show-options
 .Op Fl gqsvw


### PR DESCRIPTION
The [CHANGES][] says the default value has been changed for `xterm-keys`. This fixes the man page for this.

[CHANGES]: https://github.com/tmux/tmux/blob/e4b4125310b27ef8e33f7652eb5f96fe7e362515/CHANGES#L39-L39