### PR TITLE
Add conditional check for del_curterm

### DIFF
--- a/tty-term.c
+++ b/tty-term.c
@@ -695,7 +695,10 @@ tty_term_read_list(const char *name, int fd, char ***caps, u_int *ncaps,
 		(*ncaps)++;
 	}
 
+#if !defined(NCURSES_VERSION_MAJOR) || NCURSES_VERSION_MAJOR > 5 || \
+    (NCURSES_VERSION_MAJOR == 5 && NCURSES_VERSION_MINOR > 6)
 	del_curterm(cur_term);
+#endif
 	return (0);
 }
 


### PR DESCRIPTION
The same check exists in line 530:

https://github.com/tmux/tmux/blob/ba9f89c44e3294284493178fb34f864aafb399cd/tty-term.c#L530