### PR TITLE
Update obsolete Autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,11 +24,11 @@ SAVED_LDFLAGS="$LDFLAGS"
 # Is this oss-fuzz build?
 AC_ARG_ENABLE(
 	fuzzing,
-	AC_HELP_STRING(--enable-fuzzing, build fuzzers)
+	AS_HELP_STRING(--enable-fuzzing, build fuzzers)
 )
 AC_ARG_VAR(
 	FUZZING_LIBS,
-	AC_HELP_STRING(libraries to link fuzzing targets with)
+	AS_HELP_STRING(libraries to link fuzzing targets with)
 )
 
 # Set up convenient fuzzing defaults before initializing compiler.
@@ -59,14 +59,14 @@ test "$sysconfdir" = '${prefix}/etc' && sysconfdir=/etc
 case "x$VERSION" in xnext*) enable_debug=yes;; esac
 AC_ARG_ENABLE(
 	debug,
-	AC_HELP_STRING(--enable-debug, enable debug build flags),
+	AS_HELP_STRING(--enable-debug, enable debug build flags),
 )
 AM_CONDITIONAL(IS_DEBUG, test "x$enable_debug" = xyes)
 
 # Is this a static build?
 AC_ARG_ENABLE(
 	static,
-	AC_HELP_STRING(--enable-static, create a static build)
+	AS_HELP_STRING(--enable-static, create a static build)
 )
 if test "x$enable_static" = xyes; then
 	test "x$PKG_CONFIG" != x && PKG_CONFIG="$PKG_CONFIG --static"
@@ -77,7 +77,7 @@ fi
 # Allow default TERM to be set.
 AC_ARG_WITH(
 	TERM,
-	AC_HELP_STRING(--with-TERM, set default TERM),
+	AS_HELP_STRING(--with-TERM, set default TERM),
 	[DEFAULT_TERM=$withval],
 	[DEFAULT_TERM=]
 )
@@ -340,7 +340,7 @@ fi
 # Look for utempter.
 AC_ARG_ENABLE(
 	utempter,
-	AC_HELP_STRING(--enable-utempter, use utempter if it is installed)
+	AS_HELP_STRING(--enable-utempter, use utempter if it is installed)
 )
 if test "x$enable_utempter" = xyes; then
 	AC_CHECK_HEADER(utempter.h, enable_utempter=yes, enable_utempter=no)
@@ -362,7 +362,7 @@ fi
 # Look for utf8proc.
 AC_ARG_ENABLE(
 	utf8proc,
-	AC_HELP_STRING(--enable-utf8proc, use utf8proc if it is installed)
+	AS_HELP_STRING(--enable-utf8proc, use utf8proc if it is installed)
 )
 if test "x$enable_utf8proc" = xyes; then
 	AC_CHECK_HEADER(utf8proc.h, enable_utf8proc=yes, enable_utf8proc=no)
@@ -384,13 +384,15 @@ AM_CONDITIONAL(HAVE_UTF8PROC, [test "x$enable_utf8proc" = xyes])
 
 # Check for b64_ntop. If we have b64_ntop, we assume b64_pton as well.
 AC_MSG_CHECKING(for b64_ntop)
-AC_TRY_LINK(
-	[
-		#include <sys/types.h>
-		#include <netinet/in.h>
-		#include <resolv.h>
-	],
-	[b64_ntop(NULL, 0, NULL, 0);],
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [
+      #include <sys/types.h>
+      #include <netinet/in.h>
+      #include <resolv.h>
+    ],
+	  [pb64_ntop(NULL, 0, NULL, 0);]
+  )],
 	found_b64_ntop=yes,
 	found_b64_ntop=no
 )
@@ -399,13 +401,15 @@ OLD_LIBS="$LIBS"
 if test "x$found_b64_ntop" = xno; then
 	AC_MSG_CHECKING(for b64_ntop with -lresolv)
 	LIBS="$OLD_LIBS -lresolv"
-	AC_TRY_LINK(
-		[
-			#include <sys/types.h>
-			#include <netinet/in.h>
-			#include <resolv.h>
-		],
-		[b64_ntop(NULL, 0, NULL, 0);],
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [
+        #include <sys/types.h>
+        #include <netinet/in.h>
+        #include <resolv.h>
+      ],
+		  [b64_ntop(NULL, 0, NULL, 0);]
+    )],
 		found_b64_ntop=yes,
 		found_b64_ntop=no
 	)
@@ -414,13 +418,15 @@ fi
 if test "x$found_b64_ntop" = xno; then
 	AC_MSG_CHECKING(for b64_ntop with -lnetwork)
 	LIBS="$OLD_LIBS -lnetwork"
-	AC_TRY_LINK(
-		[
-			#include <sys/types.h>
-			#include <netinet/in.h>
-			#include <resolv.h>
-		],
-		[b64_ntop(NULL, 0, NULL, 0);],
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [
+        #include <sys/types.h>
+        #include <netinet/in.h>
+        #include <resolv.h>
+      ],
+		  [b64_ntop(NULL, 0, NULL, 0);]
+    )],
 		found_b64_ntop=yes,
 		found_b64_ntop=no
 	)
@@ -875,4 +881,5 @@ AC_SUBST(AM_LDFLAGS)
 LDFLAGS="$SAVED_LDFLAGS"
 
 # autoconf should create a Makefile.
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES(Makefile)
+AC_OUTPUT


### PR DESCRIPTION
- Rename `AC_HELP_STRING` to `AS_HELP_STRING`
- Update `AC_TRY_LINK` to `AC_LINK_IFELSE`
- Add `AC_CONFIG_FILES(Makefile)` and remove the argument to `AC_OUTPUT`

All of these settings are supported since [autoconf-2.60][1] which is already the minimum required version since 080080fa

Tested with
```console
$ autconf --version
autoconf (GNU Autoconf) 2.71
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+/Autoconf: GNU GPL version 3 or later
<https://gnu.org/licenses/gpl.html>, <https://gnu.org/licenses/exceptions.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by David J. MacKenzie and Akim Demaille.
```

Here's a comparison to show the difference. 
<details>
<summary>Before</summary>


```console
$ git clean -qfdx && bash ./autogen.sh # This is similar to running `autoreconf -f -i`
configure.ac:45: installing 'etc/compile'
configure.ac:10: installing 'etc/config.guess'
configure.ac:10: installing 'etc/config.sub'
configure.ac:8: installing 'etc/install-sh'
configure.ac:8: installing 'etc/missing'
Makefile.am: installing 'etc/depcomp'
configure.ac: installing 'etc/ylwrap'
configure.ac:27: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:27: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:27: the top level
configure.ac:31: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:31: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:31: the top level
configure.ac:47: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:47: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:47: the top level
configure.ac:62: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:62: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:62: the top level
configure.ac:69: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:69: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:69: the top level
configure.ac:80: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:80: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:80: the top level
configure.ac:343: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:343: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:343: the top level
configure.ac:365: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:365: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:365: the top level
configure.ac:387: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:387: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
configure.ac:387: the top level
configure.ac:402: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:402: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
configure.ac:402: the top level
configure.ac:417: warning: The macro `AC_TRY_LINK' is obsolete.
configure.ac:417: You should run autoupdate.
./lib/autoconf/general.m4:2920: AC_TRY_LINK is expanded from...
configure.ac:417: the top level
configure.ac:878: warning: AC_OUTPUT should be used without arguments.
configure.ac:878: You should run autoupdate.
```
</details>

<details>
<summary>After</summary>


```console
$ git clean -qfdx && bash ./autogen.sh
configure.ac:45: installing 'etc/compile'
configure.ac:10: installing 'etc/config.guess'
configure.ac:10: installing 'etc/config.sub'
configure.ac:8: installing 'etc/install-sh'
configure.ac:8: installing 'etc/missing'
Makefile.am: installing 'etc/depcomp'
configure.ac: installing 'etc/ylwrap'
configure.ac:47: warning: The macro `AC_PROG_CC_C99' is obsolete.
configure.ac:47: You should run autoupdate.
./lib/autoconf/c.m4:1659: AC_PROG_CC_C99 is expanded from...
configure.ac:47: the top level
```
</details>

Please note that `AC_PROG_CC_C99` wasn't deprecated until v2.70 which is not available in some [distros][2] just yet. I'm sadly not sure how to check the version in OpenBSD, but the [manual page][3] looks to be from 2018.

[1]: https://www.gnu.org/software/autoconf/manual/autoconf-2.60/html_node/Obsolete-Macros.html
[2]: https://packages.debian.org/search?keywords=autoconf
[3]: https://man.openbsd.org/autoconf