### PR TITLE
added -F to setenv and source

### DIFF
--- a/cmd-set-environment.c
+++ b/cmd-set-environment.c
@@ -34,8 +34,8 @@ const struct cmd_entry cmd_set_environment_entry = {
 	.name = "set-environment",
 	.alias = "setenv",
 
-	.args = { "hgrt:u", 1, 2 },
-	.usage = "[-hgru] " CMD_TARGET_SESSION_USAGE " name [value]",
+	.args = { "Fhgrt:u", 1, 2 },
+	.usage = "[-Fhgru] " CMD_TARGET_SESSION_USAGE " name [value]",
 
 	.target = { 't', CMD_FIND_SESSION, CMD_FIND_CANFAIL },
 
@@ -50,6 +50,8 @@ cmd_set_environment_exec(struct cmd *self, struct cmdq_item *item)
 	struct cmd_find_state	*target = cmdq_get_target(item);
 	struct environ		*env;
 	const char		*name, *value, *tflag;
+	char			*expand = NULL;
+	enum cmd_retval		retval = CMD_RETURN_NORMAL;
 
 	name = args->argv[0];
 	if (*name == '\0') {
@@ -61,10 +63,16 @@ cmd_set_environment_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-	if (args->argc < 2)
+	if (args->argc < 2) {
 		value = NULL;
-	else
-		value = args->argv[1];
+	} else {
+		if (args_has(args, 'F')) {
+			expand = format_single_from_target(item, args->argv[1]);
+			value = expand;
+		} else {
+			value = args->argv[1];
+		}
+	}
 
 	if (args_has(args, 'g'))
 		env = global_environ;
@@ -75,7 +83,8 @@ cmd_set_environment_exec(struct cmd *self, struct cmdq_item *item)
 				cmdq_error(item, "no such session: %s", tflag);
 			else
 				cmdq_error(item, "no current session");
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
 		env = target->s->environ;
 	}
@@ -83,25 +92,32 @@ cmd_set_environment_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_has(args, 'u')) {
 		if (value != NULL) {
 			cmdq_error(item, "can't specify a value with -u");
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
 		environ_unset(env, name);
 	} else if (args_has(args, 'r')) {
 		if (value != NULL) {
 			cmdq_error(item, "can't specify a value with -r");
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
 		environ_clear(env, name);
 	} else {
 		if (value == NULL) {
 			cmdq_error(item, "no value specified");
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
+
 		if (args_has(args, 'h'))
 			environ_set(env, name, ENVIRON_HIDDEN, "%s", value);
 		else
 			environ_set(env, name, 0, "%s", value);
 	}
 
-	return (CMD_RETURN_NORMAL);
+out:
+	if (expand)
+		free(expand);
+	return retval;
 }

--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -35,8 +35,8 @@ const struct cmd_entry cmd_source_file_entry = {
 	.name = "source-file",
 	.alias = "source",
 
-	.args = { "nqv", 1, -1 },
-	.usage = "[-nqv] path ...",
+	.args = { "Fnqv", 1, -1 },
+	.usage = "[-Fnqv] path ...",
 
 	.flags = 0,
 	.exec = cmd_source_file_exec
@@ -126,7 +126,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 	struct cmd_source_file_data	*cdata;
 	struct client			*c = cmdq_get_client(item);
 	enum cmd_retval			 retval = CMD_RETURN_NORMAL;
-	char				*pattern, *cwd;
+	char				*pattern, *cwd, *expand = NULL;
 	const char			*path, *error;
 	glob_t				 g;
 	int				 i, result;
@@ -145,7 +145,15 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 	utf8_stravis(&cwd, server_client_get_cwd(c, NULL), VIS_GLOB);
 
 	for (i = 0; i < args->argc; i++) {
-		path = args->argv[i];
+		if (args_has(args, 'F')) {
+			if (expand != NULL)
+				free(expand);
+			expand = format_single_from_target(item, args->argv[i]);
+			path = expand;
+		} else {
+			path = args->argv[i];
+		}
+
 		if (strcmp(path, "-") == 0) {
 			cmd_source_file_add(cdata, "-");
 			continue;
@@ -172,6 +180,8 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 			free(pattern);
 			continue;
 		}
+		if (expand != NULL)
+			free(expand);
 		free(pattern);
 
 		for (j = 0; j < g.gl_pathc; j++)

--- a/tmux.1
+++ b/tmux.1
@@ -1407,7 +1407,7 @@ and
 .Fl T
 show debugging information about jobs and terminals.
 .It Xo Ic source-file
-.Op Fl nqv
+.Op Fl Fnqv
 .Ar path
 .Ar ...
 .Xc
@@ -1417,6 +1417,9 @@ Execute commands from one or more files specified by
 (which may be
 .Xr glob 7
 patterns).
+If
+.Fl F
+is present, then paths are expanded as a format.
 If
 .Fl q
 is given, no error will be returned if
@@ -5098,7 +5101,7 @@ section).
 Commands to alter and view the environment are:
 .Bl -tag -width Ds
 .It Xo Ic set-environment
-.Op Fl hgru
+.Op Fl Fhgru
 .Op Fl t Ar target-session
 .Ar name Op Ar value
 .Xc
@@ -5109,6 +5112,9 @@ If
 is used, the change is made in the global environment; otherwise, it is applied
 to the session environment for
 .Ar target-session .
+If
+.Fl F
+is present, then the value is expanded as a format.
 The
 .Fl u
 flag unsets a variable.


### PR DESCRIPTION
I am planning to use the -F option to load a tmux configuration file based on #{version}.

Currently i have:
```
%if '#{==:#{version},3.2-rc}'
	source-file ~/etc/tmux/tmux.conf-3.2-rc
%elif '#{==:#{version},3.1b}'
	source-file ~/etc/tmux/tmux.conf-3.1b
%endif
```

Which is not so nice, as version was set to 3.2-rc2 recently, i need to keep adding lines.

With the -F options, i do:
```
%if '#{==:#{version},3.1b}'
	source-file ~/etc/tmux/tmux.conf-3.1b
%else
	setenv -g -F M '#{s/-rc.*//:version}'
	setenv -g -F M '#{s/^next-//:M}'
	setenv -g -F m '#{s/.*\.//:M}'
	setenv -g -F M '#{s/\..*//:M}'

	if -F 1 'source-file -qF "~/etc/tmux/tmux.conf-#{version}"'
	if -F 1 'source-file -q "~/etc/tmux/tmux.conf-$M.$m"'
	if -F 1 'source-file -q "~/etc/tmux/tmux.conf-$M"'
	if -F 1 'source-file -q ~/etc/tmux/tmux.conf-default'

	setenv -ug M; setenv -ug m
%endif
```

Where all my tmux.conf-* files contain a wrapper around the normal content (e.g.):
```
%if "#{==:$TMUX_CFG,}"
TMUX_CFG="~/etc/tmux/tmux.conf-3.2"
# 3.2 content...
%endif
```

Regards, Mike