### PR TITLE
Making cmd-split-window -v/-h  works as expected

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -94,9 +94,9 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	else
 		cwd = s->cwd;
 
-	type = LAYOUT_TOPBOTTOM;
+	type = LAYOUT_LEFTRIGHT;
 	if (args_has(args, 'h'))
-		type = LAYOUT_LEFTRIGHT;
+		type = LAYOUT_TOPBOTTOM;
 
 	size = -1;
 	if (args_has(args, 'l')) {


### PR DESCRIPTION
The current actual action of  :split-window -v and :split-window -h are not as the description in  the split-window part of the manual https://github.com/tmux/tmux/blob/19afd842bf63b28f4ea087b171a6be36a404d8e2/tmux.1#L1236

I have test on cygwin tmux 2.6 and the tmux 2.6 in Ubuntu 18.10.