### PR TITLE
Add options for cursor-style and cursor-colour

### DIFF
--- a/input.c
+++ b/input.c
@@ -2442,7 +2442,7 @@ input_top_bit_set(struct input_ctx *ictx)
 }
 
 /* Parse colour from OSC. */
-static int
+int
 input_osc_parse_colour(const char *p)
 {
 	double	 c, m, y, k = 0;

--- a/options-table.c
+++ b/options-table.c
@@ -53,12 +53,12 @@ static const char *options_table_status_position_list[] = {
 static const char *options_table_bell_action_list[] = {
 	"none", "any", "current", "other", NULL
 };
+static const char *options_table_visual_bell_list[] = {
+	"off", "on", "both", NULL
+};
 static const char *options_table_cursor_style_list[] = {
 	"default", "block-blinking", "block", "underline-blinking", "underline",
 	"bar-blinking", "bar", NULL
-};
-static const char *options_table_visual_bell_list[] = {
-	"off", "on", "both", NULL
 };
 static const char *options_table_pane_status_list[] = {
 	"off", "top", "bottom", NULL
@@ -242,7 +242,7 @@ const struct options_table_entry options_table[] = {
 	{ .name = "cursor-colour",
 	  .type = OPTIONS_TABLE_COLOUR,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
-	  .default_str = "default",
+	  .default_num = -1,
 	  .text = "Color of the cursor."
 	},
 

--- a/options-table.c
+++ b/options-table.c
@@ -53,6 +53,10 @@ static const char *options_table_status_position_list[] = {
 static const char *options_table_bell_action_list[] = {
 	"none", "any", "current", "other", NULL
 };
+static const char *options_table_cursor_style_list[] = {
+	"default", "block-blinking", "block", "underline-blinking", "underline",
+	"bar-blinking", "bar", NULL
+};
 static const char *options_table_visual_bell_list[] = {
 	"off", "on", "both", NULL
 };
@@ -187,6 +191,7 @@ const struct options_name_map options_other_names[] = {
 	{ "display-panes-color", "display-panes-colour" },
 	{ "display-panes-active-color", "display-panes-active-colour" },
 	{ "clock-mode-color", "clock-mode-colour" },
+	{ "cursor-color", "cursor-colour" },
 	{ "pane-colors", "pane-colours" },
 	{ NULL, NULL }
 };
@@ -232,6 +237,21 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "",
 	  .text = "Shell command run when text is copied. "
 		  "If empty, no command is run."
+	},
+
+	{ .name = "cursor-colour",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "default",
+	  .text = "Color of the cursor."
+	},
+
+	{ .name = "cursor-style",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .choices = options_table_cursor_style_list,
+	  .default_num = SCREEN_CURSOR_DEFAULT,
+	  .text = "Style of the cursor."
 	},
 
 	{ .name = "default-terminal",

--- a/options-table.c
+++ b/options-table.c
@@ -243,14 +243,14 @@ const struct options_table_entry options_table[] = {
 	  .type = OPTIONS_TABLE_COLOUR,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_num = -1,
-	  .text = "Color of the cursor."
+	  .text = "Colour of the cursor."
 	},
 
 	{ .name = "cursor-style",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .choices = options_table_cursor_style_list,
-	  .default_num = SCREEN_CURSOR_DEFAULT,
+	  .default_num = 0,
 	  .text = "Style of the cursor."
 	},
 

--- a/options-table.c
+++ b/options-table.c
@@ -240,15 +240,15 @@ const struct options_table_entry options_table[] = {
 	},
 
 	{ .name = "cursor-colour",
-	  .type = OPTIONS_TABLE_STRING,
-	  .scope = OPTIONS_TABLE_WINDOW,
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_str = "default",
 	  .text = "Color of the cursor."
 	},
 
 	{ .name = "cursor-style",
 	  .type = OPTIONS_TABLE_CHOICE,
-	  .scope = OPTIONS_TABLE_WINDOW,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .choices = options_table_cursor_style_list,
 	  .default_num = SCREEN_CURSOR_DEFAULT,
 	  .text = "Style of the cursor."

--- a/options.c
+++ b/options.c
@@ -1128,9 +1128,10 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows) {
 			if (w->active == NULL)
 				continue;
-			if (options_get_string(w->options, name))
+			if (options_get_number(w->options, name))
 				screen_set_cursor_colour(w->active->screen,
-				    options_get_string(w->options, name));
+				    colour_tostring(options_get_number(
+					w->options, name)));
 		}
 	}
 	if (strcmp(name, "key-table") == 0) {

--- a/options.c
+++ b/options.c
@@ -1116,16 +1116,18 @@ options_push_changes(const char *name)
 		}
 	}
 	if (strcmp(name, "cursor-colour") == 0) {
-		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
 			wp->screen->default_ccolour =
 			options_get_number(wp->options, name);
+		}
 	}
 	if (strcmp(name, "cursor-style") == 0) {
-		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
 			screen_set_cursor_style_mode(
 			    options_get_number(wp->options, name),
 			    &wp->screen->default_cstyle,
 			    &wp->screen->default_mode);
+		}
 	}
 	if (strcmp(name, "key-table") == 0) {
 		TAILQ_FOREACH(loop, &clients, entry)

--- a/options.c
+++ b/options.c
@@ -1111,24 +1111,21 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows) {
 			if (w->active == NULL)
 				continue;
-			if (options_get_number(w->options, name))
+			int option = options_get_number(w->options, name);
 				w->active->flags |= PANE_CHANGED;
 		}
 	}
