### PR TITLE
feat(commands): add command to get session cwd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,7 @@ dist_tmux_SOURCES = \
 	cmd-display-panes.c \
 	cmd-find-window.c \
 	cmd-find.c \
+	cmd-get-cwd.c \
 	cmd-if-shell.c \
 	cmd-join-pane.c \
 	cmd-kill-pane.c \

--- a/cmd-get-cwd.c
+++ b/cmd-get-cwd.c
@@ -1,0 +1,65 @@
+/* $OpenBSD$ */
+
+/*
+ * Copyright (c) 2007 Nicholas Marriott <nicholas.marriott@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "tmux.h"
+
+/*
+ * Get Session CWD
+ */
+
+
+static enum cmd_retval	cmd_get_cwd_exec(struct cmd *, struct cmdq_item *);
+
+const struct cmd_entry cmd_get_cwd_entry = {
+	.name = "get-cwd",
+	.alias = "gcwd",
+
+	.args = { "F:t:", 0, 0 },
+	.usage = "[-F format] " CMD_TARGET_SESSION_USAGE,
+
+	.target = { 't', CMD_FIND_SESSION, 0 },
+
+	.flags = CMD_READONLY|CMD_AFTERHOOK,
+
+	.exec = cmd_get_cwd_exec
+};
+
+static enum cmd_retval
+cmd_get_cwd_exec(__unused struct cmd *self, struct cmdq_item *item)
+{
+	struct cmd_find_state	*target = cmdq_get_target(item);
+	struct session		*s;
+
+	if (target == NULL)
+		return (CMD_RETURN_ERROR);
+
+	s = target->s;
+
+	if (s == NULL)
+		return (CMD_RETURN_ERROR);
+
+	cmdq_print(item, "%s", s->cwd);
+
+	return (CMD_RETURN_NORMAL);
+}

--- a/cmd.c
+++ b/cmd.c
@@ -48,6 +48,7 @@ extern const struct cmd_entry cmd_display_popup_entry;
 extern const struct cmd_entry cmd_display_panes_entry;
 extern const struct cmd_entry cmd_down_pane_entry;
 extern const struct cmd_entry cmd_find_window_entry;
+extern const struct cmd_entry cmd_get_cwd_entry;
 extern const struct cmd_entry cmd_has_session_entry;
 extern const struct cmd_entry cmd_if_shell_entry;
 extern const struct cmd_entry cmd_join_pane_entry;
@@ -138,6 +139,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_display_popup_entry,
 	&cmd_display_panes_entry,
 	&cmd_find_window_entry,
+	&cmd_get_cwd_entry,
 	&cmd_has_session_entry,
 	&cmd_if_shell_entry,
 	&cmd_join_pane_entry,

--- a/tmux.1
+++ b/tmux.1
@@ -1073,6 +1073,9 @@ With
 run
 .Ar shell-command
 to replace the client.
+.It Ic get-cwd Op Fl t Ar target-session
+.D1 (alias: Ic gcwd)
+Get the Current Working Directory (CWD) for the specified target session.
 .It Ic has-session Op Fl t Ar target-session
 .D1 (alias: Ic has )
 Report an error and exit with 1 if the specified session does not exist.


### PR DESCRIPTION
Adds new command: "get-cwd" which will return the
current working directory for the given session.

There are various workflows where it is beneficial
to be able to `cd` to the "root" of a given `tmux` 
session. 

Consider working in a large monorepo
e.g golang/x/build and "scoping" your 
working directory to a subdirectory of that tree.
It may be beneficial, after working in that directory
to be able to `cd` to the session's "root" workspace
with `cd $(tmux gcwd)` .