### PR TITLE
man: fix prefix/suffix confusion

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4783,11 +4783,11 @@ For example, to get a list of windows formatted like the status line:
 .Ed
 .Pp
 .Ql N:\&
-checks if a window (without any suffix or with the
+checks if a window (without any prefix or with the
 .Ql w
-suffix) or a session (with the
+prefix) or a session (with the
 .Ql s
-suffix) name exists, for example
+prefix) name exists, for example
 .Ql `N/w:foo`
 is replaced with 1 if a window named
 .Ql foo


### PR DESCRIPTION
The example and the code both look for a prefix, not a suffix.