### PR TITLE
Fix East Asian Ambiguous (Unity half-width)

### DIFF
--- a/tty-acs.c
+++ b/tty-acs.c
@@ -48,7 +48,7 @@ static const struct tty_acs_entry tty_acs_table[] = {
 	{ 'n', "\342\224\274" },	/* large plus or crossover */
 	{ 'o', "\342\216\272" },	/* scan line 1 */
 	{ 'p', "\342\216\273" },	/* scan line 3 */
-	{ 'q', "\342\224\200" },	/* horizontal line */
+	{ 'q', "\357\277\232" },	/* halfwidth hangul letter eu */
 	{ 'r', "\342\216\274" },	/* scan line 7 */
 	{ 's', "\342\216\275" },	/* scan line 9 */
 	{ 't', "\342\224\234" },	/* tee pointing right */

--- a/tty-acs.c
+++ b/tty-acs.c
@@ -48,14 +48,14 @@ static const struct tty_acs_entry tty_acs_table[] = {
 	{ 'n', "\342\224\274" },	/* large plus or crossover */
 	{ 'o', "\342\216\272" },	/* scan line 1 */
 	{ 'p', "\342\216\273" },	/* scan line 3 */
-	{ 'q', "\357\277\232" },	/* halfwidth hangul letter eu */
+	{ 'q', "\357\277\232" },	/* horizontal line */
 	{ 'r', "\342\216\274" },	/* scan line 7 */
 	{ 's', "\342\216\275" },	/* scan line 9 */
 	{ 't', "\342\224\234" },	/* tee pointing right */
 	{ 'u', "\342\224\244" },	/* tee pointing left */
 	{ 'v', "\342\224\264" },	/* tee pointing up */
 	{ 'w', "\342\224\254" },	/* tee pointing down */
-	{ 'x', "\342\224\202" },	/* vertical line */
+	{ 'x', "\357\277\250" },	/* vertical line */
 	{ 'y', "\342\211\244" },	/* less-than-or-equal-to */
 	{ 'z', "\342\211\245" },	/* greater-than-or-equal-to */
 	{ '{', "\317\200" },   		/* greek pi */


### PR DESCRIPTION
UTF-8 has [East Asian Ambiguous characters](http://unicode.org/reports/tr11/).
This characters fit to special characters fit to half-width main language(e.g. English) or full-width main language(e.g. Japanese)
So this characters has ambiguous width depend on language environment(LC_ALL, LC_CTYPE).
However, [utf8proc](https://github.com/JuliaLang/utf8proc/blob/master/data/charwidths.jl#L116) cannot solve this problem(statically fix to 1).
I resolve this problem in my environment with ad-hoc [patch](https://github.com/atton/utf8proc/blob/ambiguous/data/charwidths.jl#L114) (statically Ambiguous fix to 2)
I created this PR modifies tty-acs table to half-width UTF-8 characters.

Screen shots before this Pull Request:
<img width="1552" alt="before-1" src="https://user-images.githubusercontent.com/1271691/32133910-3381492c-bc1c-11e7-9bb8-76ea6800a243.png">
![image](https://user-images.githubusercontent.com/1271691/32133900-00f457a6-bc1c-11e7-99cd-00286658150b.png)

Screen shot after this Pull Request:
<img width="1552" alt="after-1" src="https://user-images.githubusercontent.com/1271691/32133927-a190d590-bc1c-11e7-8e6a-c1df9180d342.png">
<img width="1552" alt="after-2" src="https://user-images.githubusercontent.com/1271691/32133944-1c05a5b2-bc1d-11e7-93e4-b3c8c542c9b3.png">

My Environments
- OS: macOS 10.12.6
- terminal: Terminal.app(2.7.3)
- Font: Ricty 3.2.2(Japanese font. ambiguous width = full(2))

Reference : [EasitAsianAmbiguous Character Lists](http://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt)