### PR TITLE
prevent server crash when event's value is NULL

### DIFF
--- a/cmd-parse.y
+++ b/cmd-parse.y
@@ -1432,7 +1432,7 @@ yylex_token_variable(char **buf, size_t *len)
 	name[namelen] = '\0';
 
 	envent = environ_find(global_environ, name);
-	if (envent != NULL) {
+	if (envent != NULL && envent->value != NULL) {
 		value = envent->value;
 		log_debug("%s: %s -> %s", __func__, name, value);
 		yylex_append(buf, len, value, strlen(value));


### PR DESCRIPTION
An events' value may be NULL.
E.g.
`setenv -g -r x`
Then a server crash happens on
`display -p $x`

This simple fix prevents the crash.

Regards, Mike