### PR TITLE
chore: define default terminal capabilities overrides

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -305,7 +305,7 @@ const struct options_table_entry options_table[] = {
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SERVER,
 	  .flags = OPTIONS_TABLE_IS_ARRAY,
-	  .default_str = "",
+	  .default_str = ",xterm-256color:Tc",
 	  .separator = ",",
 	  .text = "List of terminal capabilities overrides."
 	},


### PR DESCRIPTION
- [x] Setting default terminal overrides not to break when showing true colors in tmux.

## TMUX Version: Pre-release (3.2-rc3)

**Broken colors**
![GIF 15-02-2021 23-55-43](https://user-images.githubusercontent.com/55293671/108013153-da920d80-6fe9-11eb-97de-1d2692df0370.gif)

**True colors**
![GIF 15-02-2021 23-22-38](https://user-images.githubusercontent.com/55293671/108011138-3908bd00-6fe5-11eb-848b-0ea54d1582c9.gif)

**Tmux with neovim**
![GIF 15-02-2021 22-10-18](https://user-images.githubusercontent.com/55293671/108011575-1c20b980-6fe6-11eb-99b4-624f9a751d2f.gif)

> P.S.: My tmux does not work the configuration file (~/ .tmux.config), I am not aware of the reason for the problem, it simply ignores this file, I cannot set override settings in the terminal or configure keybinds.

**.tmux.config**
```bash
# (~/.tmux.config)

set-option -ga terminal-overrides ",xterm-360color:Tc"

bind-key r source-file ~/.tmux.config \; display-message "~/.tmux.config reloaded"
```