### PR TITLE
Nice termination message if remain-on-exit is used

### DIFF
--- a/format.c
+++ b/format.c
@@ -1418,7 +1418,10 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 	status = wp->status;
 	if (wp->fd == -1 && WIFEXITED(status))
 		format_add(ft, "pane_dead_status", "%d", WEXITSTATUS(status));
+	if (wp->fd == -1 && WIFSIGNALED(status))
+		format_add(ft, "pane_dead_status", "%d", WTERMSIG(status));
 	format_add(ft, "pane_dead", "%d", wp->fd == -1);
+	format_add_tv(ft, "pane_dead_time", &wp->dead_time);
 
 	if (window_pane_visible(wp)) {
 		format_add(ft, "pane_left", "%u", wp->xoff);

--- a/options-table.c
+++ b/options-table.c
@@ -450,6 +450,24 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "default"
 	},
 
+	{ .name = "status-pane-died",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
+	{ .name = "status-pane-exitcode",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
+	{ .name = "status-pane-exitsignal",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "Pane is dead"
+	},
+
 	{ .name = "status-position",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/server-fn.c
+++ b/server-fn.c
@@ -276,11 +276,12 @@ void
 server_destroy_pane(struct window_pane *wp, int notify)
 {
 	struct window		*w = wp->window;
-	int			 old_fd;
 	struct screen_write_ctx	 ctx;
 	struct grid_cell	 gc;
+	const char	*template;
+	struct format_tree	*ft;
+	char		*panedied;
 
-	old_fd = wp->fd;
 	if (wp->fd != -1) {
 #ifdef HAVE_UTEMPTER
 		utempter_remove_record(wp->fd);
@@ -291,19 +292,36 @@ server_destroy_pane(struct window_pane *wp, int notify)
 	}
 
 	if (options_get_number(w->options, "remain-on-exit")) {
-		if (old_fd == -1)
+		if (wp->flags & PANE_STATUSDRAWN)
 			return;
+
+		if (!WIFEXITED(wp->status) && !WIFSIGNALED(wp->status))
+			return;
+		wp->flags |= PANE_STATUSDRAWN;
 
 		if (notify)
 			notify_pane("pane-died", wp);
 
 		screen_write_start(&ctx, wp, &wp->base);
-		screen_write_scrollregion(&ctx, 0, screen_size_y(ctx.s) - 1);
-		screen_write_cursormove(&ctx, 0, screen_size_y(ctx.s) - 1);
 		screen_write_linefeed(&ctx, 1, 8);
 		memcpy(&gc, &grid_default_cell, sizeof gc);
 		gc.attr |= GRID_ATTR_BRIGHT;
-		screen_write_puts(&ctx, &gc, "Pane is dead");
+		template = xstrdup("");
+		if WIFEXITED(wp->status)
+			if (WEXITSTATUS(wp->status) == 0) {
+				template = options_get_string(w->options, "status-pane-died");
+			} else {
+				template = options_get_string(w->options, "status-pane-exitcode");
+			}
+		if WIFSIGNALED(wp->status)
+			template = options_get_string(w->options, "status-pane-exitsignal");
+		if (WIFEXITED(wp->status) || WIFSIGNALED(wp->status)) {
+			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
+			format_defaults(ft, NULL, NULL, NULL, wp);
+			panedied = format_expand_time(ft, template, wp->dead_time.tv_sec);
+			screen_write_cnputs(&ctx, 0, &gc, "%s", panedied);
+			format_free(ft);
+		}
 		screen_write_stop(&ctx);
 		wp->flags |= PANE_REDRAW;
 

--- a/server.c
+++ b/server.c
@@ -424,6 +424,9 @@ server_child_exited(pid_t pid, int status)
 			if (wp->pid == pid) {
 				wp->status = status;
 
+				if (gettimeofday(&wp->dead_time, NULL) != 0)
+					fatal("gettimeofday failed");
+
 				log_debug("%%%u exited", wp->id);
 				wp->flags |= PANE_EXITED;
 

--- a/tmux.1
+++ b/tmux.1
@@ -2878,6 +2878,84 @@ For how to specify
 see the
 .Ic message-command-style
 option.
+.It Ic status-pane-died Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane quits normally and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ Pane >#{pane_current_command}< died at %H:%M:S on %d.%m.%Y
+.Ed
+.Pp
+.It Ic status-pane-exitcode Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane quits abnormally (returning an exitcode) and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ #[fg=yellow]#[bg=black]Pane >#{pane_current_command}< died with exit code #{pane_dead_status} at %H:%M:%S %d.%m.%Y#[default]
+.Ed
+.Pp
+.It Ic status-pane-exitsignal Ar string
+Display
+.Ar string
+(by default the text "Pane died") when the program in a pane is terminated with a signal and
+.Ic remain-on-exit
+is on.
+.Ar string
+will be passed through
+.Xr strftime 3
+and formats (see
+.Sx FORMATS )
+will be expanded.
+It may also contain the special character sequence #[] to change the colour
+or attributes, for example
+.Ql #[fg=red,bright]
+to set a bright red foreground.
+See the
+.Ic message-command-style
+option for a description of colours and attributes.
+.Pp
+.Pp
+For example:
+.Bd -literal -offset indent
+ #[fg=red]#[bg=black]Pane >#{pane_current_command}< terminated with signal #{pane_dead_status} at %H:%M:%S %d.%m.%Y#[default]
+.Ed
+.Pp
 .It Xo Ic status-position
 .Op Ic top | bottom
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -780,6 +780,7 @@ struct window_pane {
 #define PANE_INPUTOFF 0x40
 #define PANE_CHANGED 0x80
 #define PANE_EXITED 0x100
+#define PANE_STATUSDRAWN 0x200
 
 	int		 argc;
 	char	       **argv;
@@ -789,6 +790,7 @@ struct window_pane {
 	pid_t		 pid;
 	char		 tty[TTY_NAME_MAX];
 	int		 status;
+	struct timeval	 dead_time;
 
 	int		 fd;
 	struct bufferevent *event;

--- a/window.c
+++ b/window.c
@@ -811,6 +811,9 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	wp->fd = -1;
 	wp->event = NULL;
 
+	wp->status = -1;
+	wp->flags &= ~PANE_STATUSDRAWN;
+
 	wp->mode = NULL;
 	wp->modeprefix = 1;
 
@@ -912,6 +915,9 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
 		free((void *)wp->cwd);
 		wp->cwd = xstrdup(cwd);
 	}
+
+	wp->status = -1;
+	wp->flags &= ~PANE_STATUSDRAWN;
 
 	cmd = cmd_stringify_argv(wp->argc, wp->argv);
 	log_debug("spawn: %s -- %s", wp->shell, cmd);


### PR DESCRIPTION
Second version of patch, incorporating first part of nicm's comments given
on IRC. Second part of comments regarding configurability has not been
incorporated yet to facilitate examination of different formatting
options.

This adds screen-like termination messags for panes if remain-on-exit is
used. The three settings status-pane-died, status-pane-exitcode and
status-pane-exitsignal are available to be used with format strings.
Their message is formatted and printed in case the program died
normally, the program terminated with non-zero exitcode and the program
terminated with a signal, respectively. In either case, the templates
are first passed through strftime with the time of death. In cases of
abnormal termination, the format option #{pane_dead_status} will contain
either the exitcode or the signal, depending on the cause of
termination.

Test case:
tmux new-window "false"

Test Configuration:
set -g remain-on-exit on
setw -g status-pane-died '#[fg=green]#[bg=black]Pane >#{pane_current_command}< completed successfully at %H:%M:%S on %d.%m.%Y#[default]'
setw -g status-pane-exitcode '#[fg=yellow]#[bg=black]Pane >#{pane_current_command}< died with exit code #{pane_dead_status} at %H:%M:%S on %d.%m.%Y#[default]'
setw -g status-pane-exitsignal #[fg=red]#[bg=black]Pane >#{pane_current_command}< terminated with signal #{pane_dead_status} at %H:%M:%S on %d.%m.%Y#[default]'