### PR TITLE
Add C-g key to exit tree mode.

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -801,6 +801,7 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 	switch (*key) {
 	case 'q':
 	case '\033': /* Escape */
+	case '\007': /* C-g */
 		return (1);
 	case KEYC_UP:
 	case 'k':


### PR DESCRIPTION
### Summary
Tree mode has a number of hardcoded emacs and vi key bindings. One more couldn't hurt right?

### Use Case
We emacs users are pretty used to hitting C-g to abort out of things, this just makes tree-mode that much more comfortable for us.
