### PR TITLE
Add support for overscore

### DIFF
--- a/attributes.c
+++ b/attributes.c
@@ -44,7 +44,7 @@ attributes_tostring(int attr)
 	    (attr & GRID_ATTR_UNDERSCORE_3) ? "curly-underscore," : "",
 	    (attr & GRID_ATTR_UNDERSCORE_4) ? "dotted-underscore," : "",
 	    (attr & GRID_ATTR_UNDERSCORE_5) ? "dashed-underscore," : "",
-	    (attr & GRID_ATTR_OVERSCORE) ? "overscore," : "");
+	    (attr & GRID_ATTR_OVERLINE) ? "overline," : "");
 	if (len > 0)
 		buf[len - 1] = '\0';
 
@@ -75,7 +75,7 @@ attributes_fromstring(const char *str)
 		{ "curly-underscore", GRID_ATTR_UNDERSCORE_3 },
 		{ "dotted-underscore", GRID_ATTR_UNDERSCORE_4 },
 		{ "dashed-underscore", GRID_ATTR_UNDERSCORE_5 },
-		{ "overscore", GRID_ATTR_OVERSCORE }
+		{ "overline", GRID_ATTR_OVERLINE }
 	};
 
 	if (*str == '\0' || strcspn(str, delimiters) == 0)

--- a/attributes.c
+++ b/attributes.c
@@ -31,7 +31,7 @@ attributes_tostring(int attr)
 	if (attr == 0)
 		return ("none");
 
-	len = xsnprintf(buf, sizeof buf, "%s%s%s%s%s%s%s%s%s%s%s%s",
+	len = xsnprintf(buf, sizeof buf, "%s%s%s%s%s%s%s%s%s%s%s%s%s",
 	    (attr & GRID_ATTR_BRIGHT) ? "bright," : "",
 	    (attr & GRID_ATTR_DIM) ? "dim," : "",
 	    (attr & GRID_ATTR_UNDERSCORE) ? "underscore," : "",
@@ -43,7 +43,8 @@ attributes_tostring(int attr)
 	    (attr & GRID_ATTR_UNDERSCORE_2) ? "double-underscore," : "",
 	    (attr & GRID_ATTR_UNDERSCORE_3) ? "curly-underscore," : "",
 	    (attr & GRID_ATTR_UNDERSCORE_4) ? "dotted-underscore," : "",
-	    (attr & GRID_ATTR_UNDERSCORE_5) ? "dashed-underscore," : "");
+	    (attr & GRID_ATTR_UNDERSCORE_5) ? "dashed-underscore," : "",
+	    (attr & GRID_ATTR_OVERSCORE) ? "overscore," : "");
 	if (len > 0)
 		buf[len - 1] = '\0';
 
@@ -73,7 +74,8 @@ attributes_fromstring(const char *str)
 		{ "double-underscore", GRID_ATTR_UNDERSCORE_2 },
 		{ "curly-underscore", GRID_ATTR_UNDERSCORE_3 },
 		{ "dotted-underscore", GRID_ATTR_UNDERSCORE_4 },
-		{ "dashed-underscore", GRID_ATTR_UNDERSCORE_5 }
+		{ "dashed-underscore", GRID_ATTR_UNDERSCORE_5 },
+		{ "overscore", GRID_ATTR_OVERSCORE }
 	};
 
 	if (*str == '\0' || strcspn(str, delimiters) == 0)

--- a/example_tmux.conf
+++ b/example_tmux.conf
@@ -6,10 +6,7 @@
 
 # Some tweaks to the status line
 set -g status-right "%H:%M"
-set -g window-status-current-style "bold"
-set -g status-style "overline"
-set -g status-bg default
-set -g status-fg "brightblue"
+set -g window-status-current-style "underscore"
 
 # If running inside tmux ($TMUX is set), then change the status line to red
 %if #{TMUX}
@@ -23,52 +20,52 @@ set-option -sa terminal-overrides ",xterm*:Tc"
 set -g default-terminal "tmux-256color"
 
 # No bells at all
-# set -g bell-action none
+set -g bell-action none
 
 # Keep windows around after they exit
