### PR TITLE
(feature): Add client-detached message to control-mode

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -176,8 +176,8 @@ control_notify_client_detached(struct client *cc) {
 	struct client	*c;
 	TAILQ_FOREACH(c, &clients, entry) {
 		if (CONTROL_SHOULD_NOTIFY_CLIENT(c)) {
-            control_write(c, "%%client-detached %s", cc->name);
-        }
+			control_write(c, "%%client-detached %s", cc->name);
+		}
 	}
 }
 

--- a/control-notify.c
+++ b/control-notify.c
@@ -172,6 +172,16 @@ control_notify_client_session_changed(struct client *cc)
 }
 
 void
+control_notify_client_detached(struct client *cc) {
+	struct client	*c;
+	TAILQ_FOREACH(c, &clients, entry) {
+		if (CONTROL_SHOULD_NOTIFY_CLIENT(c)) {
+            control_write(c, "%%client-detached %s", cc->name);
+        }
+	}
+}
+
+void
 control_notify_session_renamed(struct session *s)
 {
 	struct client	*c;

--- a/notify.c
+++ b/notify.c
@@ -125,6 +125,8 @@ notify_callback(struct cmdq_item *item, void *data)
 		control_notify_window_renamed(ne->window);
 	if (strcmp(ne->name, "client-session-changed") == 0)
 		control_notify_client_session_changed(ne->client);
+	if (strcmp(ne->name, "client-detached") == 0)
+		control_notify_client_detached(ne->client);
 	if (strcmp(ne->name, "session-renamed") == 0)
 		control_notify_session_renamed(ne->session);
 	if (strcmp(ne->name, "session-created") == 0)

--- a/tmux.h
+++ b/tmux.h
@@ -2946,6 +2946,7 @@ void	control_notify_window_unlinked(struct session *, struct window *);
 void	control_notify_window_linked(struct session *, struct window *);
 void	control_notify_window_renamed(struct window *);
 void	control_notify_client_session_changed(struct client *);
+void	control_notify_client_detached(struct client *);
 void	control_notify_session_renamed(struct session *);
 void	control_notify_session_created(struct session *);
 void	control_notify_session_closed(struct session *);


### PR DESCRIPTION
Closes #2598

This commit adds an extra message to command-mode to indicate when a client has detached from tmux.

I wasn't sure whether there was any need to distinguish between the current client detaching and an external client detaching (such as the session changes message has both %session-changed for the current command-mode client and %client-session-changed for another client doing so) so this commit doesn't distinguish between the current and another client.

@nicm 

I believe this is what you meant when you said to take the same route as subscription-changed. I've tested on my own machine and this does echo message prior to a client detaching. Please let me know if there're any other improvements to be made.