### PR TITLE
Correctly unset user options

### DIFF
--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -192,7 +192,9 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 		if (o == NULL)
 			goto out;
 		if (idx == -1) {
-			if (oo == global_options ||
+			if(*name == '@')
+				options_remove(o);
+			else if (oo == global_options ||
 			    oo == global_s_options ||
 			    oo == global_w_options)
 				options_default(oo, options_table_entry(o));


### PR DESCRIPTION
Server died when trying to unset user options because it was trying to set them to defaults that don't exist for user options.