### PR TITLE
Add 'delay' option to 'display-panes'

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -72,19 +72,20 @@ server_client_callback_identify(__unused int fd, __unused short events,
 
 /* Set identify mode on client. */
 void
-server_client_set_identify(struct client *c)
+server_client_set_identify(struct client *c, int delay)
 {
 	struct timeval	tv;
-	int		delay;
-
-	delay = options_get_number(c->session->options, "display-panes-time");
+	if (delay < 0)
+		delay = options_get_number(c->session->options, "display-panes-time");
 	tv.tv_sec = delay / 1000;
 	tv.tv_usec = (delay % 1000) * 1000L;
 
-	if (event_initialized(&c->identify_timer))
-		evtimer_del(&c->identify_timer);
-	evtimer_set(&c->identify_timer, server_client_callback_identify, c);
-	evtimer_add(&c->identify_timer, &tv);
+	if (delay > 0) {
+		if (event_initialized(&c->identify_timer))
+			evtimer_del(&c->identify_timer);
+		evtimer_set(&c->identify_timer, server_client_callback_identify, c);
+		evtimer_add(&c->identify_timer, &tv);
+	}
 
 	c->flags |= CLIENT_IDENTIFY;
 	c->tty.flags |= (TTY_FREEZE|TTY_NOCURSOR);

--- a/tmux.1
+++ b/tmux.1
@@ -1465,6 +1465,7 @@ specifies the format for each item in the tree.
 This command works only if at least one client is attached.
 .It Xo
 .Ic display-panes
+.Op Fl d Ar duration
 .Op Fl t Ar target-client
 .Op Ar template
 .Xc
@@ -1472,11 +1473,15 @@ This command works only if at least one client is attached.
 Display a visible indicator of each pane shown by
 .Ar target-client .
 See the
-.Ic display-panes-time ,
-.Ic display-panes-colour ,
+.Ic display-panes-colour
 and
 .Ic display-panes-active-colour
 session options.
+The indicator is shown for
+.Ar duration ,
+defaulting to
+.Ic display-panes-time
+if not specified. A value of 0 indicates that it will be shown forever.
 While the indicator is on screen, a pane may be chosen with the
 .Ql 0
 to

--- a/tmux.h
+++ b/tmux.h
@@ -1874,7 +1874,7 @@ void	 server_add_accept(int);
 
 /* server-client.c */
 u_int	 server_client_how_many(void);
-void	 server_client_set_identify(struct client *);
+void	 server_client_set_identify(struct client *, int delay);
 void	 server_client_clear_identify(struct client *, struct window_pane *);
 void	 server_client_set_key_table(struct client *, const char *);
 const char *server_client_get_key_table(struct client *);


### PR DESCRIPTION
This PR adds a `-d` option to the `display-panes` command, allowing you to override `display-panes-time`. This gives you the ability to use `display-panes` with different timeout values. One possible use case is to have a long delay for picking panes (to mark them or to switch to them), and a very short delay for identifying them, which could be combined with movement commands to quickly identify the pane you have moved to.

Additionally, it changes the meaning of a delay of 0. Previously, the indicators would simply never be shown. This changes it to mean that the indicators should be displayed until further input.
