### PR TITLE
screen_write_combine: Fix off-by-one error for leftmost col

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -1316,12 +1316,14 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct utf8_data *ud,
 		fatalx("UTF-8 data empty");
 
 	/* Retrieve the previous cell. */
-	for (n = 1; n < s->cx; n++) {
+	n = 1;
+	do {
 		grid_view_get_cell(gd, s->cx - n, s->cy, &gc);
 		if (~gc.flags & GRID_FLAG_PADDING)
 			break;
-	}
-	if (n == s->cx)
+		n++;
+	} while (n <= s->cx);
+	if (n > s->cx)
 		return (NULL);
 	*xx = s->cx - n;
 


### PR DESCRIPTION
Here's an attempt at a minimal diff to allow combining characters to be applied to characters in the leftmost cell. (Fixes #898 and fixes mobile-shell/mosh#879)