### PR TITLE
Fix minor typos in the manpage and document #{l:}

### DIFF
--- a/cmd-find-window.c
+++ b/cmd-find-window.c
@@ -32,8 +32,8 @@ const struct cmd_entry cmd_find_window_entry = {
 	.name = "find-window",
 	.alias = "findw",
 
-	.args = { "CNt:TZ", 1, 1 },
-	.usage = "[-CNTZ] " CMD_TARGET_PANE_USAGE " match-string",
+	.args = { "CNrt:TZ", 1, 1 },
+	.usage = "[-CNrTZ] " CMD_TARGET_PANE_USAGE " match-string",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 
@@ -57,30 +57,59 @@ cmd_find_window_exec(struct cmd *self, struct cmdq_item *item)
 	if (!C && !N && !T)
 		C = N = T = 1;
 
-	if (C && N && T) {
-		xasprintf(&filter,
-		    "#{||:"
-		    "#{C:%s},#{||:#{m:*%s*,#{window_name}},"
-		    "#{m:*%s*,#{pane_title}}}}",
-		    s, s, s);
-	} else if (C && N) {
-		xasprintf(&filter,
-		    "#{||:#{C:%s},#{m:*%s*,#{window_name}}}",
-		    s, s);
-	} else if (C && T) {
-		xasprintf(&filter,
-		    "#{||:#{C:%s},#{m:*%s*,#{pane_title}}}",
-		    s, s);
-	} else if (N && T) {
-		xasprintf(&filter,
-		    "#{||:#{m:*%s*,#{window_name}},#{m:*%s*,#{pane_title}}}",
-		    s, s);
-	} else if (C)
-		xasprintf(&filter, "#{C:%s}", s);
-	else if (N)
-		xasprintf(&filter, "#{m:*%s*,#{window_name}}", s);
-	else
-		xasprintf(&filter, "#{m:*%s*,#{pane_title}}", s);
+	if (!args_has(args, 'r')) {
+		if (C && N && T) {
+			xasprintf(&filter,
+			    "#{||:"
+			    "#{C:%s},#{||:#{m:*%s*,#{window_name}},"
+			    "#{m:*%s*,#{pane_title}}}}",
+			    s, s, s);
+		} else if (C && N) {
+			xasprintf(&filter,
+			    "#{||:#{C:%s},#{m:*%s*,#{window_name}}}",
+			    s, s);
+		} else if (C && T) {
+			xasprintf(&filter,
+			    "#{||:#{C:%s},#{m:*%s*,#{pane_title}}}",
+			    s, s);
+		} else if (N && T) {
+			xasprintf(&filter,
+			    "#{||:#{m:*%s*,#{window_name}},"
+			    "#{m:*%s*,#{pane_title}}}",
+			    s, s);
+		} else if (C)
+			xasprintf(&filter, "#{C:%s}", s);
+		else if (N)
+			xasprintf(&filter, "#{m:*%s*,#{window_name}}", s);
+		else
+			xasprintf(&filter, "#{m:*%s*,#{pane_title}}", s);
+	} else {
+		if (C && N && T) {
+			xasprintf(&filter,
+			    "#{||:"
+			    "#{C/r:%s},#{||:#{m/r:%s,#{window_name}},"
+			    "#{m/r:%s,#{pane_title}}}}",
+			    s, s, s);
+		} else if (C && N) {
+			xasprintf(&filter,
+			    "#{||:#{C/r:%s},#{m/r:%s,#{window_name}}}",
+			    s, s);
+		} else if (C && T) {
+			xasprintf(&filter,
+			    "#{||:#{C/r:%s},#{m/r:%s,#{pane_title}}}",
+			    s, s);
+		} else if (N && T) {
+			xasprintf(&filter,
+			    "#{||:#{m/r:%s,#{window_name}},"
+			    "#{m/r:%s,#{pane_title}}}",
+			    s, s);
+		} else if (C)
+			xasprintf(&filter, "#{C/r:%s}", s);
+		else if (N)
+			xasprintf(&filter, "#{m/r:%s,#{window_name}}", s);
+		else
+			xasprintf(&filter, "#{m/r:%s,#{pane_title}}", s);
+	}
 
 	new_args = args_parse("", 1, &argv);
 	if (args_has(args, 'Z'))

--- a/server-client.c
+++ b/server-client.c
@@ -1263,10 +1263,11 @@ server_client_loop(void)
 				break;
 		}
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wl != NULL && wp->fd != -1) {
+			if (wp->fd != -1) {
 				if (focus)
 					server_client_check_focus(wp);
-				server_client_check_resize(wp);
+				if (wl != NULL)
+					server_client_check_resize(wp);
 			}
 			wp->flags &= ~PANE_REDRAW;
 		}

