### PR TITLE
Fixes screen redraw error with vim

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -1096,6 +1096,7 @@ tty_clear_area(struct tty *tty, const struct window_pane *wp, u_int py,
 		    px + nx >= tty->sx &&
 		    ny > 2 &&
 		    tty_term_has(tty->term, TTYC_CSR) &&
+		    tty_use_margin(tty) &&
 		    tty_term_has(tty->term, TTYC_INDN)) {
 			tty_region(tty, py, py + ny - 1);
 			tty_margin_off(tty);


### PR DESCRIPTION
Fixes screen redraw issue when scrolling vim inside tmux, which ends
mixing up new and old line content (as reported at issues #1085, #933
and #1228).

Steps to reproduce this issue:
 1) start tmux 2.8 from a konsole inside a yakuake session with TERM set
    to "xterm" or "xterm-256color";
 2) set tmux TERM to "xterm" or "xterm-256color";
 3) open a long file (whose lines have different lengths) with vi and
    scroll it using PageUp/PageDown keys.

At step 3), content from old lines and new lines will be mixed together.