-	if (strcmp(name, "cursor-style") == 0) {
-		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
-			if (options_get_number(wp->options, name))
-				screen_set_cursor_style(wp->screen,
-				    options_get_number(wp->options, name));
-		}
-	}
 	if (strcmp(name, "cursor-colour") == 0) {
-		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
-			if (options_get_number(wp->options, name))
-				screen_set_cursor_colour(wp->screen,
-				    colour_tostring(options_get_number(
-					wp->options, name)));
-		}
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
+			wp->screen->default_ccolour =
+			options_get_number(wp->options, name);
+	}
+	if (strcmp(name, "cursor-style") == 0) {
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
+			screen_set_cursor_style_mode(
+			    options_get_number(wp->options, name),
+			    &wp->screen->default_cstyle,
+			    &wp->screen->default_mode);
 	}
 	if (strcmp(name, "key-table") == 0) {
 		TAILQ_FOREACH(loop, &clients, entry)

--- a/options.c
+++ b/options.c
@@ -1116,22 +1116,18 @@ options_push_changes(const char *name)
 		}
 	}
 	if (strcmp(name, "cursor-style") == 0) {
-		RB_FOREACH(w, windows, &windows) {
-			if (w->active == NULL)
-				continue;
-			if (options_get_number(w->options, name))
-				screen_set_cursor_style(w->active->screen,
-				    options_get_number(w->options, name));
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
+			if (options_get_number(wp->options, name))
+				screen_set_cursor_style(wp->screen,
+				    options_get_number(wp->options, name));
 		}
 	}
 	if (strcmp(name, "cursor-colour") == 0) {
-		RB_FOREACH(w, windows, &windows) {
-			if (w->active == NULL)
-				continue;
-			if (options_get_number(w->options, name))
-				screen_set_cursor_colour(w->active->screen,
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
+			if (options_get_number(wp->options, name))
+				screen_set_cursor_colour(wp->screen,
 				    colour_tostring(options_get_number(
-					w->options, name)));
+					wp->options, name)));
 		}
 	}
 	if (strcmp(name, "key-table") == 0) {

--- a/options.c
+++ b/options.c
@@ -1111,8 +1111,26 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows) {
 			if (w->active == NULL)
 				continue;
-			if (options_get_number(w->options, "automatic-rename"))
+			if (options_get_number(w->options, name))
 				w->active->flags |= PANE_CHANGED;
+		}
+	}
+	if (strcmp(name, "cursor-style") == 0) {
+		RB_FOREACH(w, windows, &windows) {
+			if (w->active == NULL)
+				continue;
+			if (options_get_number(w->options, name))
+				screen_set_cursor_style(w->active->screen,
+				    options_get_number(w->options, name));
+		}
+	}
+	if (strcmp(name, "cursor-colour") == 0) {
+		RB_FOREACH(w, windows, &windows) {
+			if (w->active == NULL)
+				continue;
+			if (options_get_string(w->options, name))
+				screen_set_cursor_colour(w->active->screen,
+				    options_get_string(w->options, name));
 		}
 	}
 	if (strcmp(name, "key-table") == 0) {

--- a/tmux.1
+++ b/tmux.1
@@ -4420,13 +4420,13 @@ Set the colour of the cursor.
 .Pp
 .It Ic cursor-style Ar style
 Set the style of the cursor. Available styles are:
-.Ql default ,
-.Ql block-blinking ,
-.Ql block ,
-.Ql underline-blinking ,
-.Ql underline ,
-.Ql bar-blinking ,
-.Ql bar .
+.Ic default ,
+.Ic block-blinking ,
+.Ic block ,
+.Ic underline-blinking ,
+.Ic underline ,
+.Ic bar-blinking ,
+.Ic bar .
 .Pp
 .It Ic pane-colours[] Ar colour
 The default colour palette.

--- a/tmux.1
+++ b/tmux.1
@@ -4415,6 +4415,19 @@ The alternate screen feature preserves the contents of the window when an
 interactive application starts and restores it on exit, so that any output
 visible before the application starts reappears unchanged after it exits.
 .Pp
+.It Ic cursor-colour Ar colour
+Set the colour of the cursor.
+.Pp
+.It Ic cursor-style Ar style
+Set the style of the cursor. Available styles are:
+.Ql default ,
+.Ql block-blinking ,
+.Ql block ,
+.Ql underline-blinking ,
+.Ql underline ,
+.Ql bar-blinking ,
+.Ql bar .
+.Pp
 .It Ic pane-colours[] Ar colour
 The default colour palette.
 Each entry in the array defines the colour

--- a/tmux.h
+++ b/tmux.h
@@ -780,12 +780,15 @@ struct screen {
 	u_int				 cy;	  /* cursor y */
 
 	enum screen_cursor_style	 cstyle;  /* cursor style */
-	char				*ccolour; /* cursor colour */
+	enum screen_cursor_style	 default_cstyle;
+	int				 ccolour; /* cursor colour */
+	int				 default_ccolour;
 
 	u_int				 rupper;  /* scroll region top */
 	u_int				 rlower;  /* scroll region bottom */
 
 	int				 mode;
+	int				 default_mode;
 
 	u_int				 saved_cx;
 	u_int				 saved_cy;
@@ -2599,6 +2602,7 @@ void	 recalculate_sizes_now(int);
 struct input_ctx *input_init(struct window_pane *, struct bufferevent *,
 	     struct colour_palette *);
 void	 input_free(struct input_ctx *);
+int	 input_osc_parse_colour(const char *);
 void	 input_reset(struct input_ctx *, int);
 struct evbuffer *input_pending(struct input_ctx *);
 void	 input_parse_pane(struct window_pane *);
@@ -2791,6 +2795,7 @@ void	 screen_reinit(struct screen *);
 void	 screen_free(struct screen *);
 void	 screen_reset_tabs(struct screen *);
 void	 screen_set_cursor_style(struct screen *, u_int);
+void	 screen_set_cursor_style_mode(u_int, enum screen_cursor_style *, int *);
 void	 screen_set_cursor_colour(struct screen *, const char *);
 int	 screen_set_title(struct screen *, const char *);
 void	 screen_set_path(struct screen *, const char *);

--- a/tmux.h
+++ b/tmux.h
@@ -1280,7 +1280,7 @@ struct tty {
 	u_int		 cx;
 	u_int		 cy;
 	enum screen_cursor_style cstyle;
-	char		*ccolour;
+	int		 ccolour;
 
 	int		 oflag;
 	u_int		 oox;

--- a/tty.c
+++ b/tty.c
@@ -663,14 +663,26 @@ tty_force_cursor_colour(struct tty *tty, const char *ccolour)
 static void
 tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 {
-	enum screen_cursor_style cstyle;
+	enum		 screen_cursor_style cstyle;
+	int		 ccolour, cmode = mode;
+	const char	*colour;
 
 	/* Set cursor colour if changed. */
-	if (s != NULL && strcmp(s->ccolour, tty->ccolour) != 0)
-		tty_force_cursor_colour(tty, s->ccolour);
+	if (s != NULL) {
+		ccolour = s->ccolour;
+		if (ccolour == -1)
+			ccolour = s->default_ccolour;
+		ccolour = colour_force_rgb(ccolour);
+		if (ccolour == -1)
+			colour = "";
+		else
+			colour = colour_tostring(ccolour);
+		if (strcmp(colour, tty->ccolour) != 0)
+			tty_force_cursor_colour(tty, colour);
+	}
 
 	/* If cursor is off, set as invisible. */
-	if (~mode & MODE_CURSOR) {
+	if (~cmode & MODE_CURSOR) {
 		if (changed & MODE_CURSOR)
 			tty_putcode(tty, TTYC_CIVIS);
 		return;
@@ -679,8 +691,13 @@ tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 	/* Check if blinking or very visible flag changed or style changed. */
 	if (s == NULL)
 		cstyle = tty->cstyle;
-	else
+	else {
 		cstyle = s->cstyle;
+		if (cstyle == SCREEN_CURSOR_DEFAULT) {
+			cstyle = s->default_cstyle;
+			cmode = s->default_mode;
+		}
+	}
 	if ((changed & CURSOR_MODES) == 0 && cstyle == tty->cstyle)
 		return;
 
@@ -700,34 +717,34 @@ tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 			else
 				tty_putcode1(tty, TTYC_SS, 0);
 		}
-		if (mode & (MODE_CURSOR_BLINKING|MODE_CURSOR_VERY_VISIBLE))
+		if (cmode & (MODE_CURSOR_BLINKING|MODE_CURSOR_VERY_VISIBLE))
 			tty_putcode(tty, TTYC_CVVIS);
 		break;
 	case SCREEN_CURSOR_BLOCK:
 		if (tty_term_has(tty->term, TTYC_SS)) {
-			if (mode & MODE_CURSOR_BLINKING)
+			if (cmode & MODE_CURSOR_BLINKING)
 				tty_putcode1(tty, TTYC_SS, 1);
 			else
 				tty_putcode1(tty, TTYC_SS, 2);
-		} else if (mode & MODE_CURSOR_BLINKING)
+		} else if (cmode & MODE_CURSOR_BLINKING)
 			tty_putcode(tty, TTYC_CVVIS);
 		break;
 	case SCREEN_CURSOR_UNDERLINE:
 		if (tty_term_has(tty->term, TTYC_SS)) {
-			if (mode & MODE_CURSOR_BLINKING)
+			if (cmode & MODE_CURSOR_BLINKING)
 				tty_putcode1(tty, TTYC_SS, 3);
 			else
 				tty_putcode1(tty, TTYC_SS, 4);
-		} else if (mode & MODE_CURSOR_BLINKING)
+		} else if (cmode & MODE_CURSOR_BLINKING)
 			tty_putcode(tty, TTYC_CVVIS);
 		break;
 	case SCREEN_CURSOR_BAR:
 		if (tty_term_has(tty->term, TTYC_SS)) {
-			if (mode & MODE_CURSOR_BLINKING)
+			if (cmode & MODE_CURSOR_BLINKING)
 				tty_putcode1(tty, TTYC_SS, 5);
 			else
 				tty_putcode1(tty, TTYC_SS, 6);
-		} else if (mode & MODE_CURSOR_BLINKING)
+		} else if (cmode & MODE_CURSOR_BLINKING)
 			tty_putcode(tty, TTYC_CVVIS);
 		break;
 	}

--- a/tty.c
+++ b/tty.c
@@ -38,7 +38,7 @@ static int	tty_client_ready(struct client *);
 
 static void	tty_set_italics(struct tty *);
 static int	tty_try_colour(struct tty *, int, const char *);
-static void	tty_force_cursor_colour(struct tty *, const char *);
+static void	tty_force_cursor_colour(struct tty *, int);
 static void	tty_cursor_pane(struct tty *, const struct tty_ctx *, u_int,
 		    u_int);
 static void	tty_cursor_pane_unless_wrap(struct tty *,
@@ -105,7 +105,7 @@ tty_init(struct tty *tty, struct client *c)
 	tty->client = c;
 
 	tty->cstyle = SCREEN_CURSOR_DEFAULT;
-	tty->ccolour = xstrdup("");
+	tty->ccolour = -1;
 
 	if (tcgetattr(c->fd, &tty->tio) != 0)
 		return (-1);
@@ -341,8 +341,8 @@ tty_start_tty(struct tty *tty)
 	tty->flags |= TTY_STARTED;
 	tty_invalidate(tty);
 
-	if (*tty->ccolour != '\0')
-		tty_force_cursor_colour(tty, "");
+	if (tty->ccolour != -1)
+		tty_force_cursor_colour(tty, -1);
 
 	tty->mouse_drag_flag = 0;
 	tty->mouse_drag_update = NULL;
@@ -406,7 +406,7 @@ tty_stop_tty(struct tty *tty)
 	}
 	if (tty->mode & MODE_BRACKETPASTE)
 		tty_raw(tty, tty_term_string(tty->term, TTYC_DSBP));
-	if (*tty->ccolour != '\0')
+	if (tty->ccolour != -1)
 		tty_raw(tty, tty_term_string(tty->term, TTYC_CR));
 
 	tty_raw(tty, tty_term_string(tty->term, TTYC_CNORM));
@@ -451,7 +451,6 @@ void
 tty_free(struct tty *tty)
 {
 	tty_close(tty);
-	free(tty->ccolour);
 }
 
 void
@@ -650,41 +649,37 @@ tty_set_title(struct tty *tty, const char *title)
 }
 
 static void
