### PR TITLE
Address -Wint-conversion warnings (at least on NetBSD) casting them to intptr_t.

### DIFF
--- a/tty-term.c
+++ b/tty-term.c
@@ -616,14 +616,14 @@ tty_term_string3(struct tty_term *term, enum tty_code_code code, int a, int b, i
 const char *
 tty_term_ptr1(struct tty_term *term, enum tty_code_code code, const void *a)
 {
-	return (tparm((char *) tty_term_string(term, code), a, 0, 0, 0, 0, 0, 0, 0, 0));
+	return (tparm((char *) tty_term_string(term, code), (intptr_t)a, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 const char *
 tty_term_ptr2(struct tty_term *term, enum tty_code_code code, const void *a,
     const void *b)
 {
-	return (tparm((char *) tty_term_string(term, code), a, b, 0, 0, 0, 0, 0, 0, 0));
+	return (tparm((char *) tty_term_string(term, code), (intptr_t)a, (intptr_t)b, 0, 0, 0, 0, 0, 0, 0));
 }
 
 int

--- a/tty-term.c
+++ b/tty-term.c
@@ -616,14 +616,14 @@ tty_term_string3(struct tty_term *term, enum tty_code_code code, int a, int b, i
 const char *
 tty_term_ptr1(struct tty_term *term, enum tty_code_code code, const void *a)
 {
-	return (tparm((char *) tty_term_string(term, code), (intptr_t)a, 0, 0, 0, 0, 0, 0, 0, 0));
+	return (tparm((char *) tty_term_string(term, code), (long)a, 0, 0, 0, 0, 0, 0, 0, 0));
 }
 
 const char *
 tty_term_ptr2(struct tty_term *term, enum tty_code_code code, const void *a,
     const void *b)
 {
-	return (tparm((char *) tty_term_string(term, code), (intptr_t)a, (intptr_t)b, 0, 0, 0, 0, 0, 0, 0));
+	return (tparm((char *) tty_term_string(term, code), (long)a, (long)b, 0, 0, 0, 0, 0, 0, 0));
 }
 
 int


### PR DESCRIPTION
Patch from Christos Zoulas via NetBSD external/bsd/tmux/dist/tty-term.c,-r1.5.

Without this patch, on NetBSD compiling tmux produces the following warnings:

    --- tty-term.o ---
    depbase=`echo tty-term.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`; gcc -DPACKAGE_NAME=\"tmux\" -DPACKAGE_TARNAME=\"tmux\" -DPACKAGE_VERSION=\"master\" -DPACKAGE_STRING=\"tmux\ master\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"tmux\" -DVERSION=\"master\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -D__EXTENSIONS__=1 -D_ALL_SOURCE=1 -D_GNU_SOURCE=1 -D_POSIX_PTHREAD_SEMANTICS=1 -D_TANDEM_SOURCE=1 -DHAVE_BITSTRING_H=1 -DHAVE_DIRENT_H=1 -DHAVE_FCNTL_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_PATHS_H=1 -DHAVE_STDINT_H=1 -DHAVE_SYS_DIR_H=1 -DHAVE_SYS_TREE_H=1 -DHAVE_UTIL_H=1 -DHAVE_FLOCK=1 -DHAVE_SYSCONF=1 -DHAVE_ASPRINTF=1 -DHAVE_CFMAKERAW=1 -DHAVE_CLOSEFROM=1 -DHAVE_FGETLN=1 -DHAVE_GETPROGNAME=1 -DHAVE_MEMMEM=1 -DHAVE_REALLOCARRAY=1 -DHAVE_SETENV=1 -DHAVE_SETPROCTITLE=1 -DHAVE_STRCASESTR=1 -DHAVE_STRLCAT=1 -DHAVE_STRLCPY=1 -DHAVE_STRNDUP=1 -DHAVE_STRSEP=1 -DHAVE_STRTONUM=1 -DHAVE_CURSES_H=1 -DHAVE_B64_NTOP=1 -DHAVE_DAEMON=1 -DHAVE_DECL_OPTARG=1 -DHAVE_DECL_OPTIND=1 -DHAVE_DECL_OPTRESET=1 -DHAVE_GETOPT=1 -DHAVE_FPARSELN=1 -DHAVE_FORKPTY=1 -DHAVE_QUEUE_H=1 -DHAVE___PROGNAME=1 -DHAVE_FCNTL_CLOSEM=1 -DHAVE_PROC_PID=1 -I.  -DTMUX_CONF="\"/etc/tmux.conf\"" -DDEBUG  -iquote.     -D_OPENBSD_SOURCE   -I/usr/pkg/include   -std=gnu99 -O2 -g -Wno-long-long -Wall -W  -Wformat=2 -Wmissing-prototypes  -Wstrict-prototypes  -Wmissing-declarations  -Wwrite-strings -Wshadow  -Wpointer-arith -Wsign-compare  -Wundef -Wbad-function-cast  -Winline -Wcast-align  -Wdeclaration-after-statement  -Wno-pointer-sign -Wno-attributes  -Wno-unused-result    -MT tty-term.o -MD -MP -MF $depbase.Tpo -c -o tty-term.o tty-term.c && mv -f $depbase.Tpo $depbase.Po
    tty-term.c: In function ‘tty_term_ptr1’:
    tty-term.c:619:54: warning: passing argument 2 of ‘tparm’ makes integer from pointer without a cast [-Wint-conversion]
      return (tparm((char *) tty_term_string(term, code), a, 0, 0, 0, 0, 0, 0, 0, 0));
                                                          ^
    In file included from tty-term.c:29:0:
    /usr/include/term.h:1961:9: note: expected ‘long int’ but argument is of type ‘const void *’
     char *  tparm(const char *, long, long, long, long, long,
             ^~~~~
    tty-term.c: In function ‘tty_term_ptr2’:
    tty-term.c:626:54: warning: passing argument 2 of ‘tparm’ makes integer from pointer without a cast [-Wint-conversion]
      return (tparm((char *) tty_term_string(term, code), a, b, 0, 0, 0, 0, 0, 0, 0));
                                                          ^
    In file included from tty-term.c:29:0:
    /usr/include/term.h:1961:9: note: expected ‘long int’ but argument is of type ‘const void *’
     char *  tparm(const char *, long, long, long, long, long,
             ^~~~~
    tty-term.c:626:57: warning: passing argument 3 of ‘tparm’ makes integer from pointer without a cast [-Wint-conversion]
      return (tparm((char *) tty_term_string(term, code), a, b, 0, 0, 0, 0, 0, 0, 0));
                                                             ^
    In file included from tty-term.c:29:0:
    /usr/include/term.h:1961:9: note: expected ‘long int’ but argument is of type ‘const void *’
     char *  tparm(const char *, long, long, long, long, long,
             ^~~~~