### PR TITLE
Updated new-window default format in help

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1858,7 +1858,7 @@ The
 .Fl P
 option prints information about the new window after it has been created.
 By default, it uses the format
-.Ql #{session_name}:#{window_index}
+.Ql #{session_name}:#{window_index}.#{pane_index}
 but a different format may be specified with
 .Fl F .
 .It Xo Ic capture-pane


### PR DESCRIPTION
The default format for `new-window` is `#{session_name}:#{window_index}.#{pane_index}`