### PR TITLE
Fix memory leaks in history clearing with BCE

### DIFF
--- a/grid-view.c
+++ b/grid-view.c
@@ -75,7 +75,7 @@ grid_view_clear_history(struct grid *gd, u_int bg)
 
 	/* Scroll the lines into the history. */
 	for (yy = 0; yy < last; yy++) {
-		grid_collect_history(gd, bg);
+		grid_collect_history(gd);
 		grid_scroll_history(gd, bg);
 	}
 	if (last < gd->sy)
@@ -100,7 +100,7 @@ grid_view_scroll_region_up(struct grid *gd, u_int rupper, u_int rlower,
     u_int bg)
 {
 	if (gd->flags & GRID_HISTORY) {
-		grid_collect_history(gd, bg);
+		grid_collect_history(gd);
 		if (rupper == 0 && rlower == gd->sy - 1)
 			grid_scroll_history(gd, bg);
 		else {

--- a/grid.c
+++ b/grid.c
@@ -233,7 +233,7 @@ grid_compare(struct grid *ga, struct grid *gb)
  * and shift up.
  */
 void
-grid_collect_history(struct grid *gd, u_int bg)
+grid_collect_history(struct grid *gd)
 {
 	u_int	yy;
 
@@ -244,7 +244,7 @@ grid_collect_history(struct grid *gd, u_int bg)
 	if (yy < 1)
 		yy = 1;
 
-	grid_move_lines(gd, 0, yy, gd->hsize + gd->sy - yy, bg);
+	grid_move_lines(gd, 0, yy, gd->hsize + gd->sy - yy, 8);
 	gd->hsize -= yy;
 	if (gd->hscrolled > gd->hsize)
 		gd->hscrolled = gd->hsize;

--- a/tmux.h
+++ b/tmux.h
@@ -1975,7 +1975,7 @@ int	 grid_cells_equal(const struct grid_cell *, const struct grid_cell *);
 struct grid *grid_create(u_int, u_int, u_int);
 void	 grid_destroy(struct grid *);
 int	 grid_compare(struct grid *, struct grid *);
-void	 grid_collect_history(struct grid *, u_int);
+void	 grid_collect_history(struct grid *);
 void	 grid_scroll_history(struct grid *, u_int);
 void	 grid_scroll_history_region(struct grid *, u_int, u_int, u_int);
 void	 grid_clear_history(struct grid *);


### PR DESCRIPTION
When history contains lines that utilize BCE, their line data is not being properly freed when history lines are being moved. This change fixes this memory leak.

The problem is reproduced with current tmux master branch. To reproduce the issue, I have a large file containing ANSI codes that I can`cat` multiple times while observing tmux server's memory usage growing indefinitely, even when the history limit is small.