### PR TITLE
Added PANE_SYNCRONIZE flag for duplicate input to selected panes

### DIFF
--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -149,9 +149,24 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 
 	/* Change the option. */
 	if (args_has(args, 'u')) {
-		if (o == NULL)
+		if (strcmp(name, "synchronize-panes") == 0 && scope == OPTIONS_TABLE_WINDOW) {
+			struct window *w = target->w;
+			struct window_pane *wp;
+			TAILQ_FOREACH(wp, &w->panes, entry) {
+				if (options_get_number(wp->options, "synchronize-panes")) {
+					o = options_get_only(wp->options, name);
+					if (options_remove_or_default(o, idx, &cause) != 0) {
+						cmdq_error(item, "%s", cause);
+						free(cause);
+						goto fail;
+					}
+				}
+			}
+		}
+		else if (o == NULL) {
 			goto out;
-		if (options_remove_or_default(o, idx, &cause) != 0) {
+		}
+		else if (options_remove_or_default(o, idx, &cause) != 0) {
 			cmdq_error(item, "%s", cause);
 			free(cause);
 			goto fail;

--- a/format.c
+++ b/format.c
@@ -3059,7 +3059,7 @@ format_defaults_pane(struct format_tree *ft, struct window_pane *wp)
 	format_add_cb(ft, "pane_in_mode", format_cb_pane_in_mode);
 
 	format_add(ft, "pane_synchronized", "%d",
-	    !!options_get_number(w->options, "synchronize-panes"));
+	    !!options_get_number(wp->options, "synchronize-panes"));
 	if (wp->searchstr != NULL)
 		format_add(ft, "pane_search_string", "%s", wp->searchstr);
 

--- a/options-table.c
+++ b/options-table.c
@@ -957,7 +957,7 @@ const struct options_table_entry options_table[] = {
 
 	{ .name = "synchronize-panes",
 	  .type = OPTIONS_TABLE_FLAG,
-	  .scope = OPTIONS_TABLE_WINDOW,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_num = 0,
 	  .text = "Whether typing should be sent to all panes simultaneously."
 	},

--- a/window.c
+++ b/window.c
@@ -1182,9 +1182,10 @@ window_pane_key(struct window_pane *wp, struct client *c, struct session *s,
 
 	if (KEYC_IS_MOUSE(key))
 		return (0);
-	if (options_get_number(wp->window->options, "synchronize-panes")) {
+	if (options_get_number(wp->options, "synchronize-panes")) {
 		TAILQ_FOREACH(wp2, &wp->window->panes, entry) {
 			if (wp2 != wp &&
+			    options_get_number(wp2->options, "synchronize-panes") &&
 			    TAILQ_EMPTY(&wp2->modes) &&
 			    wp2->fd != -1 &&
 			    (~wp2->flags & PANE_INPUTOFF) &&


### PR DESCRIPTION
Hi. In this request, I made it possible to select panes to sync input. I think it will be useful in some cases. I also added the ability to customize the highlight of the selected pane or panes.