### PR TITLE
Add a command to configure key table transition

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -112,6 +112,7 @@ dist_tmux_SOURCES = \
 	cmd-set-buffer.c \
 	cmd-set-environment.c \
 	cmd-set-hook.c \
+	cmd-set-next-table.c \
 	cmd-set-option.c \
 	cmd-show-environment.c \
 	cmd-show-messages.c \

--- a/cmd-attach-session.c
+++ b/cmd-attach-session.c
@@ -58,6 +58,7 @@ cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
 	struct winlink		*wl;
 	struct window_pane	*wp;
 	char			*cause;
+	const char		*default_table;
 
 	if (RB_EMPTY(&sessions)) {
 		cmdq_error(item, "no sessions");
@@ -113,8 +114,10 @@ cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
 			environ_update(s->options, c->environ, s->environ);
 
 		c->session = s;
-		if (~item->shared->flags & CMDQ_SHARED_REPEAT)
-			server_client_set_key_table(c, NULL);
+		if (~item->shared->flags & CMDQ_SHARED_REPEAT) {
+			default_table = server_client_get_default_key_table(c);
+			server_client_set_key_table(c, default_table);
+		}
 		status_timer_start(c);
 		notify_client("client-session-changed", c);
 		session_update_activity(s, NULL);
@@ -141,7 +144,8 @@ cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
 			environ_update(s->options, c->environ, s->environ);
 
 		c->session = s;
-		server_client_set_key_table(c, NULL);
+		default_table = server_client_get_default_key_table(c);
+		server_client_set_key_table(c, default_table);
 		status_timer_start(c);
 		notify_client("client-session-changed", c);
 		session_update_activity(s, NULL);

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -75,6 +75,7 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 	struct session_group	*sg;
 	const char		*errstr, *template, *group, *prefix;
 	const char		*path, *cmd, *tmp;
+	const char		*default_table;
 	char		       **argv, *cause, *cp, *newname, *cwd = NULL;
 	int			 detached, already_attached, idx, argc;
 	int			 is_control = 0;
@@ -311,8 +312,10 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 		} else if (c->session != NULL)
 			c->last_session = c->session;
 		c->session = s;
-		if (~item->shared->flags & CMDQ_SHARED_REPEAT)
-			server_client_set_key_table(c, NULL);
+		if (~item->shared->flags & CMDQ_SHARED_REPEAT) {
+			default_table = server_client_get_default_key_table(c);
+			server_client_set_key_table(c, default_table);
+		}
 		status_timer_start(c);
 		notify_client("client-session-changed", c);
 		session_update_activity(s, NULL);

--- a/cmd-set-next-table.c
+++ b/cmd-set-next-table.c
@@ -1,0 +1,59 @@
+/* $OpenBSD$ */
+
+/*
+ * Copyright (c) 2007 Nicholas Marriott <nicholas.marriott@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "tmux.h"
+
+/*
+ * Bind a key to a command.
+ */
+
+static enum cmd_retval	cmd_set_next_table(struct cmd *, struct cmdq_item *);
+
+const struct cmd_entry cmd_set_next_table_entry = {
+	.name = "set-next-table",
+
+	.args = { "T:", 0, 1 },
+	.usage = "[-T key-table]",
+
+	.flags = CMD_AFTERHOOK,
+	.exec = cmd_set_next_table
+};
+
+static enum cmd_retval
+cmd_set_next_table(struct cmd *self, __unused struct cmdq_item *item)
+{
+	struct args	*args = self->args;
+	const char	*tablename;
+	const char	*next_table;
+
+	if (args_has(args, 'T'))
+		tablename = args_get(args, 'T');
+	else if (args_has(args, 'n'))
+		tablename = "root";
+	else
+		tablename = "prefix";
+
+	if (args->argc == 0) {
+		next_table = "";
+	} else {
+		next_table = args->argv[0];
+	}
+
+	key_bindings_set_next_table(tablename, next_table);
+	return (CMD_RETURN_NORMAL);
+}

--- a/cmd-switch-client.c
+++ b/cmd-switch-client.c
@@ -55,7 +55,7 @@ cmd_switch_client_exec(struct cmd *self, struct cmdq_item *item)
 	struct session		*s;
 	struct winlink		*wl;
 	struct window_pane	*wp;
-	const char		*tablename;
+	const char		*tablename, *default_table;
 	struct key_table	*table;
 
 	if ((c = cmd_find_client(item, args_get(args, 'c'), 0)) == NULL)
@@ -126,8 +126,10 @@ cmd_switch_client_exec(struct cmd *self, struct cmdq_item *item)
 	if (c->session != NULL && c->session != s)
 		c->last_session = c->session;
 	c->session = s;