-tty_force_cursor_colour(struct tty *tty, const char *ccolour)
+tty_force_cursor_colour(struct tty *tty, int c)
 {
-	if (*ccolour == '\0')
+	u_char	r, g, b;
+	char	s[13] = "";
+
+	if (c != -1)
+		c = colour_force_rgb(c);
+	if (c == tty->ccolour)
+		return;
+	if (c == -1)
 		tty_putcode(tty, TTYC_CR);
-	else
-		tty_putcode_ptr1(tty, TTYC_CS, ccolour);
-	free(tty->ccolour);
-	tty->ccolour = xstrdup(ccolour);
+	else {
+		colour_split_rgb(c, &r, &g, &b);
+		xsnprintf(s, sizeof s, "rgb:%02hhx/%02hhx/%02hhx", r, g, b);
+		tty_putcode_ptr1(tty, TTYC_CS, s);
+	}
+	tty->ccolour = c;
 }
 
 static void
 tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 {
-	enum		 screen_cursor_style cstyle;
-	int		 ccolour, cmode = mode;
-	static char	 colour[13];
-	u_char		 r, g, b;
+	enum screen_cursor_style	cstyle;
+	int				ccolour, cmode = mode;
 
 	/* Set cursor colour if changed. */
 	if (s != NULL) {
 		ccolour = s->ccolour;
-		if (ccolour == -1)
+		if (s->ccolour == -1)
 			ccolour = s->default_ccolour;
-		ccolour = colour_force_rgb(ccolour);
-		if (ccolour == -1)
-			*colour = '\0';
-		else {
-			colour_split_rgb(ccolour, &r, &g, &b);
-			xsnprintf(colour, sizeof colour,
-			    "rgb:%02hhx/%02hhx/%02hhx", r, g, b);
-
-		}
-		if (strcmp(colour, tty->ccolour) != 0) {
-			tty_force_cursor_colour(tty, colour);
-		}
+		tty_force_cursor_colour(tty, ccolour);
 	}
 
 	/* If cursor is off, set as invisible. */

--- a/tty.c
+++ b/tty.c
@@ -665,7 +665,8 @@ tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 {
 	enum		 screen_cursor_style cstyle;
 	int		 ccolour, cmode = mode;
-	const char	*colour;
+	static char	 colour[13];
+	u_char		 r, g, b;
 
 	/* Set cursor colour if changed. */
 	if (s != NULL) {
@@ -674,11 +675,16 @@ tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 			ccolour = s->default_ccolour;
 		ccolour = colour_force_rgb(ccolour);
 		if (ccolour == -1)
-			colour = "";
-		else
-			colour = colour_tostring(ccolour);
-		if (strcmp(colour, tty->ccolour) != 0)
+			*colour = '\0';
+		else {
+			colour_split_rgb(ccolour, &r, &g, &b);
+			xsnprintf(colour, sizeof colour,
+			    "rgb:%02hhx/%02hhx/%02hhx", r, g, b);
+
+		}
+		if (strcmp(colour, tty->ccolour) != 0) {
 			tty_force_cursor_colour(tty, colour);
+		}
 	}
 
 	/* If cursor is off, set as invisible. */


### PR DESCRIPTION
To test:
* Build and run tmux: `./tmux -vv -f/dev/null -Ltest`
* Set the different styles for the cursor: `./tmux set cursor-style $style` where `$style` is on of:`default`, `block-blinking`, `block`, `underline-blinking`, `underline`, `bar-blinking`, `bar`
* Set the different colours for the cursor: `./tmux set cursor-colour $(awk 'BEGIN{srand();printf ("#%x%x%x", rand()*255, rand()*255, rand()*255)}')`

@nicm, I'm curious on your thoughts regarding the cursor-style choices: Do you agree that each style should also have a `-blinking` variant?

Additionally I'm uncertain as to whether setting the screen cursor style and colour in `options_push` is done properly. Is it really necessary to loop over the windows or is there a shortcut to access the "single" screen?

ℹ️ If the changes in this PR are applied the **Options for default cursor style and colour.** item can be removed from the [Contribution — Small things](https://github.com/tmux/tmux/wiki/Contributing#small-things) wiki page

Update: Add scripts for testing `cursor-colour` and `cursor-style` options below

<details><summary><code>test_cursor_colour.sh</code></summary>

```
#!/bin/ksh

echo "Cursor should be default. Enter to continue"; read
./tmux set cursor-colour crimson
echo "Cursor should be crimson. Enter to continue"; read
echo -en "\033]12;pink\a"
echo "Cursor should be pink. Enter to continue"; read
echo -en "\033]12;#ff00ff\a"
echo "Cursor should be #ff00ff. Enter to continue"; read
echo -en "\033]112\a"
echo "Cursor should be crimson again. Enter to continue"; read
./tmux set -u cursor-colour
echo "Cursor should be default again. Enter to continue"; read
```

</details>

<details id=test_cursor_style><summary><code>test_cursor_style.sh</code></summary>

```
#!/bin/ksh

echo "Cursor should be default. Enter to continue"; read
./tmux set cursor-style bar-blinking
echo "Cursor should be bar blinking. Enter to continue"; read
./tmux set -u cursor-style
echo "Cursor should be default again. Enter to continue"; read
echo -en "\033[4 q\a"
echo "Cursor should be underline. Enter to continue"; read
echo -en "\033[0 q\a"
echo "Cursor should be default again. Enter to continue"; read
```

</details>