### PR TITLE
selection end reset position should be at the end of the first line in select-line

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -1566,12 +1566,12 @@ window_copy_cmd_select_line(struct window_copy_cmd_state *cs)
 	window_copy_cursor_start_of_line(wme);
 	data->selrx = data->cx;
 	data->selry = screen_hsize(data->backing) + data->cy - data->oy;
+	data->endselrx = window_copy_find_length(wme, data->selry);
+	data->endselry = data->selry;
 	window_copy_start_selection(wme);
 	for (; np > 1; np--)
 		window_copy_cursor_down(wme, 0);
 	window_copy_cursor_end_of_line(wme);
-	data->endselrx = data->cx;
-	data->endselry = screen_hsize(data->backing) + data->cy - data->oy;
 
 	return (WINDOW_COPY_CMD_REDRAW);
 }


### PR DESCRIPTION
Hi, while testing I caught the following edge case: If we use prefix to select multiple lines (for example `Ctrl-B [` then `10V`) then in the current code the remembered end position (data->endselrx/y) is set to the end of the entire selection.

This causes unexpected behaviour when using `other-end` (for example, if we use up arrow to move the cursor up past the first selected line and do `send -X other-end`), and is not consistent with the behaviour when we select multiple lines using the mouse or keyboard manually. This can be fixed by setting the remembered end position to the end of the first selected line.

Hope this makes sense, thanks!