### PR TITLE
Add KRB5CCNAME to the default list of variables handled by update-environment.

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -513,8 +513,8 @@ const struct options_table_entry options_table[] = {
 	{ .name = "update-environment",
 	  .type = OPTIONS_TABLE_ARRAY,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "DISPLAY SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID "
-			 "SSH_CONNECTION WINDOWID XAUTHORITY"
+	  .default_str = "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK "
+			 "SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY"
 	},
 
 	{ .name = "visual-activity",


### PR DESCRIPTION
In environments with kerberos authentication for ssh, each connection creates a unique ticket store and exports the KRB5CCNAME environment variable for that session. This is similar to other environment variables already in the default, such as SSH_AUTH_SOCK.