### PR TITLE
Allow multiple bells in non-current windows.

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -169,8 +169,6 @@ alerts_check_bell(struct window *w)
 		wl->session->flags &= ~SESSION_ALERTED;
 
 	TAILQ_FOREACH(wl, &w->winlinks, wentry) {
-		if (wl->flags & WINLINK_BELL)
-			continue;
 		s = wl->session;
 		if (s->curw != wl) {
 			wl->flags |= WINLINK_BELL;


### PR DESCRIPTION
Allow multiple bells in non-current windows. Without this, a bell can sound only once in non-current windows.