### PR TITLE
list-keys: make valid for re-input - escape keys and semicolons

### DIFF
--- a/cmd-list.c
+++ b/cmd-list.c
@@ -112,12 +112,12 @@ cmd_list_print(struct cmd_list *cmdlist)
 	TAILQ_FOREACH(cmd, &cmdlist->list, qentry) {
 		this = cmd_print(cmd);
 
-		len += strlen(this) + 3;
+		len += strlen(this) + 4;
 		buf = xrealloc(buf, len);
 
 		strlcat(buf, this, len);
 		if (TAILQ_NEXT(cmd, qentry) != NULL)
-			strlcat(buf, " ; ", len);
+			strlcat(buf, " \\; ", len);
 
 		free(this);
 	}

--- a/tmux.1
+++ b/tmux.1
@@ -2354,13 +2354,30 @@ to
 and
 .Em Tab .
 Note that to bind the
-.Ql \&"
+.Ql \&;
 or
 .Ql '
-keys, quotation marks are necessary, for example:
+or
+.Ql \&"
+or
+.Ql \&\e
+or
+.Ql #
+or
+.Ql $
+or
+.Ql ~
+keys, quoting is necessary: semicolon is quoted with backslash, single-quote
+is quoted with double-quotes, and the rest are quoted with single-quotes, for
+example:
 .Bd -literal -offset indent
-bind-key '"' split-window
-bind-key "'" new-window
+bind-key \\;    display-message semicolon-pressed
+bind-key M-\\;  display-message ALT-semicolon-pressed
+bind-key "'"   display-message single-quote-pressed
+bind-key '"'   display-message double-quote-pressed
+bind-key '#'   display-message hash-key-pressed
+bind-key '\\'   display-message backslash-pressed
+bind-key M-'\\' display-message ALT-backslash-pressed
 .Ed
 .Pp
 Commands related to key bindings are as follows:


### PR DESCRIPTION
Semicolons as command-separator were not escaped, and neither was the
key itself for special keys: semicolon, single/double quote, backslash,
hash-key '#', dollar '$', tilde '~'.

Now they are escaped and the output of `tmux list-keys` can be used as
input for `tmux source-file ...` to reproduce the bindings.