### PR TITLE
Add FreeBSD to CI

### DIFF
--- a/.github/travis/before-install.sh
+++ b/.github/travis/before-install.sh
@@ -15,3 +15,10 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 					musl-tools
 	fi
 fi
+
+if [ "$TRAVIS_OS_NAME" = "freebsd" ]; then
+	sudo pkg install -y \
+		automake \
+		libevent \
+		pkgconf
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 
 os:
   - linux
+  - freebsd
   - osx
 
 compiler:
@@ -28,6 +29,19 @@ jobs:
     - os: osx
       compiler: clang
       env: BUILD=static
+    # No musl on FreeBSD
+    - os: freebsd
+      compiler: gcc
+      env: BUILD=musl
+    - os: freebsd
+      compiler: clang
+      env: BUILD=musl
+    - os: freebsd
+      compiler: gcc
+      env: BUILD=musl-static
+    - os: freebsd
+      compiler: clang
+      env: BUILD=musl-static
     # No musl on OS X
     - os: osx
       compiler: gcc


### PR DESCRIPTION
TravisCI [supports](https://github.com/travis-ci/travis-build/pulls?q=is%3Apr+freebsd+is%3Aclosed) FreeBSD nowadays. Let's see how well it works.

CC @lwhsu ([wiki](https://wiki.freebsd.org/HostedCI)), @mat813 ([downstream](http://freshports.org/sysutils/tmux))
