### PR TITLE
Check and define '_PATH_*' macros individually

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -61,12 +61,31 @@ void	warn(const char *, ...);
 void	warnx(const char *, ...);
 #endif
 
-#ifndef HAVE_PATHS_H
-#define	_PATH_BSHELL	"/bin/sh"
-#define	_PATH_TMP	"/tmp/"
+#ifdef HAVE_PATHS_H
+#include <paths.h>
+#endif
+
+#ifndef _PATH_BSHELL
+#define _PATH_BSHELL	"/bin/sh"
+#endif
+
+#ifndef _PATH_TMP
+#define _PATH_TMP	"/tmp/"
+#endif
+
+#ifndef _PATH_DEVNULL
 #define _PATH_DEVNULL	"/dev/null"
+#endif
+
+#ifndef _PATH_TTY
 #define _PATH_TTY	"/dev/tty"
+#endif
+
+#ifndef _PATH_DEV
 #define _PATH_DEV	"/dev/"
+#endif
+
+#ifndef _PATH_DEFPATH
 #define _PATH_DEFPATH	"/usr/bin:/bin"
 #endif
 
@@ -96,10 +115,6 @@ void	warnx(const char *, ...);
 #include <bitstring.h>
 #else
 #include "compat/bitstring.h"
-#endif
-
-#ifdef HAVE_PATHS_H
-#include <paths.h>
 #endif
 
 #ifdef HAVE_LIBUTIL_H


### PR DESCRIPTION
Some systems (e.g., Solaris) don't define `_PATH_DEFPATH`, even though
the `paths.h` header exists.  Checking each `_PATH_*` individually is
more resilient by ensuring that necessary macros are defined during
compilation.

Closes: #1999 