### PR TITLE
Report client focus in 'client_flags'

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -2455,6 +2455,8 @@ server_client_get_flags(struct client *c)
 	*s = '\0';
 	if (c->flags & CLIENT_ATTACHED)
 		strlcat(s, "attached,", sizeof s);
+	if (c->flags & CLIENT_FOCUSED)
+		strlcat(s, "focused,", sizeof s);
 	if (c->flags & CLIENT_CONTROL)
 		strlcat(s, "control-mode,", sizeof s);
 	if (c->flags & CLIENT_IGNORESIZE)


### PR DESCRIPTION
For the case when a long running command has ended running in some tmux session's pane, this lets me rig a script that tells whether this pane is currently focused on any attached client. I can see if its session attached in one of the clients, and then see if that client has focus. If no currently focused client sees this pane, I can send myself an popup/email or some other kind of notification.