### PR TITLE
WINDOW_TREE_DEFAULT_FORMAT: always display pane_title

### DIFF
--- a/window-tree.c
+++ b/window-tree.c
@@ -41,8 +41,7 @@ static void		 window_tree_key(struct window_mode_entry *,
 	"," \
 		"#{?window_format," \
 			"#{window_name}#{window_flags} " \
-			"(#{window_panes} panes)" \
-			"#{?#{==:#{window_panes},1}, \"#{pane_title}\",}" \
+			"(#{window_panes} panes) #{pane_title}" \
 		"," \
 			"#{session_windows} windows" \
 			"#{?session_grouped, " \


### PR DESCRIPTION
With multiple panes it would display currently:

    (0)  - 0: 1 windows (attached)
    (1)  └─> + 1: *Z (2 panes)

But it is certainly better to see the current's pane title.
With this patch:

    (0)  - 0: 1 windows (attached)
    (1)  └─> + 1: *Z (2 panes) ⩫ ~_ (/home/user/Vcs/tmux/tmux -L test)