### PR TITLE
fix selection mode reset when display scrolls up

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -2946,11 +2946,8 @@ window_copy_synchronize_cursor(struct window_mode_entry *wme)
 
 	switch (data->cursordrag) {
 	case CURSORDRAG_ENDSEL:
-		window_copy_synchronize_cursor_end(wme);
-		break;
 	case CURSORDRAG_SEL:
-		data->selx = data->cx;
-		data->sely = screen_hsize(data->backing) + data->cy - data->oy;
+		window_copy_synchronize_cursor_end(wme);
 		break;
 	case CURSORDRAG_NONE:
 		break;

--- a/window-copy.c
+++ b/window-copy.c
@@ -2875,15 +2875,15 @@ window_copy_redraw_screen(struct window_mode_entry *wme)
 }
 
 static void
-window_copy_synchronize_cursor_end(struct window_mode_entry *wme)
+window_copy_synchronize_cursor_end(struct window_mode_entry *wme, int begin)
 {
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 xx, yy;
-	int				 begin = 0;
 
 	yy = screen_hsize(data->backing) + data->cy - data->oy;
 	switch (data->selflag) {
 	case SEL_WORD:
+		begin = 0;
 		xx = data->cx;
 		if (data->ws == NULL)
 			break;
@@ -2909,6 +2909,7 @@ window_copy_synchronize_cursor_end(struct window_mode_entry *wme)
 		}
 		break;
 	case SEL_LINE:
+		begin = 0;
 		if (data->dy > yy) {
 			/* Right to left selection. */
 			xx = 0;
@@ -2946,8 +2947,10 @@ window_copy_synchronize_cursor(struct window_mode_entry *wme)
 
 	switch (data->cursordrag) {
 	case CURSORDRAG_ENDSEL:
+		window_copy_synchronize_cursor_end(wme, 0);
+		break;
 	case CURSORDRAG_SEL:
-		window_copy_synchronize_cursor_end(wme);
+		window_copy_synchronize_cursor_end(wme, 1);
 		break;
 	case CURSORDRAG_NONE:
 		break;


### PR DESCRIPTION
Hi, I found an issue with the word/line selection mouse drag feature in commit f65b9c0. If the selection leads to the display scrolling up, such as when the cursor reaches the top line while dragging, the CURSORDRAG_SEL branch of window_copy_synchronize_cursor is called, which does not adjust the selection correctly. Instead, both branches should call window_copy_synchronize_cursor_end.

Please have a look and comment. Thanks!