### PR TITLE
unbind -q

### DIFF
--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -25,10 +25,6 @@
 
 #include "tmux.h"
 
-/* Command queue flags. */
-#define CMDQ_FIRED 0x1
-#define CMDQ_WAITING 0x2
-
 /* Command queue item type. */
 enum cmdq_type {
 	CMDQ_COMMAND,
@@ -157,6 +153,13 @@ struct client *
 cmdq_get_target_client(struct cmdq_item *item)
 {
 	return (item->target_client);
+}
+
+/* Get item flags. */
+int *
+cmdq_get_item_flags(struct cmdq_item *item)
+{
+	return &item->flags;
 }
 
 /* Get item state. */
@@ -840,6 +843,9 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 	va_end(ap);
 
 	log_debug("%s: %s", __func__, msg);
+
+	if (item->flags & CMDQ_QUIET)
+		return;
 
 	if (c == NULL) {
 		cmd_get_source(cmd, &file, &line);

--- a/cmd-unbind-key.c
+++ b/cmd-unbind-key.c
@@ -46,25 +46,12 @@ cmd_unbind_key_exec(struct cmd *self, struct cmdq_item *item)
 	key_code	 key;
 	const char	*tablename;
 
-	if (!args_has(args, 'a')) {
-		if (args->argc != 1) {
-			cmdq_error(item, "missing key");
-			return (CMD_RETURN_ERROR);
-		}
-		key = key_string_lookup_string(args->argv[0]);
-		if (key == KEYC_NONE || key == KEYC_UNKNOWN) {
-			cmdq_error(item, "unknown key: %s", args->argv[0]);
-			return (CMD_RETURN_ERROR);
-		}
-	} else {
+	if (args_has(args, 'a')) {
 		if (args->argc != 0) {
 			cmdq_error(item, "key given with -a");
 			return (CMD_RETURN_ERROR);
 		}
-		key = KEYC_UNKNOWN;
-	}
 
-	if (key == KEYC_UNKNOWN) {
 		tablename = args_get(args, 'T');
 		if (tablename == NULL) {
 			key_bindings_remove_table("root");
@@ -79,6 +66,17 @@ cmd_unbind_key_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_NORMAL);
 	}
 
+	if (args->argc != 1) {
+		cmdq_error(item, "missing key");
+		return (CMD_RETURN_ERROR);
+	}
+
+	key = key_string_lookup_string(args->argv[0]);
+	if (key == KEYC_NONE || key == KEYC_UNKNOWN) {
+		cmdq_error(item, "unknown key: %s", args->argv[0]);
+		return (CMD_RETURN_ERROR);
+	}
+
 	if (args_has(args, 'T')) {
 		tablename = args_get(args, 'T');
 		if (key_bindings_get_table(tablename, 0) == NULL) {
@@ -89,6 +87,7 @@ cmd_unbind_key_exec(struct cmd *self, struct cmdq_item *item)
 		tablename = "root";
 	else
 		tablename = "prefix";
+
 	key_bindings_remove(tablename, key);
 	return (CMD_RETURN_NORMAL);
 }

--- a/cmd-unbind-key.c
+++ b/cmd-unbind-key.c
@@ -32,8 +32,8 @@ const struct cmd_entry cmd_unbind_key_entry = {
 	.name = "unbind-key",
 	.alias = "unbind",
 
-	.args = { "anT:", 0, 1 },
-	.usage = "[-an] [-T key-table] key",
+	.args = { "anqT:", 0, 1 },
+	.usage = "[-anq] [-T key-table] key",
 
 	.flags = CMD_AFTERHOOK,
 	.exec = cmd_unbind_key_exec
@@ -45,43 +45,58 @@ cmd_unbind_key_exec(struct cmd *self, struct cmdq_item *item)
 	struct args	*args = cmd_get_args(self);
 	key_code	 key;
 	const char	*tablename;
+	int		*flags = 0;
+	enum cmd_retval  retval;
+
+	if (args_has(args, 'q')) {
+		flags = cmdq_get_item_flags (item);
+		*flags |= CMDQ_QUIET;
+	}
 
 	if (args_has(args, 'a')) {
 		if (args->argc != 0) {
 			cmdq_error(item, "key given with -a");
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
 
 		tablename = args_get(args, 'T');
 		if (tablename == NULL) {
-			key_bindings_remove_table("root");
-			key_bindings_remove_table("prefix");
-			return (CMD_RETURN_NORMAL);
+			if (args_has(args, 'n'))
+				tablename = "root";
+			else
+				tablename = "prefix";
 		}
 		if (key_bindings_get_table(tablename, 0) == NULL) {
 			cmdq_error(item, "table %s doesn't exist", tablename);
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
+
 		key_bindings_remove_table(tablename);
-		return (CMD_RETURN_NORMAL);
+		retval = CMD_RETURN_NORMAL;
+		goto out;
 	}
 
 	if (args->argc != 1) {
 		cmdq_error(item, "missing key");
-		return (CMD_RETURN_ERROR);
+		retval = CMD_RETURN_ERROR;
+		goto out;
 	}
 
 	key = key_string_lookup_string(args->argv[0]);
 	if (key == KEYC_NONE || key == KEYC_UNKNOWN) {
 		cmdq_error(item, "unknown key: %s", args->argv[0]);
-		return (CMD_RETURN_ERROR);
+		retval = CMD_RETURN_ERROR;
+		goto out;
 	}
 
 	if (args_has(args, 'T')) {
 		tablename = args_get(args, 'T');
 		if (key_bindings_get_table(tablename, 0) == NULL) {
 			cmdq_error(item, "table %s doesn't exist", tablename);
-			return (CMD_RETURN_ERROR);
+			retval = CMD_RETURN_ERROR;
+			goto out;
 		}
 	} else if (args_has(args, 'n'))
 		tablename = "root";
@@ -89,5 +104,11 @@ cmd_unbind_key_exec(struct cmd *self, struct cmdq_item *item)
 		tablename = "prefix";
 
 	key_bindings_remove(tablename, key);
-	return (CMD_RETURN_NORMAL);
+	retval = CMD_RETURN_NORMAL;
+	goto out;
+
+out:
+	if (flags)
+		*flags &= ~CMDQ_QUIET;
+	return retval;
 }

--- a/tmux.1
+++ b/tmux.1
@@ -3039,7 +3039,7 @@ Send the prefix key, or with
 .Fl 2
 the secondary prefix key, to a window as if it was pressed.
 .It Xo Ic unbind-key
-.Op Fl an
+.Op Fl anq
 .Op Fl T Ar key-table
 .Ar key
 .Xc
@@ -3054,6 +3054,9 @@ are the same as for
 If
 .Fl a
 is present, all key bindings are removed.
+The
+.Fl q
+option prevents errors being displayed.
 .El
 .Sh OPTIONS
 The appearance and behaviour of

--- a/tmux.h
+++ b/tmux.h
@@ -1473,7 +1473,12 @@ struct cmd_parse_input {
 	struct cmd_find_state	 fs;
 };
 
-/* Command queue flags. */
+/* Command queue item flags. */
+#define CMDQ_FIRED 0x1
+#define CMDQ_WAITING 0x2
+#define CMDQ_QUIET 0x4
+
+/* Command queue state flags. */
 #define CMDQ_STATE_REPEAT 0x1
 #define CMDQ_STATE_CONTROL 0x2
 #define CMDQ_STATE_NOHOOKS 0x4
@@ -2308,6 +2313,7 @@ void cmdq_free(struct cmdq_list *);
 const char	 *cmdq_get_name(struct cmdq_item *);
 struct client	 *cmdq_get_client(struct cmdq_item *);
 struct client	 *cmdq_get_target_client(struct cmdq_item *);
+int		 *cmdq_get_item_flags(struct cmdq_item *item);
 struct cmdq_state *cmdq_get_state(struct cmdq_item *);
 struct cmd_find_state *cmdq_get_target(struct cmdq_item *);
 struct cmd_find_state *cmdq_get_source(struct cmdq_item *);


### PR DESCRIPTION
`unbind -a copy-mode` in ~/.tmux.conf will bark when you reload
added a -q option to unbind to make it quiet

`unbind -a` did unbind of both root and prefix tables and `unbind -an` was not honored.
fixed that so `unbind -a` deletes prefix; unbind -an deletes root table.

Did a small refactoring of 
```
if (! args_has('a'))
  ...
else
  key = UNKNOWN

if (key== UNKNOWN) {
  ...
  return
}

code that runs when ! args_has('a')
```