### PR TITLE
Prevent #() from being expanded in #() output

### DIFF
--- a/format.c
+++ b/format.c
@@ -2471,14 +2471,7 @@ format_expand1(struct format_tree *ft, const char *fmt, int time)
 			format_log(ft, "found #(): %s", name);
 
 			if (ft->flags & FORMAT_NOJOBS) {
-				out = format_expand1(ft, fmt, time);
-				/* ugly, but works */
-				if (len - off < 3) {
-					buf = xreallocarray(buf, 2, len);
-					len *= 2;
-				}
-				buf[off++] = '#';
-				buf[off++] = '(';
+				out = xstrdup("");
 				format_log(ft, "#() is disabled");
 			} else {
 				ft->flags |= FORMAT_NOJOBS;

--- a/format.c
+++ b/format.c
@@ -2471,11 +2471,20 @@ format_expand1(struct format_tree *ft, const char *fmt, int time)
 			format_log(ft, "found #(): %s", name);
 
 			if (ft->flags & FORMAT_NOJOBS) {
-				out = xstrdup("");
+				out = format_expand1(ft, fmt, time);
+				/* ugly, but works */
+				if (len - off < 3) {
+					buf = xreallocarray(buf, 2, len);
+					len *= 2;
+				}
+				buf[off++] = '#';
+				buf[off++] = '(';
 				format_log(ft, "#() is disabled");
 			} else {
+				ft->flags |= FORMAT_NOJOBS;
 				out = format_job_get(ft, name);
 				format_log(ft, "#() result: %s", out);
+				ft->flags &= ~FORMAT_NOJOBS;
 			}
 			free(name);
 


### PR DESCRIPTION
Formats are recursively expanded. It is dangerous for a shell commands
output to be able to run further shell commands, so expansion of #()
is allowed only once.