### PR TITLE
Add popup-style and popup-border-style

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -747,7 +747,7 @@ mode_tree_draw(struct mode_tree_data *mtd)
 		mti = mti->parent;
 
 	screen_write_cursormove(&ctx, 0, h, 0);
-	screen_write_box(&ctx, w, sy - h);
+	screen_write_box(&ctx, w, sy - h, NULL);
 
 	if (mtd->sort_list != NULL) {
 		xasprintf(&text, " %s (sort: %s%s)", mti->name,

--- a/options-table.c
+++ b/options-table.c
@@ -981,6 +981,24 @@ const struct options_table_entry options_table[] = {
 	  .text = "The default colour palette for colours zero to 255."
 	},
 
+	{ .name = "popup-style",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "default",
+	  .flags = OPTIONS_TABLE_IS_STYLE,
+	  .separator = ",",
+	  .text = "Default style of popups."
+	},
+
+	{ .name = "popup-border-style",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "default",
+	  .flags = OPTIONS_TABLE_IS_STYLE,
+	  .separator = ",",
+	  .text = "Default style of popup borders."
+	},
+
 	{ .name = "remain-on-exit",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,

--- a/popup.c
+++ b/popup.c
@@ -180,16 +180,22 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	u_int			 i, px = pd->px, py = pd->py;
 	struct colour_palette	*palette = &pd->palette;
 	struct grid_cell	 gc;
+	struct grid_cell	 bgc;
 
 	screen_init(&s, pd->sx, pd->sy, 0);
 	screen_write_start(&ctx, &s);
 	screen_write_clearscreen(&ctx, 8);
 
+	memcpy(&bgc, &grid_default_cell, sizeof bgc);
+	style_apply(&bgc, c->session->curw->window->options, "popup-border-style", NULL);
+	palette->fg = bgc.fg;
+	palette->bg = bgc.bg;
+
 	if (pd->flags & POPUP_NOBORDER) {
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx, pd->sy);
 	} else if (pd->sx > 2 && pd->sy > 2) {
-		screen_write_box(&ctx, pd->sx, pd->sy);
+		screen_write_box(&ctx, pd->sx, pd->sy, &bgc);
 		screen_write_cursormove(&ctx, 1, 1, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx - 2,
 		    pd->sy - 2);
@@ -197,8 +203,9 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	screen_write_stop(&ctx);
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
-	gc.fg = pd->palette.fg;
-	gc.bg = pd->palette.bg;
+	style_apply(&gc, c->session->curw->window->options, "popup-style", NULL);
+	palette->fg = gc.fg;
+	palette->bg = gc.bg;
 
 	if (pd->md != NULL) {
 		c->overlay_check = menu_check_cb;

--- a/screen-write.c
+++ b/screen-write.c
@@ -645,7 +645,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 
 	memcpy(&default_gc, &grid_default_cell, sizeof default_gc);
 
-	screen_write_box(ctx, menu->width + 4, menu->count + 2);
+	screen_write_box(ctx, menu->width + 4, menu->count + 2, NULL);
 	screen_write_cursormove(ctx, cx + 2, cy, 0);
 	format_draw(ctx, &default_gc, menu->width, menu->title, NULL);
 
@@ -677,37 +677,37 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 
 /* Draw a box on screen. */
 void
-screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny)
+screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny, struct grid_cell *gc)
 {
 	struct screen		*s = ctx->s;
-	struct grid_cell	 gc;
 	u_int			 cx, cy, i;
 
 	cx = s->cx;
 	cy = s->cy;
 
-	memcpy(&gc, &grid_default_cell, sizeof gc);
-	gc.attr |= GRID_ATTR_CHARSET;
-	gc.flags |= GRID_FLAG_NOPALETTE;
+	if (gc == NULL)
+		memcpy(gc, &grid_default_cell, sizeof (struct grid_cell));
+	gc->attr |= GRID_ATTR_CHARSET;
+	gc->flags |= GRID_FLAG_NOPALETTE;
 
-	screen_write_putc(ctx, &gc, 'l');
+	screen_write_putc(ctx, gc, 'l');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'k');
+		screen_write_putc(ctx, gc, 'q');
+	screen_write_putc(ctx, gc, 'k');
 
 	screen_write_set_cursor(ctx, cx, cy + ny - 1);
-	screen_write_putc(ctx, &gc, 'm');
+	screen_write_putc(ctx, gc, 'm');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'j');
+		screen_write_putc(ctx, gc, 'q');
+	screen_write_putc(ctx, gc, 'j');
 
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
+		screen_write_putc(ctx, gc, 'x');
 	}
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
+		screen_write_putc(ctx, gc, 'x');
 	}
 
 	screen_write_set_cursor(ctx, cx, cy);

