### PR TITLE
Making cmd-join-window -bv/-bh works as expected

### DIFF
--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -98,10 +98,10 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "source and target panes must be different");
 		return (CMD_RETURN_ERROR);
 	}
-
-	type = LAYOUT_TOPBOTTOM;
+	
+	type = LAYOUT_LEFTRIGHT;
 	if (args_has(args, 'h'))
-		type = LAYOUT_LEFTRIGHT;
+		type = LAYOUT_TOPBOTTOM;
 
 	size = -1;
 	if (args_has(args, 'l')) {


### PR DESCRIPTION
This problem is similar to [pull request 1247](tmux#1247 (comment)), please refer it for more info. The unexpected result can be shown by the following example: if we have two window %0 and %1 in current tmux client , then in the window %0 :
1. :join-pane -bv -t %1, we get a **horisiontal** split window instead of a **vertical** split window as the **v** in -bv suggested.
2. :join-pane -bh -t %1. we get a **vertical** split window instead of a **horisiontal split window as the **h** in -bh suggested.
just exchange the line 102 and   104 can fix this problem.