### PR TITLE
correct the shortcut of window splitting

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -254,13 +254,13 @@ Suspend the
 client.
 .It !
 Break the current pane out of the window.
-.It \&"
+.It %
 Split the current pane into two, top and bottom.
 .It #
 List all paste buffers.
 .It $
 Rename the current session.
-.It %
+.It \&"
 Split the current pane into two, left and right.
 .It &
 Kill the current window.


### PR DESCRIPTION
fix the issue: https://github.com/tmux/tmux/pull/999
the `"` should split vertically, and `%` should split horizontally!
Not sure whether this is a correct fix or not.
