### PR TITLE
Fix some minor compiler warnings.

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -108,6 +108,7 @@ args_value_as_string(struct args_value *value)
 	case ARGS_STRING:
 		return (value->string);
 	}
+	return (NULL);
 }
 
 /* Create an empty arguments set. */
@@ -753,6 +754,7 @@ args_make_commands(struct args_command_state *state, int argc, char **argv,
 	case CMD_PARSE_SUCCESS:
 		return (pr->cmdlist);
 	}
+	return (NULL);
 }
 
 /* Free commands state. */

--- a/format-draw.c
+++ b/format-draw.c
@@ -1133,10 +1133,10 @@ format_trim_left(const char *expanded, u_int limit)
 char *
 format_trim_right(const char *expanded, u_int limit)
 {
-	char			*copy, *out;
-	const char		*cp = expanded, *end;
-	u_int			 width = 0, total_width, skip, n;
-	u_int			 leading_width, copy_width;
+	char			*copy = NULL, *out = NULL;
+	const char		*cp = expanded, *end = NULL;
+	u_int			 width = 0, total_width = 0, skip = 0, n = 0;
+	u_int			 leading_width, copy_width = 0;
 	struct utf8_data	 ud;
 	enum utf8_state		 more;
 

--- a/format.c
+++ b/format.c
@@ -3388,7 +3388,8 @@ found:
 		else {
 			if (time_format != NULL) {
 				localtime_r(&t, &tm);
-				strftime(s, sizeof s, time_format, &tm);
+				/* Ugly cast hack to pass with -Werror=format-nonliteral. */
+				((size_t (*)(char *, size_t, const char *, const struct tm *))strftime)(s, sizeof s, time_format, &tm);
 			} else {
 				ctime_r(&t, s);
 				s[strcspn(s, "\n")] = '\0';
@@ -4484,7 +4485,9 @@ format_expand1(struct format_expand_state *es, const char *fmt)
 			es->time = time(NULL);
 			localtime_r(&es->time, &es->tm);
 		}
-		if (strftime(expanded, sizeof expanded, fmt, &es->tm) == 0) {
+
+		/* Ugly cast hack to pass with -Werror=format-nonliteral. */
+		if(((size_t (*)(char *, size_t, const char *, const struct tm *))strftime)(expanded, sizeof expanded, fmt, &es->tm) == 0) {
 			format_log(es, "format is too long");
 			return (xstrdup(""));
 		}

--- a/notify.c
+++ b/notify.c
@@ -153,7 +153,7 @@ notify_add(const char *name, struct cmd_find_state *fs, struct client *c,
 	ne->client = c;
 	ne->session = s;
 	ne->window = w;
-	ne->pane = (wp != NULL ? wp->id : -1);
+	ne->pane = (wp != NULL ? (int)wp->id : -1);
 
 	ne->formats = format_create(NULL, NULL, 0, FORMAT_NOJOBS);
 	format_add(ne->formats, "hook", "%s", name);
@@ -199,7 +199,7 @@ notify_hook(struct cmdq_item *item, const char *name)
 	ne.client = cmdq_get_client(item);
 	ne.session = target->s;
 	ne.window = target->w;
-	ne.pane = (target->wp != NULL ? target->wp->id : -1);
+	ne.pane = (target->wp != NULL ? (int)target->wp->id : -1);
 
 	ne.formats = format_create(NULL, NULL, 0, FORMAT_NOJOBS);
 	format_add(ne.formats, "hook", "%s", name);

--- a/tty-term.c
+++ b/tty-term.c
@@ -664,10 +664,10 @@ int
 tty_term_read_list(const char *name, int fd, char ***caps, u_int *ncaps,
     char **cause)
 {
-	const struct tty_term_code_entry	*ent;
-	int					 error, n;
-	u_int					 i;
-	const char				*s;
+	const struct tty_term_code_entry	*ent = NULL;
+	int					 error = 0, n = 0;
+	u_int					 i = 0;
+	const char				*s = NULL;
 	char					 tmp[11];
 
 	if (setupterm((char *)name, fd, &error) != OK) {


### PR DESCRIPTION
Fixes a few compiler warnings:

- `-Wmaybe-uninitialized` in `format-draw.c` and `tty-term.c`
- `-Wformat-nonliteral` in `format.c`
- `-Wreturn-type` in `arguments.c`
