### PR TITLE
include header for xmalloc

### DIFF
--- a/compat/asprintf.c
+++ b/compat/asprintf.c
@@ -19,8 +19,10 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "compat.h"
+#include "xmalloc.h"
 
 int
 asprintf(char **ret, const char *fmt, ...)


### PR DESCRIPTION
xmalloc defaults to return int when no prototype is provided,so on some platforms with sizeof(int)=4 high allocated addresses could be truncated,causing invalid memory access.