### PR TITLE
mouse events: ignore pane borders while zoomed

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -535,14 +535,20 @@ have_event:
 		m->x = x + m->ox;
 		m->y = y + m->oy;
 
-		TAILQ_FOREACH(wp, &s->curw->window->panes, entry) {
-			if ((wp->xoff + wp->sx == px &&
-			    wp->yoff <= 1 + py &&
-			    wp->yoff + wp->sy >= py) ||
-			    (wp->yoff + wp->sy == py &&
-			    wp->xoff <= 1 + px &&
-			    wp->xoff + wp->sx >= px))
-				break;
+		if (s->curw->window->flags & WINDOW_ZOOMED) {
+			/* borders are irrelevant */
+			wp = NULL;
+		} else {
+			/* maybe find a border's pane */
+			TAILQ_FOREACH(wp, &s->curw->window->panes, entry) {
+				if ((wp->xoff + wp->sx == px &&
+				    wp->yoff <= 1 + py &&
+				    wp->yoff + wp->sy >= py) ||
+				    (wp->yoff + wp->sy == py &&
+				    wp->xoff <= 1 + px &&
+				    wp->xoff + wp->sx >= px))
+					break;
+			}
 		}
 		if (wp != NULL)
 			where = BORDER;


### PR DESCRIPTION
Previously, when creating a mouse event and settings its window pane,
the pane-search procedure tested pane borders unconditionally, and if
the coordinates were on a border, then this border's pane was set for
the event.

The issue is that in zoom mode borders are irrelevant, and it was
possible to end up with a pane which isn't the active (zoomed) one.

This resulted in mouse events getting ignored/other-issues in zoom mode
if they happen where a pane border exists when unzoomed.

This commit simply skips the border search procedure if the window is
zoomed.

Fixes #1473