### PR TITLE
adds window_marked_flag to expose bit for showing marked in status

### DIFF
--- a/format.c
+++ b/format.c
@@ -2214,6 +2214,11 @@ format_defaults_winlink(struct format_tree *ft, struct winlink *wl)
 	format_add(ft, "window_end_flag", "%d",
 	    !!(wl == RB_MAX(winlinks, &s->windows)));
 
+	if (server_check_marked() && marked_pane.wl == wl)
+	    format_add(ft, "window_marked_flag", "1");
+	else
+	    format_add(ft, "window_marked_flag", "0");
+
 	format_add(ft, "window_bell_flag", "%d",
 	    !!(wl->flags & WINLINK_BELL));
 	format_add(ft, "window_activity_flag", "%d",


### PR DESCRIPTION
thanks to @nicm for working this out. This is essentially the exact code he supplied from #1887. Works great! I'm attaching a screenshot to show it working... You can see the bookmark icon on the status line indicating that the window contains a marked pane. 
![image](https://user-images.githubusercontent.com/809000/64658796-5e5fc780-d3fe-11e9-9ed6-9f118a3f90e1.png)

Here's the status line if you'd like to see how I'm using it. The motivation is I want to be able to use nerd fonts to supply custom icons for each of the window statuses.

```
set -g window-status-format "#[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#I #[fg=black,bg=brightblack,nobold,noitalics,nounderscore] #[fg=white,bg=brightblack]#W #{?window_last_flag,\uf7d9,} #{?window_zoomed_flag,\uf848 ,}#{window_activity_flag,\u26a1,}#{?window_bell_flag,\uf599 ,}#{?window_marked_flag,\uf02e ,}#[fg=brightblack,bg=black,nobold,noitalics,nounderscore]"
set -g window-status-current-format "#[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#I #[fg=black,bg=cyan,nobold,noitalics,nounderscore] #[fg=black,bg=cyan]#W #{?current_window_flag,,\uf192 }#{?window_marked_flag,\uf02e ,}#{?window_zoomed_flag,\uf848 ,}#[fg=cyan,bg=black,nobold,noitalics,nounderscore]"
set -g window-status-separator ""

```
