### PR TITLE
make other-end command forget reset points like vim

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -1361,7 +1361,9 @@ window_copy_cmd_other_end(struct window_copy_cmd_state *cs)
 {
 	struct window_mode_entry	*wme = cs->wme;
 	u_int				 np = wme->prefix;
+	struct window_copy_mode_data	*data = wme->data;
 
+	data->selflag = SEL_CHAR;
 	if ((np % 2) != 0)
 		window_copy_other_end(wme);
 	return (WINDOW_COPY_CMD_NOTHING);


### PR DESCRIPTION
This is an additional patch for #2117 to make the other-end command behave more like vim. Please have a look, thanks!