### PR TITLE
Fixed choose-tree command line bug

### DIFF
--- a/window-tree.c
+++ b/window-tree.c
@@ -931,7 +931,7 @@ window_tree_command_callback(struct client *c, void *modedata, const char *s,
 {
 	struct window_tree_modedata	*data = modedata;
 
-	if (data->dead)
+	if (data->dead || s == NULL)
 		return (0);
 
 	data->entered = s;


### PR DESCRIPTION
Small fix for the choose-tree command line.  Without this, when the user opens the choose-tree command line with ':', and then closes it with ^C, the server would crash.