### PR TITLE
Compact line's grid extended data when it enters history

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -94,6 +94,49 @@ grid_need_extended_cell(const struct grid_cell_entry *gce,
 	return (0);
 }
 
+/* Free up unused grid_cells. */
+static void
+grid_compact_line(struct grid_line *gl)
+{
+	int			new_extdsize = 0;
+	struct grid_cell	*new_extddata;
+	struct grid_cell_entry	*gce;
+	struct grid_cell	*gc;
+	u_int			px, extd_i;
+
+	if (gl->extdsize == 0)
+		return;
+
+	for (px = 0; px < gl->cellsize; px++) {
+		gce = &gl->celldata[px];
+		if (gce->flags & GRID_FLAG_EXTENDED)
+			new_extdsize += 1;
+	}
+
+	if (new_extdsize == 0) {
+		free(gl->extddata);
+		gl->extddata = NULL;
+		gl->extdsize = 0;
+		return;
+	}
+
+	new_extddata = xreallocarray(NULL, new_extdsize, sizeof *gl->extddata);
+
+	extd_i = 0;
+	for (px = 0; px < gl->cellsize; px++) {
+		gce = &gl->celldata[px];
+		if (gce->flags & GRID_FLAG_EXTENDED) {
+			gc = &gl->extddata[gce->offset];
+			memcpy(&new_extddata[extd_i], gc, sizeof *gc);
+			gce->offset = extd_i++;
+		}
+	}
+
+	free(gl->extddata);
+	gl->extddata = new_extddata;
+	gl->extdsize = new_extdsize;
+}
+
 /* Set cell as extended. */
 static struct grid_cell *
 grid_extended_cell(struct grid_line *gl, struct grid_cell_entry *gce,
@@ -285,6 +328,7 @@ grid_scroll_history(struct grid *gd, u_int bg)
 	grid_empty_line(gd, yy, bg);
 
 	gd->hscrolled++;
+	grid_compact_line(&gd->linedata[gd->hsize]);
 	gd->hsize++;
 }
 


### PR DESCRIPTION
When working with a 50,000 line history, heavy with 24-bit color ANSI, I grew suspicious noticing the memory resident size of the tmux being 1.6GB. Some debugging discovered that the `extdsize` of many history lines was much greater than their `cellsize`. Regardless of the cause of that, this commit makes sure that the history's memory usage is kept closer to the optimum. After this fix, the memory resident size
of tmux under the same 50,000 line history scenario dropped down to 170MB.