### PR TITLE
Fix select-layout in case the passed layout for more panes then window have

### DIFF
--- a/layout-custom.c
+++ b/layout-custom.c
@@ -210,7 +210,7 @@ layout_parse(struct window *w, const char *layout)
 		}
 		break;
 	}
-	if (lc->sx != sx || lc->sy != sy) {
+	if (lc->type != LAYOUT_WINDOWPANE && (lc->sx != sx || lc->sy != sy)) {
 		log_debug("fix layout %u,%u to %u,%u", lc->sx, lc->sy, sx,sy);
 		layout_print_cell(lc, __func__, 0);
 		lc->sx = sx - 1; lc->sy = sy - 1;


### PR DESCRIPTION
If you try to apply layout for two panes (`fdcb,273x73,0,0{175x73,0,0,221,97x73,176,0,225}`) for the window only with one pane, tmux will SIGSEGV.
The reason is that `lc->type` will be `LAYOUT_WINDOWPANE` in this case and
it will try to adjust `layout->sx` to `sx(==0)-1`, and later it will fail in
`screen_reset_tabs()`:

       0  0x00005555555a2f8c in screen_reset_tabs (s=<optimized out>) at screen.c:134
       1  screen_reset_tabs (s=0x555555676870) at screen.c:125
       2  0x00005555555a3325 in screen_resize (s=s@entry=0x555555676870, sx=sx@entry=4294967295, sy=sy@entry=4294967295, reflow=1) at screen.c:209
       3  0x00005555555c7229 in window_pane_resize (wp=wp@entry=0x5555556766b0, sx=4294967295, sy=4294967295) at window.c:951
       4  0x000055555559395f in layout_fix_panes (w=w@entry=0x5555556763c0) at layout.c:308
       5  0x0000555555592175 in layout_parse (w=w@entry=0x5555556763c0, layout=<optimized out>, layout@entry=0x5555556292b0 "fdcb,273x73,0,0{175x73,0,0,221,97x73,176,0,225}") at layout-custom.c:236
       6  0x0000555555577c38 in cmd_select_layout_exec (self=<optimized out>, item=0x5555556c6d90) at cmd-select-layout.c:126
       7  0x00005555555756bc in cmdq_fire_command (item=0x5555556c6d90) at cmd-queue.c:303
       8  cmdq_next (c=c@entry=0x555555661630) at cmd-queue.c:438
       9  0x00005555555a89a6 in server_loop () at server.c:232
       10 0x000055555559cc62 in proc_loop (tp=0x5555556119f0, loopcb=loopcb@entry=0x5555555a8960 <server_loop>) at proc.c:201
       11 0x00005555555a906a in server_start (client=0x555555610f10, base=base@entry=0x555555610660, lockfd=lockfd@entry=5, lockfile=0x555555610a80 "\240\356eUUU") at server.c:213
       12 0x0000555555568cff in client_connect (start_server=1, path=0x55555560a040 "/tmp/tmux-1000/le", base=0x555555610660) at client.c:158
       13 client_main (base=0x555555610660, argc=6, argv=0x7fffffffd240, flags=<optimized out>) at client.c:266
       14 0x00005555555654c6 in main (argc=6, argv=<optimized out>) at tmux.c:375

Fixes: bbe8ebf9c26e45fd8c402627b84b3646db445d45