### PR TITLE
Fix chdir warnings during compile

### DIFF
--- a/job.c
+++ b/job.c
@@ -113,8 +113,11 @@ job_run(const char *cmd, struct session *s, const char *cwd,
 		sigprocmask(SIG_SETMASK, &oldset, NULL);
 
 		if (cwd == NULL || chdir(cwd) != 0) {
-			if ((home = find_home()) == NULL || chdir(home) != 0)
-				chdir("/");
+			if ((home = find_home()) == NULL || chdir(home) != 0) {
+				if (chdir("/")) {
+					fatal("chdir(\"/\") failed");
+				}
+			}
 		}
 
 		environ_push(env);

--- a/spawn.c
+++ b/spawn.c
@@ -378,8 +378,11 @@ spawn_pane(struct spawn_context *sc, char **cause)
 	 * fails.
 	 */
 	if (chdir(new_wp->cwd) != 0) {
-		if ((tmp = find_home()) == NULL || chdir(tmp) != 0)
-			chdir("/");
+		if ((tmp = find_home()) == NULL || chdir(tmp) != 0) {
+			if (chdir("/")) {
+				fatal("chdir(\"/\") failed");
+			}
+		}
 	}
 
 	/*


### PR DESCRIPTION
It's about an ignored return value, log errno if chdir fails