### PR TITLE
allow specifying -x- -y- when creating detached session

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -202,17 +202,29 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 		sy = 24;
 	}
 	if ((is_control || detached) && args_has(args, 'x')) {
-		sx = strtonum(args_get(args, 'x'), 1, USHRT_MAX, &errstr);
-		if (errstr != NULL) {
-			cmdq_error(item, "width %s", errstr);
-			goto error;
+		const char *p = args_get(args, 'x');
+
+		if (strcmp(p, "-") == 0)
+			sx = c->tty.sx;
+		else {
+			sx = strtonum(p, 1, USHRT_MAX, &errstr);
+			if (errstr != NULL) {
+				cmdq_error(item, "width %s", errstr);
+				goto error;
+			}
 		}
 	}
 	if ((is_control || detached) && args_has(args, 'y')) {
-		sy = strtonum(args_get(args, 'y'), 1, USHRT_MAX, &errstr);
-		if (errstr != NULL) {
-			cmdq_error(item, "height %s", errstr);
-			goto error;
+		const char *p = args_get(args, 'y');
+
+		if (strcmp(p, "-") == 0)
+			sy = c->tty.sy;
+		else {
+			sy = strtonum(p, 1, USHRT_MAX, &errstr);
+			if (errstr != NULL) {
+				cmdq_error(item, "height %s", errstr);
+				goto error;
+			}
 		}
 	}
 	if (sx == 0)

--- a/tmux.1
+++ b/tmux.1
@@ -854,7 +854,8 @@ the initial size is 80 x 24;
 .Fl x
 and
 .Fl y
-can be used to specify a different size.
+can be used to specify a different size, with the special case "-" which uses
+the size of the current terminal.
 .Pp
 If run from a terminal, any
 .Xr termios 4


### PR DESCRIPTION
Creating a new detached session with
tmux new-session -d -x- -y-
will now use the running terminals columns and rows size, instead of
the default 80x24.

This can be useful when setting up detached sessions for later use.
Inspired by https://github.com/tmux/tmux/issues/1335