### PR TITLE
Add support for xdg config home

### DIFF
--- a/cfg.c
+++ b/cfg.c
@@ -79,7 +79,8 @@ set_cfg_file(const char *path)
 void
 start_cfg(void)
 {
-	const char	*home;
+	const char	*home = NULL;
+	const char	*config_dir;
 	int		 quiet = 0;
 	struct client	*c;
 
@@ -106,8 +107,17 @@ start_cfg(void)
 		xasprintf(&cfg_file, "%s/.tmux.conf", home);
 		quiet = 1;
 	}
-	if (cfg_file != NULL)
+	if (cfg_file == NULL || load_cfg(cfg_file, NULL, NULL, quiet) <= 0){
+		cfg_file = NULL;
+	}
+
+	if (cfg_file == NULL && (config_dir = find_config_dir(home)) != NULL) {
+		xasprintf(&cfg_file, "%s/tmux.conf", config_dir);
+		quiet = 1;
+	}
+	if (cfg_file != NULL){
 		load_cfg(cfg_file, NULL, NULL, quiet);
+	}
 
 	cmdq_append(NULL, cmdq_get_callback(cfg_done, NULL));
 }

--- a/tmux.c
+++ b/tmux.c
@@ -185,6 +185,34 @@ find_home(void)
 	return (home);
 }
 
+const char *
+find_config_dir(const char* home)
+{
+	const char default_dir_rel_to_home[] = "/.config";
+	static char	*config_dir;
+
+	if (config_dir != NULL){
+		return (config_dir);
+	}
+
+	config_dir = getenv("XDG_CONFIG_HOME");
+	if (config_dir != NULL && *config_dir != '\0') {
+		return config_dir;
+	}
+
+	// fallback to default location
+	if(home == NULL){
+		return NULL;
+	}
+
+	config_dir = malloc(strlen(home)+ strlen(default_dir_rel_to_home) + 1);
+	if(config_dir != NULL){
+		strcpy( config_dir, home ) ;
+		strcat( config_dir, default_dir_rel_to_home ) ;
+	}
+	return config_dir;
+}
+
 int
 main(int argc, char **argv)
 {

--- a/tmux.h
+++ b/tmux.h
@@ -1507,6 +1507,7 @@ extern const char	*shell_command;
 int		 areshell(const char *);
 void		 setblocking(int, int);
 const char	*find_home(void);
+const char	*find_config_dir(const char* home);
 
 /* proc.c */
 struct imsg;


### PR DESCRIPTION
Hello,

this is a small pull request for adding support to the XDG Base Directory Specification (https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

I supposed that a breaking change would not have been welcome, so I've mplemented the following logic:
if $HOME/tmux.conf is not present (could not be loaded), then try to load $XDG_CONFIG_HOME/tmux.conf (the default value is therefore $HOME/.config/tmux.conf).

Let me know if there is something that I should change in order to make you accept this pull request

Kind regards

Federico