### PR TITLE
Add popup-border-lines

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -52,9 +52,10 @@ const struct cmd_entry cmd_display_popup_entry = {
 	.name = "display-popup",
 	.alias = "popup",
 
-	.args = { "BCc:d:e:Eh:t:w:x:y:", 0, -1, NULL },
-	.usage = "[-BCE] [-c target-client] [-d start-directory] "
-		 "[-e environment] [-h height] " CMD_TARGET_PANE_USAGE " "
+	.args = { "Bb:Cc:d:e:Eh:t:w:x:y:", 0, -1, NULL },
+	.usage = "[-BCE] [-b border-lines] [-c target-client] "
+		 "[-d start-directory] [-e environment] [-h height] "
+		 CMD_TARGET_PANE_USAGE " "
 		 "[-w width] [-x position] [-y position] [shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -354,10 +355,12 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 	struct tty		*tty = &tc->tty;
 	const char		*value, *shell, *shellcmd = NULL;
 	char			*cwd, *cause, **argv = NULL;
-	int			 flags = 0, argc = 0;
+	int			 lines = -1, flags = 0, argc = 0;
 	u_int			 px, py, w, h, count = args_count(args);
 	struct args_value	*av;
 	struct environ		*env = NULL;
+	struct options		*o = s->curw->window->options;
+	struct options_entry	*oe;
 
 	if (args_has(args, 'C')) {
 		server_client_clear_overlay(tc);
@@ -393,6 +396,23 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 	if (!cmd_display_menu_get_position(tc, item, args, &px, &py, w, h))
 		return (CMD_RETURN_NORMAL);
 
+	value = args_get(args, 'b');
+	if (args_has(args, 'B'))
+		lines = POPUP_LINES_NONE;
+	else if (value == NULL)
+		lines = options_get_number(o, "popup-border-lines");
+	else {
+		cause = NULL;
+		oe = options_get(o, "popup-border-lines");
+		lines = string_choice_from_options(options_table_entry(oe),
+		    value, &cause);
+		if (cause != NULL) {
+			cmdq_error(item, "border-lines %s", cause);
+			free(cause);
+			return (CMD_RETURN_ERROR);
+		}
+	}
+
 	value = args_get(args, 'd');
 	if (value != NULL)
 		cwd = format_single_from_target(item, value);
@@ -424,10 +444,8 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 		flags |= POPUP_CLOSEEXITZERO;
 	else if (args_has(args, 'E'))
 		flags |= POPUP_CLOSEEXIT;
-	if (args_has(args, 'B'))
-		flags |= POPUP_NOBORDER;
-	if (popup_display(flags, item, px, py, w, h, env, shellcmd, argc, argv,
-	    cwd, tc, s, NULL, NULL) != 0) {
+	if (popup_display(flags, lines, item, px, py, w, h, env, shellcmd, argc,
+	    argv, cwd, tc, s, NULL, NULL) != 0) {
 		cmd_free_argv(argc, argv);
 		if (env != NULL)
 			environ_free(env);

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -747,7 +747,7 @@ mode_tree_draw(struct mode_tree_data *mtd)
 		mti = mti->parent;
 
 	screen_write_cursormove(&ctx, 0, h, 0);
-	screen_write_box(&ctx, w, sy - h);
+	screen_write_box(&ctx, w, sy - h, NULL);
 
 	if (mtd->sort_list != NULL) {
 		xasprintf(&text, " %s (sort: %s%s)", mti->name,

--- a/options-table.c
+++ b/options-table.c
@@ -981,6 +981,24 @@ const struct options_table_entry options_table[] = {
 	  .text = "The default colour palette for colours zero to 255."
 	},
 
+	{ .name = "popup-style",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "default",
+	  .flags = OPTIONS_TABLE_IS_STYLE,
+	  .separator = ",",
+	  .text = "Default style of popups."
+	},
+
+	{ .name = "popup-border-style",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "default",
+	  .flags = OPTIONS_TABLE_IS_STYLE,
+	  .separator = ",",
+	  .text = "Default style of popup borders."
+	},
+
 	{ .name = "remain-on-exit",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,

--- a/options-table.c
+++ b/options-table.c
@@ -62,6 +62,9 @@ static const char *options_table_pane_status_list[] = {
 static const char *options_table_pane_lines_list[] = {
 	"single", "double", "heavy", "simple", "number", NULL
 };
+static const char *options_table_popup_lines_list[] = {
+	"single", "double", "heavy", "simple", "rounded", "padded", "none", NULL
+};
 static const char *options_table_set_clipboard_list[] = {
 	"off", "external", "on", NULL
 };
@@ -997,6 +1000,15 @@ const struct options_table_entry options_table[] = {
 	  .flags = OPTIONS_TABLE_IS_STYLE,
 	  .separator = ",",
 	  .text = "Default style of popup borders."
+	},
+
+	{ .name = "popup-border-lines",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .choices = options_table_popup_lines_list,
+	  .default_num = POPUP_LINES_SINGLE,
+	  .text = "Type of characters used to draw popup border lines. Some of "
+	          "these are only supported on terminals with UTF-8 support."
 	},
 
 	{ .name = "remain-on-exit",

--- a/options.c
+++ b/options.c
@@ -989,28 +989,38 @@ options_from_string_flag(struct options *oo, const char *name,
 	return (0);
 }
 
+int
+string_choice_from_options(const struct options_table_entry *oe,
+    const char *value, char **cause)
+{
+	const char	**cp;
+	int		  n = 0, choice = -1;
+	for (cp = oe->choices; *cp != NULL; cp++) {
+		if (strcmp(*cp, value) == 0)
+			choice = n;
+		n++;
+	}
+	if (choice == -1) {
+		xasprintf(cause, "unknown value: %s", value);
+		return (-1);
+	}
+	return choice;
+}
+
 static int
 options_from_string_choice(const struct options_table_entry *oe,
     struct options *oo, const char *name, const char *value, char **cause)
 {
-	const char	**cp;
-	int		  n, choice = -1;
+	int		  choice = -1;
 
 	if (value == NULL) {
 		choice = options_get_number(oo, name);
 		if (choice < 2)
 			choice = !choice;
 	} else {
-		n = 0;
-		for (cp = oe->choices; *cp != NULL; cp++) {
-			if (strcmp(*cp, value) == 0)
-				choice = n;
-			n++;
-		}
-		if (choice == -1) {
-			xasprintf(cause, "unknown value: %s", value);
+		choice = string_choice_from_options(oe, value, cause);
+		if (choice < 0)
 			return (-1);
-		}
 	}
 	options_set_number(oo, name, choice);
 	return (0);

--- a/popup.c
+++ b/popup.c
@@ -180,16 +180,22 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	u_int			 i, px = pd->px, py = pd->py;
 	struct colour_palette	*palette = &pd->palette;
 	struct grid_cell	 gc;
+	struct grid_cell	 bgc;
 
 	screen_init(&s, pd->sx, pd->sy, 0);
 	screen_write_start(&ctx, &s);
 	screen_write_clearscreen(&ctx, 8);
 
+	memcpy(&bgc, &grid_default_cell, sizeof bgc);
+	style_apply(&bgc, c->session->curw->window->options, "popup-border-style", NULL);
+	palette->fg = bgc.fg;
+	palette->bg = bgc.bg;
+
 	if (pd->flags & POPUP_NOBORDER) {
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx, pd->sy);
 	} else if (pd->sx > 2 && pd->sy > 2) {
-		screen_write_box(&ctx, pd->sx, pd->sy);
+		screen_write_box(&ctx, pd->sx, pd->sy, &bgc);
 		screen_write_cursormove(&ctx, 1, 1, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx - 2,
 		    pd->sy - 2);
@@ -197,8 +203,9 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	screen_write_stop(&ctx);
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
-	gc.fg = pd->palette.fg;
-	gc.bg = pd->palette.bg;
+	style_apply(&gc, c->session->curw->window->options, "popup-style", NULL);
+	palette->fg = gc.fg;
+	palette->bg = gc.bg;
 
 	if (pd->md != NULL) {
 		c->overlay_check = menu_check_cb;

--- a/popup.c
+++ b/popup.c
@@ -30,6 +30,7 @@ struct popup_data {
 	struct client		 *c;
 	struct cmdq_item	 *item;
 	int			  flags;
+	int			  lines;
 
 	struct screen		  s;
 	struct colour_palette	  palette;
@@ -116,7 +117,7 @@ popup_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	ttyctx->wsx = c->tty.sx;
 	ttyctx->wsy = c->tty.sy;
 
-	if (pd->flags & POPUP_NOBORDER) {
+	if (pd->lines == POPUP_LINES_NONE) {
 		ttyctx->xoff = ttyctx->rxoff = pd->px;
 		ttyctx->yoff = ttyctx->ryoff = pd->py;
 	} else {
@@ -146,7 +147,7 @@ popup_mode_cb(__unused struct client *c, void *data, u_int *cx, u_int *cy)
 	if (pd->md != NULL)
 		return (menu_mode_cb(c, pd->md, cx, cy));
 
-	if (pd->flags & POPUP_NOBORDER) {
+	if (pd->lines == POPUP_LINES_NONE) {
 		*cx = pd->px + pd->s.cx;
 		*cy = pd->py + pd->s.cy;
 	} else {
@@ -222,10 +223,11 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	bgc.attr = 0;
 	style_apply(&bgc, o, "popup-border-style", NULL);
 
-	if (pd->flags & POPUP_NOBORDER) {
+	if (pd->lines == POPUP_LINES_NONE) {
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx, pd->sy);
 	} else if (pd->sx > 2 && pd->sy > 2) {
+		ctx.box_lines = pd->lines;
 		screen_write_box(&ctx, pd->sx, pd->sy, &bgc);
 		screen_write_cursormove(&ctx, 1, 1, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx - 2,
@@ -317,7 +319,7 @@ popup_resize_cb(__unused struct client *c, void *data)
 		pd->px = pd->ppx;
 
 	/* Avoid zero size screens. */
-	if (pd->flags & POPUP_NOBORDER) {
+	if (pd->lines == POPUP_LINES_NONE) {
 		screen_resize(&pd->s, pd->sx, pd->sy, 0);
 		if (pd->job != NULL)
 			job_resize(pd->job, pd->sx, pd->sy );
@@ -443,7 +445,7 @@ popup_handle_drag(struct client *c, struct popup_data *pd,
 		pd->ppy = py;
 		server_redraw_client(c);
 	} else if (pd->dragging == SIZE) {
-		if (pd->flags & POPUP_NOBORDER) {
+		if (pd->lines == POPUP_LINES_NONE) {
 			if (m->x < pd->px + 1)
 				return;
 			if (m->y < pd->py + 1)
@@ -459,7 +461,7 @@ popup_handle_drag(struct client *c, struct popup_data *pd,
 		pd->psx = pd->sx;
 		pd->psy = pd->sy;
 
-		if (pd->flags & POPUP_NOBORDER) {
+		if (pd->lines == POPUP_LINES_NONE) {
 			screen_resize(&pd->s, pd->sx, pd->sy, 0);
 			if (pd->job != NULL)
 				job_resize(pd->job, pd->sx, pd->sy);
@@ -507,7 +509,7 @@ popup_key_cb(struct client *c, void *data, struct key_event *event)
 				goto menu;
 			return (0);
 		}
-		if (~pd->flags & POPUP_NOBORDER) {
+		if (pd->lines != POPUP_LINES_NONE) {
 			if (m->x == pd->px)
 				border = LEFT;
 			else if (m->x == pd->px + pd->sx - 1)
@@ -541,7 +543,7 @@ popup_key_cb(struct client *c, void *data, struct key_event *event)
 	if (pd->job != NULL) {
 		if (KEYC_IS_MOUSE(event->key)) {
 			/* Must be inside, checked already. */
-			if (pd->flags & POPUP_NOBORDER) {
+			if (pd->lines == POPUP_LINES_NONE) {
 				px = m->x - pd->px;
 				py = m->y - pd->py;
 			} else {
@@ -627,15 +629,15 @@ popup_job_complete_cb(struct job *job)
 }
 
 int
-popup_display(int flags, struct cmdq_item *item, u_int px, u_int py, u_int sx,
-    u_int sy, struct environ *env, const char *shellcmd, int argc, char **argv,
-    const char *cwd, struct client *c, struct session *s, popup_close_cb cb,
-    void *arg)
+popup_display(int flags, int lines, struct cmdq_item *item, u_int px, u_int py,
+    u_int sx, u_int sy, struct environ *env, const char *shellcmd, int argc,
+    char **argv, const char *cwd, struct client *c, struct session *s,
+    popup_close_cb cb, void *arg)
 {
 	struct popup_data	*pd;
 	u_int			 jx, jy;
 
-	if (flags & POPUP_NOBORDER) {
+	if (lines == POPUP_LINES_NONE) {
 		if (sx < 1 || sy < 1)
 			return (-1);
 		jx = sx;
@@ -652,6 +654,7 @@ popup_display(int flags, struct cmdq_item *item, u_int px, u_int py, u_int sx,
 	pd = xcalloc(1, sizeof *pd);
 	pd->item = item;
 	pd->flags = flags;
+	pd->lines = lines;
 
 	pd->c = c;
 	pd->c->references++;
@@ -763,7 +766,7 @@ popup_editor(struct client *c, const char *buf, size_t len,
 	py = (c->tty.sy / 2) - (sy / 2);
 
 	xasprintf(&cmd, "%s %s", editor, path);
-	if (popup_display(POPUP_INTERNAL|POPUP_CLOSEEXIT, NULL, px, py, sx, sy,
+	if (popup_display(POPUP_INTERNAL|POPUP_CLOSEEXIT, -1, NULL, px, py, sx, sy,
 	    NULL, cmd, 0, NULL, _PATH_TMP, c, NULL, popup_editor_close_cb, pe) != 0) {
 		popup_editor_free(pe);
 		free(cmd);

--- a/popup.c
+++ b/popup.c
@@ -219,6 +219,7 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	screen_write_clearscreen(&ctx, 8);
 
 	memcpy(&bgc, &grid_default_cell, sizeof bgc);
+	bgc.attr = 0;
 	style_apply(&bgc, o, "popup-border-style", NULL);
 	palette->fg = bgc.fg;
 	palette->bg = bgc.bg;
@@ -235,6 +236,7 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	screen_write_stop(&ctx);
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
+	gc.attr = 0;
 	style_apply(&gc, o, "popup-style", NULL);
 	palette->fg = gc.fg;
 	palette->bg = gc.bg;

--- a/popup.c
+++ b/popup.c
@@ -221,8 +221,6 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	memcpy(&bgc, &grid_default_cell, sizeof bgc);
 	bgc.attr = 0;
 	style_apply(&bgc, o, "popup-border-style", NULL);
-	palette->fg = bgc.fg;
-	palette->bg = bgc.bg;
 
 	if (pd->flags & POPUP_NOBORDER) {
 		screen_write_cursormove(&ctx, 0, 0, 0);

--- a/popup.c
+++ b/popup.c
@@ -212,13 +212,14 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	struct colour_palette	*palette = &pd->palette;
 	struct grid_cell	 gc;
 	struct grid_cell	 bgc;
+	struct options          *o = c->session->curw->window->options;
 
 	screen_init(&s, pd->sx, pd->sy, 0);
 	screen_write_start(&ctx, &s);
 	screen_write_clearscreen(&ctx, 8);
 
 	memcpy(&bgc, &grid_default_cell, sizeof bgc);
-	style_apply(&bgc, c->session->curw->window->options, "popup-border-style", NULL);
+	style_apply(&bgc, o, "popup-border-style", NULL);
 	palette->fg = bgc.fg;
 	palette->bg = bgc.bg;
 
@@ -234,7 +235,7 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	screen_write_stop(&ctx);
 
 	memcpy(&gc, &grid_default_cell, sizeof gc);
-	style_apply(&gc, c->session->curw->window->options, "popup-style", NULL);
+	style_apply(&gc, o, "popup-style", NULL);
 	palette->fg = gc.fg;
 	palette->bg = gc.bg;
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -31,22 +31,6 @@ static void	screen_redraw_draw_pane(struct screen_redraw_ctx *,
 static void	screen_redraw_set_context(struct client *,
 		    struct screen_redraw_ctx *);
 
-#define CELL_INSIDE 0
-#define CELL_TOPBOTTOM 1
-#define CELL_LEFTRIGHT 2
-#define CELL_TOPLEFT 3
-#define CELL_TOPRIGHT 4
-#define CELL_BOTTOMLEFT 5
-#define CELL_BOTTOMRIGHT 6
-#define CELL_TOPJOIN 7
-#define CELL_BOTTOMJOIN 8
-#define CELL_LEFTJOIN 9
-#define CELL_RIGHTJOIN 10
-#define CELL_JOIN 11
-#define CELL_OUTSIDE 12
-
-#define CELL_BORDERS " xqlkmjwvtun~"
-
 #define START_ISOLATE "\342\201\246"
 #define END_ISOLATE   "\342\201\251"
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -34,38 +34,6 @@ static void	screen_redraw_set_context(struct client *,
 #define START_ISOLATE "\342\201\246"
 #define END_ISOLATE   "\342\201\251"
 
-static const struct utf8_data screen_redraw_double_borders[] = {
-	{ "", 0, 0, 0 },
-	{ "\342\225\221", 0, 3, 1 }, /* U+2551 */
-	{ "\342\225\220", 0, 3, 1 }, /* U+2550 */
-	{ "\342\225\224", 0, 3, 1 }, /* U+2554 */
-	{ "\342\225\227", 0, 3, 1 }, /* U+2557 */
-	{ "\342\225\232", 0, 3, 1 }, /* U+255A */
-	{ "\342\225\235", 0, 3, 1 }, /* U+255D */
-	{ "\342\225\246", 0, 3, 1 }, /* U+2566 */
-	{ "\342\225\251", 0, 3, 1 }, /* U+2569 */
-	{ "\342\225\240", 0, 3, 1 }, /* U+2560 */
-	{ "\342\225\243", 0, 3, 1 }, /* U+2563 */
-	{ "\342\225\254", 0, 3, 1 }, /* U+256C */
-	{ "\302\267",     0, 2, 1 }  /* U+00B7 */
-};
-
-static const struct utf8_data screen_redraw_heavy_borders[] = {
-	{ "", 0, 0, 0 },
-	{ "\342\224\203", 0, 3, 1 }, /* U+2503 */
-	{ "\342\224\201", 0, 3, 1 }, /* U+2501 */
-	{ "\342\224\223", 0, 3, 1 }, /* U+2513 */
-	{ "\342\224\217", 0, 3, 1 }, /* U+250F */
-	{ "\342\224\227", 0, 3, 1 }, /* U+2517 */
-	{ "\342\224\233", 0, 3, 1 }, /* U+251B */
-	{ "\342\224\263", 0, 3, 1 }, /* U+2533 */
-	{ "\342\224\273", 0, 3, 1 }, /* U+253B */
-	{ "\342\224\243", 0, 3, 1 }, /* U+2523 */
-	{ "\342\224\253", 0, 3, 1 }, /* U+252B */
-	{ "\342\225\213", 0, 3, 1 }, /* U+254B */
-	{ "\302\267",     0, 2, 1 }  /* U+00B7 */
-};
-
 enum screen_redraw_border_type {
 	SCREEN_REDRAW_OUTSIDE,
 	SCREEN_REDRAW_INSIDE,
@@ -102,7 +70,7 @@ screen_redraw_border_set(struct window_pane *wp, int pane_lines, int cell_type,
 		break;
 	case PANE_LINES_SIMPLE:
 		gc->attr &= ~GRID_ATTR_CHARSET;
-		utf8_set(&gc->data, " |-+++++++++."[cell_type]);
+		utf8_set(&gc->data, SIMPLE_BORDERS[cell_type]);
 		break;
 	default:
 		gc->attr |= GRID_ATTR_CHARSET;

--- a/screen-write.c
+++ b/screen-write.c
@@ -677,7 +677,8 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 
 /* Draw a box on screen. */
 void
-screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny, struct grid_cell *gc)
+screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
+    struct grid_cell *gcp)
 {
 	struct screen		*s = ctx->s;
 	u_int			 cx, cy, i;

--- a/screen-write.c
+++ b/screen-write.c
@@ -679,6 +679,28 @@ static void
 popup_redraw_border_set(int popup_lines, int cell_type, struct grid_cell *gc)
 {
 	switch(popup_lines) {
+        case POPUP_LINES_NONE:
+		break;
+        case POPUP_LINES_DOUBLE:
+                gc->attr &= ~GRID_ATTR_CHARSET;
+                utf8_copy(&gc->data, &screen_redraw_double_borders[cell_type]);
+		break;
+        case POPUP_LINES_HEAVY:
+                gc->attr &= ~GRID_ATTR_CHARSET;
+                utf8_copy(&gc->data, &screen_redraw_heavy_borders[cell_type]);
+		break;
+        case POPUP_LINES_ROUNDED:
+                gc->attr &= ~GRID_ATTR_CHARSET;
+                utf8_copy(&gc->data, &screen_redraw_rounded_borders[cell_type]);
+		break;
+        case POPUP_LINES_SIMPLE:
+                gc->attr &= ~GRID_ATTR_CHARSET;
+                utf8_set(&gc->data, SIMPLE_BORDERS[cell_type]);
+                break;
+        case POPUP_LINES_PADDED:
+                gc->attr &= ~GRID_ATTR_CHARSET;
+                utf8_set(&gc->data, PADDED_BORDERS[cell_type]);
+                break;
 	default:
 		gc->attr |= GRID_ATTR_CHARSET;
 		utf8_set(&gc->data, CELL_BORDERS[cell_type]);
@@ -706,30 +728,31 @@ screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
 	gc.flags |= GRID_FLAG_NOPALETTE;
 
 	// Draw top border
-	popup_redraw_border_set(-1, CELL_TOPLEFT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_TOPLEFT, &gc);
 	screen_write_cell(ctx, &gc);
-	popup_redraw_border_set(-1, CELL_LEFTRIGHT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_LEFTRIGHT, &gc);
 	for (i = 1; i < nx - 1; i++)
 		screen_write_cell(ctx, &gc);
-	popup_redraw_border_set(-1, CELL_TOPRIGHT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_TOPRIGHT, &gc);
 	screen_write_cell(ctx, &gc);
 
 	// Draw bottom border
 	screen_write_set_cursor(ctx, cx, cy + ny - 1);
-	popup_redraw_border_set(-1, CELL_BOTTOMLEFT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_BOTTOMLEFT, &gc);
 	screen_write_cell(ctx, &gc);
-	popup_redraw_border_set(-1, CELL_LEFTRIGHT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_LEFTRIGHT, &gc);
 	for (i = 1; i < nx - 1; i++)
 		screen_write_cell(ctx, &gc);
-	popup_redraw_border_set(-1, CELL_BOTTOMRIGHT, &gc);
+	popup_redraw_border_set(ctx->box_lines, CELL_BOTTOMRIGHT, &gc);
 	screen_write_cell(ctx, &gc);
 
-	popup_redraw_border_set(-1, CELL_TOPBOTTOM, &gc);
+	// Draw sides
+	popup_redraw_border_set(ctx->box_lines, CELL_TOPBOTTOM, &gc);
 	for (i = 1; i < ny - 1; i++) {
-		// Draw left border
+		// left side
 		screen_write_set_cursor(ctx, cx, cy + i);
 		screen_write_cell(ctx, &gc);
-		// Draw right border
+		// right side
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
 		screen_write_cell(ctx, &gc);
 	}

--- a/screen-write.c
+++ b/screen-write.c
@@ -675,6 +675,17 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 	screen_write_set_cursor(ctx, cx, cy);
 }
 
+static void
+popup_redraw_border_set(int popup_lines, int cell_type, struct grid_cell *gc)
+{
+	switch(popup_lines) {
+	default:
+		gc->attr |= GRID_ATTR_CHARSET;
+		utf8_set(&gc->data, CELL_BORDERS[cell_type]);
+		break;
+	}
+}
+
 /* Draw a box on screen. */
 void
 screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
@@ -694,24 +705,33 @@ screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
 	gc.attr |= GRID_ATTR_CHARSET;
 	gc.flags |= GRID_FLAG_NOPALETTE;
 
-	screen_write_putc(ctx, &gc, 'l');
+	// Draw top border
+	popup_redraw_border_set(-1, CELL_TOPLEFT, &gc);
+	screen_write_cell(ctx, &gc);
+	popup_redraw_border_set(-1, CELL_LEFTRIGHT, &gc);
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'k');
+		screen_write_cell(ctx, &gc);
+	popup_redraw_border_set(-1, CELL_TOPRIGHT, &gc);
+	screen_write_cell(ctx, &gc);
 
+	// Draw bottom border
 	screen_write_set_cursor(ctx, cx, cy + ny - 1);
-	screen_write_putc(ctx, &gc, 'm');
+	popup_redraw_border_set(-1, CELL_BOTTOMLEFT, &gc);
+	screen_write_cell(ctx, &gc);
+	popup_redraw_border_set(-1, CELL_LEFTRIGHT, &gc);
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'j');
+		screen_write_cell(ctx, &gc);
+	popup_redraw_border_set(-1, CELL_BOTTOMRIGHT, &gc);
+	screen_write_cell(ctx, &gc);
 
+	popup_redraw_border_set(-1, CELL_TOPBOTTOM, &gc);
 	for (i = 1; i < ny - 1; i++) {
+		// Draw left border
 		screen_write_set_cursor(ctx, cx, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
-	}
-	for (i = 1; i < ny - 1; i++) {
+		screen_write_cell(ctx, &gc);
+		// Draw right border
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
+		screen_write_cell(ctx, &gc);
 	}
 
 	screen_write_set_cursor(ctx, cx, cy);

--- a/screen-write.c
+++ b/screen-write.c
@@ -681,34 +681,37 @@ screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
     struct grid_cell *gcp)
 {
 	struct screen		*s = ctx->s;
+	struct grid_cell         gc;
 	u_int			 cx, cy, i;
 
 	cx = s->cx;
 	cy = s->cy;
 
-	if (gc == NULL)
-		memcpy(gc, &grid_default_cell, sizeof (struct grid_cell));
-	gc->attr |= GRID_ATTR_CHARSET;
-	gc->flags |= GRID_FLAG_NOPALETTE;
+	if (gcp != NULL)
+		memcpy(&gc, gcp, sizeof gc);
+	else
+		memcpy(&gc, &grid_default_cell, sizeof gc);
+	gc.attr |= GRID_ATTR_CHARSET;
+	gc.flags |= GRID_FLAG_NOPALETTE;
 
-	screen_write_putc(ctx, gc, 'l');
+	screen_write_putc(ctx, &gc, 'l');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, gc, 'q');
-	screen_write_putc(ctx, gc, 'k');
+		screen_write_putc(ctx, &gc, 'q');
+	screen_write_putc(ctx, &gc, 'k');
 
 	screen_write_set_cursor(ctx, cx, cy + ny - 1);
-	screen_write_putc(ctx, gc, 'm');
+	screen_write_putc(ctx, &gc, 'm');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, gc, 'q');
-	screen_write_putc(ctx, gc, 'j');
+		screen_write_putc(ctx, &gc, 'q');
+	screen_write_putc(ctx, &gc, 'j');
 
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx, cy + i);
-		screen_write_putc(ctx, gc, 'x');
+		screen_write_putc(ctx, &gc, 'x');
 	}
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
-		screen_write_putc(ctx, gc, 'x');
+		screen_write_putc(ctx, &gc, 'x');
 	}
 
 	screen_write_set_cursor(ctx, cx, cy);

--- a/screen-write.c
+++ b/screen-write.c
@@ -645,7 +645,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 
 	memcpy(&default_gc, &grid_default_cell, sizeof default_gc);
 
-	screen_write_box(ctx, menu->width + 4, menu->count + 2);
+	screen_write_box(ctx, menu->width + 4, menu->count + 2, NULL);
 	screen_write_cursormove(ctx, cx + 2, cy, 0);
 	format_draw(ctx, &default_gc, menu->width, menu->title, NULL);
 
@@ -677,37 +677,37 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 
 /* Draw a box on screen. */
 void
-screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny)
+screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny, struct grid_cell *gc)
 {
 	struct screen		*s = ctx->s;
-	struct grid_cell	 gc;
 	u_int			 cx, cy, i;
 
 	cx = s->cx;
 	cy = s->cy;
 
-	memcpy(&gc, &grid_default_cell, sizeof gc);
-	gc.attr |= GRID_ATTR_CHARSET;
-	gc.flags |= GRID_FLAG_NOPALETTE;
+	if (gc == NULL)
+		memcpy(gc, &grid_default_cell, sizeof (struct grid_cell));
+	gc->attr |= GRID_ATTR_CHARSET;
+	gc->flags |= GRID_FLAG_NOPALETTE;
 
-	screen_write_putc(ctx, &gc, 'l');
+	screen_write_putc(ctx, gc, 'l');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'k');
+		screen_write_putc(ctx, gc, 'q');
+	screen_write_putc(ctx, gc, 'k');
 
 	screen_write_set_cursor(ctx, cx, cy + ny - 1);
-	screen_write_putc(ctx, &gc, 'm');
+	screen_write_putc(ctx, gc, 'm');
 	for (i = 1; i < nx - 1; i++)
-		screen_write_putc(ctx, &gc, 'q');
-	screen_write_putc(ctx, &gc, 'j');
+		screen_write_putc(ctx, gc, 'q');
+	screen_write_putc(ctx, gc, 'j');
 
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
+		screen_write_putc(ctx, gc, 'x');
 	}
 	for (i = 1; i < ny - 1; i++) {
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
-		screen_write_putc(ctx, &gc, 'x');
+		screen_write_putc(ctx, gc, 'x');
 	}
 
 	screen_write_set_cursor(ctx, cx, cy);

--- a/tmux.1
+++ b/tmux.1
@@ -4258,6 +4258,24 @@ see the
 section.
 Attributes are ignored.
 .Pp
+.It Ic popup-style Ar style
+Set the popup style.
+For how to specify
+.Ar style ,
+see the
+.Sx STYLES
+section.
+Attributes are ignored.
+.Pp
+.It Ic popup-border-style Ar style
+Set the popup border style.
+For how to specify
+.Ar style ,
+see the
+.Sx STYLES
+section.
+Attributes are ignored.
+.Pp
 .It Ic window-status-activity-style Ar style
 Set status line style for windows with an activity alert.
 For how to specify

--- a/tmux.1
+++ b/tmux.1
@@ -4276,6 +4276,32 @@ see the
 section.
 Attributes are ignored.
 .Pp
+.It Ic popup-border-lines Ar type
+Set the type of characters used for drawing popup borders.
+.Ar type
+may be one of:
+.Bl -tag -width Ds
+.It single
+single lines using ACS or UTF-8 characters (default)
+.It rounded
+variation of single with rounded corners using UTF-8 characters
+.It double
+double lines using UTF-8 characters
+.It heavy
+heavy lines using UTF-8 characters
+.It simple
+simple ASCII characters
+.It padded
+simple ASCII space character
+.It none
+no border
+.El
+.Pp
+.Ql double
+and
+.Ql heavy
+will fall back to standard ACS line drawing when UTF-8 is not supported.
+.Pp
 .It Ic window-status-activity-style Ar style
 Set status line style for windows with an activity alert.
 For how to specify
@@ -5769,6 +5795,7 @@ forwards any input read from stdin to the empty pane given by
 .Tg popup
 .It Xo Ic display-popup
 .Op Fl BCE
+.Op Fl b Ar border-lines
 .Op Fl c Ar target-client
 .Op Fl d Ar start-directory
 .Op Fl e Ar environment
@@ -5809,8 +5836,21 @@ and
 give the width and height - both may be a percentage (followed by
 .Ql % ) .
 If omitted, half of the terminal size is used.
+.Pp
 .Fl B
 does not surround the popup by a border.
+.Pp
+.Fl b
+sets the type of border line for the popup.
+When
+.Fl B
+is specified the
+.Fl b
+option is ignored.
+See
+.Ic popup-border-lines
+for possible values for
+.Ar border-lines .
 .Pp
 .Fl e
 takes the form

--- a/tmux.h
+++ b/tmux.h
@@ -2690,7 +2690,7 @@ void	 screen_write_hline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
 	     const struct grid_cell *);
-void	 screen_write_box(struct screen_write_ctx *, u_int, u_int);
+void	 screen_write_box(struct screen_write_ctx *, u_int, u_int, struct grid_cell *gc);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 	     u_int);
 void	 screen_write_backspace(struct screen_write_ctx *);

--- a/tmux.h
+++ b/tmux.h
@@ -2700,7 +2700,8 @@ void	 screen_write_hline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
 	     const struct grid_cell *);
-void	 screen_write_box(struct screen_write_ctx *, u_int, u_int, struct grid_cell *gc);
+void	 screen_write_box(struct screen_write_ctx *, u_int, u_int,
+	    struct grid_cell *gc);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 	     u_int);
 void	 screen_write_backspace(struct screen_write_ctx *);

--- a/tmux.h
+++ b/tmux.h
@@ -614,6 +614,22 @@ struct colour_palette {
 #define GRID_LINE_EXTENDED 0x2
 #define GRID_LINE_DEAD 0x4
 
+#define CELL_INSIDE 0
+#define CELL_TOPBOTTOM 1
+#define CELL_LEFTRIGHT 2
+#define CELL_TOPLEFT 3
+#define CELL_TOPRIGHT 4
+#define CELL_BOTTOMLEFT 5
+#define CELL_BOTTOMRIGHT 6
+#define CELL_TOPJOIN 7
+#define CELL_BOTTOMJOIN 8
+#define CELL_LEFTJOIN 9
+#define CELL_RIGHTJOIN 10
+#define CELL_JOIN 11
+#define CELL_OUTSIDE 12
+
+#define CELL_BORDERS " xqlkmjwvtun~"
+
 /* Grid cell data. */
 struct grid_cell {
 	struct utf8_data	data;

--- a/tmux.h
+++ b/tmux.h
@@ -629,6 +629,8 @@ struct colour_palette {
 #define CELL_OUTSIDE 12
 
 #define CELL_BORDERS " xqlkmjwvtun~"
+#define SIMPLE_BORDERS " |-+++++++++."
+#define PADDED_BORDERS "             "
 
 /* Grid cell data. */
 struct grid_cell {
@@ -805,6 +807,7 @@ struct screen_write_ctx {
 	struct screen			*s;
 
 	int				 flags;
+	int				 box_lines;
 #define SCREEN_WRITE_SYNC 0x1
 #define SCREEN_WRITE_ZWJ 0x2
 
@@ -1084,6 +1087,63 @@ TAILQ_HEAD(winlink_stack, winlink);
 #define PANE_LINES_HEAVY 2
 #define PANE_LINES_SIMPLE 3
 #define PANE_LINES_NUMBER 4
+
+/* Popup border lines option. */
+#define POPUP_LINES_SINGLE 0
+#define POPUP_LINES_DOUBLE 1
+#define POPUP_LINES_HEAVY 2
+#define POPUP_LINES_SIMPLE 3
+#define POPUP_LINES_ROUNDED 4
+#define POPUP_LINES_PADDED 5
+#define POPUP_LINES_NONE 6
+
+static const struct utf8_data screen_redraw_double_borders[] = {
+	{ "", 0, 0, 0 },
+	{ "\342\225\221", 0, 3, 1 }, /* U+2551 */
+	{ "\342\225\220", 0, 3, 1 }, /* U+2550 */
+	{ "\342\225\224", 0, 3, 1 }, /* U+2554 */
+	{ "\342\225\227", 0, 3, 1 }, /* U+2557 */
+	{ "\342\225\232", 0, 3, 1 }, /* U+255A */
+	{ "\342\225\235", 0, 3, 1 }, /* U+255D */
+	{ "\342\225\246", 0, 3, 1 }, /* U+2566 */
+	{ "\342\225\251", 0, 3, 1 }, /* U+2569 */
+	{ "\342\225\240", 0, 3, 1 }, /* U+2560 */
+	{ "\342\225\243", 0, 3, 1 }, /* U+2563 */
+	{ "\342\225\254", 0, 3, 1 }, /* U+256C */
+	{ "\302\267",     0, 2, 1 }  /* U+00B7 */
+};
+
+static const struct utf8_data screen_redraw_heavy_borders[] = {
+	{ "", 0, 0, 0 },
+	{ "\342\224\203", 0, 3, 1 }, /* U+2503 */
+	{ "\342\224\201", 0, 3, 1 }, /* U+2501 */
+	{ "\342\224\217", 0, 3, 1 }, /* U+250F */
+	{ "\342\224\223", 0, 3, 1 }, /* U+2513 */
+	{ "\342\224\227", 0, 3, 1 }, /* U+2517 */
+	{ "\342\224\233", 0, 3, 1 }, /* U+251B */
+	{ "\342\224\263", 0, 3, 1 }, /* U+2533 */
+	{ "\342\224\273", 0, 3, 1 }, /* U+253B */
+	{ "\342\224\243", 0, 3, 1 }, /* U+2523 */
+	{ "\342\224\253", 0, 3, 1 }, /* U+252B */
+	{ "\342\225\213", 0, 3, 1 }, /* U+254B */
+	{ "\302\267",     0, 2, 1 }  /* U+00B7 */
+};
+
+static const struct utf8_data screen_redraw_rounded_borders[] = {
+       { "", 0, 0, 0 },
+       { "\342\224\202", 0, 3, 1 }, /* U+2502 */
+       { "\342\224\200", 0, 3, 1 }, /* U+2500 */
+       { "\342\225\255", 0, 3, 1 }, /* U+256D */
+       { "\342\225\256", 0, 3, 1 }, /* U+256E */
+       { "\342\225\260", 0, 3, 1 }, /* U+2570 */
+       { "\342\225\257", 0, 3, 1 }, /* U+256F */
+       { "\342\224\263", 0, 3, 1 }, /* U+2533 */
+       { "\342\224\273", 0, 3, 1 }, /* U+253B */
+       { "\342\224\243", 0, 3, 1 }, /* U+2523 */
+       { "\342\224\253", 0, 3, 1 }, /* U+252B */
+       { "\342\225\213", 0, 3, 1 }, /* U+254B */
+       { "\302\267",     0, 2, 1 }  /* U+00B7 */
+};
 
 /* Layout direction. */
 enum layout_type {
@@ -2083,6 +2143,9 @@ struct style	*options_string_to_style(struct options *, const char *,
 int		 options_from_string(struct options *,
 		     const struct options_table_entry *, const char *,
 		     const char *, int, char **);
+int		 string_choice_from_options(
+		     const struct options_table_entry *oe, const char *value,
+		     char **cause);
 void		 options_push_changes(const char *);
 int		 options_remove_or_default(struct options_entry *, int,
 		     char **);
@@ -3130,11 +3193,10 @@ int		 menu_key_cb(struct client *, void *, struct key_event *);
 /* popup.c */
 #define POPUP_CLOSEEXIT 0x1
 #define POPUP_CLOSEEXITZERO 0x2
-#define POPUP_NOBORDER 0x4
 #define POPUP_INTERNAL 0x8
 typedef void (*popup_close_cb)(int, void *);
 typedef void (*popup_finish_edit_cb)(char *, size_t, void *);
-int		 popup_display(int, struct cmdq_item *, u_int, u_int, u_int,
+int		 popup_display(int, int, struct cmdq_item *, u_int, u_int, u_int,
 		    u_int, struct environ *, const char *, int, char **,
 		    const char *, struct client *, struct session *,
 		    popup_close_cb, void *);

--- a/window-tree.c
+++ b/window-tree.c
@@ -519,7 +519,7 @@ window_tree_draw_label(struct screen_write_ctx *ctx, u_int px, u_int py,
 
 	if (ox > 1 && ox + len < sx - 1 && sy >= 3) {
 		screen_write_cursormove(ctx, px + ox - 1, py + oy - 1, 0);
-		screen_write_box(ctx, len + 2, 3);
+		screen_write_box(ctx, len + 2, 3, NULL);
 	}
 	screen_write_cursormove(ctx, px + ox, py + oy, 0);
 	screen_write_puts(ctx, gc, "%s", label);


### PR DESCRIPTION
This PR adds the `popup-border-lines` option and the `-b` flag to `display-popup` as suggested in [@nicm's comment on #2927](https://github.com/tmux/tmux/pull/2927#issuecomment-939905955):
> How about adding a popup-border-lines option also to allow -B to be set globally? Or if you want to be really clever it could have the more of the same values as pane-border-lines (none, single, double, heavy, simple?)

To test:
* Build and run tmux `./tmux -vv -f/dev/null -Ltest`
* Then test out the different popup borders (see `test_popup_border.sh` and screenshots below for example commands)

<details><summary><code>test_popup_border.sh</code>: Script to test various <code>border-popup-lines</code> combinations</summary>

```
#!/bin/ksh
./tmux set -g mouse on

./tmux set -gw popup-style bg=blue,fg=brightwhite
./tmux set -gw popup-border-style bg=cyan,fg=brightmagenta

popup_border_lines="single rounded heavy double simple padded none"

for style in $popup_border_lines; do
  clear;echo "\$ ./tmux popup -b $style \"echo popup -b $style\""
	# ./tmux display -p '#{popup-border-lines}'
  ./tmux popup -b $style "echo popup -b $style"
done

for style in $popup_border_lines; do
  clear; echo "\$ ./tmux popup -B -b $style \"echo popup -B -b $style\""
  ./tmux popup -B -b $style "echo popup -B -b $style"
done

for style in $popup_border_lines; do
  clear; echo "\$ ./tmux set -gw popup-border-lines $style"
  ./tmux set -gw popup-border-lines $style
  echo "\$ ./tmux popup \"echo popup-border-lines $style\""
  ./tmux popup "echo popup-border-lines $style"
  #./tmux set -gwU popup-border-lines
done

for style in $popup_border_lines; do
  clear; echo "\$ ./tmux set -gw popup-border-lines $style"
  ./tmux set -gw popup-border-lines $style
  echo "\$ ./tmux popup -B \"echo -B popup-border-lines $style\""
  ./tmux popup -B "echo -B popup-border-lines $style"
  #./tmux set -gwU popup-border-lines
done

clear; echo "\$ ./tmux set -gw popup-border-lines fancy"
./tmux set -gw popup-border-lines fancy
echo "\$ ./tmux popup -b fancy \"echo popup -b fancy\""
./tmux popup -b fancy "echo popup -b fancy"

#./tmux display -p '#{popup-border-lines}'
./tmux set -gwU popup-border-lines
```

</details>

* [tmux-client-62018.log](https://github.com/tmux/tmux/files/7336273/tmux-client-62018.log)
* [tmux-out-62030.log](https://github.com/tmux/tmux/files/7336275/tmux-out-62030.log)
* [tmux-server-62030.log](https://github.com/tmux/tmux/files/7336277/tmux-server-62030.log)

| Popup Border Lines | 📸 |
| --- | --- |
| `single` | ![image](https://user-images.githubusercontent.com/16507/137093566-01d7cef9-363e-457e-9f79-747cae1e93d6.png)|
| `rounded` | ![image](https://user-images.githubusercontent.com/16507/137093886-b06b4490-41ab-474a-b1c6-1b5bfef88d6a.png)|
| `heavy` | ![image](https://user-images.githubusercontent.com/16507/137094317-c5af4251-782d-4b43-913e-2b6392a2a091.png)|
| `double` | ![image](https://user-images.githubusercontent.com/16507/137094385-6fb23bcc-d27a-4442-87e8-a7d744a27299.png)|
| `simple` | ![image](https://user-images.githubusercontent.com/16507/137094425-f86c09db-2c37-4708-abb1-64e778f78e99.png)|
| `padded` | ![image](https://user-images.githubusercontent.com/16507/137094477-5183e545-8959-4552-b031-7ac03b2e33c4.png)|
| `none` | ![image](https://user-images.githubusercontent.com/16507/137094534-c4215ede-7bfd-4ac5-b795-80fc72925878.png)|
| Invalid value | ![image](https://user-images.githubusercontent.com/16507/137095601-d4755e82-b0b0-435b-adc7-2a3d60c1c65d.png)|

| Without `-B` option | With `-B` option |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/16507/137095880-5dd3e154-fde4-435b-b8a4-2e14809bfbfa.png)|![image](https://user-images.githubusercontent.com/16507/137095919-73a3fef9-2de6-46de-a2b1-a5fed1a77d4a.png)|
| ![image](https://user-images.githubusercontent.com/16507/137093566-01d7cef9-363e-457e-9f79-747cae1e93d6.png) | ![image](https://user-images.githubusercontent.com/16507/137096022-7cbd0641-b90d-4b00-a752-06e5f8cebaee.png)|

