### PR TITLE
Fix missing comma punctuation

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -3149,8 +3149,8 @@ The appearance and behaviour of
 may be modified by changing the value of various options.
 There are four types of option:
 .Em server options ,
-.Em session options
-.Em window options
+.Em session options ,
+.Em window options ,
 and
 .Em pane options .
 .Pp


### PR DESCRIPTION
While mentioning different options for appearance and behavior of tmux in the man page, we've missed comma punctuation to separate list of options. After changes, manpage looks like this:
```console
OPTIONS
     The appearance and behaviour of tmux may be modified by changing the
     value of various options.  There are four types of option: server
     options, session options, window options, and pane options.
```