### PR TITLE
Add xterm-like stack for pane titles

### DIFF
--- a/input.c
+++ b/input.c
@@ -1667,7 +1667,6 @@ input_csi_dispatch_winops(struct input_ctx *ictx)
 {
 	struct window_pane	*wp = ictx->wp;
 	int			 n, m;
-	struct title_entry	*title_entry;
 
 	m = 0;
 	while ((n = input_get(ictx, m, 0, -1)) != -1) {
@@ -1704,10 +1703,7 @@ input_csi_dispatch_winops(struct input_ctx *ictx)
 				return;
 			case 0:
 			case 2:
-				title_entry = xmalloc(sizeof *title_entry);
-				title_entry->text = xstrdup(ictx->ctx.s->title);
-				TAILQ_INSERT_HEAD(&ictx->wp->titles,
-				    title_entry, entry);
+				screen_push_title(ictx->ctx.s);
 				break;
 			}
 			break;
@@ -1718,15 +1714,8 @@ input_csi_dispatch_winops(struct input_ctx *ictx)
 				return;
 			case 0:
 			case 2:
-				title_entry = TAILQ_FIRST(&ictx->wp->titles);
-				if (title_entry) {
-					TAILQ_REMOVE(&ictx->wp->titles,
-					    title_entry, entry);
-					screen_set_title(ictx->ctx.s,
-					    title_entry->text);
-					server_status_window(ictx->wp->window);
-					free(title_entry);
-				}
+				screen_pop_title(ictx->ctx.s);
+				server_status_window(ictx->wp->window);
 				break;
 			}
 			break;

--- a/tmux.h
+++ b/tmux.h
@@ -664,6 +664,7 @@ struct screen_sel {
 };
 
 /* Virtual screen. */
+struct screen_title_entry;
 struct screen {
 	char			*title;
 
@@ -683,6 +684,8 @@ struct screen {
 	bitstr_t		*tabs;
 
 	struct screen_sel	 sel;
+
+	struct screen_titles	*titles;
 };
 
 /* Screen write context. */
@@ -750,13 +753,6 @@ struct window_choose_data {
 
 	char			*command;
 };
-
-struct title_entry {
-	char				*text;
-
-	TAILQ_ENTRY(title_entry)	 entry;
-};
-TAILQ_HEAD(titles, title_entry);
 
 /* Child window structure. */
 struct window_pane {
@@ -830,8 +826,6 @@ struct window_pane {
 	time_t		 modelast;
 	u_int		 modeprefix;
 	char		*searchstr;
-
-	struct titles	 titles;
 
 	TAILQ_ENTRY(window_pane) entry;
 	RB_ENTRY(window_pane) tree_entry;
@@ -2095,6 +2089,8 @@ void	 screen_reset_tabs(struct screen *);
 void	 screen_set_cursor_style(struct screen *, u_int);
 void	 screen_set_cursor_colour(struct screen *, const char *);
 void	 screen_set_title(struct screen *, const char *);
+void	 screen_push_title(struct screen *);
+void	 screen_pop_title(struct screen *);
 void	 screen_resize(struct screen *, u_int, u_int, int);
 void	 screen_set_selection(struct screen *,
 	     u_int, u_int, u_int, u_int, u_int, struct grid_cell *);

--- a/tmux.h
+++ b/tmux.h
@@ -664,7 +664,7 @@ struct screen_sel {
 };
 
 /* Virtual screen. */
-struct screen_title_entry;
+struct screen_titles;
 struct screen {
 	char			*title;
 

--- a/tmux.h
+++ b/tmux.h
@@ -751,6 +751,13 @@ struct window_choose_data {
 	char			*command;
 };
 
+struct title_entry {
+	char				*text;
+
+	TAILQ_ENTRY(title_entry)	 entry;
+};
+TAILQ_HEAD(titles, title_entry);
+
 /* Child window structure. */
 struct window_pane {
 	u_int		 id;
@@ -823,6 +830,8 @@ struct window_pane {
 	time_t		 modelast;
 	u_int		 modeprefix;
 	char		*searchstr;
+
+	struct titles	 titles;
 
 	TAILQ_ENTRY(window_pane) entry;
 	RB_ENTRY(window_pane) tree_entry;

--- a/window.c
+++ b/window.c
@@ -828,6 +828,8 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 
 	wp->saved_grid = NULL;
 
+	TAILQ_INIT(&wp->titles);
+
 	memcpy(&wp->colgc, &grid_default_cell, sizeof wp->colgc);
 
 	screen_init(&wp->base, sx, sy, hlimit);
@@ -846,6 +848,8 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 static void
 window_pane_destroy(struct window_pane *wp)
 {
+	struct title_entry	*title_entry;
+
 	window_pane_reset_mode(wp);
 	free(wp->searchstr);
 
@@ -872,6 +876,12 @@ window_pane_destroy(struct window_pane *wp)
 		event_del(&wp->resize_timer);
 
 	RB_REMOVE(window_pane_tree, &all_window_panes, wp);
+
+	while ((title_entry = TAILQ_FIRST(&wp->titles)) != NULL) {
+		TAILQ_REMOVE(&wp->titles, title_entry, entry);
+		free(title_entry->text);
+		free(title_entry);
+	}
 
 	free((void *)wp->cwd);
 	free(wp->shell);

--- a/window.c
+++ b/window.c
@@ -828,8 +828,6 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 
 	wp->saved_grid = NULL;
 
-	TAILQ_INIT(&wp->titles);
-
 	memcpy(&wp->colgc, &grid_default_cell, sizeof wp->colgc);
 
 	screen_init(&wp->base, sx, sy, hlimit);
@@ -848,8 +846,6 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 static void
 window_pane_destroy(struct window_pane *wp)
 {
-	struct title_entry	*title_entry;
-
 	window_pane_reset_mode(wp);
 	free(wp->searchstr);
 
@@ -876,12 +872,6 @@ window_pane_destroy(struct window_pane *wp)
 		event_del(&wp->resize_timer);
 
 	RB_REMOVE(window_pane_tree, &all_window_panes, wp);
-
-	while ((title_entry = TAILQ_FIRST(&wp->titles)) != NULL) {
-		TAILQ_REMOVE(&wp->titles, title_entry, entry);
-		free(title_entry->text);
-		free(title_entry);
-	}
 
 	free((void *)wp->cwd);
 	free(wp->shell);


### PR DESCRIPTION
Add xterm-like stack for pane titles.

* `\033[22;0t` pushes the current pane title onto the pane's stack. The title is unchanged.
* `\033[23;0t` pops the current pane title from the pane's stack and changes the pane title.

(References: http://invisible-island.net/xterm/ctlseqs/ctlseqs.pdf)
