### PR TITLE
Alias FNM_CASEFOLD to FNM_IGNORECASE for Illumos and Solaris

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -171,7 +171,11 @@ void	warnx(const char *, ...);
 #endif
 
 #ifndef FNM_CASEFOLD
+#ifdef FNM_IGNORECASE
+#define FNM_CASEFOLD FNM_IGNORECASE
+#else
 #define FNM_CASEFOLD 0
+#endif
 #endif
 
 #ifndef INFTIM


### PR DESCRIPTION
Improve compatibility for case insensitive functionality for older
versions of Solaris and Illumos systems.

CC: @jperkin, thanks for https://github.com/tmux/tmux/pull/2020#issuecomment-577610179.  I didn't know enough about older versions of Solaris nor Illumos.  TIL!