### PR TITLE
fix buffer overrun caused by an ESC key with no following keys

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -464,6 +464,9 @@ tty_keys_find(struct tty *tty, const char *buf, size_t len, size_t *size)
 static struct tty_key *
 tty_keys_find1(struct tty_key *tk, const char *buf, size_t len, size_t *size)
 {
+	if (len == 0)
+		return NULL;
+
 	/* If the node is NULL, this is the end of the tree. No match. */
 	if (tk == NULL)
 		return (NULL);


### PR DESCRIPTION
How to replay:
1. in an xterm, run vim (or nvi) in a tmux pane.
2. type following key-sequence in vim.

 i a a ESC I x ESC

after the operation, the first line should be "xaa" and cursor should be located on "x" ,
but tmux generates extra keys `ESC O C', and the cursor will move onto "a".
