### PR TITLE
Fix handling of ST terminator when parsing OSC-52 reply

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1186,7 +1186,7 @@ tty_keys_clipboard(__unused struct tty *tty, const char *buf, size_t len,
 		return (1);
 
 	/* Find the terminator if any. */
-	for (end = 5; end < len; end++) {
+	for (end = 5, terminator = 0; end < len; end++) {
 		if (buf[end] == '\007') {
 			terminator = 1;
 			break;
@@ -1203,6 +1203,9 @@ tty_keys_clipboard(__unused struct tty *tty, const char *buf, size_t len,
 	/* Skip the initial part. */
 	buf += 5;
 	end -= 5;
+
+	/* Adjust end so that it points to the *start* of the terminator sequence */
+	end -= terminator - 1;
 
 	/* Get the second argument. */
 	while (end != 0 && *buf != ';') {


### PR DESCRIPTION
While parsing an OSC-52 reply, we search the input buffer for both `BEL` and `ST`.

Once one of them has been found, we proceed to copy and base64 decode the payload, and then adding the decoded data to a new paste buffer.

The check for `ST` looks backward in the buffer. I.e. it checks if the *previous* character is `ESC`, and the *current* character is `\`.

This means, our ‘end’ index points to the **end** of the terminator. This is correct when calculating the length of the entire escape sequence, which is done immediately after having found the terminator.

It is however **not** correct when copying out the payload. When an OSC-52 reply is `ST` terminated, we end up including `ESC` in the payload. This in turn causes the base64 decode to fail, and no paste buffer is created.

Note: I had to initialize `terminator` to silence a "may be used uninitialized" warning. Not sure why the assignment to `*size` a couple of lines up doesn't trigger this warning. In any case, the warning should be a false positive, since we'll either have found a terminator, or `end == len` (and thus we return before using `terminator`).

Originally reported here: https://codeberg.org/dnkl/foot/issues/752