### PR TITLE
Fix musl build

### DIFF
--- a/regsub.c
+++ b/regsub.c
@@ -17,8 +17,11 @@
  */
 
 #include <sys/types.h>
-
+#if defined(__GLIBC__)
 #include <regex.h>
+#else
+#include <pcreposix.h>
+#endif
 #include <string.h>
 
 #include "tmux.h"


### PR DESCRIPTION
Musl's regex.h does not have the needed define of: REG_STARTEND
While, pcre's pcreposix.h gives the definition that is needed.

Though #1982 would be best bet IMO
Signed-off-by: Nathan Owens <ndowens04@gmail.com>