### PR TITLE
Select_word change for single char word in copy-mode-vi

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -1521,14 +1521,27 @@ window_copy_cmd_select_word(struct window_copy_cmd_state *cs)
 	struct session			*s = cs->s;
 	struct window_copy_mode_data	*data = wme->data;
 	const char			*ws;
+	struct screen			*back_s = data->backing;
+	u_int				 px, py, xx;
 
 	data->lineflag = LINE_SEL_LEFT_RIGHT;
 	data->rectflag = 0;
 
+	px = data->cx;
+	py = screen_hsize(back_s) + data->cy - data->oy;
+	xx = window_copy_find_length(wme, py);
+
 	ws = options_get_string(s->options, "word-separators");
 	window_copy_cursor_previous_word(wme, ws, 0);
 	window_copy_start_selection(wme);
-	window_copy_cursor_next_word_end(wme, ws);
+
+	if ( (px >= xx) || !window_copy_in_set(wme, px+1, py, ws) )
+		window_copy_cursor_next_word_end(wme, ws);
+	else {
+		window_copy_update_cursor(wme, px, data->cy);
+		if (window_copy_update_selection(wme, 1))
+			window_copy_redraw_lines(wme, data->cy, 1);
+	}
 
 	return (WINDOW_COPY_CMD_REDRAW);
 }


### PR DESCRIPTION
@nicm here is another way for the single char select_word.  Do you think it makes sense ?