### PR TITLE
Fix a regression where client doesn't exit when stdout write fails

### DIFF
--- a/file.c
+++ b/file.c
@@ -503,14 +503,14 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
 
 	log_debug("write error file %d", cf->stream);
 
-	if (cf->cb != NULL)
-		cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
-
 	bufferevent_free(cf->event);
 	cf->event = NULL;
 
 	close(cf->fd);
 	cf->fd = -1;
+
+	if (cf->cb != NULL)
+		cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
 }
 
 /* Client file write callback. */


### PR DESCRIPTION
This PR addresses https://github.com/tmux/tmux/issues/2694.

When the output of tmux client is pipelined and the latter process fails
without reading all the output, tmux is supposed to terminate silently.

Due to the changes introduced by the commit e40831a, tmux client fails
to exit when writes to stdout fails. `client_write_error_callback`
correctly cleans up the event relevant to the client file for stdout. But
the problem is that exit-checking code `client_file_check_cb` is called
before the clean-up. As the result, it fails to recognize the write failure
and the tmux client remains in the event loop and the tmux server does
the same.

This patch moves the call for `client_file_check_cb` after the clean-up
in `file_write_error_callback`, which is the same to the code before e40831a.
~~The patch also changes the order of the call for the call-back in
`file_write_callback`, which does not change the logic and is also more
consistent.~~