### PR TITLE
Fix musl compile error in proc.c

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -17,7 +17,6 @@
  */
 
 #include <sys/types.h>
-#include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/uio.h>
 #include <sys/utsname.h>


### PR DESCRIPTION
```
proc.c:20:10: fatal error: sys/queue.h: No such file or directory
   20 | #include <sys/queue.h>
```

This was already fixed in 7b085136, but got reintroduced with ce5de765.