### PR TITLE
Do not select spaces after word in select-word

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -1569,13 +1569,12 @@ window_copy_cmd_select_word(struct window_copy_cmd_state *cs)
 	data->dx = data->cx;
 	data->dy = screen_hsize(data->backing) + data->cy - data->oy;
 
-	px = data->cx;
-	py = screen_hsize(data->backing) + data->cy - data->oy;
-
 	data->ws = options_get_string(s->options, "word-separators");
 	window_copy_cursor_previous_word(wme, data->ws, 0);
-	data->selrx = data->cx;
-	data->selry = screen_hsize(data->backing) + data->cy - data->oy;
+	px = data->cx;
+	py = screen_hsize(data->backing) + data->cy - data->oy;
+	data->selrx = px;
+	data->selry = py;
 	window_copy_start_selection(wme);
 
 	if (px >= window_copy_find_length(wme, py) ||
@@ -1588,6 +1587,8 @@ window_copy_cmd_select_word(struct window_copy_cmd_state *cs)
 	}
 	data->endselrx = data->cx;
 	data->endselry = screen_hsize(data->backing) + data->cy - data->oy;
+	if (data->dx > data->endselrx)
+		data->dx = data->endselrx;
 
 	return (WINDOW_COPY_CMD_REDRAW);
 }


### PR DESCRIPTION
Hi, I noticed a problem caused by f48b041cf22a55bbd9f6e1ab498cf610fdfc1a5f when one issues the select-word command when the cursor is positioned past the end of a word. In this case, earlier versions of tmux would just select the word, but now it also selects the spaces up to the cursor position. In the following illustration, periods are spaces and + is the cursor:
`word...+....word2` selects `word....`, expected `word`.

However, if there is another word immediately after the cursor, then the word is correctly selected:
`word...+word2` selects `word` as expected.

It is caused by initialising px and py too early. They should be initialised after the cursor has been moved to the start of the word.