### PR TITLE
Fix search when the match is at the end of the line.

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -1001,7 +1001,7 @@ window_copy_search_lr(struct grid *gd,
 	int	matched;
 
 	for (ax = first; ax < last; ax++) {
-		if (ax + sgd->sx >= gd->sx)
+		if (ax + sgd->sx > gd->sx)
 			break;
 		for (bx = 0; bx < sgd->sx; bx++) {
 			px = ax + bx;


### PR DESCRIPTION
Fix search when the match is at the end of the line. Fixes `search-forward` (finding and highlighting) and `search-backward` (highlighting).