### PR TITLE
Import OpenSSH's setproctitle() compat shim.

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -279,6 +279,7 @@ const char	*getprogname(void);
 #ifndef HAVE_SETPROCTITLE
 /* setproctitle.c */
 void		 setproctitle(const char *, ...);
+void		 compat_init_setproctitle(int argc, char *argv[]);
 #endif
 
 #ifndef HAVE_B64_NTOP

--- a/compat/setproctitle.c
+++ b/compat/setproctitle.c
@@ -1,52 +1,170 @@
+/* Based on conf.c from UCB sendmail 8.8.8 */
+
 /*
- * Copyright (c) 2016 Nicholas Marriott <nicholas.marriott@gmail.com>
+ * Copyright 2003 Damien Miller
+ * Copyright (c) 1983, 1995-1997 Eric P. Allman
+ * Copyright (c) 1988, 1993
+ *	The Regents of the University of California.  All rights reserved.
  *
- * Permission to use, copy, modify, and distribute this software for any
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
- * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
- * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  */
-
-#include <sys/types.h>
-
-#include <stdarg.h>
-#include <string.h>
 
 #include "compat.h"
 
-#if defined(HAVE_PRCTL) && defined(HAVE_PR_SET_NAME)
+#ifndef HAVE_SETPROCTITLE
 
-#include <sys/prctl.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <unistd.h>
+#ifdef HAVE_SYS_PSTAT_H
+#include <sys/pstat.h>
+#endif
+#include <string.h>
 
+
+#define SPT_NONE	0	/* don't use it at all */
+#define SPT_PSTAT	1	/* use pstat(PSTAT_SETCMD, ...) */
+#define SPT_REUSEARGV	2	/* cover argv with title information */
+
+#ifndef SPT_TYPE
+# define SPT_TYPE	SPT_NONE
+#endif
+
+#ifndef SPT_PADCHAR
+# define SPT_PADCHAR	'\0'
+#endif
+
+#if SPT_TYPE == SPT_REUSEARGV
+static char *argv_start = NULL;
+static size_t argv_env_len = 0;
+static char progname[1024];
+#endif
+
+#endif /* HAVE_SETPROCTITLE */
+
+void
+compat_init_setproctitle(int argc, char *argv[])
+{
+#if !defined(HAVE_SETPROCTITLE) && \
+    defined(SPT_TYPE) && SPT_TYPE == SPT_REUSEARGV
+	extern char **environ;
+	extern char *__progname;
+	char *lastargv = NULL;
+	char **envp = environ;
+	int i;
+
+	/*
+	 * NB: This assumes that argv has already been copied out of the
+	 * way. This is true for sshd, but may not be true for other
+	 * programs. Beware.
+	 */
+
+	if (argc == 0 || argv[0] == NULL)
+		return;
+
+	/* Fail if we can't allocate room for the new environment */
+	for (i = 0; envp[i] != NULL; i++)
+		;
+	if ((environ = calloc(i + 1, sizeof(*environ))) == NULL) {
+		environ = envp;	/* put it back */
+		return;
+	}
+
+	/* Copy __progname in case it's an alias for argv[0] */
+	strlcpy(progname, __progname, sizeof(progname));
+
+	/*
+	 * Find the last argv string or environment variable within
+	 * our process memory area.
+	 */
+	for (i = 0; i < argc; i++) {
+		if (lastargv == NULL || lastargv + 1 == argv[i])
+			lastargv = argv[i] + strlen(argv[i]);
+	}
+	for (i = 0; envp[i] != NULL; i++) {
+		if (lastargv + 1 == envp[i])
+			lastargv = envp[i] + strlen(envp[i]);
+	}
+
+	argv[1] = NULL;
+	argv_start = argv[0];
+	argv_env_len = lastargv - argv[0] - 1;
+
+	/*
+	 * Copy environment
+	 * XXX - will truncate env on strdup fail
+	 */
+	for (i = 0; envp[i] != NULL; i++)
+		environ[i] = strdup(envp[i]);
+	environ[i] = NULL;
+#endif /* SPT_REUSEARGV */
+}
+
+#ifndef HAVE_SETPROCTITLE
 void
 setproctitle(const char *fmt, ...)
 {
-	char	title[16], name[16], *cp;
-	va_list	ap;
-	int	used;
-
-	va_start(ap, fmt);
-	vsnprintf(title, sizeof title, fmt, ap);
-	va_end(ap);
-
-	used = snprintf(name, sizeof name, "%s: %s", getprogname(), title);
-	if (used >= (int)sizeof name) {
-		cp = strrchr(name, ' ');
-		if (cp != NULL)
-			*cp = '\0';
-	}
-	prctl(PR_SET_NAME, name);
-}
-#else
-void
-setproctitle(__unused const char *fmt, ...)
-{
-}
+#if SPT_TYPE != SPT_NONE
+	va_list ap;
+	char buf[1024], ptitle[1024];
+	size_t len = 0;
+	int r;
+#if SPT_TYPE == SPT_PSTAT
+	union pstun pst;
 #endif
