### PR TITLE
Remove reference to non-existent option in tmux.1

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4367,7 +4367,7 @@ interface, for example
 .Ic status-style
 for the status line.
 In addition, embedded styles may be specified in format options, such as
-.Ic status-left-format ,
+.Ic status-left ,
 by enclosing them in
 .Ql #[
 and


### PR DESCRIPTION
The first paragraph of the STYLES section in the tmux manpage refers to
"status-left-format," which appears nowhere else in the manpage nor in
the tmux source.