### PR TITLE
Fix special value R for -x position of display-menu and display-popup

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -205,7 +205,7 @@ cmd_display_menu_get_position(struct client *tc, struct cmdq_item *item,
 	if (xp == NULL || strcmp(xp, "C") == 0)
 		xp = "#{popup_centre_x}";
 	else if (strcmp(xp, "R") == 0)
-		xp = "#{popup_right}";
+		xp = "#{popup_pane_right}";
 	else if (strcmp(xp, "P") == 0)
 		xp = "#{popup_pane_left}";
 	else if (strcmp(xp, "M") == 0)


### PR DESCRIPTION
### Issue description

When displaying a menu or popup and using the special value `R` with the `-x` option the menu or popup is positioned on the **left** side of the terminal instead of the **right** side as documented in [`tmux(1)`](https://man.openbsd.org/tmux#R) (see [screenshots below](#screenshots)).


**Steps to reproduce:**
* Build Tmux from the latest git commit (at the time of writing 0a1c01d11c997f773a1c210eaf4c4610dfeca16c)
* Run Tmux `./tmux -vv -f/dev/test -Ltest`
* Configure tmux to display a menu and position it on the right as follows:
```
$ ./tmux display-menu -xR -yS -T Test 'Positioned Right' '' ''
```

**Expected behaviour:**
The menu or popup is positioned on the **right** side of the terminal.

**Actual behaviour:**
The menu or popup is positioned on the **left** side of the terminal (see [screenshots below](#screenshots)).

<summary id=screenshots>:camera: Screenshots of macOS Terminal.app running Tmux showing menu and popup positioned on the left when `-xR` argument is used with `display-menu` (click image to enlarge).</summary>

|Menu|Popup|
| --- | --- |
|<img width="650" alt="image" src="https://user-images.githubusercontent.com/16507/114941474-836eb480-9e43-11eb-9432-7d8e8dd20161.png">|<img width="650" alt="image" src="https://user-images.githubusercontent.com/16507/114942725-3f7caf00-9e45-11eb-9292-b797142fa494.png">|


### Required information

```
» echo $TERM
screen
» ./tmux -V
tmux next-3.3
» uname -sp
Darwin i386
» sw_vers
ProductName:    macOS
ProductVersion: 11.2.3
BuildVersion:   20D91
» clang --version
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

<!--
Please read https://github.com/tmux/tmux/blob/master/.github/CONTRIBUTING.md
before opening an issue.

If you have upgraded, make sure your issue is not covered in the CHANGES file
for your version: https://raw.githubusercontent.com/tmux/tmux/master/CHANGES

Describe the problem and the steps to reproduce. Add a minimal tmux config if
necessary. Screenshots can be helpful, but no more than one or two.

Do not report bugs (crashes, incorrect behaviour) without reproducing on a tmux
built from the latest code in Git.



Please provide the following information:

* tmux version (`tmux -V`).
* Platform (`uname -sp`).
* $TERM inside and outside of tmux (`echo $TERM`).
* Logs from tmux (`tmux kill-server; tmux -vv new`).

-->
