### PR TITLE
Fix handling "optional" color space identifier parameter for the direct-color SGR sequence

### DIFF
--- a/input.c
+++ b/input.c
@@ -1940,12 +1940,11 @@ input_csi_dispatch_sgr_colon(struct input_ctx *ictx, u_int i)
 	}
 	if (p[0] != 38 && p[0] != 48)
 		return;
-	if (p[1] == -1)
-		i = 2;
-	else
-		i = 1;
+	i = 1;
 	switch (p[i]) {
 	case 2:
+		if (p[i + 1] == -1)
+			i++;
 		if (n < i + 4)
 			break;
 		input_csi_dispatch_sgr_rgb_do(ictx, p[0], p[i + 1], p[i + 2],

--- a/input.c
+++ b/input.c
@@ -1938,22 +1938,25 @@ input_csi_dispatch_sgr_colon(struct input_ctx *ictx, u_int i)
 		}
 		return;
 	}
-	if (p[0] != 38 && p[0] != 48)
+	if (n < 2 || (p[0] != 38 && p[0] != 48))
 		return;
-	i = 1;
-	switch (p[i]) {
+	switch (p[1]) {
 	case 2:
-		if (p[i + 1] == -1)
-			i++;
-		if (n < i + 4)
+		if (n < 3)
 			break;
-		input_csi_dispatch_sgr_rgb_do(ictx, p[0], p[i + 1], p[i + 2],
-		    p[i + 3]);
+		if (n == 5)
+			i = 2;
+		else
+			i = 3;
+		if (n < i + 3)
+			break;
+		input_csi_dispatch_sgr_rgb_do(ictx, p[0], p[i], p[i + 1],
+		    p[i + 2]);
 		break;
 	case 5:
-		if (n < i + 2)
+		if (n < 3)
 			break;
-		input_csi_dispatch_sgr_256_do(ictx, p[0], p[i + 1]);
+		input_csi_dispatch_sgr_256_do(ictx, p[0], p[2]);
 		break;
 	}
 }


### PR DESCRIPTION
ITU T.416-199303, for example, specifies a color space identifier parameter for the direct-color SGR sequence. `tmux` support was added in https://github.com/tmux/tmux/commit/051a29ca03718c8fedd5918ba86556f29672348e but broken as a result of https://github.com/tmux/tmux/commit/4e3d6612845e190a490f40cce79c858dadaee74b.

To test:
* Run the command `printf '\x1B[48:2:255:0:0m(noparam:red)\x1B[48:2::0:0:255m(withparam:blue)\x1B[m\n'`. The output should be in red and blue. (Before this fix, it was only in red.)