### PR TITLE
Preserve cursor position during copy mode resize

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -1285,7 +1285,7 @@ grid_reflow(struct grid *gd, u_int sx)
 
 		/*
 		 * If the line is exactly right or the first character is wider
-		 * than the targe width, just move it across unchanged.
+		 * than the target width, just move it across unchanged.
 		 */
 		if (width == sx || first > sx) {
 			grid_reflow_move(target, gl);

--- a/screen.c
+++ b/screen.c
@@ -219,27 +219,19 @@ screen_pop_title(struct screen *s)
 	}
 }
 
-/* Resize screen and return cursor position. */
+/* Resize screen with options. */
 void
 screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
-    int eat_empty, u_int *cx, u_int *cy, int cursor)
+    int eat_empty, int cursor)
 {
-	u_int	tcx, tcy;
+	u_int	cx = s->cx, cy = s->grid->hsize + s->cy;
 
 	if (s->write_list != NULL)
 		screen_write_free_list(s);
 
-	if (cx == NULL)
-		cx = &tcx;
-	*cx = s->cx;
-
-	if (cy == NULL)
-		cy = &tcy;
-	*cy = s->grid->hsize + s->cy;
-
 	log_debug("%s: new size %ux%u, now %ux%u (cursor %u,%u = %u,%u)",
 	    __func__, sx, sy, screen_size_x(s), screen_size_y(s), s->cx, s->cy,
-	    *cx, *cy);
+	    cx, cy);
 
 	if (sx < 1)
 		sx = 1;
@@ -253,20 +245,21 @@ screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
 		reflow = 0;
 
 	if (sy != screen_size_y(s))
-		screen_resize_y(s, sy, eat_empty, cy);
+		screen_resize_y(s, sy, eat_empty, &cy);
 
 	if (reflow)
-		screen_reflow(s, sx, cx, cy, cursor);
+		screen_reflow(s, sx, &cx, &cy, cursor);
 
-	if (*cy >= s->grid->hsize) {
-		s->cx = *cx;
-		s->cy = (*cy) - s->grid->hsize;
+	if (cy >= s->grid->hsize) {
+		s->cx = cx;
+		s->cy = cy - s->grid->hsize;
 	} else {
 		s->cx = 0;
 		s->cy = 0;
 	}
+
 	log_debug("%s: cursor finished at %u,%u = %u,%u", __func__, s->cx,
-	    s->cy, *cx, *cy);
+	    s->cy, cx, cy);
 
 	if (s->write_list != NULL)
 		screen_write_make_list(s);
@@ -276,7 +269,7 @@ screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
 void
 screen_resize(struct screen *s, u_int sx, u_int sy, int reflow)
 {
-	screen_resize_cursor(s, sx, sy, reflow, 1, NULL, NULL, 1);
+	screen_resize_cursor(s, sx, sy, reflow, 1, 1);
 }
 
 static void
@@ -538,7 +531,11 @@ screen_reflow(struct screen *s, u_int new_x, u_int *cx, u_int *cy, int cursor)
 
 	if (cursor) {
 		grid_unwrap_position(s->grid, cx, cy, wx, wy);
-		log_debug("%s: new cursor is %u,%u", __func__, *cx,* cy);
+		log_debug("%s: new cursor is %u,%u", __func__, *cx, *cy);
+	}
+	else {
+		*cx = 0;
+		*cy = s->grid->hsize;
 	}
 }
 

--- a/tmux.h
+++ b/tmux.h
@@ -2526,7 +2526,7 @@ void	 screen_push_title(struct screen *);
 void	 screen_pop_title(struct screen *);
 void	 screen_resize(struct screen *, u_int, u_int, int);
 void	 screen_resize_cursor(struct screen *, u_int, u_int, int, int, u_int *,
-	     u_int *);
+	     u_int *, int);
 void	 screen_set_selection(struct screen *, u_int, u_int, u_int, u_int,
 	     u_int, int, struct grid_cell *);
 void	 screen_clear_selection(struct screen *);

--- a/tmux.h
+++ b/tmux.h
@@ -2525,8 +2525,7 @@ void	 screen_set_path(struct screen *, const char *);
 void	 screen_push_title(struct screen *);
 void	 screen_pop_title(struct screen *);
 void	 screen_resize(struct screen *, u_int, u_int, int);
-void	 screen_resize_cursor(struct screen *, u_int, u_int, int, int, u_int *,
-	     u_int *, int);
+void	 screen_resize_cursor(struct screen *, u_int, u_int, int, int, int);
 void	 screen_set_selection(struct screen *, u_int, u_int, u_int, u_int,
 	     u_int, int, struct grid_cell *);
 void	 screen_clear_selection(struct screen *);


### PR DESCRIPTION
The following changeset preserves the cursor position while resizing the pane in copy mode. Please have a look and comment, thanks!