### PR TITLE
Fix: tmux crashing when moving window to big negative offset

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -389,7 +389,7 @@ cmd_find_get_window_with_session(struct cmd_find_state *fs, const char *window)
 					return (-1);
 				fs->idx = s->curw->idx + n;
 			} else {
-				if (n < s->curw->idx)
+				if (n > s->curw->idx)
 					return (-1);
 				fs->idx = s->curw->idx - n;
 			}


### PR DESCRIPTION
Debug log trace:

1521061074.948271 continuing cmdq 0x55be015e40f0: flags=0, client=7
1521061074.948277 cmdq 0x55be015e40f0: move-window -t -99
1521061074.948282 cmd_find_window: target none
1521061074.948285 \ts=$0
1521061074.948288 \twl=0 1 w=@0 bash
1521061074.948290 \twp=%0
1521061074.948293 \tidx=0
1521061074.948298 target -99 (flags 0x4): session=none, window=-99, pane=none
1521061074.948301 cmd_find_get_window: -99
1521061074.948304 cmd_find_get_window_with_session: -99
1521061074.948308 cmd_find_index: target -99
1521061074.948310 \ts=$0
1521061074.948313 \twl=none
1521061074.948315 \twp=none
1521061074.948317 \tidx=-99
1521061074.948321 fatal: winlink_find_by_index: bad index
