### PR TITLE
Add support to set cursor style via OSC 50

### DIFF
--- a/input.c
+++ b/input.c
@@ -2652,19 +2652,23 @@ input_osc_50(struct input_ctx *ictx, const char *p)
 		s = 0;
 		break;
 	case SCREEN_CURSOR_BLOCK:
-		s = 2;
+		s = 1;
 		break;
 	case SCREEN_CURSOR_UNDERLINE:
-		s = 4;
+		s = 3;
 		break;
 	case SCREEN_CURSOR_BAR:
-		s = 6;
+		s = 5;
 		break;
 	case -1:
 	default:
 		log_debug("bad OSC 50: '%s'", p);
 		return;
 	}
+
+	if (s > 0 &&
+	    (wp->screen->mode & MODE_CURSOR_BLINKING) != MODE_CURSOR_BLINKING)
+		s++;
 	screen_set_cursor_style(wp->screen, s);
 }
 


### PR DESCRIPTION
To test:
* Build and run tmux: `./tmux -vv -f/dev/null -Ltest`
* Issue OSC sequence for the cursor shapes 0 through 3: `echo -en "\033]50;CursorShape=2"`

| CursorShape | 📸 |
| --- | --- |
| default | ![image](https://user-images.githubusercontent.com/16507/138588590-ef5173b5-b585-453e-9cb2-9908b9924583.png)|
| block | ![image](https://user-images.githubusercontent.com/16507/138588613-539e3934-2bb0-4ad9-b98a-8edc22ba2587.png)|
| underline | ![image](https://user-images.githubusercontent.com/16507/138588661-60e07db7-e9d5-4193-b764-ce58243ad803.png)|
| bar | ![image](https://user-images.githubusercontent.com/16507/138588634-06b04460-68fb-41ba-af94-e18c6822a264.png)|
