### PR TITLE
Fix strtonm run test when crosscompiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,7 @@ AC_RUN_IFELSE([AC_LANG_PROGRAM(
          [return (strtonum("0", 0, 1, NULL) == 0 ? 0 : 1);]
 	 )],
 	 [AC_DEFINE(HAVE_STRTONUM) AC_MSG_RESULT(yes)],
+	 [AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)],
 	 [AC_LIBOBJ(strtonum) AC_MSG_RESULT(no)]
 )
 


### PR DESCRIPTION
Same fix as in https://github.com/tmux/tmux/pull/2651 for the `strtonum` function introduced in https://github.com/tmux/tmux/commit/b2588eed03640dc74ffdbebd10c719064b575291.