-# set -g remain-on-exit on
+set -g remain-on-exit on
 
 # Change the prefix key to C-a
-# set -g prefix C-a
-# unbind C-b
-# bind C-a send-prefix
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
 
 # Turn the mouse on, but without copy mode dragging
 set -g mouse on
-# unbind -n MouseDrag1Pane
-# unbind -Tcopy-mode MouseDrag1Pane
+unbind -n MouseDrag1Pane
+unbind -Tcopy-mode MouseDrag1Pane
 
 # Some extra key bindings to select higher numbered windows
-# bind F1 selectw -t:10
-# bind F2 selectw -t:11
-# bind F3 selectw -t:12
-# bind F4 selectw -t:13
-# bind F5 selectw -t:14
-# bind F6 selectw -t:15
-# bind F7 selectw -t:16
-# bind F8 selectw -t:17
-# bind F9 selectw -t:18
-# bind F10 selectw -t:19
-# bind F11 selectw -t:20
-# bind F12 selectw -t:21
+bind F1 selectw -t:10
+bind F2 selectw -t:11
+bind F3 selectw -t:12
+bind F4 selectw -t:13
+bind F5 selectw -t:14
+bind F6 selectw -t:15
+bind F7 selectw -t:16
+bind F8 selectw -t:17
+bind F9 selectw -t:18
+bind F10 selectw -t:19
+bind F11 selectw -t:20
+bind F12 selectw -t:21
 
 # A key to toggle between smallest and largest sizes if a window is visible in
 # multiple places
-# bind F set -w window-size
+bind F set -w window-size
 
 # Keys to toggle monitoring activity in a window and the synchronize-panes option
-# bind m set monitor-activity
-# bind y set synchronize-panes\; display 'synchronize-panes #{?synchronize-panes,on,off}'
+bind m set monitor-activity
+bind y set synchronize-panes\; display 'synchronize-panes #{?synchronize-panes,on,off}'
 
 # Create a single default session - because a session is created here, tmux
 # should be started with "tmux attach" rather than "tmux new"
-# new -d -s0 -nirssi 'exec irssi'
-# set -t0:0 monitor-activity on
-# set  -t0:0 aggressive-resize on
-# neww -d -ntodo 'exec emacs ~/TODO'
-# setw -t0:1 aggressive-resize on
-# neww -d -nmutt 'exec mutt'
-# setw -t0:2 aggressive-resize on
-# neww -d
-# neww -d
-# neww -d
+new -d -s0 -nirssi 'exec irssi'
+set -t0:0 monitor-activity on
+set  -t0:0 aggressive-resize on
+neww -d -ntodo 'exec emacs ~/TODO'
+setw -t0:1 aggressive-resize on
+neww -d -nmutt 'exec mutt'
+setw -t0:2 aggressive-resize on
+neww -d
+neww -d
+neww -d

--- a/example_tmux.conf
+++ b/example_tmux.conf
@@ -5,8 +5,9 @@
 #
 
 # Some tweaks to the status line
-set -g status-right "%H:%M"
-set -g window-status-current-style "underscore"
+set -g status-right "%H:%M:%S"
+set -g window-status-current-style "none"
+set -g status-style "overscore"
 
 # If running inside tmux ($TMUX is set), then change the status line to red
 %if #{TMUX}
@@ -20,52 +21,52 @@ set-option -sa terminal-overrides ",xterm*:Tc"
 set -g default-terminal "tmux-256color"
 
 # No bells at all
-set -g bell-action none
+# set -g bell-action none
 
 # Keep windows around after they exit
-set -g remain-on-exit on
+# set -g remain-on-exit on
 
 # Change the prefix key to C-a
-set -g prefix C-a
-unbind C-b
-bind C-a send-prefix
+# set -g prefix C-a
+# unbind C-b
+# bind C-a send-prefix
 
 # Turn the mouse on, but without copy mode dragging
 set -g mouse on
-unbind -n MouseDrag1Pane
-unbind -Tcopy-mode MouseDrag1Pane
+# unbind -n MouseDrag1Pane
+# unbind -Tcopy-mode MouseDrag1Pane
 
 # Some extra key bindings to select higher numbered windows
