### PR TITLE
Add -Wno-format-nonliteral.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,7 @@ AM_CFLAGS += -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations
 AM_CFLAGS += -Wwrite-strings -Wshadow -Wpointer-arith -Wsign-compare
 AM_CFLAGS += -Wundef -Wbad-function-cast -Winline -Wcast-align
 AM_CFLAGS += -Wdeclaration-after-statement -Wno-pointer-sign -Wno-attributes
-AM_CFLAGS += -Wno-unused-result -Wno-format-y2k
+AM_CFLAGS += -Wno-unused-result -Wno-format-y2k -Wno-format-nonliteral
 AM_CPPFLAGS += -DDEBUG
 endif
 AM_CPPFLAGS += -iquote.


### PR DESCRIPTION
This is my first contribution to tmux. Please correct me if I'm sending the change to the wrong place.

When building tmux source code on OSX 10.15.7 I got the following warnings:

```
file.c:209:36: warning: format string is not a string literal [-Wformat-nonliteral]
                evbuffer_add_vprintf(cf->buffer, fmt, ap);
                                                 ^~~
file.c:216:36: warning: format string is not a string literal [-Wformat-nonliteral]
                evbuffer_add_vprintf(cf->buffer, fmt, ap);
                                                 ^~~
2 warnings generated.
log.c:112:22: warning: format string is not a string literal [-Wformat-nonliteral]
        if (vasprintf(&fmt, msg, ap) == -1)
                            ^~~
1 warning generated.
xmalloc.c:126:21: warning: format string is not a string literal [-Wformat-nonliteral]
        i = vasprintf(ret, fmt, ap);
                           ^~~
xmalloc.c:155:26: warning: format string is not a string literal [-Wformat-nonliteral]
        i = vsnprintf(str, len, fmt, ap);
                                ^~~
```

This PR adds `-Wno-format-nonliteral` flag to suppress these warnings.