### PR TITLE
Reset window name or pane title when attempting to rename/retitle using invalid UTF-8

### DIFF
--- a/input.c
+++ b/input.c
@@ -1956,8 +1956,10 @@ input_exit_osc(struct input_ctx *ictx)
 	case 2:
 		if (utf8_isvalid(p)) {
 			screen_set_title(ictx->ctx.s, p);
-			server_status_window(ictx->wp->window);
+		} else {
+			screen_set_title(ictx->ctx.s, NULL);
 		}
+		server_status_window(ictx->wp->window);
 		break;
 	case 4:
 		input_osc_4(ictx->wp, p);
@@ -2007,9 +2009,11 @@ input_exit_apc(struct input_ctx *ictx)
 		return;
 	log_debug("%s: \"%s\"", __func__, ictx->input_buf);
 
-	if (!utf8_isvalid(ictx->input_buf))
-		return;
-	screen_set_title(ictx->ctx.s, ictx->input_buf);
+	if (utf8_isvalid(ictx->input_buf)) {
+		screen_set_title(ictx->ctx.s, ictx->input_buf);
+	} else {
+		screen_set_title(ictx->ctx.s, NULL);
+	}
 	server_status_window(ictx->wp->window);
 }
 
@@ -2034,10 +2038,15 @@ input_exit_rename(struct input_ctx *ictx)
 		return;
 	log_debug("%s: \"%s\"", __func__, ictx->input_buf);
 
-	if (!utf8_isvalid(ictx->input_buf))
-		return;
-	window_set_name(ictx->wp->window, ictx->input_buf);
-	options_set_number(ictx->wp->window->options, "automatic-rename", 0);
+	if (utf8_isvalid(ictx->input_buf)) {
+		window_set_name(ictx->wp->window, ictx->input_buf);
+		options_set_number(ictx->wp->window->options,
+		    "automatic-rename", 0);
+	} else {
+		window_set_name(ictx->wp->window, NULL);
+		options_set_number(ictx->wp->window->options,
+		    "automatic-rename", 1);
+	}
 	server_status_window(ictx->wp->window);
 }
 

--- a/names.c
+++ b/names.c
@@ -22,6 +22,7 @@
 #include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "tmux.h"
 
@@ -101,6 +102,16 @@ check_window_name(struct window *w)
 		log_debug("@%u name not changed (still %s)", w->id, w->name);
 
 	free(name);
+}
+
+char *
+default_pane_title()
+{
+	char	host[HOST_NAME_MAX + 1];
+
+	if (gethostname(host, sizeof host) == 0)
+		return xstrdup(host);
+        return xstrdup("");
 }
 
 char *

--- a/screen.c
+++ b/screen.c
@@ -107,7 +107,11 @@ void
 screen_set_title(struct screen *s, const char *title)
 {
 	free(s->title);
-	utf8_stravis(&s->title, title, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
+	if (title != NULL) {
+		utf8_stravis(&s->title, title, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
+	} else {
+		s->title = default_pane_title();
+	}
 }
 
 /* Resize screen. */

--- a/tmux.h
+++ b/tmux.h
@@ -2269,6 +2269,7 @@ void		 window_copy_add_formats(struct window_pane *,
 
 /* names.c */
 void	 check_window_name(struct window *);
+char	*default_pane_title(void);
 char	*default_window_name(struct window *);
 char	*parse_window_name(const char *);
 

--- a/window.c
+++ b/window.c
@@ -425,7 +425,10 @@ void
 window_set_name(struct window *w, const char *new_name)
 {
 	free(w->name);
-	utf8_stravis(&w->name, new_name, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
+	if (new_name != NULL)
+		utf8_stravis(&w->name, new_name, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
+	else
+		w->name = default_window_name(w);
 	notify_window("window-renamed", w);
 }
 
@@ -795,7 +798,6 @@ static struct window_pane *
 window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 {
 	struct window_pane	*wp;
-	char			 host[HOST_NAME_MAX + 1];
 
 	wp = xcalloc(1, sizeof *wp);
 	wp->window = w;
@@ -835,8 +837,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 
 	screen_init(&wp->status_screen, 1, 1, 0);
 
-	if (gethostname(host, sizeof host) == 0)
-		screen_set_title(&wp->base, host);
+	screen_set_title(&wp->base, NULL);
 
 	input_init(wp);
 


### PR DESCRIPTION
Since the user can change the window name and pane title using escape sequences, it'd be nice to have a way to go back to the defaults using a similar method. This gives the user a way to change the window name and pane title back to their defaults using escape sequences (any non–UTF-8 name/title). For example, this would allow a terminfo entry to specify `dsl=\E]0;\377\E\\` to reset it.