### PR TITLE
Suppress misleading gseq not found warning

### DIFF
--- a/tools/24-bit-color.sh
+++ b/tools/24-bit-color.sh
@@ -14,7 +14,7 @@
 # https://github.com/gnachman/iTerm2/blob/master/LICENSE
 #
 
-if which gseq >/dev/null
+if which gseq &>/dev/null
 then
     SEQ=gseq
 else


### PR DESCRIPTION
The `which gseq` command's stderr wasn't being redirected, so it would print an error even when it was working. I was trying to debug 24-bit color support (in a context where it was broken), and I thought I was missing a script dependency for a bit before realizing what was happening.