### PR TITLE
Check whether strtonum function actually works

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,9 +150,17 @@ AC_REPLACE_FUNCS([ \
 	strlcpy \
 	strndup \
 	strsep \
-	strtonum \
 ])
 AC_FUNC_STRNLEN
+
+AC_MSG_CHECKING([for working strtonum])
+AC_RUN_IFELSE([AC_LANG_PROGRAM(
+         [#include <stdlib.h>],
+         [return (strtonum("0", 0, 1, NULL) == 0 ? 0 : 1);]
+ )],
+ [AC_DEFINE(HAVE_STRTONUM) AC_MSG_RESULT(yes)],
+ [AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)]
+)
 
 # Clang sanitizers wrap reallocarray even if it isn't available on the target
 # system. When compiled it always returns NULL and crashes the program. To


### PR DESCRIPTION
The `strtonum` function is available from macOS 11.0, and it is declared in the corresponding Xcode SDK.  But when using the newest SDK with macOS 10.x then `configure` detects falsely that `strtonum` is available.  The build will complete (with warnings about the unavailable) but when the resulted `tmux` binary tries to call `strtonum` then it crashes with Dyld error message: Symbol not found: _strtonum.

This patch checks whether `strtonum()` really works by executing the configure test binary.