### PR TITLE
Add -T title argument to display-popup

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -52,10 +52,10 @@ const struct cmd_entry cmd_display_popup_entry = {
 	.name = "display-popup",
 	.alias = "popup",
 
-	.args = { "Bb:Cc:d:e:Eh:t:w:x:y:", 0, -1, NULL },
+	.args = { "Bb:Cc:d:e:Eh:t:T:w:x:y:", 0, -1, NULL },
 	.usage = "[-BCE] [-b border-lines] [-c target-client] "
 		 "[-d start-directory] [-e environment] [-h height] "
-		 CMD_TARGET_PANE_USAGE " "
+		 CMD_TARGET_PANE_USAGE " [-T title] "
 		 "[-w width] [-x position] [-y position] [shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -354,7 +354,7 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 	struct client		*tc = cmdq_get_target_client(item);
 	struct tty		*tty = &tc->tty;
 	const char		*value, *shell, *shellcmd = NULL;
-	char			*cwd, *cause = NULL, **argv = NULL;
+	char			*cwd, *cause = NULL, **argv = NULL, *title;
 	int			 flags = 0, argc = 0;
 	enum box_lines		 lines = BOX_LINES_DEFAULT;
 	u_int			 px, py, w, h, count = args_count(args);
@@ -396,6 +396,11 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 		h = tty->sy;
 	if (!cmd_display_menu_get_position(tc, item, args, &px, &py, w, h))
 		return (CMD_RETURN_NORMAL);
+
+	if (args_has(args, 'T'))
+		title = format_single_from_target(item, args_get(args, 'T'));
+	else
+		title = xstrdup("");
 
 	value = args_get(args, 'b');
 	if (args_has(args, 'B'))
@@ -443,7 +448,7 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 	else if (args_has(args, 'E'))
 		flags |= POPUP_CLOSEEXIT;
 	if (popup_display(flags, lines, item, px, py, w, h, env, shellcmd, argc,
-	    argv, cwd, tc, s, NULL, NULL) != 0) {
+	    argv, cwd, title, tc, s, NULL, NULL) != 0) {
 		cmd_free_argv(argc, argv);
 		if (env != NULL)
 			environ_free(env);

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -747,7 +747,7 @@ mode_tree_draw(struct mode_tree_data *mtd)
 		mti = mti->parent;
 
 	screen_write_cursormove(&ctx, 0, h, 0);
-	screen_write_box(&ctx, w, sy - h, BOX_LINES_DEFAULT, NULL);
+	screen_write_box(&ctx, w, sy - h, BOX_LINES_DEFAULT, NULL, NULL);
 
 	if (mtd->sort_list != NULL) {
 		xasprintf(&text, " %s (sort: %s%s)", mti->name,

--- a/popup.c
+++ b/popup.c
@@ -228,7 +228,7 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx, pd->sy);
 	} else if (pd->sx > 2 && pd->sy > 2) {
-		screen_write_box(&ctx, pd->sx, pd->sy, pd->lines, &bgc);
+		screen_write_box(&ctx, pd->sx, pd->sy, pd->lines, &bgc, NULL);
 		screen_write_cursormove(&ctx, 1, 1, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx - 2,
 		    pd->sy - 2);

--- a/popup.c
+++ b/popup.c
@@ -31,6 +31,7 @@ struct popup_data {
 	struct cmdq_item	 *item;
 	int			  flags;
 	enum box_lines		  lines;
+	char			 *title;
 
 	struct screen		  s;
 	struct colour_palette	  palette;
@@ -228,7 +229,8 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx, pd->sy);
 	} else if (pd->sx > 2 && pd->sy > 2) {
-		screen_write_box(&ctx, pd->sx, pd->sy, pd->lines, &bgc, NULL);
+		screen_write_box(&ctx, pd->sx, pd->sy, pd->lines, &bgc,
+		    pd->title);
 		screen_write_cursormove(&ctx, 1, 1, 0);
 		screen_write_fast_copy(&ctx, &pd->s, 0, 0, pd->sx - 2,
 		    pd->sy - 2);
@@ -286,6 +288,7 @@ popup_free_cb(struct client *c, void *data)
 	screen_free(&pd->s);
 	colour_palette_free(&pd->palette);
 
+	free(pd->title);
 	free(pd);
 }
 
@@ -631,8 +634,8 @@ popup_job_complete_cb(struct job *job)
 int
 popup_display(int flags, enum box_lines lines, struct cmdq_item *item, u_int px,
     u_int py, u_int sx, u_int sy, struct environ *env, const char *shellcmd,
-    int argc, char **argv, const char *cwd, struct client *c, struct session *s,
-    popup_close_cb cb, void *arg)
+    int argc, char **argv, const char *cwd, char *t, struct client *c,
+    struct session *s, popup_close_cb cb, void *arg)
 {
 	struct popup_data	*pd;
 	u_int			 jx, jy;
@@ -663,6 +666,7 @@ popup_display(int flags, enum box_lines lines, struct cmdq_item *item, u_int px,
 	pd->item = item;
 	pd->flags = flags;
 	pd->lines = lines;
+	pd->title = t;
 
 	pd->c = c;
 	pd->c->references++;
@@ -775,7 +779,8 @@ popup_editor(struct client *c, const char *buf, size_t len,
 
 	xasprintf(&cmd, "%s %s", editor, path);
 	if (popup_display(POPUP_INTERNAL|POPUP_CLOSEEXIT, BOX_LINES_DEFAULT,
-	    NULL, px, py, sx, sy, NULL, cmd, 0, NULL, _PATH_TMP, c, NULL,
+	    // TODO: Helpful to use path as a title?
+	    NULL, px, py, sx, sy, NULL, cmd, 0, NULL, _PATH_TMP, NULL, c, NULL,
 	    popup_editor_close_cb, pe) != 0) {
 		popup_editor_free(pe);
 		free(cmd);

--- a/screen-write.c
+++ b/screen-write.c
@@ -646,9 +646,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu,
 	memcpy(&default_gc, &grid_default_cell, sizeof default_gc);
 
 	screen_write_box(ctx, menu->width + 4, menu->count + 2,
-	    BOX_LINES_DEFAULT, NULL);
-	screen_write_cursormove(ctx, cx + 2, cy, 0);
-	format_draw(ctx, &default_gc, menu->width, menu->title, NULL);
+	    BOX_LINES_DEFAULT, &default_gc, menu->title);
 
 	for (i = 0; i < menu->count; i++) {
 		name = menu->items[i].name;
@@ -714,7 +712,7 @@ screen_write_box_border_set(enum box_lines box_lines, int cell_type,
 /* Draw a box on screen. */
 void
 screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
-    enum box_lines l, const struct grid_cell *gcp)
+    enum box_lines l, const struct grid_cell *gcp, const char *title)
 {
 	struct screen		*s = ctx->s;
 	struct grid_cell         gc;
@@ -727,6 +725,7 @@ screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
 		memcpy(&gc, gcp, sizeof gc);
 	else
 		memcpy(&gc, &grid_default_cell, sizeof gc);
+
 	gc.attr |= GRID_ATTR_CHARSET;
 	gc.flags |= GRID_FLAG_NOPALETTE;
 
@@ -758,6 +757,13 @@ screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
 		/* right side */
 		screen_write_set_cursor(ctx, cx + nx - 1, cy + i);
 		screen_write_cell(ctx, &gc);
+	}
+
+
+	if (title != NULL) {
+                gc.attr &= ~GRID_ATTR_CHARSET;
+		screen_write_cursormove(ctx, cx + 2, cy, 0);
+		format_draw(ctx, &gc, nx - 4, title, NULL);
 	}
 
 	screen_write_set_cursor(ctx, cx, cy);

--- a/screen-write.c
+++ b/screen-write.c
@@ -712,7 +712,7 @@ screen_write_box_border_set(enum box_lines box_lines, int cell_type,
 /* Draw a box on screen. */
 void
 screen_write_box(struct screen_write_ctx *ctx, u_int nx, u_int ny,
-    enum box_lines l, const struct grid_cell *gcp, const char *title)
+    enum box_lines l, const struct grid_cell *gcp, char *title)
 {
 	struct screen		*s = ctx->s;
 	struct grid_cell         gc;

--- a/tmux.1
+++ b/tmux.1
@@ -5801,6 +5801,7 @@ forwards any input read from stdin to the empty pane given by
 .Op Fl e Ar environment
 .Op Fl h Ar height
 .Op Fl t Ar target-pane
+.Op Fl T Ar title
 .Op Fl w Ar width
 .Op Fl x Ar position
 .Op Fl y Ar position
@@ -5857,6 +5858,10 @@ takes the form
 .Ql VARIABLE=value
 and sets an environment variable for the popup; it may be specified multiple
 times.
+.Pp
+.Fl T
+is a format for the popup title (see
+.Sx FORMATS ) .
 .Pp
 The
 .Fl C

--- a/tmux.h
+++ b/tmux.h
@@ -2738,7 +2738,7 @@ void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
 	     const struct grid_cell *);
 void	 screen_write_box(struct screen_write_ctx *, u_int, u_int, int,
-	     const struct grid_cell *);
+	     const struct grid_cell *, const char *);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 	     u_int);
 void	 screen_write_backspace(struct screen_write_ctx *);

--- a/tmux.h
+++ b/tmux.h
@@ -2738,7 +2738,7 @@ void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
 	     const struct grid_cell *);
 void	 screen_write_box(struct screen_write_ctx *, u_int, u_int, int,
-	     const struct grid_cell *, const char *);
+	     const struct grid_cell *, char *);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 	     u_int);
 void	 screen_write_backspace(struct screen_write_ctx *);
