### PR TITLE
add format support to search commands

### DIFF
--- a/cmd-send-keys.c
+++ b/cmd-send-keys.c
@@ -33,8 +33,8 @@ const struct cmd_entry cmd_send_keys_entry = {
 	.name = "send-keys",
 	.alias = "send",
 
-	.args = { "HlXRMN:t:", 0, -1 },
-	.usage = "[-HlXRM] [-N repeat-count] " CMD_TARGET_PANE_USAGE " key ...",
+	.args = { "HlXRMFN:t:", 0, -1 },
+	.usage = "[-HlXRMF] [-N repeat-count] " CMD_TARGET_PANE_USAGE " key ...",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 

--- a/tmux.1
+++ b/tmux.1
@@ -2677,7 +2677,7 @@ With
 only
 .Ar key-table .
 .It Xo Ic send-keys
-.Op Fl HlMRX
+.Op Fl FHlMRX
 .Op Fl N Ar repeat-count
 .Op Fl t Ar target-pane
 .Ar key Ar ...
@@ -2694,6 +2694,9 @@ to send; if the string is not recognised as a key, it is sent as a series of
 characters.
 All arguments are sent sequentially from first to last.
 .Pp
+The
+.Fl F
+flag enables format expansion in the supplied string.
 The
 .Fl l
 flag disables key name lookup and processes the keys as literal UTF-8

--- a/window-copy.c
+++ b/window-copy.c
@@ -1673,16 +1673,13 @@ window_copy_cmd_search_backward(struct window_copy_cmd_state *cs)
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 	const char			*argument;
-	struct format_tree		*ft;
 	char				*expanded;
 
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
-			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
-			window_copy_formats(wme, ft);
-			expanded = format_expand(ft, argument);
-			free(ft);
+			expanded = format_single(NULL, argument, NULL, NULL,
+						 NULL, wme->wp);
 			free(data->searchstr);
 			data->searchstr = xstrdup(expanded);
 			free(expanded);
@@ -1703,16 +1700,13 @@ window_copy_cmd_search_forward(struct window_copy_cmd_state *cs)
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 	const char			*argument;
-	struct format_tree		*ft;
 	char				*expanded;
 
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
-			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
-			window_copy_formats(wme, ft);
-			expanded = format_expand(ft, argument);
-			free(ft);
+			expanded = format_single(NULL, argument, NULL, NULL,
+						 NULL, wme->wp);
 			free(data->searchstr);
 			data->searchstr = xstrdup(expanded);
 			free(expanded);

--- a/window-copy.c
+++ b/window-copy.c
@@ -1673,12 +1673,19 @@ window_copy_cmd_search_backward(struct window_copy_cmd_state *cs)
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 	const char			*argument;
+	struct format_tree		*ft;
+	char				*expanded;
 
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
+			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
+			window_copy_formats(wme, ft);
+			expanded = format_expand(ft, argument);
+			free(ft);
 			free(data->searchstr);
-			data->searchstr = xstrdup(argument);
+			data->searchstr = xstrdup(expanded);
+			free(expanded);
 		}
 	}
 	if (data->searchstr != NULL) {
@@ -1696,12 +1703,19 @@ window_copy_cmd_search_forward(struct window_copy_cmd_state *cs)
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 	const char			*argument;
+	struct format_tree		*ft;
+	char				*expanded;
 
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
+			ft = format_create(NULL, NULL, FORMAT_NONE, 0);
+			window_copy_formats(wme, ft);
+			expanded = format_expand(ft, argument);
+			free(ft);
 			free(data->searchstr);
-			data->searchstr = xstrdup(argument);
+			data->searchstr = xstrdup(expanded);
+			free(expanded);
 		}
 	}
 	if (data->searchstr != NULL) {

--- a/window-copy.c
+++ b/window-copy.c
@@ -1678,11 +1678,18 @@ window_copy_cmd_search_backward(struct window_copy_cmd_state *cs)
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
-			expanded = format_single(NULL, argument, NULL, NULL,
-						 NULL, wme->wp);
 			free(data->searchstr);
-			data->searchstr = xstrdup(expanded);
-			free(expanded);
+			if (args_has(cs->args, 'F')) {
+				expanded = format_single(NULL, argument, NULL,
+							 NULL, NULL, wme->wp);
+				if (*expanded != '\0')
+					data->searchstr = expanded;
+				else {
+					free(expanded);
+					data->searchstr = xstrdup(argument);
+				}
+			} else
+				data->searchstr = xstrdup(argument);
 		}
 	}
 	if (data->searchstr != NULL) {
@@ -1705,11 +1712,18 @@ window_copy_cmd_search_forward(struct window_copy_cmd_state *cs)
 	if (cs->args->argc == 2) {
 		argument = cs->args->argv[1];
 		if (*argument != '\0') {
-			expanded = format_single(NULL, argument, NULL, NULL,
-						 NULL, wme->wp);
 			free(data->searchstr);
-			data->searchstr = xstrdup(expanded);
-			free(expanded);
+			if (args_has(cs->args, 'F')) {
+				expanded = format_single(NULL, argument, NULL,
+							 NULL, NULL, wme->wp);
+				if (*expanded != '\0')
+					data->searchstr = expanded;
+				else {
+					free(expanded);
+					data->searchstr = xstrdup(argument);
+				}
+			} else
+				data->searchstr = xstrdup(argument);
 		}
 	}
 	if (data->searchstr != NULL) {


### PR DESCRIPTION
Hi, this is my initial attempt to make search-backward and search-forward expand their argument as a format, as discussed earlier in https://github.com/tmux/tmux/pull/1945.

This makes it possible to have the key bindings below to enable vi-like search in copy mode:
```
tmux bind -Tcopy-mode-vi '#' 'send -X search-backward "#{copy_cursor_word}"'
tmux bind -Tcopy-mode-vi '*' 'send -X search-forward "#{copy_cursor_word}"'
```
Please have a look and comment, thank you!