### PR TITLE
Adding YACC to dependencies in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,6 +14,9 @@ page](https://github.com/libevent/libevent/releases/latest).
 It also depends on [ncurses](https://www.gnu.org/software/ncurses/), available
 from [this page](https://invisible-mirror.net/archives/ncurses/).
 
+Last dependency necessary for compilation is [YACC](http://dinosaur.compilertools.net/), 
+available from [this page](https://www.tuhs.org/cgi-bin/utree.pl?file=V6/usr/source/yacc).
+
 ## Installation
 
 ### From release tarball

--- a/README
+++ b/README
@@ -16,6 +16,10 @@ It also depends on ncurses, available from:
 
 	https://invisible-mirror.net/archives/ncurses/
 
+Last dependency necessary for compilation is YACC, available from:
+
+	https://www.tuhs.org/cgi-bin/utree.pl?file=V6/usr/source/yacc
+
 * Installation
 
 To build and install tmux from a release tarball, use:


### PR DESCRIPTION
As stated in #2127 and #2396, YACC is required for compilation. This pull request is created to resolve those issues.