### PR TITLE
Add push_default and pop_default as style options

### DIFF
--- a/format-draw.c
+++ b/format-draw.c
@@ -514,7 +514,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	int			 list_state = -1, fill = -1;
 	enum style_align	 list_align = STYLE_ALIGN_DEFAULT;
 	struct grid_cell	 gc;
-	struct style		 sy;
+	struct style		 sy, saved_sy;
 	struct utf8_data	*ud = &sy.gc.data;
 	const char		*cp, *end;
 	enum utf8_state		 more;
@@ -522,8 +522,10 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	struct format_range	*fr = NULL, *fr1;
 	struct format_ranges	 frs;
 	struct style_range	*sr;
+	struct grid_cell	 current_default;
 
-	style_set(&sy, base);
+	memcpy(&current_default, base, sizeof current_default);
+	style_set(&sy, &current_default);
 	TAILQ_INIT(&frs);
 	log_debug("%s: %s", __func__, expanded);
 
@@ -535,7 +537,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	for (i = 0; i < TOTAL; i++) {
 		screen_init(&s[i], size, 1, 0);
 		screen_write_start(&ctx[i], NULL, &s[i]);
-		screen_write_clearendofline(&ctx[i], base->bg);
+		screen_write_clearendofline(&ctx[i], current_default.bg);
 		width[i] = 0;
 	}
 
@@ -581,7 +583,8 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 			goto out;
 		}
 		tmp = xstrndup(cp + 2, end - (cp + 2));
