### PR TITLE
add 'delay' option to display-message

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -316,9 +316,9 @@ alerts_set_message(struct winlink *wl, const char *type, const char *option)
 		if (visual == VISUAL_OFF)
 			continue;
 		if (c->session->curw == wl)
-			status_message_set(c, 1, "%s in current window", type);
+			status_message_set(c, 0, 1, "%s in current window", type);
 		else {
-			status_message_set(c, 1, "%s in window %d", type,
+			status_message_set(c, 0, 1, "%s in window %d", type,
 			    wl->idx);
 		}
 	}

--- a/alerts.c
+++ b/alerts.c
@@ -316,9 +316,9 @@ alerts_set_message(struct winlink *wl, const char *type, const char *option)
 		if (visual == VISUAL_OFF)
 			continue;
 		if (c->session->curw == wl)
-			status_message_set(c, 0, 1, "%s in current window", type);
+			status_message_set(c, -1, 1, "%s in current window", type);
 		else {
-			status_message_set(c, 0, 1, "%s in window %d", type,
+			status_message_set(c, -1, 1, "%s in window %d", type,
 			    wl->idx);
 		}
 	}

--- a/cmd-display-message.c
+++ b/cmd-display-message.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_display_message_entry = {
 	.name = "display-message",
 	.alias = "display",
 
-	.args = { "ac:Ipt:F:v", 0, 1 },
-	.usage = "[-aIpv] [-c target-client] [-F format] "
+	.args = { "acd:Ipt:F:v", 0, 1 },
+	.usage = "[-aIpv] [-d delay] [-c target-client] [-F format] "
 		 CMD_TARGET_PANE_USAGE " [message]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -68,6 +68,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	const char		*template;
 	char			*msg, *cause;
+  int      delay;
 	struct format_tree	*ft;
 	int			 flags;
 
@@ -84,6 +85,15 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "only one of -F or argument must be given");
 		return (CMD_RETURN_ERROR);
 	}
+
+  if (args_has(args, 'd')) {
+    delay = args_strtonum(args, 'd', 0, UINT_MAX, &cause);
+    if (cause != NULL) {
+      cmdq_error(item, "delay: %s", cause);
+      free(cause);
+      return (CMD_RETURN_ERROR);
+    }
+  }
 
 	template = args_get(args, 'F');
 	if (args->argc != 0)
@@ -117,7 +127,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_has(args, 'p'))
 		cmdq_print(item, "%s", msg);
 	else if (tc != NULL)
-		status_message_set(tc, 0, "%s", msg);
+		status_message_set(tc, delay, 0, "%s", msg);
 	free(msg);
 
 	format_free(ft);

