### PR TITLE
Fix compiler warnings: maybe-ununitialized, format

### DIFF
--- a/format.c
+++ b/format.c
@@ -4199,7 +4199,7 @@ format_replace(struct format_expand_state *es, const char *key, size_t keylen,
 			value = xstrdup("0");
 		} else {
 			format_log(es, "search '%s' pane %%%u", new, wp->id);
-			value = format_search(fm, wp, new);
+			value = format_search(search, wp, new);
 		}
 		free(new);
 	} else if (cmp != NULL) {

--- a/server.c
+++ b/server.c
@@ -163,7 +163,8 @@ server_tidy_event(__unused int fd, __unused short events, __unused void *data)
     malloc_trim(0);
 #endif
 
-    log_debug("%s: took %llu milliseconds", __func__, get_timer() - t);
+    log_debug("%s: took %llu milliseconds", __func__,
+        (unsigned long long)(get_timer() - t));
     evtimer_add(&server_ev_tidy, &tv);
 }
 

--- a/tty-term.c
+++ b/tty-term.c
@@ -697,7 +697,7 @@ tty_term_read_list(const char *name, int fd, char ***caps, u_int *ncaps,
 		ent = &tty_term_codes[i];
 		switch (ent->type) {
 		case TTYCODE_NONE:
-			break;
+			fatalx("invalid code in tty_term_codes");
 		case TTYCODE_STRING:
 			s = tigetstr((char *)ent->name);
 			if (s == NULL || s == (char *)-1)

--- a/window-buffer.c
+++ b/window-buffer.c
@@ -294,9 +294,9 @@ window_buffer_get_key(void *modedata, void *itemdata, u_int line)
 	struct window_buffer_modedata	*data = modedata;
 	struct window_buffer_itemdata	*item = itemdata;
 	struct format_tree		*ft;
-	struct session			*s;
-	struct winlink			*wl;
-	struct window_pane		*wp;
+	struct session			*s = NULL;
+	struct winlink			*wl = NULL;
+	struct window_pane		*wp = NULL;
 	struct paste_buffer		*pb;
 	char				*expanded;
 	key_code			 key;


### PR DESCRIPTION
Compiling the latest master in my environment, I get the warnings below. The first two are not fixable, but the rest are fixed in this PR.

```
format.c: In function ‘format_find’:
format.c:3359:5: warning: format not a string literal, format string not checked [-Wformat-nonliteral]
 3359 |     strftime(s, sizeof s, time_format, &tm);
      |     ^~~~~~~~
format.c: In function ‘format_expand1’:
format.c:4455:3: warning: format not a string literal, format string not checked [-Wformat-nonliteral]
 4455 |   if (strftime(expanded, sizeof expanded, fmt, &es->tm) == 0) {
      |   ^~
format.c: In function ‘format_replace’:
format.c:4202:12: warning: ‘fm’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 4202 |    value = format_search(fm, wp, new);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~



server.c: In function ‘server_tidy_event’:
server.c:166:28: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
  166 |     log_debug("%s: took %llu milliseconds", __func__, get_timer() - t);
      |                         ~~~^                          ~~~~~~~~~~~~~~~
      |                            |                                      |
      |                            long long unsigned int                 uint64_t {aka long unsigned int}
      |                         %lu



tty-term.c: In function ‘tty_term_read_list’:
tty-term.c:724:3: warning: ‘s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  724 |   xasprintf(&(*caps)[*ncaps], "%s=%s", ent->name, s);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~



window-buffer.c: In function ‘window_buffer_get_key’:
window-buffer.c:315:2: warning: ‘wp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  315 |  format_defaults(ft, NULL, s, wl, wp);
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
window-buffer.c:315:2: warning: ‘wl’ may be used uninitialized in this function [-Wmaybe-uninitialized]
window-buffer.c:315:2: warning: ‘s’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```