### PR TITLE
Fix bounds check in layout_parse overflowing to max u_int.

### DIFF
--- a/layout-custom.c
+++ b/layout-custom.c
@@ -211,9 +211,10 @@ layout_parse(struct window *w, const char *layout)
 		break;
 	}
 	if (lc->type != LAYOUT_WINDOWPANE && (lc->sx != sx || lc->sy != sy)) {
-		log_debug("fix layout %u,%u to %u,%u", lc->sx, lc->sy, sx,sy);
+		log_debug("fix layout %u,%u to %u,%u", lc->sx, lc->sy, sx, sy);
 		layout_print_cell(lc, __func__, 0);
-		lc->sx = sx - 1; lc->sy = sy - 1;
+		lc->sx = (sx > 0) ? sx - 1 : 0;
+		lc->sy = (sy > 0) ? sy - 1 : 0;
 	}
 
 	/* Check the new layout. */


### PR DESCRIPTION
See https://github.com/tmux-plugins/tmux-resurrect/issues/316 for full debug logs of the bug. Basically `layout_parse()` would try to correctly alter the layout to match what is currently available, however it would incorrectly attempt to subtract past 0 to max u_int by not checking bounds. 

Thanks to @DarkKnight288 for finding the issue, and if they wish to submit an MR directly I will gladly let them have it lol.