### PR TITLE
Add a new option to detach-on-destroy

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -71,6 +71,9 @@ static const char *options_table_window_size_list[] = {
 static const char *options_table_remain_on_exit_list[] = {
 	"off", "on", "failed", NULL
 };
+static const char *options_table_detach_on_destroy_list[] = {
+	"off", "on", "smart", NULL
+};
 
 /* Status line format. */
 #define OPTIONS_TABLE_STATUS_FORMAT1 \
@@ -404,8 +407,9 @@ const struct options_table_entry options_table[] = {
 	},
 
 	{ .name = "detach-on-destroy",
-	  .type = OPTIONS_TABLE_FLAG,
+	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_detach_on_destroy_list,
 	  .default_num = 1,
 	  .text = "Whether to detach when a session is destroyed, or switch "
 		  "the client to another session if any exist."

--- a/options-table.c
+++ b/options-table.c
@@ -72,7 +72,7 @@ static const char *options_table_remain_on_exit_list[] = {
 	"off", "on", "failed", NULL
 };
 static const char *options_table_detach_on_destroy_list[] = {
-	"off", "on", "smart", NULL
+	"off", "on", "no-detached", NULL
 };
 
 /* Status line format. */

--- a/server-fn.c
+++ b/server-fn.c
@@ -415,14 +415,34 @@ server_next_session(struct session *s)
 	return (s_out);
 }
 
+static struct session *
+server_next_detached_session(struct session *s)
+{
+	struct session *s_loop, *s_out;
+
+	s_out = NULL;
+	RB_FOREACH(s_loop, sessions, &sessions) {
+		if (s_loop == s)
+			continue;
+		if (!s_loop->attached && (s_out == NULL ||
+					timercmp(&s_loop->activity_time, &s_out->activity_time, <)))
+			s_out = s_loop;
+	}
+	return (s_out);
+}
+
 void
 server_destroy_session(struct session *s)
 {
 	struct client	*c;
 	struct session	*s_new;
 
-	if (!options_get_number(s->options, "detach-on-destroy"))
+	const long long detach_on_destroy =
+			options_get_number(s->options, "detach-on-destroy");
+	if (detach_on_destroy == 0)
 		s_new = server_next_session(s);
+	else if (detach_on_destroy == 2)
+		s_new = server_next_detached_session(s);
 	else
 		s_new = NULL;
 

--- a/tmux.1
+++ b/tmux.1
@@ -3575,12 +3575,14 @@ The default is 80x24.
 If enabled and the session is no longer attached to any clients, it is
 destroyed.
 .It Xo Ic detach-on-destroy
-.Op Ic on | off
+.Op Ic off | on | smart
 .Xc
 If on (the default), the client is detached when the session it is attached to
 is destroyed.
 If off, the client is switched to the most recently active of the remaining
 sessions.
+If smart, the client is switched to the most recently active of the remaining
+detached sessions.
 .It Ic display-panes-active-colour Ar colour
 Set the colour used by the
 .Ic display-panes

--- a/tmux.1
+++ b/tmux.1
@@ -3575,13 +3575,13 @@ The default is 80x24.
 If enabled and the session is no longer attached to any clients, it is
 destroyed.
 .It Xo Ic detach-on-destroy
-.Op Ic off | on | smart
+.Op Ic off | on | no-detached
 .Xc
 If on (the default), the client is detached when the session it is attached to
 is destroyed.
 If off, the client is switched to the most recently active of the remaining
 sessions.
-If smart, the client is switched to the most recently active of the remaining
+If no-detached, the client is switched to the most recently active of the remaining
 detached sessions.
 .It Ic display-panes-active-colour Ar colour
 Set the colour used by the


### PR DESCRIPTION
A new option, "smart", to not detach on destroy if there is any detached tmux
sessions. If all available sessions are attached, destroying detaches.