### PR TITLE
Allow user-defined escape sequences for keys

### DIFF
--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -240,6 +240,12 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 		TAILQ_FOREACH(loop, &clients, entry)
 			server_client_set_key_table(loop, NULL);
 	}
+	if (strcmp(name, "user-keys") == 0) {
+		TAILQ_FOREACH(loop, &clients, entry) {
+			if (loop->tty.flags & TTY_OPENED)
+				tty_keys_build(&loop->tty);
+		}
+	}
 	if (strcmp(name, "status") == 0 ||
 	    strcmp(name, "status-interval") == 0)
 		status_timer_start_all();

--- a/key-string.c
+++ b/key-string.c
@@ -110,12 +110,17 @@ static const struct {
 static key_code
 key_string_search_table(const char *string)
 {
-	u_int	i;
+	u_int	i, user_idx;
 
 	for (i = 0; i < nitems(key_string_table); i++) {
 		if (strcasecmp(string, key_string_table[i].string) == 0)
 			return (key_string_table[i].key);
 	}
+
+	if (sscanf(string, "User%d", &user_idx) == 1)
+		if (user_idx < KEYC_NUSER)
+			return (KEYC_USER + user_idx);
+
 	return (KEYC_UNKNOWN);
 }
 
@@ -265,6 +270,10 @@ key_string_lookup_key(key_code key)
 		return ("MouseMoveStatus");
 	if (key == KEYC_MOUSEMOVE_BORDER)
 		return ("MouseMoveBorder");
+	if (key >= KEYC_USER && key < KEYC_USER + KEYC_NUSER) {
+		snprintf(out, sizeof(out), "User%d", (u_int)(key - KEYC_USER));
+		return (out);
+	}
 
 	/*
 	 * Special case: display C-@ as C-Space. Could do this below in

--- a/options-table.c
+++ b/options-table.c
@@ -731,6 +731,13 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "user-keys",
+	  .type = OPTIONS_TABLE_ARRAY,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_str = "",
+	  .separator = " "
+	},
+
 	{ .name = "window-active-style",
 	  .type = OPTIONS_TABLE_STYLE,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/tmux.1
+++ b/tmux.1
@@ -2867,6 +2867,17 @@ removed from the session environment (as if
 was given to the
 .Ic set-environment
 command).
+.It Ic user-keys[] Ar variable
+Set list of user-defined escape sequences for the terminals. These will be
+be associated with keys named 'User<index>', and can be used with the
+.Fl bind
+command.
+.Pp
+For example:
+.Bd -literal -offset indent
+set -s user-keys[0] '\e[5;30012~'
+bind User0 resize-pane -L 3
+.Ed
 .It Xo Ic visual-activity
 .Op Ic on | off
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -91,6 +91,8 @@ struct tmuxproc;
 #define KEYC_NONE 0xffff00000000ULL
 #define KEYC_UNKNOWN 0xfffe00000000ULL
 #define KEYC_BASE 0x000010000000ULL
+#define KEYC_USER 0x000020000000ULL
+#define KEYC_NUSER 1000
 
 /* Key modifier bits. */
 #define KEYC_ESCAPE 0x200000000000ULL

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -391,6 +391,9 @@ tty_keys_build(struct tty *tty)
 	const struct tty_default_key_code	*tdkc;
 	u_int		 			 i;
 	const char				*s;
+	const char				*value;
+	u_int					size;
+	struct options_entry			*o;
 
 	if (tty->key_tree != NULL)
 		tty_keys_free(tty);
@@ -410,6 +413,17 @@ tty_keys_build(struct tty *tty)
 		if (*s != '\0')
 			tty_keys_add(tty, s, tdkc->key);
 
+	}
+
+	o = options_get(global_options, "user-keys");
+	if (o == NULL || options_array_size(o, &size) == -1)
+		return;
+	for (i = 0; i < size; i++) {
+		value = options_array_get(o, i);
+		if (value == NULL)
+			continue;
+
+		tty_keys_add(tty, value, KEYC_USER + i);
 	}
 }
 


### PR DESCRIPTION
These days in other terminal programs such as Zsh and Vim, it is possible to bind arbitrary escape sequences to actions. While tmux allows to pass right throught from the terminal program,
bindings them to tmux itself requires editing terminfo entries.

For example, consider an addition of a key binding for Ctrl-Shift-[, which is by default indistinguishable from Ctrl-[. one can modify terminal program settings such as the one of rxvt via the `Xdefaults` file:

    URxvt.keysym.C-braceleft      : \033[5;30012~

And then add the same bindings in `.tmux.conf`:

    define-key "\e[5;30012~" C-braceleft
    bind-key -n C-braceleft resize-pane -L 3