### PR TITLE
Add #{session_cwd} format variable

### DIFF
--- a/format.c
+++ b/format.c
@@ -2492,6 +2492,7 @@ format_defaults_session(struct format_tree *ft, struct session *s)
 	ft->s = s;
 
 	format_add(ft, "session_name", "%s", s->name);
+	format_add(ft, "session_path", "%s", s->cwd);
 	format_add(ft, "session_windows", "%u", winlink_count(&s->windows));
 	format_add(ft, "session_id", "$%u", s->id);
 

--- a/tmux.1
+++ b/tmux.1
@@ -4414,6 +4414,7 @@ The following variables are available, where appropriate:
 .It Li "session_last_attached" Ta "" Ta "Time session last attached"
 .It Li "session_many_attached" Ta "" Ta "1 if multiple clients attached"
 .It Li "session_name" Ta "#S" Ta "Name of session"
+.It Li "session_path" Ta "" Ta "Working directory of session"
 .It Li "session_stack" Ta "" Ta "Window indexes in most recent order"
 .It Li "session_windows" Ta "" Ta "Number of windows in session"
 .It Li "socket_path" Ta "" Ta "Server socket path"


### PR DESCRIPTION
This patch adds a format variable `#{session_cwd}` that exposes the current session working directory. I could not find any other way to obtain this information. The use case is that I usually have one tmux session per project / repo, with the repo root as working directory so that new windows automatically open in the proper directory, and I would like to have that visible on the status line and in the terminal window title.