### PR TITLE
last-pane: select the other pane as the last pane in two-pane window

### DIFF
--- a/cmd-select-pane.c
+++ b/cmd-select-pane.c
@@ -69,6 +69,11 @@ cmd_select_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (self->entry == &cmd_last_pane_entry || args_has(args, 'l')) {
 		lastwp = w->last;
+		if (lastwp == NULL && window_count_panes(w) == 2) {
+			lastwp = TAILQ_PREV(w->active, window_panes, entry);
+			if (lastwp == NULL)
+				lastwp = TAILQ_NEXT(w->active, entry);
+		}
 		if (lastwp == NULL) {
 			cmdq_error(item, "no last pane");
 			return (CMD_RETURN_ERROR);


### PR DESCRIPTION
This is basically for convenience because `last-pane` is usually for quickly switching between two panes. Imagine the user creates three panes, then delete one, `last-pane` would refuse to switch to the remaining pane, and the user has to select it explicitly before `last-pane` works again.