-		if (style_parse(&sy, base, tmp) != 0) {
+		style_copy(&saved_sy, &sy);
+		if (style_parse(&sy, &current_default, tmp) != 0) {
 			log_debug("%s: invalid style '%s'", __func__, tmp);
 			free(tmp);
 			cp = end + 1;
@@ -594,6 +597,16 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 		/* If this style has a fill colour, store it for later. */
 		if (sy.fill != 8)
 			fill = sy.fill;
+
+		/* If this style pushed or popped the default, update it. */
+		if (sy.default_type == STYLE_DEFAULT_PUSH) {
+			memcpy(&current_default, &saved_sy.gc, sizeof current_default);
+			sy.default_type = STYLE_DEFAULT_BASE;
+		}
+		else if (sy.default_type == STYLE_DEFAULT_POP) {
+			memcpy(&current_default, base, sizeof current_default);
+			sy.default_type = STYLE_DEFAULT_BASE;
+		}
 
 		/* Check the list state. */
 		switch (sy.list) {

--- a/options-table.c
+++ b/options-table.c
@@ -91,7 +91,9 @@ static const char *options_table_window_size_list[] = {
 				"}" \
 			"}" \
 		"]" \
+		"#[push-default]" \
 		"#{T:window-status-format}" \
+		"#[pop-default]" \
 		"#[norange default]" \
 		"#{?window_end_flag,,#{window-status-separator}}" \
 	"," \
@@ -116,7 +118,9 @@ static const char *options_table_window_size_list[] = {
 				"}" \
 			"}" \
 		"]" \
+		"#[push-default]" \
 		"#{T:window-status-current-format}" \
+		"#[pop-default]" \
 		"#[norange list=on default]" \
 		"#{?window_end_flag,,#{window-status-separator}}" \
 	"}" \

--- a/style.c
+++ b/style.c
@@ -36,7 +36,9 @@ static struct style style_default = {
 	STYLE_ALIGN_DEFAULT,
 	STYLE_LIST_OFF,
 
-	STYLE_RANGE_NONE, 0
+	STYLE_RANGE_NONE, 0,
+	
+	STYLE_DEFAULT_BASE
 };
 
 /*
@@ -74,7 +76,11 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 			sy->gc.bg = base->bg;
 			sy->gc.attr = base->attr;
 			sy->gc.flags = base->flags;
-		} else if (strcasecmp(tmp, "nolist") == 0)
+		} else if (strcasecmp(tmp, "push-default") == 0)
+			sy->default_type = STYLE_DEFAULT_PUSH;
+		else if (strcasecmp(tmp, "pop-default") == 0)
+			sy->default_type = STYLE_DEFAULT_POP;
+		else if (strcasecmp(tmp, "nolist") == 0)
 			sy->list = STYLE_LIST_OFF;
 		else if (strncasecmp(tmp, "list=", 5) == 0) {
 			if (strcasecmp(tmp + 5, "on") == 0)
@@ -218,6 +224,14 @@ style_tostring(struct style *sy)
 		    tmp);
 		comma = ",";
 	}
+	if (sy->default_type != STYLE_DEFAULT_BASE) {
+		if (sy->default_type == STYLE_DEFAULT_PUSH)
+			tmp = "push-default";
+		else if (sy->default_type == STYLE_DEFAULT_POP)
+			tmp = "pop-default";
+		off += xsnprintf(s + off, sizeof s - off, "%s%s", comma, tmp);
+		comma = ",";
+	}
 	if (sy->fill != 8) {
 		off += xsnprintf(s + off, sizeof s - off, "%sfill=%s", comma,
 		    colour_tostring(sy->fill));
@@ -255,21 +269,6 @@ style_apply(struct grid_cell *gc, struct options *oo, const char *name)
 	gc->fg = sy->gc.fg;
 	gc->bg = sy->gc.bg;
 	gc->attr |= sy->gc.attr;
-}
-
-/* Apply a style, updating if default. */
-void
-style_apply_update(struct grid_cell *gc, struct options *oo, const char *name)
-{
-	struct style	*sy;
-
-	sy = options_get_style(oo, name);
-	if (sy->gc.fg != 8)
-		gc->fg = sy->gc.fg;
-	if (sy->gc.bg != 8)
-		gc->bg = sy->gc.bg;
-	if (sy->gc.attr != 0)
-		gc->attr |= sy->gc.attr;
 }
 
 /* Initialize style from cell. */

--- a/tmux.1
+++ b/tmux.1
@@ -4338,10 +4338,19 @@ by enclosing them in
 and
 .Ql \&] .
 .Pp
-A style may be the single term
-.Ql default
-to specify the default style (which may inherit from another option) or a space
-or comma separated list of the following:
+A style may be one of the following single terms:
+.Bl -tag -width Ds
+.It Ic default
+Use the default style (which may inherit from another option).
+.It Ic push-default
+Remember the current style as the default style for later uses of
+.Ql default .
+.It Ic pop-default
+Go back to the base style for later uses of
+.Ql default .
+.El
+.Pp
+A style can also be a space or comma separated list of the following:
 .Bl -tag -width Ds
 .It Ic fg=colour
 Set the foreground colour.

--- a/tmux.h
+++ b/tmux.h
@@ -683,6 +683,12 @@ struct style_range {
 TAILQ_HEAD(style_ranges, style_range);
 
 /* Style option. */
+enum style_default_type {
+	STYLE_DEFAULT_BASE,
+	STYLE_DEFAULT_PUSH,
+	STYLE_DEFAULT_POP
+};
+
 struct style {
 	struct grid_cell	gc;
 
@@ -692,6 +698,8 @@ struct style {
 
 	enum style_range_type	range_type;
 	u_int			range_argument;
+
+	enum style_default_type	default_type;
 };
 
 /* Virtual screen. */
@@ -2651,8 +2659,6 @@ int		 style_parse(struct style *,const struct grid_cell *,
 		     const char *);
 const char	*style_tostring(struct style *);
 void		 style_apply(struct grid_cell *, struct options *,
-		     const char *);
-void		 style_apply_update(struct grid_cell *, struct options *,
 		     const char *);
 int		 style_equal(struct style *, struct style *);
 void		 style_set(struct style *, const struct grid_cell *);


### PR DESCRIPTION
This adds push_default and pop_default as style options in format strings.

* `#[push-default]` will save the current style as the new default when `#[default]` is specified later
* `#[pop-default]` will revert this and cause #[default] to go back to the base style
* Add `#[push-default]` and `#[pop-default]` around `#{window-status-format}` and `#{window-status-current-format}` in the default `status-format[]`

Fixes #1909 