-bind F1 selectw -t:10
-bind F2 selectw -t:11
-bind F3 selectw -t:12
-bind F4 selectw -t:13
-bind F5 selectw -t:14
-bind F6 selectw -t:15
-bind F7 selectw -t:16
-bind F8 selectw -t:17
-bind F9 selectw -t:18
-bind F10 selectw -t:19
-bind F11 selectw -t:20
-bind F12 selectw -t:21
+# bind F1 selectw -t:10
+# bind F2 selectw -t:11
+# bind F3 selectw -t:12
+# bind F4 selectw -t:13
+# bind F5 selectw -t:14
+# bind F6 selectw -t:15
+# bind F7 selectw -t:16
+# bind F8 selectw -t:17
+# bind F9 selectw -t:18
+# bind F10 selectw -t:19
+# bind F11 selectw -t:20
+# bind F12 selectw -t:21
 
 # A key to toggle between smallest and largest sizes if a window is visible in
 # multiple places
-bind F set -w window-size
+# bind F set -w window-size
 
 # Keys to toggle monitoring activity in a window and the synchronize-panes option
-bind m set monitor-activity
-bind y set synchronize-panes\; display 'synchronize-panes #{?synchronize-panes,on,off}'
+# bind m set monitor-activity
+# bind y set synchronize-panes\; display 'synchronize-panes #{?synchronize-panes,on,off}'
 
 # Create a single default session - because a session is created here, tmux
 # should be started with "tmux attach" rather than "tmux new"
-new -d -s0 -nirssi 'exec irssi'
-set -t0:0 monitor-activity on
-set  -t0:0 aggressive-resize on
-neww -d -ntodo 'exec emacs ~/TODO'
-setw -t0:1 aggressive-resize on
-neww -d -nmutt 'exec mutt'
-setw -t0:2 aggressive-resize on
-neww -d
-neww -d
-neww -d
+# new -d -s0 -nirssi 'exec irssi'
+# set -t0:0 monitor-activity on
+# set  -t0:0 aggressive-resize on
+# neww -d -ntodo 'exec emacs ~/TODO'
+# setw -t0:1 aggressive-resize on
+# neww -d -nmutt 'exec mutt'
+# setw -t0:2 aggressive-resize on
+# neww -d
+# neww -d
+# neww -d

--- a/example_tmux.conf
+++ b/example_tmux.conf
@@ -5,9 +5,11 @@
 #
 
 # Some tweaks to the status line
-set -g status-right "%H:%M:%S"
-set -g window-status-current-style "none"
-set -g status-style "overscore"
+set -g status-right "%H:%M"
+set -g window-status-current-style "bold"
+set -g status-style "overline"
+set -g status-bg default
+set -g status-fg "brightblue"
 
 # If running inside tmux ($TMUX is set), then change the status line to red
 %if #{TMUX}

--- a/grid.c
+++ b/grid.c
@@ -790,6 +790,7 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 		{ GRID_ATTR_UNDERSCORE_3, 43 },
 		{ GRID_ATTR_UNDERSCORE_4, 44 },
 		{ GRID_ATTR_UNDERSCORE_5, 45 },
+		{ GRID_ATTR_OVERSCORE, 82 },
 	};
 	n = 0;
 

--- a/grid.c
+++ b/grid.c
@@ -790,7 +790,7 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 		{ GRID_ATTR_UNDERSCORE_3, 43 },
 		{ GRID_ATTR_UNDERSCORE_4, 44 },
 		{ GRID_ATTR_UNDERSCORE_5, 45 },
-		{ GRID_ATTR_OVERSCORE, 82 },
+		{ GRID_ATTR_OVERSCORE, 53 },
 	};
 	n = 0;
 

--- a/grid.c
+++ b/grid.c
@@ -790,7 +790,7 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 		{ GRID_ATTR_UNDERSCORE_3, 43 },
 		{ GRID_ATTR_UNDERSCORE_4, 44 },
 		{ GRID_ATTR_UNDERSCORE_5, 45 },
