### PR TITLE
Add abstract socket name support

### DIFF
--- a/client.c
+++ b/client.c
@@ -160,7 +160,7 @@ retry:
 			goto retry;
 		}
 
-		if (lockfd >= 0 && unlink(path) != 0 && errno != ENOENT) {
+		if (lockfd >= 0 && (path[0] != '@' && unlink(path) != 0) && errno != ENOENT) {
 			free(lockfile);
 			close(lockfd);
 			return (-1);

--- a/client.c
+++ b/client.c
@@ -118,6 +118,10 @@ client_connect(struct event_base *base, const char *path, uint64_t flags)
 	}
 	log_debug("socket is %s", path);
 
+	if (path[0] == '@') {
+	    sa.sun_path[0] = '\0';
+	}
+
 retry:
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
 		return (-1);

--- a/client.c
+++ b/client.c
@@ -118,9 +118,11 @@ client_connect(struct event_base *base, const char *path, uint64_t flags)
 	}
 	log_debug("socket is %s", path);
 
+#ifdef __ANDROID__
 	if (path[0] == '@') {
 	    sa.sun_path[0] = '\0';
 	}
+#endif
 
 retry:
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
@@ -160,7 +162,13 @@ retry:
 			goto retry;
 		}
 
-		if (lockfd >= 0 && (path[0] != '@' && unlink(path) != 0) && errno != ENOENT) {
+		if (lockfd >= 0 &&
+			(
+#ifdef __ANDROID__
+			    path[0] != '@' &&
+#endif
+			    unlink(path) != 0
+			) && errno != ENOENT) {
 			free(lockfile);
 			close(lockfd);
 			return (-1);

--- a/server.c
+++ b/server.c
@@ -115,10 +115,11 @@ server_create_socket(int flags, char **cause)
 		errno = ENAMETOOLONG;
 		goto fail;
 	}
-	unlink(sa.sun_path);
 
 	if (socket_path[0] == '@') {
 	    sa.sun_path[0] = '\0';
+	} else {
+	    unlink(sa.sun_path);
 	}
 
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
@@ -339,7 +340,7 @@ server_update_socket(void)
 	if (n != last) {
 		last = n;
 
-		if (stat(socket_path, &sb) != 0)
+		if (socket_path[0] == '@' || stat(socket_path, &sb) != 0)
 			return;
 		mode = sb.st_mode & ACCESSPERMS;
 		if (n != 0) {

--- a/server.c
+++ b/server.c
@@ -117,6 +117,10 @@ server_create_socket(int flags, char **cause)
 	}
 	unlink(sa.sun_path);
 
+	if (socket_path[0] == '@') {
+	    sa.sun_path[0] = '\0';
+	}
+
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
 		goto fail;
 

--- a/server.c
+++ b/server.c
@@ -116,11 +116,15 @@ server_create_socket(int flags, char **cause)
 		goto fail;
 	}
 
+#ifdef __ANDROID__
 	if (socket_path[0] == '@') {
 	    sa.sun_path[0] = '\0';
 	} else {
+#endif
 	    unlink(sa.sun_path);
+#ifdef __ANDROID__
 	}
+#endif
 
 	if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
 		goto fail;
@@ -340,7 +344,12 @@ server_update_socket(void)
 	if (n != last) {
 		last = n;
 
-		if (socket_path[0] == '@' || stat(socket_path, &sb) != 0)
+		if (
+#ifdef __ANDROID__
+			socket_path[0] == '@' ||
+#endif
+			stat(socket_path, &sb) != 0
+		)
 			return;
 		mode = sb.st_mode & ACCESSPERMS;
 		if (n != 0) {


### PR DESCRIPTION
This PR adds support for specifying abstract socket names using `-S`. This allows the use of tmux on unrooted Android.