### PR TITLE
Add "attach-session -x" and "new-session -AX"

### DIFF
--- a/cmd-attach-session.c
+++ b/cmd-attach-session.c
@@ -37,8 +37,8 @@ const struct cmd_entry cmd_attach_session_entry = {
 	.name = "attach-session",
 	.alias = "attach",
 
-	.args = { "c:dErt:", 0, 0 },
-	.usage = "[-dEr] [-c working-directory] " CMD_TARGET_SESSION_USAGE,
+	.args = { "c:dErt:x", 0, 0 },
+	.usage = "[-dErx] [-c working-directory] " CMD_TARGET_SESSION_USAGE,
 
 	/* -t is special */
 
@@ -48,7 +48,7 @@ const struct cmd_entry cmd_attach_session_entry = {
 
 enum cmd_retval
 cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
-    int rflag, const char *cflag, int Eflag)
+    int xflag, int rflag, const char *cflag, int Eflag)
 {
 	struct cmd_find_state	*current = &item->shared->current;
 	enum cmd_find_type	 type;
@@ -102,11 +102,12 @@ cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
 
 	c->last_session = c->session;
 	if (c->session != NULL) {
-		if (dflag) {
+		if (dflag || xflag) {
 			TAILQ_FOREACH(c_loop, &clients, entry) {
 				if (c_loop->session != s || c == c_loop)
 					continue;
-				server_client_detach(c_loop, MSG_DETACH);
+				server_client_detach(c_loop,
+				    xflag ? MSG_DETACHKILL : MSG_DETACH);
 			}
 		}
 		if (!Eflag)
@@ -131,11 +132,12 @@ cmd_attach_session(struct cmdq_item *item, const char *tflag, int dflag,
 		if (rflag)
 			c->flags |= CLIENT_READONLY;
 
-		if (dflag) {
+		if (dflag || xflag) {
 			TAILQ_FOREACH(c_loop, &clients, entry) {
 				if (c_loop->session != s || c == c_loop)
 					continue;
-				server_client_detach(c_loop, MSG_DETACH);
+				server_client_detach(c_loop,
+				    xflag ? MSG_DETACHKILL : MSG_DETACH);
 			}
 		}
 		if (!Eflag)
@@ -169,6 +171,6 @@ cmd_attach_session_exec(struct cmd *self, struct cmdq_item *item)
 	struct args	*args = self->args;
 
 	return (cmd_attach_session(item, args_get(args, 't'),
-	    args_has(args, 'd'), args_has(args, 'r'), args_get(args, 'c'),
-	    args_has(args, 'E')));
+	    args_has(args, 'd'), args_has(args, 'x'), args_has(args, 'r'),
+	    args_get(args, 'c'), args_has(args, 'E')));
 }

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_new_session_entry = {
 	.name = "new-session",
 	.alias = "new",
 
-	.args = { "Ac:dDEF:n:Ps:t:x:y:", 0, -1 },
-	.usage = "[-AdDEP] [-c start-directory] [-F format] [-n window-name] "
+	.args = { "Ac:dDEF:n:Ps:t:x:Xy:", 0, -1 },
+	.usage = "[-AdDEPX] [-c start-directory] [-F format] [-n window-name] "
 		 "[-s session-name] " CMD_TARGET_SESSION_USAGE " [-x width] "
 		 "[-y height] [command]",
 
@@ -105,7 +105,8 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 			if (args_has(args, 'A')) {
 				retval = cmd_attach_session(item,
 				    newname, args_has(args, 'D'),
-				    0, NULL, args_has(args, 'E'));
+				    args_has(args, 'X'), 0, NULL,
+				    args_has(args, 'E'));
 				free(newname);
 				return (retval);
 			}

--- a/tmux.1
+++ b/tmux.1
@@ -923,7 +923,7 @@ section.
 The following commands are available to manage clients and sessions:
 .Bl -tag -width Ds
 .It Xo Ic attach-session
-.Op Fl dEr
+.Op Fl dErx
 .Op Fl c Ar working-directory
 .Op Fl t Ar target-session
 .Xc
@@ -936,6 +936,10 @@ If used from inside, switch the current client.
 If
 .Fl d
 is specified, any other clients attached to the session are detached.
+If
+.Fl x
+is given, send SIGHUP to the parent process of the client as well as
+detaching the client, typically causing it to exit.
 .Fl r
 signifies the client is read-only (only keys bound to the
 .Ic detach-client
@@ -1053,7 +1057,7 @@ command.
 Lock all clients attached to
 .Ar target-session .
 .It Xo Ic new-session
-.Op Fl AdDEP
+.Op Fl AdDEPX
 .Op Fl c Ar start-directory
 .Op Fl F Ar format
 .Op Fl n Ar window-name
@@ -1109,6 +1113,12 @@ already exists; in this case,
 .Fl D
 behaves like
 .Fl d
+to
+.Ic attach-session ,
+and
+.Fl X
+behaves like
+.Fl x
 to
 .Ic attach-session .
 .Pp

--- a/tmux.h
+++ b/tmux.h
@@ -2011,7 +2011,7 @@ extern const struct cmd_entry *cmd_table[];
 
 /* cmd-attach-session.c */
 enum cmd_retval	 cmd_attach_session(struct cmdq_item *, const char *, int, int,
-		     const char *, int);
+		     int, const char *, int);
 
 /* cmd-parse.c */
 void	    	 cmd_parse_empty(struct cmd_parse_input *);


### PR DESCRIPTION
These are roughly the equivalent of "screen -D -r" and "screen -D -R"
respectively (except that new-session also needs to be given a session
name).  The primitive for this was already available via detach-client,
but it wasn't in the most convenient form if you wanted to attach,
detach all other clients, and send SIGHUP to the parents of all other
clients in a single operation.

The best choice of option letter was a little unclear.  detach-client
uses -P, but that felt odd in this context where it's clearly a minor
variation of -d/-D (and it doesn't make sense to require users to type
both).  Both -D and -P were already taken in new-session.  In the end I
felt that making attach-session and new-session be similar was more
important than making either be exactly like detach-client, so I went
for -x/-X by analogy with the keys available in client mode.