### PR TITLE
Fix indentation of Availabe window option section

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -3996,6 +3996,7 @@ If set to both, a bell and a message are produced.
 Sets the session's conception of what characters are considered word
 separators, for the purposes of the next and previous word commands in
 copy mode.
+.El
 .Pp
 Available window options are:
 .Pp


### PR DESCRIPTION
I would expect the "Availabe window options"-section and the following "Availabe pane options"-section to be at the same level as the previous "Available session options"-section. Yet the former the window and pane options sections are intended one level deeper as the list in the preceding session options section is not ended due to a missing `.El`. Is this intentional and window and pane options are logically grouped under session options or should they reside at the same level?

This PR adds the potentially missing `\.El` to put the window and pane options sections at the same level as the session options section.

To test view the manpage an in your favourite pager and search for `Available window`, e.g.:
`% groff -Tascii -mdoc tmux.1 | less +'/Available window` 

**Before:**
```
      word-separators string
              Sets the session's conception of what characters are considered
              word separators, for the purposes of the next and previous word
              commands in copy mode.

              Available window options are:

              aggressive-resize [on | off]
                      Aggressively resize the chosen window.  This means that
```

**After:**
```
      word-separators string
              Sets the session's conception of what characters are considered
              word separators, for the purposes of the next and previous word
              commands in copy mode.

      Available window options are:

      aggressive-resize [on | off]
              Aggressively resize the chosen window.  This means that tmux will
```