--- a/tmux.1
+++ b/tmux.1
@@ -461,7 +461,7 @@ Will execute
 .Ic if-shell ,
 the shell command
 .Xr true 1 ,
-.Ic new-window
+.Ic split-window
 and
 .Ic kill-session
 in that order.
@@ -475,7 +475,7 @@ commands and their arguments.
 This section describes the syntax of commands parsed by
 .Nm ,
 for example in a configuration file or at the command prompt.
-Note the when commands are entered into the shell, they are parsed by the shell
+Note that when commands are entered into the shell, they are parsed by the shell
 - see for example
 .Xr ksh 1
 or
@@ -1833,14 +1833,16 @@ With
 .Fl b ,
 other commands are not blocked from running until the indicator is closed.
 .It Xo Ic find-window
-.Op Fl CNTZ
+.Op Fl rCNTZ
 .Op Fl t Ar target-pane
 .Ar match-string
 .Xc
 .D1 (alias: Ic findw )
-Search for the
+Search for a
 .Xr fnmatch 3
-pattern
+pattern or, with
+.Fl r ,
+regular expression
 .Ar match-string
 in window names, titles, and visible content (but not history).
 The flags control matching behavior:
@@ -4068,7 +4070,7 @@ will expand the format twice, for example
 .Ql #{E:status-left}
 is the result of expanding the content of the
 .Ic status-left
-option rather than the content itself.
+option rather than the option itself.
 .Ql T:
 is like
 .Ql E:
@@ -4104,7 +4106,7 @@ would change
 into
 .Ql bxBxbx .
 .Pp
-In addition, the first line of a shell command's output may be inserted using
+In addition, the last line of a shell command's output may be inserted using
 .Ql #() .
 For example,
 .Ql #(uptime)
@@ -4122,6 +4124,14 @@ Commands are executed with the
 global environment set (see the
 .Sx GLOBAL AND SESSION ENVIRONMENT
 section).
+.Pp
+An
+.Ql l
+specifies that any character in a string should be interpreted literally.
+For example:
+.Ql #{l:#{?pane_in_mode,#{?#{==:#{session_name},Summer},ABC,XYZ},xyz}}
+will be replaced by
+.Ql #{?pane_in_mode,#{?#{==:#{session_name},Summer},ABC,XYZ},xyz} .
 .Pp
 The following variables are available, where appropriate:
 .Bl -column "XXXXXXXXXXXXXXXXXXX" "XXXXX"


### PR DESCRIPTION
I may be wrong, but I think I found a few minor typos in the manpage.
I'm not familiar with the troff syntax, so maybe the formatting is not correct.
I've just tested how the updated manpage was rendered with `$ groff -man tmux.1 | zathura -`, and it looked ok.

I also included a short description for the `#{l:}` format modifier, and used one of the few examples I could find in the codebase:

https://github.com/tmux/tmux/blob/c4a92e57993f3c45944428a6b7cf0a1be421d023/regress/format-strings.sh#L173

There were simpler examples, but for those simply doubling one `#` was enough. So I thought that maybe a complex example would show how useful `#{l:}` really is (i.e. you don't have to worry about missing a special character anywhere, no matter how complex a string is).

Let me know if you want something to be changed.
Feel free not to merge some of the fixes if I made mistakes.
