### PR TITLE
Help clarify "lost server" situation

### DIFF
--- a/client.c
+++ b/client.c
@@ -202,7 +202,7 @@ client_exit_message(void)
 	case CLIENT_EXIT_TERMINATED:
 		return ("terminated");
 	case CLIENT_EXIT_LOST_SERVER:
-		return ("lost server");
+		return ("Client lost connection to tmux server. Try tmux -vv");
 	case CLIENT_EXIT_EXITED:
 		return ("exited");
 	case CLIENT_EXIT_SERVER_EXITED:

--- a/client.c
+++ b/client.c
@@ -202,7 +202,7 @@ client_exit_message(void)
 	case CLIENT_EXIT_TERMINATED:
 		return ("terminated");
 	case CLIENT_EXIT_LOST_SERVER:
-		return ("Client lost connection to tmux server. Try tmux -vv");
+		return ("server exited unexpectedly");
 	case CLIENT_EXIT_EXITED:
 		return ("exited");
 	case CLIENT_EXIT_SERVER_EXITED:


### PR DESCRIPTION
As discussed in https://github.com/tmux/tmux/issues/1840, the "lost server" message can be confusing to users.
Return a more helpful string.