### PR TITLE
Change default string for status-right

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -662,7 +662,7 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .default_str = "#{?window_bigger,"
 			 "[#{window_offset_x}#,#{window_offset_y}] ,}"
-			 "\"#{=21:pane_title}\" %H:%M %d-%b-%y",
+			 "\"#{=21:pane_title}\" %Y-%m-%d %H:%M",
 	  .text = "Contents of the right side of the status line."
 
 	},


### PR DESCRIPTION
Date format was not internationally recognizable. Especially `%b` which East Asians will have hard time understanding. Changed it to be ISO 8601 compliant.

I don't know what I'm doing.