### PR TITLE
man: Silence mandoc warnings.

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -214,7 +214,6 @@ was given) and off.
 Report the
 .Nm
 version.
-.Pp
 .It Ar command Op Ar flags
 This specifies one of a set of commands used to control
 .Nm ,
@@ -1156,7 +1155,7 @@ The
 .Fl P
 option prints information about the new session after it has been created.
 By default, it uses the format
-.Ql #{session_name}:
+.Ql #{session_name}:\&
 but a different format may be specified with
 .Fl F .
 .Pp
@@ -4091,7 +4090,7 @@ will append
 if the pane title is more than five characters.
 .Pp
 Prefixing a time variable with
-.Ql t:
+.Ql t:\&
 will convert it to a string, so if
 .Ql #{window_activity}
 gives
@@ -4100,34 +4099,34 @@ gives
 gives
 .Ql Sun Oct 25 09:25:02 2015 .
 The
-.Ql b:
+.Ql b:\&
 and
-.Ql d:
+.Ql d:\&
 prefixes are
 .Xr basename 3
 and
 .Xr dirname 3
 of the variable respectively.
-.Ql q:
+.Ql q:\&
 will escape
 .Xr sh 1
 special characters.
-.Ql E:
+.Ql E:\&
 will expand the format twice, for example
 .Ql #{E:status-left}
 is the result of expanding the content of the
 .Ic status-left
 option rather than the option itself.
-.Ql T:
+.Ql T:\&
 is like
-.Ql E:
+.Ql E:\&
 but also expands
 .Xr strftime 3
 specifiers.
-.Ql S: ,
-.Ql W:
+.Ql S:\& ,
+.Ql W:\&
 or
-.Ql P:
+.Ql P:\&
 will loop over each session, window or pane and insert the format once
 for each.
 For windows and panes, two comma-separated formats may be given:
@@ -4138,7 +4137,7 @@ For example, to get a list of windows formatted like the status line:
 .Ed
 .Pp
 A prefix of the form
-.Ql s/foo/bar/:
+.Ql s/foo/bar/:\&
 will substitute
 .Ql foo
 with
@@ -4147,7 +4146,7 @@ throughout.
 The first argument may be an extended regular expression and a final argument may be
 .Ql i
 to ignore case, for example
-.Ql s/a(.)/\e1x/i:
+.Ql s/a(.)/\e1x/i:\&
 would change
 .Ql abABab
 into


### PR DESCRIPTION
Silences the following trivial warnings with `mandoc-1.14.5`.
```
man: tmux.1:217:2: WARNING: skipping paragraph macro: Pp before It
man: tmux.1:1159:20: STYLE: no blank before trailing delimiter: Ql #{session_name}:
man: tmux.1:4094:6: STYLE: no blank before trailing delimiter: Ql t:
man: tmux.1:4103:6: STYLE: no blank before trailing delimiter: Ql b:
man: tmux.1:4105:6: STYLE: no blank before trailing delimiter: Ql d:
man: tmux.1:4111:6: STYLE: no blank before trailing delimiter: Ql q:
man: tmux.1:4115:6: STYLE: no blank before trailing delimiter: Ql E:
man: tmux.1:4121:6: STYLE: no blank before trailing delimiter: Ql T:
man: tmux.1:4123:6: STYLE: no blank before trailing delimiter: Ql E:
man: tmux.1:4127:6: STYLE: no blank before trailing delimiter: Ql S:
man: tmux.1:4128:6: STYLE: no blank before trailing delimiter: Ql W:
man: tmux.1:4130:6: STYLE: no blank before trailing delimiter: Ql P:
man: tmux.1:4141:15: STYLE: no blank before trailing delimiter: Ql s/foo/bar/:
man: tmux.1:4150:18: STYLE: no blank before trailing delimiter: Ql s/a(.)/\e1x/i:
```
These are the remaining warnings, but I am not sure there is anything to be done.
```
man: tmux.1:17:2: WARNING: missing date, using today's date
man: tmux.1:64:6: STYLE: referenced manual not found: Xr pty 4 (3 times)
man: tmux.1:856:6: STYLE: referenced manual not found: Xr vi 1 (2 times)
man: tmux.1:1100:6: STYLE: referenced manual not found: Xr termios 4
man: tmux.1:3201:6: STYLE: referenced manual not found: Xr lock 1
```
These can be reproduced with `man -Tlint -l tmux.1`.