### PR TITLE
Provided an option to make menus more GUI friendly

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -36,9 +36,9 @@ const struct cmd_entry cmd_display_menu_entry = {
 	.name = "display-menu",
 	.alias = "menu",
 
-	.args = { "c:t:T:x:y:", 1, -1 },
+	.args = { "c:t:T:x:y:O", 1, -1 },
 	.usage = "[-c target-client] " CMD_TARGET_PANE_USAGE " [-T title] "
-		 "[-x position] [-y position] name key command ...",
+		 "[-x position] [-y position] [-O] name key command ...",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 
@@ -195,6 +195,10 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	else
 		title = xstrdup("");
 	menu = menu_create(title);
+
+	if (args_has(args, 'O')) {
+		flags |= MENU_STAYOPEN;
+	}
 
 	for (i = 0; i != args->argc; /* nothing */) {
 		name = args->argv[i++];

--- a/menu.c
+++ b/menu.c
@@ -204,6 +204,9 @@ menu_key_cb(struct client *c, struct key_event *event)
 		    m->y < md->py + 1 ||
 		    m->y > md->py + 1 + count - 1) {
 			if (MOUSE_RELEASE(m->b))
+				// Keeps menu open if parameter provided
+				return (!(md->flags & MENU_STAYOPEN));
+			else if ((MOUSE_BUTTONS(m->b) && !MOUSE_DRAG(m->b)) || !m->b)
 				return (1);
 			if (md->choice != -1) {
 				md->choice = -1;
@@ -303,6 +306,8 @@ chosen:
 	if (md->choice == -1)
 		return (1);
 	item = &menu->items[md->choice];
+	if ((md->flags & MENU_STAYOPEN) && item->name == NULL)
+		return (0);
 	if (item->name == NULL || *item->name == '-')
 		return (1);
 	if (md->cb != NULL) {

--- a/tmux.h
+++ b/tmux.h
@@ -1198,6 +1198,7 @@ RB_HEAD(sessions, session);
 #define MOUSE_WHEEL_DOWN 1
 
 /* Mouse helpers. */
+// Beware that MOUSE_BUTTONS doesn't consider left mouse button as its code is 0x0
 #define MOUSE_BUTTONS(b) ((b) & MOUSE_MASK_BUTTONS)
 #define MOUSE_WHEEL(b) ((b) & MOUSE_MASK_WHEEL)
 #define MOUSE_DRAG(b) ((b) & MOUSE_MASK_DRAG)
@@ -2981,6 +2982,7 @@ __dead void printflike(1, 2) fatalx(const char *, ...);
 /* menu.c */
 #define MENU_NOMOUSE 0x1
 #define MENU_TAB 0x2
+#define MENU_STAYOPEN 0x4
 struct menu	*menu_create(const char *);
 void		 menu_add_items(struct menu *, const struct menu_item *,
 		    struct cmdq_item *, struct client *,


### PR DESCRIPTION
A solution for [Issue #2439](https://github.com/tmux/tmux/issues/2439), now right click menus behave more like most GUIs if -O parameter is provided to display-menu