### PR TITLE
for tree mode session nodes, restored keybindings 'h' and 'l'

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -847,6 +847,7 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 			mtd->sort_type = 0;
 		mode_tree_build(mtd);
 		break;
+	case 'h':
 	case KEYC_LEFT:
 	case '-':
 		if (line->flat || !current->expanded)
@@ -859,6 +860,7 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 			mode_tree_build(mtd);
 		}
 		break;
+	case 'l':
 	case KEYC_RIGHT:
 	case '+':
 		if (line->flat || current->expanded)


### PR DESCRIPTION
I'm so used to 'h' and 'l' for vi-mode session tree navigation, and I know I can't be the only one. These bindings worked prior to the 2.6 tree code rewrite.

