### PR TITLE
Make move-pane behave like join-pane with marked panes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES FROM 3.0 to X.X
 
+* Change move-pane to automatically source a marked pane, if any, like 
+  join-pane does.
+
 * Change file reading and writing to go through the client if necessary. This
   fixes commands like "tmux loadb /dev/fd/X". Also modify source-file to
   support "-" for standard input, like load-buffer and save-buffer.

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -52,7 +52,7 @@ const struct cmd_entry cmd_move_pane_entry = {
 	.args = { "bdhvp:l:s:t:", 0, 0 },
 	.usage = "[-bdhv] [-p percentage|-l size] " CMD_SRCDST_PANE_USAGE,
 
-	.source = { 's', CMD_FIND_PANE, 0 },
+	.source = { 's', CMD_FIND_PANE, CMD_FIND_DEFAULT_MARKED },
 	.target = { 't', CMD_FIND_PANE, 0 },
 
 	.flags = 0,


### PR DESCRIPTION
The man says that `move-pane` is "Like join-pane, but src-pane and dst-pane may belong to the same window.".

I actually did not when trying to move a marked pane. This PR fixes it.