### PR TITLE
Allow spelling "colour" as "color" in config files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 CHANGES FROM 3.2 TO 3.3
 
-* Allow spelling "colour" as "color"
+* Allow spelling "colour" as "color" for the options display-panes-active-colour,
+  display-panes-colour, and clock-mode-colour as well as when specifying colours
+  with colour0 to colour255.
 
 CHANGES FROM 3.1b TO 3.2
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+CHANGES FROM 3.2 TO 3.3
+
+* Allow spelling "colour" as "color"
+
 CHANGES FROM 3.1b TO 3.2
 
 * Add a way for control mode clients to subscribe to a format and be notified

--- a/colour.c
+++ b/colour.c
@@ -189,6 +189,12 @@ colour_fromstring(const char *s)
 			return (-1);
 		return (n | COLOUR_FLAG_256);
 	}
+	if (strncasecmp(s, "color", (sizeof "color") - 1) == 0) {
+		n = strtonum(s + (sizeof "color") - 1, 0, 255, &errstr);
+		if (errstr != NULL)
+			return (-1);
+		return (n | COLOUR_FLAG_256);
+	}
 
 	if (strcasecmp(s, "default") == 0)
 		return (8);

--- a/options-table.c
+++ b/options-table.c
@@ -170,6 +170,14 @@ static const char *options_table_status_format_default[] = {
 	  .separator = "" \
 	}
 
+/* Map of name conversions. */
+const struct options_name_map options_other_names[] = {
+	{ "display-panes-color", "display-panes-colour" },
+	{ "display-panes-active-color", "display-panes-active-colour" },
+	{ "clock-mode-color", "clock-mode-colour" },
+	{ NULL, NULL }
+};
+
 /* Top-level options. */
 const struct options_table_entry options_table[] = {
 	/* Server options. */

--- a/tmux.1
+++ b/tmux.1
@@ -3560,10 +3560,12 @@ is destroyed.
 If off, the client is switched to the most recently active of the remaining
 sessions.
 .It Ic display-panes-active-colour Ar colour
+.D1 (alias: Ic display-panes-active-color )
 Set the colour used by the
 .Ic display-panes
 command to show the indicator for the active pane.
 .It Ic display-panes-colour Ar colour
+.D1 (alias: Ic display-panes-color )
 Set the colour used by the
 .Ic display-panes
 command to show the indicators for inactive panes.
@@ -3894,6 +3896,7 @@ used when the
 option is enabled.
 .Pp
 .It Ic clock-mode-colour Ar colour
+.D1 (alias: Ic clock-mode-color )
 Set clock colour.
 .Pp
 .It Xo Ic clock-mode-style
@@ -4901,6 +4904,10 @@ if supported the bright variants
 .Ic colour0
 to
 .Ic colour255
+(or
+.Ic color0
+to
+.Ic color255 )
 from the 256-colour set;
 .Ic default
 for the default colour;

--- a/tmux.h
+++ b/tmux.h
@@ -1790,6 +1790,7 @@ enum options_table_type {
 
 struct options_table_entry {
 	const char		 *name;
+	const char		 *alternative_name;
 	enum options_table_type	  type;
 	int			  scope;
 	int			  flags;
@@ -1807,6 +1808,11 @@ struct options_table_entry {
 
 	const char		 *text;
 	const char		 *unit;
+};
+
+struct options_name_map {
+	const char		*from;
+	const char		*to;
 };
 
 /* Common command usages. */
@@ -2041,7 +2047,8 @@ int		 options_remove_or_default(struct options_entry *, int,
 		     char **);
 
 /* options-table.c */
-extern const struct options_table_entry options_table[];
+extern const struct options_table_entry	options_table[];
+extern const struct options_name_map	options_other_names[];
 
 /* job.c */
 typedef void (*job_update_cb) (struct job *);


### PR DESCRIPTION
#2313

Still need to do `ccolour`