### PR TITLE
Add preview option

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -307,7 +307,7 @@ mode_tree_start(struct window_pane *wp, struct args *args,
 	mtd->sort_size = sort_size;
 	mtd->sort_type = 0;
 
-	mtd->preview = !args_has(args, 'N');
+	mtd->preview = !args_has(args, 'N') && options_get_number(global_s_options, "preview");
 
 	sort = args_get(args, 'O');
 	if (sort != NULL) {

--- a/options-table.c
+++ b/options-table.c
@@ -746,6 +746,12 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "default"
 	},
 
+	{ .name = "preview",
+		.type = OPTIONS_TABLE_FLAG,
+		.scope = OPTIONS_TABLE_SESSION,
+		.default_num = 1
+	},
+
 	{ .name = "remain-on-exit",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/tmux.1
+++ b/tmux.1
@@ -2775,6 +2775,10 @@ Like
 .Ic prefix2
 can be set to
 .Ql None .
+.It Xo Ic preview
+.Op Ic on | off
+.Xc
+Show or hide a preview screen when switching between windows or sessions.
 .It Xo Ic renumber-windows
 .Op Ic on | off
 .Xc


### PR DESCRIPTION
Hi!
This is my first time contributing to tmux, so bear with me. This adds an option to disable the recently added preview screen when switching between windows or sessions with `set -g preview off`. I included this as a session option, but maybe it makes more sense to include it as a server option?