### PR TITLE
Do not reduce window height by status bar height for control mode clients

### DIFF
--- a/resize.c
+++ b/resize.c
@@ -174,7 +174,7 @@ recalculate_sizes(void)
 	TAILQ_FOREACH(c, &clients, entry) {
 		if (ignore_client_size(c))
 			continue;
-		if (c->tty.sy <= status_line_size(c))
+		if (c->tty.sy <= status_line_size(c) || (c->flags & CLIENT_CONTROL))
 			c->flags |= CLIENT_STATUSOFF;
 		else
 			c->flags &= ~CLIENT_STATUSOFF;


### PR DESCRIPTION
Prior to commit 646995384d695eed9de1b2363fd2b315ca01785e, the status bar's height was not deducted from window heights in `recalculate_sizes()` for control mode client. That commit moved one of the two checks for control mode into `ignore_client_size`, and the other was lost.

As a result, control mode windows have a usable area that is always smaller than the available space.