--- a/tmux.1
+++ b/tmux.1
@@ -4258,6 +4258,24 @@ see the
 section.
 Attributes are ignored.
 .Pp
+.It Ic popup-style Ar style
+Set the popup style.
+For how to specify
+.Ar style ,
+see the
+.Sx STYLES
+section.
+Attributes are ignored.
+.Pp
+.It Ic popup-border-style Ar style
+Set the popup border style.
+For how to specify
+.Ar style ,
+see the
+.Sx STYLES
+section.
+Attributes are ignored.
+.Pp
 .It Ic window-status-activity-style Ar style
 Set status line style for windows with an activity alert.
 For how to specify

--- a/tmux.h
+++ b/tmux.h
@@ -2690,7 +2690,7 @@ void	 screen_write_hline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
 	     const struct grid_cell *);
-void	 screen_write_box(struct screen_write_ctx *, u_int, u_int);
+void	 screen_write_box(struct screen_write_ctx *, u_int, u_int, struct grid_cell *gc);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 	     u_int);
 void	 screen_write_backspace(struct screen_write_ctx *);

--- a/window-tree.c
+++ b/window-tree.c
@@ -519,7 +519,7 @@ window_tree_draw_label(struct screen_write_ctx *ctx, u_int px, u_int py,
 
 	if (ox > 1 && ox + len < sx - 1 && sy >= 3) {
 		screen_write_cursormove(ctx, px + ox - 1, py + oy - 1, 0);
-		screen_write_box(ctx, len + 2, 3);
+		screen_write_box(ctx, len + 2, 3, NULL);
 	}
 	screen_write_cursormove(ctx, px + ox, py + oy, 0);
 	screen_write_puts(ctx, gc, "%s", label);


### PR DESCRIPTION
This PR adds ` popup-style` and `popup-border-style` options  to address the #2776.

To test:
* Build and run tmux `SHELL=/bin/ksh ./tmux -vv -f/dev/null -Ltest`
* Set the `popup-style` option `./tmux set -gw popup-style bg=blue,fg=brightwhite`
* Set the `popup-border-style` option `./tmux set -gw popup-border-style bg=cyan,fg=brightmagenta`
* Open a popup with a border `./tmux popup -yS 'echo tmux popup with border'` (use `^C` to close popup)
* Open a popup without a border `./tmux popup -B -yS 'echo tmux popup without border'` (use `^C` to close popup)

❓ In the test steps above I'm using `set -gw` to set the `popup-style` and `popup-border-style` options but I'm wondering whether these newly added options  are actually window options?
While documenting I noticed that the `window-style` option is documented in the "Available session options" section and I've added the documentation for the `popup-style` and `popup-border-style` options in the same section. Obviously I need to understand more about tmux's implementation and logical grouping of options. @nicm Maybe you could explain this a bit to help things clear up for me.

ℹ️ If this PR is accepted then the reference to #2776 can be removed from the "Popup improvements" on the [**Contributing Medium things**](https://github.com/tmux/tmux/wiki/Contributing#medium-things) wiki page.

/cc @reportaman

| With Border | Without Border |
| --- | --- |
| <img width="570" alt="image" src="https://user-images.githubusercontent.com/16507/136749297-c416d664-a6d7-4a36-9343-9e9c6b5f1615.png"> | <img width="570" alt="image" src="https://user-images.githubusercontent.com/16507/136749312-88a0781e-4ff7-44d0-adbe-d49fb2530dad.png"> |

* [tmux-client-86552.log](https://github.com/tmux/tmux/files/7320304/tmux-client-86552.log)
* [tmux-out-86554.log](https://github.com/tmux/tmux/files/7320306/tmux-out-86554.log)
* [tmux-server-86554.log](https://github.com/tmux/tmux/files/7320307/tmux-server-86554.log)

