### PR TITLE
Correct pane_path alias in documentation

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4553,7 +4553,7 @@ The following variables are available, where appropriate:
 .It Li "pane_marked" Ta "" Ta "1 if this is the marked pane"
 .It Li "pane_marked_set" Ta "" Ta "1 if a marked pane is set"
 .It Li "pane_mode" Ta "" Ta "Name of pane mode, if any"
-.It Li "pane_path" Ta "#T" Ta "Path of pane (can be set by application)"
+.It Li "pane_path" Ta "" Ta "Path of pane (can be set by application)"
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"
 .It Li "pane_pipe" Ta "" Ta "1 if pane is being piped"
 .It Li "pane_right" Ta "" Ta "Right of pane"


### PR DESCRIPTION
`#T` appears to map to `pane_title` in [format.c](https://github.com/tmux/tmux/blob/a43a156/format.c#L176)