### PR TITLE
ISSUE_TEMPLATE: make audience explicit

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,1 +1,1 @@
-Please read https://raw.githubusercontent.com/tmux/tmux/master/CONTRIBUTING
+If you're reporting a bug, please read https://raw.githubusercontent.com/tmux/tmux/master/CONTRIBUTING


### PR DESCRIPTION
The instructions in CONTRIBUTING are useful for people who are reporting problems with tmux (bugs, unexpected behavior, etc.) but they don't apply to feature requests or other types of issues. This change makes that clearer.