### PR TITLE
Avoid unportable `==` test(1) operator in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,10 +34,10 @@ AC_ARG_VAR(
 # Set up convenient fuzzing defaults before initializing compiler.
 if test "x$enable_fuzzing" = xyes; then
 	AC_DEFINE(NEED_FUZZING)
-	test "x$CC" == x && CC=clang
-	test "x$FUZZING_LIBS" == x && \
+	test "x$CC" = x && CC=clang
+	test "x$FUZZING_LIBS" = x && \
 		FUZZING_LIBS="-fsanitize=fuzzer"
-	test "x$SAVED_CFLAGS" == x && \
+	test "x$SAVED_CFLAGS" = x && \
 		AM_CFLAGS="-g -fsanitize=fuzzer-no-link,address"
 fi
 


### PR DESCRIPTION
The `==` test(1) operator is not POSIX and not all test(1) implementations support it.
Consistently use `=` test(1) operator as done for the rest of `configure.ac`.

Noticed when updating `misc/tmux` package in [pkgsrc](https://www.pkgsrc.org/) via `pkgsrc/mk/check/check-portability.sh` script.
