### PR TITLE
CHANGES: fix search-backward-incremental example

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -210,7 +210,7 @@ Incompatible Changes
   and history is now used for searching, jumping, and so on instead of a custom
   one. The default C-r binding is now:
 
-    bind -Tcopy-mode C-r command-prompt -p'search up' "send -X search-backward-incremental '%%'"
+    bind -Tcopy-mode C-r command-prompt -i -p'search up' "send -X search-backward-incremental '%%'"
 
   There are also some new commmands available with send -X, such as
   copy-pipe-and-cancel.


### PR DESCRIPTION
`search-backward-incremental` doesn't work with `command-prompt` unless the `-i` option is given in order to re-run the `search-backward-incremental` command each time a key is pressed.