### PR TITLE
quickfix for breaking pane_index order by "split-window -f"

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -130,7 +130,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		cause = xstrdup("pane too small");
 		goto error;
 	}
-	new_wp = window_add_pane(w, wp, args_has(args, 'b'), hlimit);
+	new_wp = window_add_pane(w, wp, args_has(args, 'b'), hlimit, args_has(args, 'f'));
 	layout_make_leaf(lc, new_wp);
 
 	path = NULL;

--- a/tmux.h
+++ b/tmux.h
@@ -2150,7 +2150,7 @@ int		 window_set_active_pane(struct window *, struct window_pane *);
 void		 window_redraw_active_switch(struct window *,
 		     struct window_pane *);
 struct window_pane *window_add_pane(struct window *, struct window_pane *,
-		     int, u_int);
+		     int, u_int, int);
 void		 window_resize(struct window *, u_int, u_int);
 int		 window_zoom(struct window_pane *);
 int		 window_unzoom(struct window *);

--- a/window.c
+++ b/window.c
@@ -339,7 +339,7 @@ window_create_spawn(const char *name, int argc, char **argv, const char *path,
 	struct window_pane	*wp;
 
 	w = window_create(sx, sy);
-	wp = window_add_pane(w, NULL, 0, hlimit);
+	wp = window_add_pane(w, NULL, 0, hlimit, 0);
 	layout_init(w, wp);
 
 	if (window_pane_spawn(wp, argc, argv, path, shell, cwd,
@@ -608,7 +608,7 @@ window_unzoom(struct window *w)
 
 struct window_pane *
 window_add_pane(struct window *w, struct window_pane *other, int before,
-    u_int hlimit)
+    u_int hlimit, int full_size)
 {
 	struct window_pane	*wp;
 
@@ -619,6 +619,14 @@ window_add_pane(struct window *w, struct window_pane *other, int before,
 	if (TAILQ_EMPTY(&w->panes)) {
 		log_debug("%s: @%u at start", __func__, w->id);
 		TAILQ_INSERT_HEAD(&w->panes, wp, entry);
+	} else if (full_size) {
+		if (before) {
+			log_debug("%s: @%u full before %%%u", __func__, w->id, wp->id);
+			TAILQ_INSERT_HEAD(&w->panes, wp, entry);
+		} else {
+			log_debug("%s: @%u full after %%%u", __func__, w->id, wp->id);
+			TAILQ_INSERT_TAIL(&w->panes, wp, entry);
+		}
 	} else if (before) {
 		log_debug("%s: @%u before %%%u", __func__, w->id, wp->id);
 		TAILQ_INSERT_BEFORE(other, wp, entry);


### PR DESCRIPTION
## description

"split-window -f" breaks pane_index order.

## example

    tmux split-window -h -b \; split-window -h -f \; display-pane -d 10000
    => 0 2 1

    tmux split-window -h \; split-window -h -f -b \; display-pane -d 10000
    => 1 0 2

I expect 0 1 2 in both cases.