-		{ GRID_ATTR_OVERSCORE, 53 },
+		{ GRID_ATTR_OVERLINE, 53 },
 	};
 	n = 0;
 

--- a/input.c
+++ b/input.c
@@ -2071,10 +2071,10 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 			gc->bg = 8;
 			break;
 		case 53:
-			gc->attr &= GRID_ATTR_OVERSCORE;
+			gc->attr &= GRID_ATTR_OVERLINE;
 			break;
 		case 55:
-			gc->attr &= ~GRID_ATTR_OVERSCORE;
+			gc->attr &= ~GRID_ATTR_OVERLINE;
 			break;
 		case 90:
 		case 91:

--- a/input.c
+++ b/input.c
@@ -2071,10 +2071,10 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 			gc->bg = 8;
 			break;
 		case 53:
-			gc->attr &= ~GRID_ATTR_OVERSCORE;
+			gc->attr &= GRID_ATTR_OVERSCORE;
 			break;
 		case 55:
-			gc->attr &= GRID_ATTR_OVERSCORE;
+			gc->attr &= ~GRID_ATTR_OVERSCORE;
 			break;
 		case 90:
 		case 91:

--- a/input.c
+++ b/input.c
@@ -2070,6 +2070,12 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 		case 49:
 			gc->bg = 8;
 			break;
+		case 53:
+			gc->attr &= ~GRID_ATTR_OVERSCORE;
+			break;
+		case 55:
+			gc->attr &= GRID_ATTR_OVERSCORE;
+			break;
 		case 90:
 		case 91:
 		case 92:

--- a/input.c
+++ b/input.c
@@ -2071,7 +2071,7 @@ input_csi_dispatch_sgr(struct input_ctx *ictx)
 			gc->bg = 8;
 			break;
 		case 53:
-			gc->attr &= GRID_ATTR_OVERLINE;
+			gc->attr |= GRID_ATTR_OVERLINE;
 			break;
 		case 55:
 			gc->attr &= ~GRID_ATTR_OVERLINE;

--- a/tmux.1
+++ b/tmux.1
@@ -4094,7 +4094,7 @@ Set no attributes (turn off any active attributes).
 .Ic reverse ,
 .Ic hidden ,
 .Ic italics ,
-.Ic overscore ,
+.Ic overline ,
 .Ic strikethrough ,
 .Ic double-underscore ,
 .Ic curly-underscore ,

--- a/tmux.1
+++ b/tmux.1
@@ -4094,6 +4094,7 @@ Set no attributes (turn off any active attributes).
 .Ic reverse ,
 .Ic hidden ,
 .Ic italics ,
+.Ic overscore ,
 .Ic strikethrough ,
 .Ic double-underscore ,
 .Ic curly-underscore ,

