### PR TITLE
map ctrl-j to \r in mode_tree_key

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -928,6 +928,9 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 	case '\033': /* Escape */
 	case '\007': /* C-g */
 		return (1);
+  case '\012': /* C-j */
+    *key = '\r';
+    return (0);
 	case KEYC_UP:
 	case 'k':
 	case KEYC_WHEELUP_PANE:


### PR DESCRIPTION
The choose-session menu used to have this INLCR-like behavior in some older version of tmux and I got used to it, but now it doesn't have that any more.

Please consider restoring that behavior with this patch.

Signed-off-by: yl790 <yitao@rstudio.com>