### PR TITLE
Enable build on Cygwin

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -298,7 +298,11 @@ pid_t		 fdforkpty(int, int *, char *, struct termios *,
 
 #ifndef HAVE_FORKPTY
 /* forkpty.c */
+#ifndef __CYGWIN__
 pid_t		 forkpty(int *, char *, struct termios *, struct winsize *);
+#else
+int forkpty(int *, char *, const struct termios *, const struct winsize *);
+#endif
 #endif
 
 #ifndef HAVE_ASPRINTF


### PR DESCRIPTION
Hi,

It seem forkpty signature is different on Cygwin which breaks the build.

Regards,
Wojtek