--- a/tmux.h
+++ b/tmux.h
@@ -433,6 +433,7 @@ enum tty_code_code {
 	TTYC_SITM,
 	TTYC_SMACS,
 	TTYC_SMCUP,
+	TTYC_SMOL,
 	TTYC_SMKX,
 	TTYC_SMSO,
 	TTYC_SMULX,
@@ -445,7 +446,6 @@ enum tty_code_code {
 	TTYC_VPA,
 	TTYC_XENL,
 	TTYC_XT,
-	TTYC_OVERLINE,
 };
 
 /* Message codes. */

--- a/tmux.h
+++ b/tmux.h
@@ -570,6 +570,7 @@ enum utf8_state {
 #define GRID_ATTR_UNDERSCORE_3 0x400
 #define GRID_ATTR_UNDERSCORE_4 0x800
 #define GRID_ATTR_UNDERSCORE_5 0x1000
+#define GRID_ATTR_OVERSCORE 0x2000
 
 /* All underscore attributes. */
 #define GRID_ATTR_ALL_UNDERSCORE \

--- a/tmux.h
+++ b/tmux.h
@@ -445,6 +445,7 @@ enum tty_code_code {
 	TTYC_VPA,
 	TTYC_XENL,
 	TTYC_XT,
+	TTYC_OVERLINE,
 };
 
 /* Message codes. */
@@ -570,7 +571,7 @@ enum utf8_state {
 #define GRID_ATTR_UNDERSCORE_3 0x400
 #define GRID_ATTR_UNDERSCORE_4 0x800
 #define GRID_ATTR_UNDERSCORE_5 0x1000
-#define GRID_ATTR_OVERSCORE 0x2000
+#define GRID_ATTR_OVERLINE 0x2000
 
 /* All underscore attributes. */
 #define GRID_ATTR_ALL_UNDERSCORE \

--- a/tty-term.c
+++ b/tty-term.c
@@ -255,6 +255,7 @@ static const struct tty_term_code_entry tty_term_codes[] = {
 	[TTYC_SMACS] = { TTYCODE_STRING, "smacs" },
 	[TTYC_SMCUP] = { TTYCODE_STRING, "smcup" },
 	[TTYC_SMKX] = { TTYCODE_STRING, "smkx" },
+	[TTYC_SMOL] = { TTYCODE_STRING, "smol" },
 	[TTYC_SMSO] = { TTYCODE_STRING, "smso" },
 	[TTYC_SMULX] = { TTYCODE_STRING, "Smulx" },
 	[TTYC_SMUL] = { TTYCODE_STRING, "smul" },

--- a/tty.c
+++ b/tty.c
@@ -2199,6 +2199,8 @@ tty_attributes(struct tty *tty, const struct grid_cell *gc,
 		tty_putcode(tty, TTYC_INVIS);
 	if (changed & GRID_ATTR_STRIKETHROUGH)
 		tty_putcode(tty, TTYC_SMXX);
+	if (changed & GRID_ATTR_OVERSCORE)
+	        tty_puts(tty, "\033[53m");
 	if ((changed & GRID_ATTR_CHARSET) && tty_acs_needed(tty))
 		tty_putcode(tty, TTYC_SMACS);
 }

--- a/tty.c
+++ b/tty.c
@@ -2200,7 +2200,7 @@ tty_attributes(struct tty *tty, const struct grid_cell *gc,
 	if (changed & GRID_ATTR_STRIKETHROUGH)
 		tty_putcode(tty, TTYC_SMXX);
 	if (changed & GRID_ATTR_OVERLINE)
-		tty_puts(tty, "\033[53m");
+		tty_putcode(tty, TTYC_SMOL);
 	if ((changed & GRID_ATTR_CHARSET) && tty_acs_needed(tty))
 		tty_putcode(tty, TTYC_SMACS);
 }

--- a/tty.c
+++ b/tty.c
@@ -2200,7 +2200,7 @@ tty_attributes(struct tty *tty, const struct grid_cell *gc,
 	if (changed & GRID_ATTR_STRIKETHROUGH)
 		tty_putcode(tty, TTYC_SMXX);
 	if (changed & GRID_ATTR_OVERSCORE)
-	        tty_puts(tty, "\033[53m");
+		tty_puts(tty, "\033[53m");
 	if ((changed & GRID_ATTR_CHARSET) && tty_acs_needed(tty))
 		tty_putcode(tty, TTYC_SMACS);
 }

--- a/tty.c
+++ b/tty.c
@@ -2199,7 +2199,7 @@ tty_attributes(struct tty *tty, const struct grid_cell *gc,
 		tty_putcode(tty, TTYC_INVIS);
 	if (changed & GRID_ATTR_STRIKETHROUGH)
 		tty_putcode(tty, TTYC_SMXX);
-	if (changed & GRID_ATTR_OVERSCORE)
+	if (changed & GRID_ATTR_OVERLINE)
 		tty_puts(tty, "\033[53m");
 	if ((changed & GRID_ATTR_CHARSET) && tty_acs_needed(tty))
 		tty_putcode(tty, TTYC_SMACS);


### PR DESCRIPTION
Adding support for overline (from ECMA-48) to the status bar styling. Tested on Gnome Terminal and Konsole (also tested on xterm, pandoterm, rxvt, Cool Retro Term, macOS's Terminal, Cathode and iTerm, but none of these support the attribute)