### PR TITLE
Add termination messags if remain-on-exit is used

### DIFF
--- a/format.c
+++ b/format.c
@@ -1418,7 +1418,10 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 	status = wp->status;
 	if (wp->fd == -1 && WIFEXITED(status))
 		format_add(ft, "pane_dead_status", "%d", WEXITSTATUS(status));
+	if (wp->fd == -1 && WIFSIGNALED(status))
+		format_add(ft, "pane_dead_status", "%d", WTERMSIG(status));
 	format_add(ft, "pane_dead", "%d", wp->fd == -1);
+	format_add_tv(ft, "pane_dead_time", &wp->dead_time);
 
 	if (window_pane_visible(wp)) {
 		format_add(ft, "pane_left", "%u", wp->xoff);

--- a/server-fn.c
+++ b/server-fn.c
@@ -276,11 +276,12 @@ void
 server_destroy_pane(struct window_pane *wp, int notify)
 {
 	struct window		*w = wp->window;
-	int			 old_fd;
 	struct screen_write_ctx	 ctx;
 	struct grid_cell	 gc;
+	const char	*template;
+	struct format_tree	*ft;
+	char		*panedied;
 
-	old_fd = wp->fd;
 	if (wp->fd != -1) {
 #ifdef HAVE_UTEMPTER
 		utempter_remove_record(wp->fd);
@@ -291,19 +292,36 @@ server_destroy_pane(struct window_pane *wp, int notify)
 	}
 
 	if (options_get_number(w->options, "remain-on-exit")) {
-		if (old_fd == -1)
+		if (wp->flags & PANE_STATUSDRAWN)
 			return;
+
+		if (!WIFEXITED(wp->status) && !WIFSIGNALED(wp->status))
+			return;
+		wp->flags |= PANE_STATUSDRAWN;
 
 		if (notify)
 			notify_pane("pane-died", wp);
 
 		screen_write_start(&ctx, wp, &wp->base);
-		screen_write_scrollregion(&ctx, 0, screen_size_y(ctx.s) - 1);
-		screen_write_cursormove(&ctx, 0, screen_size_y(ctx.s) - 1);
 		screen_write_linefeed(&ctx, 1, 8);
 		memcpy(&gc, &grid_default_cell, sizeof gc);
 		gc.attr |= GRID_ATTR_BRIGHT;
-		screen_write_puts(&ctx, &gc, "Pane is dead");
+		template = xstrdup("");
+		if WIFEXITED(wp->status)
+			if (WEXITSTATUS(wp->status) == 0) {
+				template = "Pane >#{pane_current_command}< died at %c";
+			} else {
+				template = "Pane >#{pane_current_command}< died with exit code #{pane_dead_status} at %c";
+			}
+		if WIFSIGNALED(wp->status)
+			template = "Pane >#{pane_current_command}< died with signal #{pane_dead_status} at %c";
+		if (WIFEXITED(wp->status) || WIFSIGNALED(wp->status)) {
+			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
+			format_defaults(ft, NULL, NULL, NULL, wp);
+			panedied = format_expand_time(ft, template, wp->dead_time.tv_sec);
+			screen_write_cnputs(&ctx, 0, &gc, "%s", panedied);
+			format_free(ft);
+		}
 		screen_write_stop(&ctx);
 		wp->flags |= PANE_REDRAW;
 

--- a/server.c
+++ b/server.c
@@ -424,6 +424,9 @@ server_child_exited(pid_t pid, int status)
 			if (wp->pid == pid) {
 				wp->status = status;
 
+				if (gettimeofday(&wp->dead_time, NULL) != 0)
+					fatal("gettimeofday failed");
+
 				log_debug("%%%u exited", wp->id);
 				wp->flags |= PANE_EXITED;
 

--- a/tmux.h
+++ b/tmux.h
@@ -780,6 +780,7 @@ struct window_pane {
 #define PANE_INPUTOFF 0x40
 #define PANE_CHANGED 0x80
 #define PANE_EXITED 0x100
+#define PANE_STATUSDRAWN 0x200
 
 	int		 argc;
 	char	       **argv;
@@ -789,6 +790,7 @@ struct window_pane {
 	pid_t		 pid;
 	char		 tty[TTY_NAME_MAX];
 	int		 status;
+	struct timeval	 dead_time;
 
 	int		 fd;
 	struct bufferevent *event;

--- a/window.c
+++ b/window.c
@@ -811,6 +811,9 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	wp->fd = -1;
 	wp->event = NULL;
 
+	wp->status = -1;
+	wp->flags &= ~PANE_STATUSDRAWN;
+
 	wp->mode = NULL;
 	wp->modeprefix = 1;
 
@@ -912,6 +915,9 @@ window_pane_spawn(struct window_pane *wp, int argc, char **argv,
 		free((void *)wp->cwd);
 		wp->cwd = xstrdup(cwd);
 	}
+
+	wp->status = -1;
+	wp->flags &= ~PANE_STATUSDRAWN;
 
 	cmd = cmd_stringify_argv(wp->argc, wp->argv);
 	log_debug("spawn: %s -- %s", wp->shell, cmd);


### PR DESCRIPTION
This adds screen-like termination messages for panes if remain-on-exit is used. Third version of the patch, as discussed with nicm on IRC, without configuration options.