### PR TITLE
Fix warnings

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -201,7 +201,8 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 				goto fail;
 			}
 		}
-	}
+	} else
+		dsx = 80;
 	if (args_has(args, 'y')) {
 		tmp = args_get(args, 'y');
 		if (strcmp(tmp, "-") == 0) {
@@ -216,7 +217,8 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 				goto fail;
 			}
 		}
-	}
+	} else
+		dsy = 24;
 
 	/* Find new session size. */
 	if (!detached && !is_control) {

--- a/cmd-parse.y
+++ b/cmd-parse.y
@@ -23,6 +23,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <pwd.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -206,6 +206,7 @@ cmdq_get_command(struct cmd_list *cmdlist, struct cmd_find_state *current,
 	u_int			 group = 0;
 
 	TAILQ_FOREACH(cmd, &cmdlist->list, qentry) {
+		shared = NULL;
 		if (cmd->group != group) {
 			shared = xcalloc(1, sizeof *shared);
 			if (current != NULL)
@@ -230,7 +231,8 @@ cmdq_get_command(struct cmd_list *cmdlist, struct cmd_find_state *current,
 
 		log_debug("%s: %s group %u", __func__, item->name, item->group);
 
-		shared->references++;
+		if (shared)
+			shared->references++;
 		cmdlist->references++;
 
 		if (first == NULL)

--- a/format.c
+++ b/format.c
@@ -1518,7 +1518,7 @@ format_replace(struct format_tree *ft, const char *key, size_t keylen,
     char **buf, size_t *len, size_t *off)
 {
 	struct window_pane	*wp = ft->wp;
-	const char		*errptr, *copy, *cp, *marker;
+	const char		*errptr, *copy, *cp, *marker = NULL;
 	char			*copy0, *condition, *found, *new;
 	char			*value, *left, *right;
 	size_t			 valuelen;

--- a/options.c
+++ b/options.c
@@ -353,7 +353,7 @@ options_array_set(struct options_entry *o, u_int idx, const char *value,
 {
 	struct options_array_item	*a;
 	char				*new;
-	struct cmd_parse_result		*pr;
+	struct cmd_parse_result		*pr = NULL;
 
 	if (!OPTIONS_IS_ARRAY(o)) {
 		if (cause != NULL)
@@ -402,8 +402,11 @@ options_array_set(struct options_entry *o, u_int idx, const char *value,
 
 	if (OPTIONS_IS_STRING(o))
 		a->value.string = new;
-	else if (OPTIONS_IS_COMMAND(o))
+	else if (OPTIONS_IS_COMMAND(o)) {
+		if (!pr)
+			fatalx("internal error: no command parse result set");
 		a->value.cmdlist = pr->cmdlist;
+	}
 	return (0);
 }
 


### PR DESCRIPTION
---
Feel free to cherry-pick the ones you want.

For the `dsx` and `dsy` commit (c4cc767), it may be better to check `args_has(args, 'x') && args_has(args, 'y')` instead.