### PR TITLE
Remove EVENT_NOEPOLL from environment after initializing libevent

### DIFF
--- a/osdep-darwin.c
+++ b/osdep-darwin.c
@@ -92,7 +92,11 @@ osdep_event_init(void)
 	 * On OS X, kqueue and poll are both completely broken and don't
 	 * work on anything except socket file descriptors (yes, really).
 	 */
+	struct event_base *base;
 	setenv("EVENT_NOKQUEUE", "1", 1);
 	setenv("EVENT_NOPOLL", "1", 1);
-	return (event_init());
+	base = event_init();
+	unsetenv("EVENT_NOKQUEUE");
+	unsetenv("EVENT_NOPOLL");
+	return base;
 }

--- a/osdep-freebsd.c
+++ b/osdep-freebsd.c
@@ -197,6 +197,9 @@ osdep_event_init(void)
 	 * On some versions of FreeBSD, kqueue doesn't work properly on tty
 	 * file descriptors. This is fixed in recent FreeBSD versions.
 	 */
+	struct event_base *base;
 	setenv("EVENT_NOKQUEUE", "1", 1);
-	return (event_init());
+	base = event_init();
+	unsetenv("EVENT_NOKQUEUE");
+	return base;
 }

--- a/osdep-linux.c
+++ b/osdep-linux.c
@@ -92,7 +92,10 @@ osdep_get_cwd(int fd)
 struct event_base *
 osdep_event_init(void)
 {
+	struct event_base *base;
 	/* On Linux, epoll doesn't work on /dev/null (yes, really). */
 	setenv("EVENT_NOEPOLL", "1", 1);
-	return (event_init());
+	base = event_init();
+	unsetenv("EVENT_NOEPOLL");
+	return base;
 }


### PR DESCRIPTION
This pull request fixes [Issue 1288](https://github.com/tmux/tmux/issues/1288).