### PR TITLE
[fix] Fix a crash due buggy log_debug usage

### DIFF
--- a/input.c
+++ b/input.c
@@ -1863,7 +1863,9 @@ input_csi_dispatch_sgr_colon(struct input_ctx *ictx, u_int i)
 				return;
 			}
 		}
-		log_debug("%s: %u = %d", __func__, n - 1, p[n - 1]);
+		if (n > 0) {
+			log_debug("%s: %u = %d", __func__, n - 1, p[n - 1]);
+		}
 	}
 	free(copy);
 


### PR DESCRIPTION
    1. To reproduce a crash please type in the following inside tmux:
        python -c "import sys; sys.stdout.buffer.write(bytes.fromhex('1b5b3a33346d28'))"