### PR TITLE
Fix warnings

### DIFF
--- a/options.c
+++ b/options.c
@@ -359,7 +359,7 @@ options_array_set(struct options_entry *o, u_int idx, const char *value,
 {
 	struct options_array_item	*a;
 	char				*new;
-	struct cmd_parse_result		*pr;
+	struct cmd_parse_result		*pr = NULL;
 
 	if (!OPTIONS_IS_ARRAY(o)) {
 		if (cause != NULL)
@@ -408,7 +408,7 @@ options_array_set(struct options_entry *o, u_int idx, const char *value,
 
 	if (OPTIONS_IS_STRING(o))
 		a->value.string = new;
-	else if (OPTIONS_IS_COMMAND(o))
+	else if (OPTIONS_IS_COMMAND(o) && pr != NULL)
 		a->value.cmdlist = pr->cmdlist;
 	return (0);
 }

--- a/window-tree.c
+++ b/window-tree.c
@@ -191,7 +191,7 @@ window_tree_cmp_session(const void *a0, const void *b0)
 	const struct session *const	*b = b0;
 	const struct session		*sa = *a;
 	const struct session		*sb = *b;
-	int				 result;
+	int				 result = 0;
 
 	switch (window_tree_sort->field) {
 	case WINDOW_TREE_BY_INDEX:
@@ -226,7 +226,7 @@ window_tree_cmp_window(const void *a0, const void *b0)
 	const struct winlink		*wlb = *b;
 	struct window			*wa = wla->window;
 	struct window			*wb = wlb->window;
-	int				 result;
+	int				 result = 0;
 
 	switch (window_tree_sort->field) {
 	case WINDOW_TREE_BY_INDEX:


### PR DESCRIPTION
---
The `window-tree` patch might be a bit too cautious for your tastes, but the former is a possibility (without auditing that `value` is never passed in as `NULL`…but then why check it in the code above?).