### PR TITLE
Break line before `screen*`, add `Smol` ANSI sequence to `xterm*` and `screen*`

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -226,7 +226,8 @@ const struct options_table_entry options_table[] = {
 	  .flags = OPTIONS_TABLE_IS_ARRAY,
 	  .default_str = "xterm*:XT:Ms=\\E]52;%p1%s;%p2%s\\007"
 			 ":Cs=\\E]12;%p1%s\\007:Cr=\\E]112\\007"
-			 ":Ss=\\E[%p1%d q:Se=\\E[2 q,screen*:XT",
+			 ":Ss=\\E[%p1%d q:Se=\\E[2 q:Smol=\\E[53m,"
+	                 "screen*:XT:Smol=\\E[53m",
 	  .separator = ","
 	},
 


### PR DESCRIPTION
A little bit unsure if there aren't more non-ncurses sequences that are nevertheless commonly implemented in popular terminal programs. Smol is my favorite, of course, because it allows beautiful overlined status lines, but there are others that  many terminal programs implement that are dear to other people like me.

In any case, it's nice to break lines for each terminal override rule anyway.