### PR TITLE
respect bold/bright attr when fallback from 256 colorname to 8 colors…

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -2374,10 +2374,7 @@ tty_check_fg(struct tty *tty, struct window_pane *wp, struct grid_cell *gc)
 				gc->fg &= 7;
 				if (colours >= 16)
 					gc->fg += 90;
-				else
-					gc->attr |= GRID_ATTR_BRIGHT;
-			} else
-				gc->attr &= ~GRID_ATTR_BRIGHT;
+			}
 		}
 		return;
 	}


### PR DESCRIPTION
respect bold/bright attr when fallback from 256 colorname to 8 colors, since SGR code 1 means bold or bright according to the standard
(https://github.com/tmux/tmux/issues/1911)