### PR TITLE
Try C.UTF-8 locale if en_US.UTF-8 isn't usable

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -193,7 +193,8 @@ main(int argc, char **argv)
 	int					 opt, flags, keys;
 	const struct options_table_entry	*oe;
 
-	if (setlocale(LC_CTYPE, "en_US.UTF-8") == NULL) {
+	if (setlocale(LC_CTYPE, "en_US.UTF-8") == NULL &&
+	    setlocale(LC_CTYPE, "C.UTF-8") == NULL) {
 		if (setlocale(LC_CTYPE, "") == NULL)
 			errx(1, "invalid LC_ALL, LC_CTYPE or LANG");
 		s = nl_langinfo(CODESET);


### PR DESCRIPTION
The en_US.UTF-8 locale may not always be usable on Linux, either because
the locales package isn't installed or because the user uses
another locale. However, modern distributions (at least Debian and
derivatives, and Fedora and derivatives) provide a fallback C.UTF-8
locale that is guaranteed to always be present and work, so try that if
en_US.UTF-8 isn't available.