### PR TITLE
Add persist-without-sessions server option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -96,6 +96,12 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 500
 	},
 
+	{ .name = "exit-empty",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_num = 1
+	},
+
 	{ .name = "exit-unattached",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/server.c
+++ b/server.c
@@ -254,6 +254,10 @@ server_loop(void)
 
 	server_client_loop();
 
+	if (!options_get_number(global_options, "exit-empty") && !server_exit) {
+		return (0);
+	}
+
 	if (!options_get_number(global_options, "exit-unattached")) {
 		if (!RB_EMPTY(&sessions))
 			return (0);

--- a/tmux.1
+++ b/tmux.1
@@ -2507,6 +2507,11 @@ Set the time in milliseconds for which
 waits after an escape is input to determine if it is part of a function or meta
 key sequences.
 The default is 500 milliseconds.
+.It Xo Ic exit-empty
+.Op Ic on | off
+.Xc
+If enabled (the default), the server will exit when there are no active
+sessions.
 .It Xo Ic exit-unattached
 .Op Ic on | off
 .Xc


### PR DESCRIPTION
Defaults to `off`, if set to `on` it causes the tmux server process to keep running even without any active sessions.

## Use Case
My motivation for this change is that I'd like to run a tmux server as a systemd user service, and while I can currently do so by having it spawn an empty or default session, this is kind of a hack.
I typically start a new session per terminal rather than defaulting to re-connecting to an existing session, and having an extra session hanging around purely to keep the server alive is... somewhere between annoying and potentially confusing. 

More generally, the benefits of running the server under some form of service management are:
- If using systemd, can persist across logouts (if lingering is enabled for the user, and generally only relevant if logind is configured with `KillUserProcesses=yes`)
- Can use a different configuration file location than the default, without having to pass it in the command line directly or use an alias
- Can have the tmux server ready and waiting before any terminal or ssh sessions need to use it, effectively eliminating server startup time (in my experience this is trivial, but I know it affects some people on older hardware more noticeably)

There are at least a few other people who want this behaviour, based on a couple of previous issues where people were confused as to the behaviour of the `exit-unattached` option (namely #182 and #512).

## Notes

- I've only tested this out under Linux (NixOS, specifically)
- The unmodified `list-sessions` code called against an empty server simply results in no lines being printed, which seems suitable to me


----------

As an aside, is there anything in the way of development or high-level design documentation for tmux? I noticed the presentations but haven't done more than glance through them yet. 

I'm asking because I'm interested in contributing more generally; I haven't written much C in a long time, and am feeling oddly nostalgic. What I've seen of tmux's code looks pretty clean to me, so it's an attractive option as something to work on.