### PR TITLE
When a blank title is set re-enable automatic-rename.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ CHANGES FROM 3.0 to X.X
 
 * Add reverse sorting in tree, client and buffer modes.
 
+* When a blank title is set (via \033k\033\\) re-enable automatic-rename.
+
 CHANGES FROM 2.9 to 3.0
 
 * xterm 348 now disables margins when resized, so send DECLRMM again after

--- a/input.c
+++ b/input.c
@@ -2286,6 +2286,11 @@ input_exit_rename(struct input_ctx *ictx)
 
 	if (!utf8_isvalid(ictx->input_buf))
 		return;
+
+	if (ictx->input_len == 0) {
+		options_set_number(ictx->wp->window->options, "automatic-rename", 1);
+		return;
+	}
 	window_set_name(ictx->wp->window, ictx->input_buf);
 	options_set_number(ictx->wp->window->options, "automatic-rename", 0);
 	server_status_window(ictx->wp->window);


### PR DESCRIPTION
This allows apps (when allow-rename is enabled) to drop back out of manual mode by printing `\033k\033\\`