### PR TITLE
Nice termination message if remain-on-exit is used

### DIFF
--- a/format.c
+++ b/format.c
@@ -1418,7 +1418,10 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 	status = wp->status;
 	if (wp->fd == -1 && WIFEXITED(status))
 		format_add(ft, "pane_dead_status", "%d", WEXITSTATUS(status));
+	if (wp->fd == -1 && WIFSIGNALED(status))
+		format_add(ft, "pane_dead_status", "%d", WTERMSIG(status));
 	format_add(ft, "pane_dead", "%d", wp->fd == -1);
+	format_add_tv(ft, "pane_death_time", &wp->death_time);
 
 	if (window_pane_visible(wp)) {
 		format_add(ft, "pane_left", "%u", wp->xoff);

--- a/options-table.c
+++ b/options-table.c
@@ -450,6 +450,24 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "default"
 	},
 
+	{ .name = "status-pane-died",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
+	{ .name = "status-pane-exitcode",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
+	{ .name = "status-pane-exitsignal",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
 	{ .name = "status-position",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/tmux.1
+++ b/tmux.1
@@ -2878,6 +2878,84 @@ For how to specify
 see the
 .Ic message-command-style
 option.
+.It Ic status-pane-died Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane quits normally and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ Pane >#{pane_current_command}< died at %H:%M:S on %d.%m.%Y
+.Ed
+.Pp
+.It Ic status-pane-exitcode Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane quits abnormally (returning an exitcode) and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ #[fg=yellow]#[bg=black]Pane >#{pane_current_command}< died with exit code #{pane_dead_status} at %H:%M:%S %d.%m.%Y#[default]
+.Ed
+.Pp
+.It Ic status-pane-exitsignal Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane is terminated with a signal and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ #[fg=red]#[bg=black]Pane >#{pane_current_command}< terminated with signal #{pane_dead_status} at %H:%M:%S %d.%m.%Y#[default]
+.Ed
+.Pp
 .It Xo Ic status-position
 .Op Ic top | bottom
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -789,6 +789,7 @@ struct window_pane {
 	pid_t		 pid;
 	char		 tty[TTY_NAME_MAX];
 	int		 status;
+	struct timeval	 death_time;
 
 	int		 fd;
 	struct bufferevent *event;


### PR DESCRIPTION
This adds screen-like termination messages for panes if remain-on-exit is
used. The three settings status-pane-died, status-pane-exitcode and
status-pane-exitsignal are available to be used with format strings.
Their message is formatted and printed in case the program died
normally, the program terminated with non-zero exitcode and the program
terminated with a signal, respectively. In either case, the templates
are first passed through strftime with the time of death. In cases of
abnormal termination, the format option #{pane_dead_status} will contain
either the exitcode or the signal, depending on the cause of
termination.

Test case:
tmux new-window "false"

Test Configuration:
set -g remain-on-exit on
setw -g status-pane-died '#[fg=green]#[bg=black]Pane >#{pane_current_command}< completed successfully at %H:%M:%S on %d.%m.%Y#[default]'
setw -g status-pane-exitcode '#[fg=yellow]#[bg=black]Pane >#{pane_current_command}< died with exit code #{pane_dead_status} at %H:%M:%S on %d.%m.%Y#[default]'
setw -g status-pane-exitsignal #[fg=red]#[bg=black]Pane >#{pane_current_command}< terminated with signal #{pane_dead_status} at %H:%M:%S on %d.%m.%Y#[default]'