### PR TITLE
Add a highlight-search option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -614,6 +614,12 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 1
 	},
 
+	{ .name = "highlight-search",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_num = 1
+	},
+
 	{ .name = "main-pane-height",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/tmux.1
+++ b/tmux.1
@@ -3517,6 +3517,11 @@ Set clock colour.
 .Xc
 Set clock hour format.
 .Pp
+.It Xo Ic highlight-search
+.Op Ic on | off
+.Xc
+Highlight all occurences of search term in the window.
+.Pp
 .It Ic main-pane-height Ar height
 .It Ic main-pane-width Ar width
 Set the width or height of the main (left or top) pane in the

--- a/window-copy.c
+++ b/window-copy.c
@@ -2595,8 +2595,10 @@ window_copy_search(struct window_mode_entry *wme, int direction, int regex)
 	found = window_copy_search_jump(wme, gd, ss.grid, fx, fy, endline, cis,
 	    wrapflag, direction, regex);
 
-	if (window_copy_search_marks(wme, &ss, regex))
+	if (options_get_number(wp->window->options, "highlight-search") &&
+	    window_copy_search_marks(wme, &ss, regex)) {
 		window_copy_redraw_screen(wme);
+	}
 
 	screen_free(&ss);
 	return (found);


### PR DESCRIPTION
Highlight-search can make searching unusable on really large buffers. This is due to it trying to look for all occurrences of the result in the whole buffer, which can be very slow. We cannot simply highlight the occurrences in the current view as that requires updating the search as the view changes and while this is possible seemed very complex.

To repro:
set -g history-limit 300000

then run:
$ seq 300000

Searching through this buffer is very sluggish due to the search algorithm.

With highlight-search set to 0 this works much better.