### PR TITLE
Update session activity when a pane is focused.

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -1379,6 +1379,7 @@ focused:
 		if (wp->base.mode & MODE_FOCUSON)
 			bufferevent_write(wp->event, "\033[I", 3);
 		notify_pane("pane-focus-in", wp);
+		session_update_activity(c->session, NULL);
 	}
 	wp->flags |= PANE_FOCUSED;
 }


### PR DESCRIPTION
Focus-in events are a good indication that the client that received the event is now in use. Updating the session activity after such an event allows commands issued outside of a session to affect the newly focused client instead of the last client that saw a key-press.