### PR TITLE
Update the session environment when the latest active client changes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ CHANGES FROM 3.2a TO 3.3
 * Add different command histories for different types of prompts ("command",
   "search" etc). From Anindya Mukherjee.
 
+* Update the session environment when the latest active client changes.
+
 CHANGES FROM 3.2 TO 3.2a
 
 * Add an "always" value for the "extended-keys" option; if set then tmux will
@@ -133,7 +135,7 @@ CHANGES FROM 3.1c TO 3.2
 
 * Add a way for control mode clients to subscribe to a format and be notified
   of changes rather than having to poll.
-    
+
 * Add some formats for search in copy mode (search_present, search_match).
 
 * Do not wait on shutdown for commands started with run -b.

--- a/options-table.c
+++ b/options-table.c
@@ -721,7 +721,7 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "DISPLAY KRB5CCNAME SSH_ASKPASS SSH_AUTH_SOCK "
 			 "SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY",
 	  .text = "List of environment variables to update in the session "
-		  "environment when a client is attached."
+		  "environment when a client is attached or has activity."
 	},
 
 	{ .name = "visual-activity",

--- a/server-client.c
+++ b/server-client.c
@@ -1124,6 +1124,8 @@ server_client_update_latest(struct client *c)
 
 	if (options_get_number(w->options, "window-size") == WINDOW_SIZE_LATEST)
 		recalculate_size(w, 0);
+
+    environ_update(c->session->options, c->environ, c->session->environ);
 }
 
 /*

--- a/tmux.1
+++ b/tmux.1
@@ -3941,7 +3941,7 @@ see the
 section.
 .It Ic update-environment[] Ar variable
 Set list of environment variables to be copied into the session environment
-when a new session is created or an existing session is attached.
+from the latest active client attached to that session.
 Any variables that do not exist in the source environment are set to be
 removed from the session environment (as if
 .Fl r
@@ -5253,8 +5253,8 @@ The result is the initial environment passed to the new process.
 .Pp
 The
 .Ic update-environment
-session option may be used to update the session environment from the client
-when a new session is created or an old reattached.
+session option may be used to update the session environment with the
+environment of the latest active client attached to that session.
 .Nm
 also initialises the
 .Ev TMUX


### PR DESCRIPTION
This allows one to switch between multiple clients attached to the same session and have the environment update without needing to reattach.

(If you need to credit me but can't use my name, please use my GitHub username instead)