### PR TITLE
Define FNM_CASEFOLD to 0 for compatibility

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -21,6 +21,7 @@
 #include <sys/ioctl.h>
 #include <sys/uio.h>
 
+#include <fnmatch.h>
 #include <limits.h>
 #include <stdio.h>
 #include <termios.h>
@@ -167,6 +168,10 @@ void	warnx(const char *, ...);
 
 #ifndef O_DIRECTORY
 #define O_DIRECTORY 0
+#endif
+
+#ifndef FNM_CASEFOLD
+#define FNM_CASEFOLD 0
 #endif
 
 #ifndef INFTIM


### PR DESCRIPTION
Some systems (e.g., AIX) don't define `FNM_CASEFOLD` nor support
ignoring case.  To avoid flag value collisions, fallback to setting the
flag to 0 so it doesn't do anything in case the system may define it in
the future.