--- a/cmd-display-message.c
+++ b/cmd-display-message.c
@@ -33,7 +33,7 @@
 	"- (%H:%M %d-%b-%y)"
 
 static enum cmd_retval	cmd_display_message_exec(struct cmd *,
-			    struct cmdq_item *);
+					struct cmdq_item *);
 
 const struct cmd_entry cmd_display_message_entry = {
 	.name = "display-message",
@@ -68,7 +68,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	const char		*template;
 	char			*msg, *cause;
-  int      delay;
+	int			 delay;
 	struct format_tree	*ft;
 	int			 flags;
 
@@ -86,14 +86,16 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-  if (args_has(args, 'd')) {
-    delay = args_strtonum(args, 'd', 0, UINT_MAX, &cause);
-    if (cause != NULL) {
-      cmdq_error(item, "delay: %s", cause);
-      free(cause);
-      return (CMD_RETURN_ERROR);
-    }
-  }
+	if (args_has(args, 'd')) {
+		delay = args_strtonum(args, 'd', -1, UINT_MAX, &cause);
+		if (cause != NULL) {
+			cmdq_error(item, "delay: %s", cause);
+			free(cause);
+			return (CMD_RETURN_ERROR);
+		}
+	} else {
+		delay = -1;
+	}
 
 	template = args_get(args, 'F');
 	if (args->argc != 0)

--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -114,7 +114,7 @@ cmd_list_keys_print_notes(struct cmdq_item *item, struct args *args,
 			note = xstrdup(bd->note);
 		tmp = utf8_padcstr(key, keywidth + 1);
 		if (args_has(args, '1') && tc != NULL)
-			status_message_set(tc, 1, "%s%s%s", prefix, tmp, note);
+			status_message_set(tc, 0, 1, "%s%s%s", prefix, tmp, note);
 		else
 			cmdq_print(item, "%s%s%s", prefix, tmp, note);
 		free(tmp);

--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -114,7 +114,7 @@ cmd_list_keys_print_notes(struct cmdq_item *item, struct args *args,
 			note = xstrdup(bd->note);
 		tmp = utf8_padcstr(key, keywidth + 1);
 		if (args_has(args, '1') && tc != NULL)
-			status_message_set(tc, 0, 1, "%s%s%s", prefix, tmp, note);
+			status_message_set(tc, -1, 1, "%s%s%s", prefix, tmp, note);
 		else
 			cmdq_print(item, "%s%s%s", prefix, tmp, note);
 		free(tmp);

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -858,7 +858,7 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 		c->retval = 1;
 	} else {
 		*msg = toupper((u_char) *msg);
-		status_message_set(c, 0, 1, "%s", msg);
+		status_message_set(c, -1, 1, "%s", msg);
 	}
 
 	free(msg);

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -858,7 +858,7 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 		c->retval = 1;
 	} else {
 		*msg = toupper((u_char) *msg);
-		status_message_set(c, 1, "%s", msg);
+		status_message_set(c, 0, 1, "%s", msg);
 	}
 
 	free(msg);

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -1176,7 +1176,7 @@ mode_tree_run_command(struct client *c, struct cmd_find_state *fs,
 		if (status == CMD_PARSE_ERROR) {
 			if (c != NULL) {
 				*error = toupper((u_char)*error);
-				status_message_set(c, 1, "%s", error);
+				status_message_set(c, 0, 1, "%s", error);
 			}
 			free(error);
 		}

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -1176,7 +1176,7 @@ mode_tree_run_command(struct client *c, struct cmd_find_state *fs,
 		if (status == CMD_PARSE_ERROR) {
 			if (c != NULL) {
 				*error = toupper((u_char)*error);
-				status_message_set(c, 0, 1, "%s", error);
+				status_message_set(c, -1, 1, "%s", error);
 			}
 			free(error);
 		}

--- a/status.c
+++ b/status.c
@@ -423,11 +423,10 @@ status_redraw(struct client *c)
 
 /* Set a status line message. */
 void
-status_message_set(struct client *c, int ignore_styles, const char *fmt, ...)
+status_message_set(struct client *c, int delay, int ignore_styles, const char *fmt, ...)
 {
 	struct timeval	tv;
 	va_list		ap;
-	int		delay;
 
 	status_message_clear(c);
 	status_push_screen(c);
@@ -439,7 +438,9 @@ status_message_set(struct client *c, int ignore_styles, const char *fmt, ...)
 
 	server_add_message("%s message: %s", c->name, c->message_string);
 
-	delay = options_get_number(c->session->options, "display-time");
+  if (!delay) {
+    delay = options_get_number(c->session->options, "display-time");
+  }
 	if (delay > 0) {
 		tv.tv_sec = delay / 1000;
 		tv.tv_usec = (delay % 1000) * 1000L;

--- a/tmux.h
+++ b/tmux.h
@@ -2452,8 +2452,7 @@ struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);
 int	 status_redraw(struct client *);
-void printflike(3, 4) status_message_set(struct client *, int, const char *,
-	     ...);
+void status_message_set(struct client *, int, int, const char *, ...);
 void	 status_message_clear(struct client *);
 int	 status_message_redraw(struct client *);
 void	 status_prompt_set(struct client *, struct cmd_find_state *,

--- a/window-customize.c
+++ b/window-customize.c
@@ -1003,7 +1003,7 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 
 fail:
 	*cause = toupper((u_char)*cause);
-	status_message_set(c, 0, 1, "%s", cause);
+	status_message_set(c, -1, 1, "%s", cause);
 	free(cause);
 	return (0);
 }
@@ -1209,7 +1209,7 @@ window_customize_set_command_callback(struct client *c, void *itemdata,
 
 fail:
 	*error = toupper((u_char)*error);
-	status_message_set(c, 0, 1, "%s", error);
+	status_message_set(c, -1, 1, "%s", error);
 	free(error);
 	return (0);
 }

--- a/window-customize.c
+++ b/window-customize.c
@@ -1003,7 +1003,7 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 
 fail:
 	*cause = toupper((u_char)*cause);
-	status_message_set(c, 1, "%s", cause);
+	status_message_set(c, 0, 1, "%s", cause);
 	free(cause);
 	return (0);
 }
@@ -1209,7 +1209,7 @@ window_customize_set_command_callback(struct client *c, void *itemdata,
 
 fail:
 	*error = toupper((u_char)*error);
-	status_message_set(c, 1, "%s", error);
+	status_message_set(c, 0, 1, "%s", error);
 	free(error);
 	return (0);
 }


### PR DESCRIPTION
I think this is necessary addition, because changing `display-time` every time if you need more/less time to display-message something seems inconvenient