### PR TITLE
Faster grid reflow for vertical resize with many split lines

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -34,7 +34,7 @@ TAILQ_HEAD(screen_titles, screen_title_entry);
 static void	screen_resize_x(struct screen *, u_int);
 static void	screen_resize_y(struct screen *, u_int);
 
-static void	screen_reflow(struct screen *, u_int);
+static void	screen_reflow(struct screen *, u_int, u_int);
 
 /* Free titles stack. */
 static void
@@ -182,6 +182,8 @@ screen_pop_title(struct screen *s)
 void
 screen_resize(struct screen *s, u_int sx, u_int sy, int reflow)
 {
+	u_int	old_sx = s->grid->sx;
+
 	if (sx < 1)
 		sx = 1;
 	if (sy < 1)
@@ -202,7 +204,7 @@ screen_resize(struct screen *s, u_int sx, u_int sy, int reflow)
 		screen_resize_y(s, sy);
 
 	if (reflow)
-		screen_reflow(s, sx);
+		screen_reflow(s, sx, old_sx);
 }
 
 static void
@@ -466,14 +468,14 @@ screen_select_cell(struct screen *s, struct grid_cell *dst,
 
 /* Reflow wrapped lines. */
 static void
-screen_reflow(struct screen *s, u_int new_x)
+screen_reflow(struct screen *s, u_int new_x, u_int old_x)
 {
 	struct grid	*old = s->grid;
 	u_int		 change;
 
 	s->grid = grid_create(old->sx, old->sy, old->hlimit);
 
-	change = grid_reflow(s->grid, old, new_x);
+	change = grid_reflow(s->grid, old, new_x, old_x);
 	if (change < s->cy)
 		s->cy -= change;
 	else

--- a/tmux.h
+++ b/tmux.h
@@ -2000,7 +2000,7 @@ char	*grid_string_cells(struct grid *, u_int, u_int, u_int,
 	     struct grid_cell **, int, int, int);
 void	 grid_duplicate_lines(struct grid *, u_int, struct grid *, u_int,
 	     u_int);
-u_int	 grid_reflow(struct grid *, struct grid *, u_int);
+u_int	 grid_reflow(struct grid *, struct grid *, u_int, u_int);
 
 /* grid-view.c */
 void	 grid_view_get_cell(struct grid *, u_int, u_int, struct grid_cell *);


### PR DESCRIPTION
For large 200,000 lines pane histories which contain split lines, the latency in vertical pane resize is noticable due to joins and re-splits in the grid reflow process.

If we take into account that the pane's horizontal size has not changed, we can just move those lines from the old grid instead of spending time joining and re-spliting them.