### PR TITLE
compat: make sure _PATH_DEFPATH is defined

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -67,6 +67,7 @@ void	warnx(const char *, ...);
 #define _PATH_DEVNULL	"/dev/null"
 #define _PATH_TTY	"/dev/tty"
 #define _PATH_DEV	"/dev/"
+#define _PATH_DEFPATH	"/usr/bin:/bin"
 #endif
 
 #ifndef __OpenBSD__


### PR DESCRIPTION
if system doesn't provide paths.h, all _PATH_* variables used should
come instead from compat.h (included from tmux.h)