### PR TITLE
Make README easier to read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,81 @@
+# tmux
+
 Welcome to tmux!
 
 tmux is a "terminal multiplexer", it enables a number of terminals (or windows)
 to be accessed and controlled from a single terminal. tmux is intended to be a
 simple, modern, BSD-licensed alternative to programs such as GNU screen.
 
-This release runs on OpenBSD, FreeBSD, NetBSD, Linux, OS X and Solaris.
+This code can be compiled to run on OpenBSD, FreeBSD, NetBSD, Linux, OS X and Solaris.
 
-tmux depends on libevent 2.x. Download it from:
 
-	http://libevent.org
+## Instalation
 
-It also depends on ncurses, available from:
+### On Debian / Ubuntu
 
-	http://invisible-island.net/ncurses/
+    apt install tmux
+
+### On Redhat / Fedora
+
+    yum install tmux
+
+### On macOS
+
+    brew install tmux
+    
+### From source
 
 To build and install tmux from a release tarball, use:
 
-	$ ./configure && make
-	$ sudo make install
+```sh
+$ ./configure && make
+$ sudo make install
+```
 
 tmux can use the utempter library to update utmp(5), if it is installed - run
-configure with --enable-utempter to enable this.
+`configure --enable-utempter` to enable this.
 
 To get and build the latest from version control:
 
-	$ git clone https://github.com/tmux/tmux.git
-	$ cd tmux
-	$ sh autogen.sh
-	$ ./configure && make
+```sh
+$ git clone https://github.com/tmux/tmux.git
+$ cd tmux
+$ sh autogen.sh
+$ ./configure && make
+```
 
-(Note that this requires at least a working C compiler, make, autoconf,
-automake, pkg-config as well as libevent and ncurses libraries and headers.)
+## Dependencies
+
+At least a working C compiler, make, autoconf,
+automake, pkg-config as well as libevent and ncurses libraries and headers.
+
+tmux depends on [libevent](http://libevent.org) 2.x and [ncurses](http://invisible-island.net/ncurses/).
 
 For more information see http://git-scm.com. Patches should be sent by email to
 the mailing list at tmux-users@googlegroups.com or submitted through GitHub at
 https://github.com/tmux/tmux/issues.
 
-For documentation on using tmux, see the tmux.1 manpage. It can be viewed from
-the source tree with:
+## Usage
 
-	$ nroff -mdoc tmux.1|less
+For documentation on using tmux, see the [tmux.1 manpage](http://man7.org/linux/man-pages/man1/tmux.1.html). 
+It can also be viewed from the source tree with:
 
-A small example configuration in example_tmux.conf.
+```sh
+$ nroff -mdoc tmux.1|less
+```
 
-And a bash(1) completion file at:
+See a small example configuration in `example_tmux.conf`.
 
-	https://github.com/imomaliev/tmux-bash-completion
+## Bash completion
 
-For debugging, running tmux with -v or -vv will generate server and client log
+Check bash completion at: https://github.com/imomaliev/tmux-bash-completion
+
+## Debugging
+
+For debugging, running tmux with `-v` or `-vv` will generate server and client log
 files in the current directory.
+
+## Mailing lists
 
 tmux mailing lists are available. For general discussion and bug reports:
 
@@ -64,6 +91,8 @@ Bug reports, feature suggestions and especially code contributions are most
 welcome. Please send by email to:
 
 	tmux-users@googlegroups.com
+
+## Licence
 
 This file and the CHANGES, FAQ, SYNCING and TODO files are licensed under the
 ISC license. All other files have a license and copyright notice at their start.


### PR DESCRIPTION
The README looks old, when viewed on github. This is a first step in making it more readable.

Renamed to README.md so it displays better on github.
Add markdown formatting.
Add sections (Installation / Dependencies / Usage...).

