### PR TITLE
Add -e flag to set environment for popup

### DIFF
--- a/cmd-if-shell.c
+++ b/cmd-if-shell.c
@@ -118,7 +118,7 @@ cmd_if_shell_exec(struct cmd *self, struct cmdq_item *item)
 	if (cdata->client != NULL)
 		cdata->client->references++;
 
-	if (job_run(shellcmd, 0, NULL, s,
+	if (job_run(shellcmd, 0, NULL, NULL, s,
 	    server_client_get_cwd(cmdq_get_client(item), s), NULL,
 	    cmd_if_shell_callback, cmd_if_shell_free, cdata, 0, -1,
 	    -1) == NULL) {

--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -188,7 +188,7 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 			cmd_run_shell_free(cdata);
 			return;
 		}
-		if (job_run(cmd, 0, NULL, cdata->s, cdata->cwd, NULL,
+		if (job_run(cmd, 0, NULL, NULL, cdata->s, cdata->cwd, NULL,
 		    cmd_run_shell_callback, cmd_run_shell_free, cdata,
 		    cdata->flags, -1, -1) == NULL)
 			cmd_run_shell_free(cdata);

--- a/format.c
+++ b/format.c
@@ -390,7 +390,7 @@ format_job_get(struct format_expand_state *es, const char *cmd)
 	if (force && fj->job != NULL)
 	       job_free(fj->job);
 	if (force || (fj->job == NULL && fj->last != t)) {
-		fj->job = job_run(expanded, 0, NULL, NULL,
+		fj->job = job_run(expanded, 0, NULL, NULL, NULL,
 		    server_client_get_cwd(ft->client, NULL), format_job_update,
 		    format_job_complete, NULL, fj, JOB_NOWAIT, -1, -1);
 		if (fj->job == NULL) {

--- a/job.c
+++ b/job.c
@@ -69,7 +69,7 @@ static LIST_HEAD(joblist, job) all_jobs = LIST_HEAD_INITIALIZER(all_jobs);
 
 /* Start a job running. */
 struct job *
-job_run(const char *cmd, int argc, char **argv, struct session *s,
+job_run(const char *cmd, int argc, char **argv, struct environ *e, struct session *s,
     const char *cwd, job_update_cb updatecb, job_complete_cb completecb,
     job_free_cb freecb, void *data, int flags, int sx, int sy)
 {
@@ -87,6 +87,9 @@ job_run(const char *cmd, int argc, char **argv, struct session *s,
 	 * if-shell to decide on default-terminal based on outside TERM.
 	 */
 	env = environ_for_session(s, !cfg_finished);
+	if (e != NULL) {
+		environ_copy(e, env);
+	}
 
 	sigfillset(&set);
 	sigprocmask(SIG_BLOCK, &set, &oldset);

--- a/popup.c
+++ b/popup.c
@@ -589,8 +589,9 @@ popup_job_complete_cb(struct job *job)
 
 int
 popup_display(int flags, struct cmdq_item *item, u_int px, u_int py, u_int sx,
-    u_int sy, const char *shellcmd, int argc, char **argv, const char *cwd,
-    struct client *c, struct session *s, popup_close_cb cb, void *arg)
+    u_int sy, struct environ *env, const char *shellcmd, int argc, char **argv,
+    const char *cwd, struct client *c, struct session *s, popup_close_cb cb,
+    void *arg)
 {
 	struct popup_data	*pd;
 	u_int			 jx, jy;
@@ -634,7 +635,7 @@ popup_display(int flags, struct cmdq_item *item, u_int px, u_int py, u_int sx,
 	pd->psx = sx;
 	pd->psy = sy;
 
-	pd->job = job_run(shellcmd, argc, argv, s, cwd,
+	pd->job = job_run(shellcmd, argc, argv, env, s, cwd,
 	    popup_job_update_cb, popup_job_complete_cb, NULL, pd,
 	    JOB_NOWAIT|JOB_PTY|JOB_KEEPWRITE, jx, jy);
 	pd->ictx = input_init(NULL, job_get_event(pd->job), &pd->palette);
@@ -724,7 +725,7 @@ popup_editor(struct client *c, const char *buf, size_t len,
 
 	xasprintf(&cmd, "%s %s", editor, path);
 	if (popup_display(POPUP_INTERNAL|POPUP_CLOSEEXIT, NULL, px, py, sx, sy,
-	    cmd, 0, NULL, _PATH_TMP, c, NULL, popup_editor_close_cb, pe) != 0) {
+	    NULL, cmd, 0, NULL, _PATH_TMP, c, NULL, popup_editor_close_cb, pe) != 0) {
 		popup_editor_free(pe);
 		free(cmd);
 		return (-1);

--- a/tmux.1
+++ b/tmux.1
@@ -5753,6 +5753,7 @@ forwards any input read from stdin to the empty pane given by
 .Op Fl BCE
 .Op Fl c Ar target-client
 .Op Fl d Ar start-directory
+.Op Fl e Ar environment
 .Op Fl h Ar height
 .Op Fl t Ar target-pane
 .Op Fl w Ar width
@@ -5792,6 +5793,12 @@ give the width and height - both may be a percentage (followed by
 If omitted, half of the terminal size is used.
 .Fl B
 does not surround the popup by a border.
+.Pp
+.Fl e
+takes the form
+.Ql VARIABLE=value
+and sets an environment variable for the popup; it may be specified multiple
+times.
 .Pp
 The
 .Fl C

--- a/tmux.h
+++ b/tmux.h
@@ -2074,9 +2074,9 @@ typedef void (*job_free_cb) (void *);
 #define JOB_NOWAIT 0x1
 #define JOB_KEEPWRITE 0x2
 #define JOB_PTY 0x4
-struct job	*job_run(const char *, int, char **, struct session *,
-		     const char *, job_update_cb, job_complete_cb, job_free_cb,
-		     void *, int, int, int);
+struct job	*job_run(const char *, int, char **, struct environ *,
+			 struct session *, const char *, job_update_cb, job_complete_cb,
+			 job_free_cb, void *, int, int, int);
 void		 job_free(struct job *);
 int		 job_transfer(struct job *, pid_t *, char *, size_t);
 void		 job_resize(struct job *, u_int, u_int);
@@ -3107,7 +3107,7 @@ int		 menu_key_cb(struct client *, void *, struct key_event *);
 typedef void (*popup_close_cb)(int, void *);
 typedef void (*popup_finish_edit_cb)(char *, size_t, void *);
 int		 popup_display(int, struct cmdq_item *, u_int, u_int, u_int,
-		    u_int, const char *, int, char **, const char *,
+		    u_int, struct environ *, const char *, int, char **, const char *,
 		    struct client *, struct session *, popup_close_cb, void *);
 int		 popup_editor(struct client *, const char *, size_t,
 		    popup_finish_edit_cb, void *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -4531,7 +4531,7 @@ window_copy_pipe_run(struct window_mode_entry *wme, struct session *s,
 	if (cmd == NULL || *cmd == '\0')
 		cmd = options_get_string(global_options, "copy-command");
 	if (cmd != NULL && *cmd != '\0') {
-		job = job_run(cmd, 0, NULL, s, NULL, NULL, NULL, NULL, NULL,
+		job = job_run(cmd, 0, NULL, NULL, s, NULL, NULL, NULL, NULL, NULL,
 		    JOB_NOWAIT, -1, -1);
 		bufferevent_write(job_get_event(job), buf, *len);
 	}


### PR DESCRIPTION
This PR adds the `-e` flag to the `display-popup` command to set environment variables as mentioned on the [**Contributing Medium Things**](https://github.com/tmux/tmux/wiki/Contributing#medium-things) wiki page.

To test:

* Build and run tmux: `make && ./tmux -vv -f/dev/null -Ltest`
* Display a popup and specify a custom environment variable: `tmux popup -Ee POPUP_VAR=Success`
* Verify that the custom environment variable is set in the popup: `echo $POPUP_VAR`
* Display a popup and specify a custom environment variable: `tmux popup -E`
* Verify that the custom environment variable is **not** set in the popup: `echo $POPUP_VAR`

| Popup showing custom env var | Popup without custom env var | 
| --- | --- |
| <img alt="tmux popup showing custom env var" src="https://user-images.githubusercontent.com/16507/136659983-15b8d6af-704f-458e-add2-a5f337d932f9.png"> | <img alt="tmux popup showing no custom env var" src="https://user-images.githubusercontent.com/16507/136659997-2f49f88b-e7ba-46cd-a81d-ac7f06397b9a.png"> |

[tmux-client-47260.log](https://github.com/tmux/tmux/files/7315691/tmux-client-47260.log)
[tmux-out-47262.log](https://github.com/tmux/tmux/files/7315692/tmux-out-47262.log)
[tmux-server-47262.log](https://github.com/tmux/tmux/files/7315693/tmux-server-47262.log)