### PR TITLE
Correctly interpret `send-keys 0x0` as the null character

### DIFF
--- a/key-string.c
+++ b/key-string.c
@@ -183,6 +183,8 @@ key_string_lookup_string(const char *string)
 	if (string[0] == '0' && string[1] == 'x') {
 		if (sscanf(string + 2, "%x", &u) != 1)
 			return (KEYC_UNKNOWN);
+		if (u < 32)
+				return (u);
 		mlen = wctomb(m, u);
 		if (mlen <= 0 || mlen > MB_LEN_MAX)
 			return (KEYC_UNKNOWN);


### PR DESCRIPTION
This was failing due to `udp[0].size` being zero and thus tmux ended up
sending the literal string `0x0` in the next if statement.

Check for u being equal to 0 before assuming udp[0].size == 0 was a
failure and return 0 if so.