### PR TITLE
Add a space between -f and program filename when invoking ${AWK}

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -196,7 +196,7 @@ install-exec-hook:
 			>$(srcdir)/tmux.1.mdoc; \
 	else \
 		sed -e "s|@SYSCONFDIR@|$(sysconfdir)|g" $(srcdir)/tmux.1| \
-			$(AWK) -f$(srcdir)/mdoc2man.awk >$(srcdir)/tmux.1.man; \
+			$(AWK) -f $(srcdir)/mdoc2man.awk >$(srcdir)/tmux.1.man; \
 	fi
 	$(mkdir_p) $(DESTDIR)$(mandir)/man1
 	$(INSTALL_DATA) $(srcdir)/tmux.1.@MANFORMAT@ \


### PR DESCRIPTION
At least on SunOS, nawk-20050424 insists on a space
between -f and the program file name, by penalty of
"/opt/local/bin/nawk: no program filename".

Patch from Hauke Fath via pkgsrc.