+
+#if SPT_TYPE == SPT_REUSEARGV
+	if (argv_env_len <= 0)
+		return;
+#endif
+
+        strlcpy(buf, progname, sizeof(buf));
+
+	r = -1;
+	va_start(ap, fmt);
+	if (fmt != NULL) {
+		len = strlcat(buf, ": ", sizeof(buf));
+		if (len < sizeof(buf))
+			r = vsnprintf(buf + len, sizeof(buf) - len , fmt, ap);
+	}
+	va_end(ap);
+	if (r == -1 || (size_t)r >= sizeof(buf) - len)
+		return;
+	strnvis(ptitle, buf, sizeof(ptitle),
+	    VIS_CSTYLE|VIS_NL|VIS_TAB|VIS_OCTAL);
+
+#if SPT_TYPE == SPT_PSTAT
+	pst.pst_command = ptitle;
+	pstat(PSTAT_SETCMD, pst, strlen(ptitle), 0, 0);
+#elif SPT_TYPE == SPT_REUSEARGV
+	len = strlcpy(argv_start, ptitle, argv_env_len);
+	for(; len < argv_env_len; len++)
+		argv_start[len] = SPT_PADCHAR;
+#endif
+
+#endif /* SPT_NONE */
+}
+
+#endif /* HAVE_SETPROCTITLE */

--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,6 @@ AC_SEARCH_LIBS(flock, bsd)
 AC_CHECK_FUNCS([ \
 	dirfd \
 	flock \
-	prctl \
 	sysconf \
 ])
 
@@ -538,14 +537,6 @@ AC_LINK_IFELSE([AC_LANG_SOURCE(
 	AC_MSG_RESULT(no)
 )
 
-# Look for prctl(PR_SET_NAME).
-AC_CHECK_DECL(
-	PR_SET_NAME,
-	AC_DEFINE(HAVE_PR_SET_NAME),
-	,
-	[#include <sys/prctl.h>]
-)
-
 # Look for fcntl(F_CLOSEM).
 AC_CHECK_DECL(
 	F_CLOSEM,
@@ -573,6 +564,9 @@ case "$host_os" in
 	*aix*)
 		AC_MSG_RESULT(aix)
 		PLATFORM=aix
+		AC_DEFINE([SPT_TYPE], [SPT_REUSEARGV],
+			[Define to a Set Process Title type if your system is
+			supported by setproctitle.c])
 		;;
 	*darwin*)
 		AC_MSG_RESULT(darwin)
@@ -593,6 +587,7 @@ case "$host_os" in
 	*linux*)
 		AC_MSG_RESULT(linux)
 		PLATFORM=linux
+		AC_DEFINE([SPT_TYPE], [SPT_REUSEARGV])
 		;;
 	*freebsd*)
 		AC_MSG_RESULT(freebsd)
@@ -627,10 +622,12 @@ case "$host_os" in
 	*hpux*)
 		AC_MSG_RESULT(hpux)
 		PLATFORM=hpux
+		AC_DEFINE([SPT_TYPE], [SPT_PSTAT])
 		;;
 	*cygwin*|*msys*)
 		AC_MSG_RESULT(cygwin)
 		PLATFORM=cygwin
+		AC_DEFINE([SPT_TYPE], [SPT_REUSEARGV])
 		;;
 	*)
 		AC_MSG_RESULT(unknown)


### PR DESCRIPTION
The current code sets the process title on Linux using `prctl(2)`, which according to the manual page is a Linux-specific system call. This is limited to sixteen bytes, and exposed via `/proc/<PID>/comm` -- some process viewers don't read the `comm` file (instead reading `/proc/<PID>/cmdline`), so any changes to the process title are not visible. From reading the code, I'm also assuming that tmux doesn't support changing the process title on platforms which lack a native `setproctitle()` and aren't Linux.

The way that OpenSSH and Postgresql do this on Linux is to make a copy of `argv` and move `environ` at startup, and then to overwrite the kernel-allocated `argv` and `environ` space with the desired process title, which is then exposed in the `cmdline` file under `/proc`. This also works on some other platforms which don't have a native `setproctitle()`, such as Cygwin and AIX (according to OpenSSH's `configure.ac`), and OpenSSH's code also supports `pstat()` on HP-UX, so I've attempted to import OpenSSH's `setproctitle()` shim as a replacement for the current code.

I've only been able to test this on (x86_64 glibc) Linux, as I don't have access to either a Cygwin or AIX system.