### PR TITLE
tmux.c: add support for XDG_RUNTIME_DIR

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES FROM 2.9 to X.X
 
+* Add support for XDG_RUNTIME_DIR. When TMUX_TMPDIR is not set,
+  try to use XDG_RUNTIME_DIR before falling back to _PATH_TMP (/tmp).
+
 * Add an addition form of string syntax in the configuration file - {}. This
   means commands that take other commands as string arguments can be expressed
   more clearly and without additional escaping. This means that a literal { and

--- a/tmux.c
+++ b/tmux.c
@@ -119,6 +119,8 @@ make_label(const char *label, char **cause)
 
 	if ((s = getenv("TMUX_TMPDIR")) != NULL && *s != '\0')
 		xasprintf(&base, "%s/tmux-%ld", s, (long)uid);
+	else if((s = getenv("XDG_RUNTIME_DIR")) != NULL && *s != '\0')
+		xasprintf(&base, "%s/tmux-%ld", s, (long)uid);
 	else
 		xasprintf(&base, "%s/tmux-%ld", _PATH_TMP, (long)uid);
 	if (realpath(base, resolved) == NULL &&


### PR DESCRIPTION
When `TMUX_TMPDIR` is not set, try to use `XDG_RUNTIME_DIR` before falling
back to `_PATH_TMP` (`/tmp`).