### PR TITLE
Fix failure to update old content at end of line.

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -885,7 +885,7 @@ tty_draw_line(struct tty *tty, const struct window_pane *wp,
 	u_int			 i, j, sx, nx, width;
 	int			 flags, cleared = 0;
 	char			 buf[512];
-	size_t			 len, old_len;
+	size_t			 len;
 
 	flags = (tty->flags & TTY_NOCURSOR);
 	tty->flags |= TTY_NOCURSOR;
@@ -973,17 +973,8 @@ tty_draw_line(struct tty *tty, const struct window_pane *wp,
 		}
 	}
 	if (len != 0) {
-		if (grid_cells_equal(&last, &grid_default_cell)) {
-			old_len = len;
-			while (len > 0 && buf[len - 1] == ' ')
-				len--;
-			log_debug("%s: trimmed %zu spaces", __func__,
-			    old_len - len);
-		}
-		if (len != 0) {
-			tty_attributes(tty, &last, wp);
-			tty_putn(tty, buf, len, width);
-		}
+		tty_attributes(tty, &last, wp);
+		tty_putn(tty, buf, len, width);
 	}
 
 	nx = screen_size_x(s) - sx;


### PR DESCRIPTION
In the latest tmux commit 26db50d6df220afc4530d379e81acf9010ae02d8, when a short line should replace a long line on the screen, old content from the end of the long line often sticks around on the right side of the screen, instead of getting erased like it should.

Actions affected by this bug include:
- scrolling with page-up and page-down in `copy-mode-vi`
- switching between tmux windows using the shortcuts for `previous-window` and `next-window`
- quitting vim

Affected terminal emulators and platforms include:
- thestinger/termite@d87e7c8269718f8408b80e31a7d5655b259cbf7a with thestinger/vte-ng@d5149e91e8670b06716cdbd7ba425297f4454723 on Arch Linux
- [ConnectBot v1.9.2](https://play.google.com/store/apps/details?id=org.connectbot) on Android 6.0, served by [OpenSSH 7.5p1](https://www.openssh.com/portable.html) on Arch Linux

It appears this bug was caused by commit 8c6ad5532076254ec138f9b598b41d035bdf68e7. Reverting that commit has fixed the bug on my systems.