### PR TITLE
Apply ctrl modifier to more characters in key strings.

### DIFF
--- a/key-string.c
+++ b/key-string.c
@@ -159,7 +159,7 @@ key_string_get_modifiers(const char **string)
 key_code
 key_string_lookup_string(const char *string)
 {
-	static const char	*other = "!#()+,-.0123456789:;<=>'\r\t";
+	static const char	*other = "!#%(){}+,-.0123456789:;<=>'\"\r\t";
 	key_code		 key;
 	u_int			 u;
 	key_code		 modifiers;


### PR DESCRIPTION
This should allow using the CTRL key to modify 4 more characters in key strings, enabling more freedom for configuring key bindings.

Before:
```
key_string_lookup_string("^%") -> KEYC_UNKNOWN
key_string_lookup_string("^\"") -> KEYC_UNKNOWN
key_string_lookup_string("^{") -> KEYC_UNKNOWN
key_string_lookup_string("^}") -> KEYC_UNKNOWN
```

After:
```
key_string_lookup_string("^%") -> (KEYC_CTRL | '%')
key_string_lookup_string("^\"") -> (KEYC_CTRL | '"')
key_string_lookup_string("^{") -> (KEYC_CTRL | '{')
key_string_lookup_string("^}") -> (KEYC_CTRL | '}')
```