### PR TITLE
Make parse_window_name() aware of quoted commands

### DIFF
--- a/names.c
+++ b/names.c
@@ -142,6 +142,9 @@ parse_window_name(const char *in)
 	char	*copy, *name, *ptr;
 
 	name = copy = xstrdup(in);
+	if (*name == '"')
+			name++;
+	name[strcspn (name, "\"")] = '\0';
 	if (strncmp(name, "exec ", (sizeof "exec ") - 1) == 0)
 		name = name + (sizeof "exec ") - 1;
 


### PR DESCRIPTION
I noticed the following:

```
$ tmux setw -g remain-on-exit on
$ tmux new-window "yes | head -n1"
```
```
→ ~ tmux list-panes -s -t tmux-bug -F '#{pane_dead} #{pane_tty} #{pane_id} #{pane_start_command}'
0 /dev/ttys015 %76 
1 /dev/ttys016 %77 "yes | head -n1"
```
![image](https://user-images.githubusercontent.com/553208/94680574-436e3700-0322-11eb-87d9-5b1aca93605e.png)

As you can see, the command is now quoted, which tmux didn't do before but I'm not sure when the behavior changed.

The proposed change adjusts the `name` string in `parse_window_name()` to trim `"` characters.