### PR TITLE
Move sysconfdir/tmux.conf to end of path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ dist_EXTRA_tmux_SOURCES = compat/*.[ch]
 # Preprocessor flags.
 AM_CPPFLAGS += @XOPEN_DEFINES@ \
 	-DTMUX_VERSION='"@VERSION@"' \
-	-DTMUX_CONF='"$(sysconfdir)/tmux.conf:~/.tmux.conf:$$XDG_CONFIG_HOME/tmux/tmux.conf:~/.config/tmux/tmux.conf"'
+	-DTMUX_CONF='"~/.tmux.conf:$$XDG_CONFIG_HOME/tmux/tmux.conf:~/.config/tmux/tmux.conf:$(sysconfdir)/tmux.conf"'
 
 # Additional object files.
 LDADD = $(LIBOBJS)


### PR DESCRIPTION
Fixes #2308 by moving $sysconfdir/tmux.conf to end of path for precedence