### PR TITLE
fix: don't clear window_bell_flag in active window of detached sessions

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -200,7 +200,7 @@ alerts_check_bell(struct window *w)
 		 * not check WINLINK_BELL).
 		 */
 		s = wl->session;
-		if (s->curw != wl) {
+		if (s->curw != wl || !s->attached) {
 			wl->flags |= WINLINK_BELL;
 			server_status_session(s);
 		}
@@ -236,7 +236,7 @@ alerts_check_activity(struct window *w)
 		if (wl->flags & WINLINK_ACTIVITY)
 			continue;
 		s = wl->session;
-		if (s->curw != wl) {
+		if (s->curw != wl || !s->attached) {
 			wl->flags |= WINLINK_ACTIVITY;
 			server_status_session(s);
 		}
@@ -272,7 +272,7 @@ alerts_check_silence(struct window *w)
 		if (wl->flags & WINLINK_SILENCE)
 			continue;
 		s = wl->session;
-		if (s->curw != wl) {
+		if (s->curw != wl || !s->attached) {
 			wl->flags |= WINLINK_SILENCE;
 			server_status_session(s);
 		}


### PR DESCRIPTION
Github Issue 1182.

If a detached session has an active window that produces a bell the
window_bell_flag will be immediately cleared. This breaks notifications
for "background" tasks. This change only clears window flags if the
session is attached.

----

Patch based on @nicm's suggestion in Github Issue 1182.

I've been using this patch for two months to get notifications from my detached sessions. I use the below config to append to my status line. It lists the detached sessions with bells.
```
set -ag status-left "#(tmux list-windows -a -F \"##{?window_bell_flag,##S:##{window_index},}\" | sed -e '/^$/d' -e 's/\\(.*\\)/[\\1]/' | tr -d '\\n')"
```

Looks like this:
```
    [notes][firewalld policy:1] 0:vim* 1:mksh-
    ^^^^^^  ^^^^^^^^^^^^     ^
   current  session with     window index
   session  bell             with bell
```