### PR TITLE
New option 'full-search' to control copy-mode history search coverage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES FROM 2.8 to X.X
 
+* New option 'full-search' to control if copy-mode will search
+  over the full history.  Defaults to on, when off number of
+  results and highlighting is not shown.
+
 * New "terminal" colour allowing options to use the terminal default
   colour rather than inheriting the default from a parent option.
 

--- a/options-table.c
+++ b/options-table.c
@@ -117,6 +117,12 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 0
 	},
 
+	{ .name = "full-search",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_num = 1
+	},
+
 	{ .name = "history-file",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/tmux.1
+++ b/tmux.1
@@ -2627,6 +2627,11 @@ passed through to applications running in
 .Nm .
 Attached clients should be detached and attached again after changing this
 option.
+.It Xo Ic full-search
+.Op Ic on | off
+.Xc
+When enabled (the default), search in copy-mode will cover the full history
+and highlight matching text with the number of results.
 .It Ic history-file Ar path
 If not empty, a file to which
 .Nm

--- a/window-copy.c
+++ b/window-copy.c
@@ -1153,7 +1153,7 @@ window_copy_search(struct window_pane *wp, int direction)
 	struct screen_write_ctx		 ctx;
 	struct grid			*gd = s->grid;
 	u_int				 fx, fy, endline;
-	int				 wrapflag, cis, found;
+	int				 wrapflag, cis, found, fullsearch;
 
 	free(wp->searchstr);
 	wp->searchstr = xstrdup(data->searchstr);
@@ -1172,6 +1172,8 @@ window_copy_search(struct window_pane *wp, int direction)
 		window_copy_move_left(s, &fx, &fy);
 
 	wrapflag = options_get_number(wp->window->options, "wrap-search");
+	fullsearch = options_get_number(wp->window->options, "full-search");
+
 	cis = window_copy_is_lowercase(data->searchstr);
 
 	if (direction)
@@ -1181,7 +1183,7 @@ window_copy_search(struct window_pane *wp, int direction)
 	found = window_copy_search_jump(wp, gd, ss.grid, fx, fy, endline, cis,
 	    wrapflag, direction);
 
-	if (window_copy_search_marks(wp, &ss))
+	if (fullsearch && window_copy_search_marks(wp, &ss))
 		window_copy_redraw_screen(wp);
 
 	screen_free(&ss);


### PR DESCRIPTION
New option 'full-search' to control if copy-mode will search
over the full history.  Defaults to on, when off number of
results and highlighting is not shown.

When dealing with a history of ~20000 lines there's a small,
but noticeable, lag in the amount of time to jump to the first
result and search-again.  >50k+ histories results in multi-second wait.