### PR TITLE
Fix menu width containing disabled items

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -76,7 +76,7 @@ menu_add_item(struct menu *menu, const struct menu_item *item,
 		s = format_single_from_state(qitem, item->name, c, fs);
 	else
 		s = format_single(qitem, item->name, c, NULL, NULL, NULL);
-	if (*s == '\0') { /* no item if empty after format expanded */
+	if (*s == '\0') { /* No item if empty after format expanded */
 		menu->count--;
 		return;
 	}
@@ -100,6 +100,9 @@ menu_add_item(struct menu *menu, const struct menu_item *item,
 	new_item->key = item->key;
 
 	width = format_width(new_item->name);
+	/* Shorten width by 1 to disregard hyphen indicating disabled item */
+	if (*new_item->name == '-')
+		width--;
 	if (width > menu->width)
 		menu->width = width;
 }


### PR DESCRIPTION
This PR fixes an issue where the width of a menu is one character wider than the widest menu item when the menu contains at least one disabled menu item.

|| Only Enabled Items | With Disabled Item |
|---|---|---|
|Before|![2021-10-16-203846_825x514_scrot](https://user-images.githubusercontent.com/16507/137598901-5e84d912-7840-4025-a19b-568d66218771.png)|![2021-10-16-203857_825x514_scrot](https://user-images.githubusercontent.com/16507/137598903-b34603bf-0b7e-4240-814b-1efb53d4e398.png)|
|After|![2021-10-16-203943_825x514_scrot](https://user-images.githubusercontent.com/16507/137598909-ff01a6c1-c4e0-40c9-b81c-464fb81ed456.png)|![2021-10-16-203953_825x514_scrot](https://user-images.githubusercontent.com/16507/137598920-5caaa659-4f10-4753-8eda-8703c30b5249.png)|