-	if (~item->shared->flags & CMDQ_SHARED_REPEAT)
-		server_client_set_key_table(c, NULL);
+	if (~item->shared->flags & CMDQ_SHARED_REPEAT) {
+		default_table = server_client_get_default_key_table(c);
+		server_client_set_key_table(c, default_table);
+	}
 	status_timer_start(c);
 	notify_client("client-session-changed", c);
 	session_update_activity(s, NULL);

--- a/cmd.c
+++ b/cmd.c
@@ -93,6 +93,7 @@ extern const struct cmd_entry cmd_send_prefix_entry;
 extern const struct cmd_entry cmd_set_buffer_entry;
 extern const struct cmd_entry cmd_set_environment_entry;
 extern const struct cmd_entry cmd_set_hook_entry;
+extern const struct cmd_entry cmd_set_next_table_entry;
 extern const struct cmd_entry cmd_set_option_entry;
 extern const struct cmd_entry cmd_set_window_option_entry;
 extern const struct cmd_entry cmd_show_buffer_entry;
@@ -179,6 +180,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_set_buffer_entry,
 	&cmd_set_environment_entry,
 	&cmd_set_hook_entry,
+	&cmd_set_next_table_entry,
 	&cmd_set_option_entry,
 	&cmd_set_window_option_entry,
 	&cmd_show_buffer_entry,

--- a/format.c
+++ b/format.c
@@ -1386,7 +1386,7 @@ format_defaults_client(struct format_tree *ft, struct client *c)
 	format_add(ft, "client_written", "%zu", c->written);
 	format_add(ft, "client_discarded", "%zu", c->discarded);
 
-	name = server_client_get_key_table(c);
+	name = server_client_get_default_key_table(c);
 	if (strcmp(c->keytable->name, name) == 0)
 		format_add(ft, "client_prefix", "%d", 0);
 	else

--- a/server-fn.c
+++ b/server-fn.c
@@ -394,6 +394,7 @@ server_destroy_session(struct session *s)
 {
 	struct client	*c;
 	struct session	*s_new;
+	const char	*default_table;
 
 	if (!options_get_number(s->options, "detach-on-destroy"))
 		s_new = server_next_session(s);
@@ -409,7 +410,8 @@ server_destroy_session(struct session *s)
 		} else {
 			c->last_session = NULL;
 			c->session = s_new;
-			server_client_set_key_table(c, NULL);
+			default_table = server_client_get_default_key_table(c);
+			server_client_set_key_table(c, default_table);
 			status_timer_start(c);
 			notify_client("client-session-changed", c);
 			session_update_activity(s_new, NULL);

--- a/tmux.h
+++ b/tmux.h
@@ -1451,6 +1451,7 @@ struct key_table {
 	struct key_bindings	 key_bindings;
 
 	u_int			 references;
+	const char		 *next_table;
 
 	RB_ENTRY(key_table)	 entry;
 };
@@ -1860,6 +1861,8 @@ int	 key_table_cmp(struct key_table *, struct key_table *);
 int	 key_bindings_cmp(struct key_binding *, struct key_binding *);
 struct key_table *key_bindings_get_table(const char *, int);
 void	 key_bindings_unref_table(struct key_table *);
+void	 key_bindings_set_next_table(const char *name, const char *next);
+int	 key_bindings_has_next_table(struct key_table *table);
 void	 key_bindings_add(const char *, key_code, int, struct cmd_list *);
 void	 key_bindings_remove(const char *, key_code);
 void	 key_bindings_remove_table(const char *);
@@ -1895,7 +1898,8 @@ u_int	 server_client_how_many(void);
 void	 server_client_set_identify(struct client *, u_int);
 void	 server_client_clear_identify(struct client *, struct window_pane *);
 void	 server_client_set_key_table(struct client *, const char *);
-const char *server_client_get_key_table(struct client *);
+const char *server_client_get_default_key_table(struct client *);
+const char * server_client_get_next_key_table(struct client *c);
 int	 server_client_check_nested(struct client *);
 void	 server_client_handle_key(struct client *, key_code);
 struct client *server_client_create(int);


### PR DESCRIPTION
I've been using custom key tables to use vim-like modal keybinding in tmux. It works by switching the key table back to prefix mode for every command executed, like below:

```tmux
bind k select-pane -U \; switch-client -T prefix
bind j select-pane -D \; switch-client -T prefix
bind h select-pane -L \; switch-client -T prefix
bind l select-pane -R \; switch-client -T prefix
```

But this approach doesn't work for undefined key sequences, meaning that tmux goes back to root mode if you mistype a command. This PR adds a way to let users specify which key table to transition to after a command is executed. With these changes, the above configuration can be re-written like this:

```tmux
set-next-table -T prefix prefix
bind k select-pane -U
bind j select-pane -D
bind h select-pane -L
bind l select-pane -R
```

This will allow you to keep tmux in prefix mode even if you enter an undefined key sequence.

Here's [a link](https://github.com/midchildan/dotfiles/blob/ca3f0261dddd5846370da50451c5091f70c99600/home/.tmux.conf) to my current tmux configuration, if you're interested.