### PR TITLE
Inline note in the README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -33,15 +33,16 @@ configure with `--enable-utempter` to enable this.
 To get and build the latest from version control:
 
 ~~~bash
+# Note that this requires at least a working C compiler, `make`, `autoconf`,
+# `automake`, `pkg-config` as well as `libevent` and `ncurses` libraries and
+# headers.
 git clone https://github.com/tmux/tmux.git
 cd tmux
 sh autogen.sh
 ./configure && make
 ~~~
 
-(Note that this requires at least a working C compiler, `make`, `autoconf`,
-`automake`, `pkg-config` as well as `libevent` and `ncurses` libraries and
-headers.)
+
 
 ## Contributing
 


### PR DESCRIPTION
Ensure that the first time contributor read the prerequisites before trying to build.

Long story: I tried to build the project from WSL and failed multiple times, each time installing a new package. When it finally built, I continued reading the `README` to realize the prerequisites are *after* the build command. I therefore think
that first time contributors would benefit from having the prerequisites listed before the build
command.