### PR TITLE
add support for line wrapped search

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -2082,16 +2082,24 @@ static int
 window_copy_search_lr(struct grid *gd,
     struct grid *sgd, u_int *ppx, u_int py, u_int first, u_int last, int cis)
 {
-	u_int	ax, bx, px;
+	u_int	ax, bx, px, pywrap, endline;
 	int	matched;
 
+	endline = gd->hsize + gd->sy - 1;
 	for (ax = first; ax < last; ax++) {
-		if (ax + sgd->sx > gd->sx)
-			break;
 		for (bx = 0; bx < sgd->sx; bx++) {
 			px = ax + bx;
-			matched = window_copy_search_compare(gd, px, py, sgd,
-			    bx, cis);
+			pywrap = py;
+			/* Wrap line. */
+			while (px >= gd->sx && pywrap < endline) {
+				px -= gd->sx;
+				pywrap++;
+			}
+			/* We have run off the end of the grid. */
+			if (px >= gd->sx)
+				break;
+			matched = window_copy_search_compare(gd, px, pywrap,
+			    sgd, bx, cis);
 			if (!matched)
 				break;
 		}
@@ -2107,16 +2115,24 @@ static int
 window_copy_search_rl(struct grid *gd,
     struct grid *sgd, u_int *ppx, u_int py, u_int first, u_int last, int cis)
 {
-	u_int	ax, bx, px;
+	u_int	ax, bx, px, pywrap, endline;
 	int	matched;
 
-	for (ax = last + 1; ax > first; ax--) {
-		if (gd->sx - (ax - 1) < sgd->sx)
-			continue;
+	endline = gd->hsize + gd->sy - 1;
+	for (ax = last; ax > first; ax--) {
 		for (bx = 0; bx < sgd->sx; bx++) {
 			px = ax - 1 + bx;
-			matched = window_copy_search_compare(gd, px, py, sgd,
-			    bx, cis);
+			pywrap = py;
+			/* Wrap line. */
+			while (px >= gd->sx && pywrap < endline) {
+				px -= gd->sx;
+				pywrap++;
+			}
+			/* We have run off the end of the grid. */
+			if (px >= gd->sx)
+				break;
+			matched = window_copy_search_compare(gd, px, pywrap,
+			    sgd, bx, cis);
 			if (!matched)
 				break;
 		}
@@ -2135,7 +2151,7 @@ window_copy_move_left(struct screen *s, u_int *fx, u_int *fy, int wrapflag)
 		if (*fy == 0) { /* top */
 			if (wrapflag) {
 				*fx = screen_size_x(s) - 1;
-				*fy = screen_hsize(s) + screen_size_y(s);
+				*fy = screen_hsize(s) + screen_size_y(s) - 1;
 			}
 			return;
 		}
@@ -2149,7 +2165,7 @@ static void
 window_copy_move_right(struct screen *s, u_int *fx, u_int *fy, int wrapflag)
 {
 	if (*fx == screen_size_x(s) - 1) { /* right */
-		if (*fy == screen_hsize(s) + screen_size_y(s)) { /* bottom */
+		if (*fy == screen_hsize(s) + screen_size_y(s) - 1) { /* bottom */
 			if (wrapflag) {
 				*fx = 0;
 				*fy = 0;
@@ -2199,12 +2215,12 @@ window_copy_search_jump(struct window_mode_entry *wme, struct grid *gd,
 	} else {
 		for (i = fy + 1; endline < i; i--) {
 			found = window_copy_search_rl(gd, sgd, &px, i - 1, 0,
-			    fx, cis);
+			    fx + 1, cis);
 			if (found) {
 				i--;
 				break;
 			}
-			fx = gd->sx;
+			fx = gd->sx - 1;
 		}
 	}
 


### PR DESCRIPTION
Hi, this adds support for line wrapped searches in copy mode. In addition, there are a few adjustments:

- In window_copy_search_lr/rl, the convention is: first = the starting coordinate, last = one past the ending coordinate. window_copy_search jump is adjusted to follow this and make everything consistent.
- In window_copy_move_right/left the coordinates are adjusted so that they don't go off the grid.

Please comment. Thanks!