### PR TITLE
Reinstate SIGQUIT

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -271,6 +271,7 @@ proc_clear_signals(struct tmuxproc *tp, int defaults)
 
 	sigaction(SIGPIPE, &sa, NULL);
 	sigaction(SIGTSTP, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
 
 	signal_del(&tp->ev_sigint);
 	signal_del(&tp->ev_sighup);


### PR DESCRIPTION
Also clear SIGQUIT handler, thus allowing it to once again be passed through to the foreground process.

Fixes https://github.com/tmux/tmux/issues/2435