### PR TITLE
Update jump-xxx copy mode functions and clean up.

### DIFF
--- a/grid-reader.c
+++ b/grid-reader.c
@@ -17,6 +17,7 @@
  */
 
 #include "tmux.h"
+#include <string.h>
 
 /* Initialise virtual cursor. */
 void
@@ -304,7 +305,7 @@ grid_reader_cursor_previous_word(struct grid_reader *gr, const char *separators,
 
 /* Jump forward to character. */
 int
-grid_reader_cursor_jump(struct grid_reader *gr, char jc)
+grid_reader_cursor_jump(struct grid_reader *gr, const struct utf8_data *jc)
 {
 	struct grid_cell	gc;
 	u_int			px, py, xx, yy;
@@ -317,8 +318,8 @@ grid_reader_cursor_jump(struct grid_reader *gr, char jc)
 		while (px < xx) {
 			grid_get_cell(gr->gd, px, py, &gc);
 			if (!(gc.flags & GRID_FLAG_PADDING) &&
-			    gc.data.size == 1 &&
-			    *gc.data.data == jc) {
+			    gc.data.size == jc->size &&
+			    memcmp(gc.data.data, jc->data, gc.data.size) == 0) {
 				gr->cx = px;
 				gr->cy = py;
 				return 1;
@@ -331,11 +332,12 @@ grid_reader_cursor_jump(struct grid_reader *gr, char jc)
 			return 0;
 		px = 0;
 	}
+	return 0;
 }
 
 /* Jump back to character. */
 int
-grid_reader_cursor_jump_back(struct grid_reader *gr, char jc)
+grid_reader_cursor_jump_back(struct grid_reader *gr, const struct utf8_data *jc)
 {
 	struct grid_cell	gc;
 	u_int			px, py, xx;
@@ -346,8 +348,8 @@ grid_reader_cursor_jump_back(struct grid_reader *gr, char jc)
 		for (px = xx; px > 0; px--) {
 			grid_get_cell(gr->gd, px - 1, py - 1, &gc);
 			if (!(gc.flags & GRID_FLAG_PADDING) &&
-			    gc.data.size == 1 &&
-			    *gc.data.data == jc) {
+			    gc.data.size == jc->size &&
+			    memcmp(gc.data.data, jc->data, gc.data.size) == 0) {
 				gr->cx = px - 1;
 				gr->cy = py - 1;
 				return 1;
@@ -359,4 +361,5 @@ grid_reader_cursor_jump_back(struct grid_reader *gr, char jc)
 			return 0;
 		xx = grid_line_length(gr->gd, py - 2);
 	}
+	return 0;
 }

--- a/status.c
+++ b/status.c
@@ -1319,12 +1319,14 @@ append_key:
 	}
 
 	if (c->prompt_flags & PROMPT_SINGLE) {
-		s = utf8_tocstr(c->prompt_buffer);
-		if (strlen(s) != 1)
+		if (utf8_strlen(c->prompt_buffer) != 1)
 			status_prompt_clear(c);
-		else if (c->prompt_inputcb(c, c->prompt_data, s, 1) == 0)
-			status_prompt_clear(c);
-		free(s);
+		else {
+			s = utf8_tocstr(c->prompt_buffer);
+			if (c->prompt_inputcb(c, c->prompt_data, s, 1) == 0)
+				status_prompt_clear(c);
+			free(s);
+		}
 	}
 
 changed:

--- a/tmux.h
+++ b/tmux.h
@@ -2590,6 +2590,8 @@ void	 grid_reader_cursor_next_word(struct grid_reader *, const char *);
 void	 grid_reader_cursor_next_word_end(struct grid_reader *, const char *);
 void	 grid_reader_cursor_previous_word(struct grid_reader *, const char *,
 	     int);
+int	 grid_reader_cursor_jump(struct grid_reader *, char);
+int	 grid_reader_cursor_jump_back(struct grid_reader *, char);
 
 /* grid-view.c */
 void	 grid_view_get_cell(struct grid *, u_int, u_int, struct grid_cell *);

--- a/tmux.h
+++ b/tmux.h
@@ -2590,8 +2590,10 @@ void	 grid_reader_cursor_next_word(struct grid_reader *, const char *);
 void	 grid_reader_cursor_next_word_end(struct grid_reader *, const char *);
 void	 grid_reader_cursor_previous_word(struct grid_reader *, const char *,
 	     int);
-int	 grid_reader_cursor_jump(struct grid_reader *, char);
-int	 grid_reader_cursor_jump_back(struct grid_reader *, char);
+int	 grid_reader_cursor_jump(struct grid_reader *,
+	     const struct utf8_data *);
+int	 grid_reader_cursor_jump_back(struct grid_reader *,
+	     const struct utf8_data *);
 
 /* grid-view.c */
 void	 grid_view_get_cell(struct grid *, u_int, u_int, struct grid_cell *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -288,8 +288,8 @@ struct window_copy_mode_data {
 #define WINDOW_COPY_SEARCH_TIMEOUT 10000
 #define WINDOW_COPY_SEARCH_ALL_TIMEOUT 200
 
-	int		 jumptype;
-	char		 jumpchar;
+	int			 jumptype;
+	struct utf8_data	*jumpchar;
 
 	struct event	 dragtimer;
 #define WINDOW_COPY_DRAG_REPEAT_TIME 50000
@@ -405,7 +405,7 @@ window_copy_common_init(struct window_mode_entry *wme)
 	data->searchall = 1;
 
 	data->jumptype = WINDOW_COPY_OFF;
-	data->jumpchar = '\0';
+	data->jumpchar = NULL;
 
 	screen_init(&data->screen, screen_size_x(base), screen_size_y(base), 0);
 	data->modekeys = options_get_number(wp->window->options, "mode-keys");
@@ -486,6 +486,7 @@ window_copy_free(struct window_mode_entry *wme)
 
 	free(data->searchmark);
 	free(data->searchstr);
+	free(data->jumpchar);
 
 	screen_free(data->backing);
 	free(data->backing);
@@ -1939,7 +1940,8 @@ window_copy_cmd_jump_backward(struct window_copy_cmd_state *cs)
 
 	if (*argument != '\0') {
 		data->jumptype = WINDOW_COPY_JUMPBACKWARD;
-		data->jumpchar = *argument;
+		free(data->jumpchar);
+		data->jumpchar = utf8_fromcstr(argument);
 		for (; np != 0; np--)
 			window_copy_cursor_jump_back(wme);
 	}
@@ -1956,7 +1958,8 @@ window_copy_cmd_jump_forward(struct window_copy_cmd_state *cs)
 
 	if (*argument != '\0') {
 		data->jumptype = WINDOW_COPY_JUMPFORWARD;
-		data->jumpchar = *argument;
+		free(data->jumpchar);
+		data->jumpchar = utf8_fromcstr(argument);
 		for (; np != 0; np--)
 			window_copy_cursor_jump(wme);
 	}
@@ -1973,7 +1976,8 @@ window_copy_cmd_jump_to_backward(struct window_copy_cmd_state *cs)
 
 	if (*argument != '\0') {
 		data->jumptype = WINDOW_COPY_JUMPTOBACKWARD;
-		data->jumpchar = *argument;
+		free(data->jumpchar);
+		data->jumpchar = utf8_fromcstr(argument);
 		for (; np != 0; np--)
 			window_copy_cursor_jump_to_back(wme);
 	}
@@ -1990,7 +1994,8 @@ window_copy_cmd_jump_to_forward(struct window_copy_cmd_state *cs)
 
 	if (*argument != '\0') {
 		data->jumptype = WINDOW_COPY_JUMPTOFORWARD;
-		data->jumpchar = *argument;
+		free(data->jumpchar);
+		data->jumpchar = utf8_fromcstr(argument);
 		for (; np != 0; np--)
 			window_copy_cursor_jump_to(wme);
 	}


### PR DESCRIPTION
The jump functions were not yet updated to use the grid-reader code and did not wrap correctly. I think I have fixed all of them in this update. Also cleaned up some duplication with the associated cursor positioning code. Please have a look, thanks!