### PR TITLE
copy-mode-vi * and # command impl

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4219,6 +4219,8 @@ The following variables are available, where appropriate:
 .It Li "command_list_alias" Ta "" Ta "Command alias if listing commands"
 .It Li "command_list_name" Ta "" Ta "Command name if listing commands"
 .It Li "command_list_usage" Ta "" Ta "Command usage if listing commands"
+.It Li "copy_cursor_line" Ta "" Ta "Line the cursor is on in copy mode"
+.It Li "copy_cursor_word" Ta "" Ta "Word under cursor in copy mode"
 .It Li "copy_cursor_x" Ta "" Ta "Cursor X position in copy mode"
 .It Li "copy_cursor_y" Ta "" Ta "Cursor Y position in copy mode"
 .It Li "cursor_character" Ta "" Ta "Character at cursor in pane"

--- a/tmux.h
+++ b/tmux.h
@@ -1789,6 +1789,10 @@ void		 format_defaults_pane(struct format_tree *,
 void		 format_defaults_paste_buffer(struct format_tree *,
 		     struct paste_buffer *);
 void		 format_lost_client(struct client *);
+struct
+utf8_data	*format_current_word(struct grid *, u_int, u_int);
+struct
+utf8_data	*format_current_line(struct grid *, u_int, u_int);
 
 /* format-draw.c */
 void		 format_draw(struct screen_write_ctx *,

--- a/tmux.h
+++ b/tmux.h
@@ -1789,10 +1789,8 @@ void		 format_defaults_pane(struct format_tree *,
 void		 format_defaults_paste_buffer(struct format_tree *,
 		     struct paste_buffer *);
 void		 format_lost_client(struct client *);
-struct
-utf8_data	*format_current_word(struct grid *, u_int, u_int);
-struct
-utf8_data	*format_current_line(struct grid *, u_int, u_int);
+char		*format_current_word(struct grid *, u_int, u_int);
+char		*format_current_line(struct grid *, u_int, u_int);
 
 /* format-draw.c */
 void		 format_draw(struct screen_write_ctx *,

--- a/window-copy.c
+++ b/window-copy.c
@@ -564,7 +564,6 @@ static void
 window_copy_formats(struct window_mode_entry *wme, struct format_tree *ft)
 {
 	struct window_copy_mode_data	*data = wme->data;
-	struct utf8_data		*ud = NULL;
 	char				*s;
 
 	format_add(ft, "scroll_position", "%d", data->oy);
@@ -581,20 +580,16 @@ window_copy_formats(struct window_mode_entry *wme, struct format_tree *ft)
 		format_add(ft, "selection_end_y", "%d", data->endsely);
 	}
 
-	ud = format_current_word(data->screen.grid, data->cx, data->cy);
-	if (ud != NULL)
+	s = format_current_word(data->screen.grid, data->cx, data->cy);
+	if (s != NULL)
 	{
-		s = utf8_tocstr(ud);
-		free(ud);
 		format_add(ft, "copy_cursor_word", "%s", s);
 		free(s);
 	}
 
-	ud = format_current_line(data->screen.grid, data->cx, data->cy);
-	if (ud != NULL)
+	s = format_current_line(data->screen.grid, data->cx, data->cy);
+	if (s != NULL)
 	{
-		s = utf8_tocstr(ud);
-		free(ud);
 		format_add(ft, "copy_cursor_line", "%s", s);
 		free(s);
 	}

--- a/window-copy.c
+++ b/window-copy.c
@@ -564,6 +564,8 @@ static void
 window_copy_formats(struct window_mode_entry *wme, struct format_tree *ft)
 {
 	struct window_copy_mode_data	*data = wme->data;
+	struct utf8_data		*ud = NULL;
+	char				*s;
 
 	format_add(ft, "scroll_position", "%d", data->oy);
 	format_add(ft, "rectangle_toggle", "%d", data->rectflag);
@@ -577,6 +579,24 @@ window_copy_formats(struct window_mode_entry *wme, struct format_tree *ft)
 		format_add(ft, "selection_start_y", "%d", data->sely);
 		format_add(ft, "selection_end_x", "%d", data->endselx);
 		format_add(ft, "selection_end_y", "%d", data->endsely);
+	}
+
+	ud = format_current_word(data->screen.grid, data->cx, data->cy);
+	if (ud != NULL)
+	{
+		s = utf8_tocstr(ud);
+		free(ud);
+		format_add(ft, "copy_cursor_word", "%s", s);
+		free(s);
+	}
+
+	ud = format_current_line(data->screen.grid, data->cx, data->cy);
+	if (ud != NULL)
+	{
+		s = utf8_tocstr(ud);
+		free(ud);
+		format_add(ft, "copy_cursor_line", "%s", s);
+		free(s);
 	}
 }
 


### PR DESCRIPTION
Hi, here is an implementation of search word under cursor in copy-mode-vi that I've been playing with. It currently supports # and * like in vi. Would you kindly take a look and comment? Thanks!