### PR TITLE
Add copy-mode commands to explicitly turn rectangle selection on or off.

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1657,6 +1657,8 @@ The following commands are supported in copy mode:
 .It Li "previous-paragraph" Ta "{" Ta "M-{"
 .It Li "previous-space" Ta "B" Ta ""
 .It Li "previous-word" Ta "b" Ta "M-b"
+.It Li "rectangle-on" Ta "" Ta ""
+.It Li "rectangle-off" Ta "" Ta ""
 .It Li "rectangle-toggle" Ta "v" Ta "R"
 .It Li "refresh-from-pane" Ta "r" Ta "r"
 .It Li "scroll-down" Ta "C-e" Ta "C-Down"


### PR DESCRIPTION
Currently, users can only toggle rectangle selection, but cannot set it explicitly. This would allow you add something like the following to .tmux.conf:

    bind -T copy-mode-vi v send -X rectangle-off \; send -X begin-selection
    bind -T copy-mode-vi C-v send -X rectangle-on \; send -X begin-selection

to make `copy-mode-vi` even more similar to vim's visual mode keybindings, rather than requiring you to press space after toggling rectangle selection. Default behavior is unchanged.

I've tested this out locally and it works as expected.