### PR TITLE
Trivial

### DIFF
--- a/cmd-respawn-pane.c
+++ b/cmd-respawn-pane.c
@@ -52,7 +52,6 @@ cmd_respawn_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct session		*s = item->target.s;
 	struct winlink		*wl = item->target.wl;
 	struct window_pane	*wp = item->target.wp;
-	struct client		*c = cmd_find_client(item, NULL, 1);
 	char			*cause = NULL;
 
 	memset(&sc, 0, sizeof sc);

--- a/osdep-darwin.c
+++ b/osdep-darwin.c
@@ -30,7 +30,9 @@ char			*osdep_get_name(int, char *);
 char			*osdep_get_cwd(int);
 struct event_base	*osdep_event_init(void);
 
+#ifndef __unused
 #define __unused __attribute__ ((__unused__))
+#endif
 
 char *
 osdep_get_name(int fd, __unused char *tty)
@@ -47,6 +49,7 @@ osdep_get_name(int fd, __unused char *tty)
 			&bsdinfo, sizeof bsdinfo);
 	if (ret == sizeof bsdinfo && *bsdinfo.pbsi_comm != '\0')
 		return (strdup(bsdinfo.pbsi_comm));
+	return (NULL);
 #else
 	int	mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0 };
 	size_t	size;


### PR DESCRIPTION
trivial warnings when building with Apple LLVM 10.0.1 in macOS 10.14.4