### PR TITLE
Remove use of REG_STARTEND

### DIFF
--- a/regsub.c
+++ b/regsub.c
@@ -77,10 +77,7 @@ regsub(const char *pattern, const char *with, const char *text, int flags)
 	end = strlen(text);
 
 	while (start <= end) {
-		m[0].rm_so = start;
-		m[0].rm_eo = end;
-
-		if (regexec(&r, text, nitems(m), m, REG_STARTEND) != 0) {
+		if (regexec(&r, text + start, nitems(m), m, 0) != 0) {
 			regsub_copy(&buf, &len, text, start, end);
 			break;
 		}
@@ -89,22 +86,22 @@ regsub(const char *pattern, const char *with, const char *text, int flags)
 		 * Append any text not part of this match (from the end of the
 		 * last match).
 		 */
-		regsub_copy(&buf, &len, text, last, m[0].rm_so);
+		regsub_copy(&buf, &len, text, last, m[0].rm_so + start);
 
 		/*
 		 * If the last match was empty and this one isn't (it is either
 		 * later or has matched text), expand this match. If it is
 		 * empty, move on one character and try again from there.
 		 */
-		if (empty || m[0].rm_so != last || m[0].rm_so != m[0].rm_eo) {
-			regsub_expand(&buf, &len, with, text, m, nitems(m));
+		if (empty || start + m[0].rm_so != last || m[0].rm_so != m[0].rm_eo) {
+			regsub_expand(&buf, &len, with, text + start, m, nitems(m));
 
-			last = m[0].rm_eo;
-			start = m[0].rm_eo;
+			last = start + m[0].rm_eo;
+			start += m[0].rm_eo;
 			empty = 0;
 		} else {
-			last = m[0].rm_eo;
-			start = m[0].rm_eo + 1;
+			last = start + m[0].rm_eo;
+			start += m[0].rm_eo + 1;
 			empty = 1;
 		}
 	}


### PR DESCRIPTION
The REG_STARTEND flag is not a part of POSIX standard regular
expressions (see [1]). Avoid using it to maintain tmux's portability to
many operating systems.

Removing it is fairly straightforward. We never used it to limit the
search before the end of the string, we only used it to move search start
offset forward. Instead of passing REG_STARTEND, simply pass string +
start into regexec(). Fix up uses of rm_so and rm_eo to be relative to
start, and Bob's your uncle.

[1] https://pubs.opengroup.org/onlinepubs/009695399/functions/regexec.html

---
Note: I haven't actually tested this patch. Let me know if anything is broken.