### PR TITLE
Fix description about vim(1) support

### DIFF
--- a/README
+++ b/README
@@ -43,7 +43,8 @@ the source tree with:
 
 A small example configuration in example_tmux.conf.
 
-A vim(1) syntax file is available at:
+vim(1) officially supports syntax highlight in v8.0.420 or later.
+To support in former version, syntax file is available at:
 
 	https://github.com/ericpruitt/tmux.vim
 	https://raw.githubusercontent.com/ericpruitt/tmux.vim/master/vim/syntax/tmux.vim


### PR DESCRIPTION
Vim now bundles the syntax file in official package and supports syntax highlight for `.tmux.conf`. Vim user no longer needs to install syntax file manually for tmux.

https://github.com/vim/vim/blob/036986f1507d223549d110af300144468bd3a1f7/runtime/syntax/tmux.vim

It was added on Mar 6 and in v8.0.420. I updatebbd README file following the update.