### PR TITLE
Fix resizing of panes by mouse

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -2207,6 +2207,10 @@ void		 layout_free_cell(struct layout_cell *);
 void		 layout_print_cell(struct layout_cell *, const char *, u_int);
 void		 layout_destroy_cell(struct window *, struct layout_cell *,
 		     struct layout_cell **);
+void		 layout_resize_layout(struct window *w, struct layout_cell *lc,
+		     enum layout_type type, int change, int opposite);
+struct layout_cell *layout_search_by_border(struct layout_cell *lc,
+		     u_int x, u_int y);
 void		 layout_set_size(struct layout_cell *, u_int, u_int, u_int,
 		     u_int);
 void		 layout_make_leaf(struct layout_cell *, struct window_pane *);


### PR DESCRIPTION
The iteration of the list pane was not reliable in finding the right pane to resize. Moreover, we actually want to find the inter-pane border that is relevant to the resize action.

Therefore, instead of iterating the list of panes, go over the list of layouts in order to find the window that is next to the border that we are trying to resize. The behavior of a pane border drag is to always move the border, regardless of pane sizes (as long as they don't go over the minimum)

This addresses issue #1002.