@@ -3156,7 +3156,7 @@ typedef void (*popup_close_cb)(int, void *);
 typedef void (*popup_finish_edit_cb)(char *, size_t, void *);
 int		 popup_display(int, int, struct cmdq_item *, u_int, u_int,
 		    u_int, u_int, struct environ *, const char *, int, char **,
-		    const char *, struct client *, struct session *,
+		    const char *, char *, struct client *, struct session *,
 		    popup_close_cb, void *);
 int		 popup_editor(struct client *, const char *, size_t,
 		    popup_finish_edit_cb, void *);

--- a/window-tree.c
+++ b/window-tree.c
@@ -519,7 +519,8 @@ window_tree_draw_label(struct screen_write_ctx *ctx, u_int px, u_int py,
 
 	if (ox > 1 && ox + len < sx - 1 && sy >= 3) {
 		screen_write_cursormove(ctx, px + ox - 1, py + oy - 1, 0);
-		screen_write_box(ctx, len + 2, 3, BOX_LINES_DEFAULT, NULL);
+		screen_write_box(ctx, len + 2, 3, BOX_LINES_DEFAULT, NULL,
+		    NULL);
 	}
 	screen_write_cursormove(ctx, px + ox, py + oy, 0);
 	screen_write_puts(ctx, gc, "%s", label);


### PR DESCRIPTION
Given that popups and menus in tmux are quite similar and share common code it seems useful to add the possibility to set a title on a popup with the `-T` argument.

For the implementation I added the capability to render a title to `screen_write_box`, this would potentially allow for a title position of either top or bottom (or even on the sides if we wanted to go really crazy). What are your thoughts on that, @nicm?

Not sure if `popup_data` is the best place to keep

To test:

* Build and run tmux `make -j$(sysctl -n hw.ncpu); ./tmux -vv -f/dev/null -Ltest`
* Display a popup with a title: `./tmux popup -T 'Popup with Title'
* Verify that the menu title refactoring did not introduce any regression by displaying a menu with a title

<details><summary><code>test_popup_title.sh</code> Test Script</summary>

```
#!/bin/ksh

clear; echo "\$ ./tmux popup -T '#[align=centre]Visor' echo \"Popup with Title\""
./tmux popup -T '#[align=centre]Popup Title' echo "Popup with Title"
clear; echo "\$ ./tmux menu -T '#[align=right]Menu Title' Menu '' '' with '' '' title 'M-C-Right' ''"
./tmux menu -T '#[align=right]Menu Title' Menu '' '' with '' '' title 'M-C-Right' ''
```

</details>

| Popup with Title | Menu with Title |
| --- | --- |
|![2021-10-20-100405_905x562_scrot](https://user-images.githubusercontent.com/16507/138053264-ff3274be-400b-467f-846f-20e288413746.png)|![2021-10-20-100418_905x562_scrot](https://user-images.githubusercontent.com/16507/138053257-ad72d558-ab85-496e-aa5b-6d163a39d568.png)|