### PR TITLE
Add paragraph between pane-active-border-style and pane-base-index

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4214,6 +4214,7 @@ see the
 .Sx STYLES
 section.
 Attributes are ignored.
+.Pp
 .It Ic pane-base-index Ar index
 Like
 .Ic base-index ,


### PR DESCRIPTION
While reading through the manpage I noticed a missing paragraph between the description of pane-active-border-style and pane-base-index.

Before
```
      pane-active-border-style style
              Set the pane border style for the currently active pane.  For how to specify style, see
              the STYLES section.  Attributes are ignored.
     pane-base-index index
              Like base-index, but set the starting index for pane numbers.
```

After
```
      pane-active-border-style style
              Set the pane border style for the currently active pane.  For how to specify style, see
              the STYLES section.  Attributes are ignored.
              
     pane-base-index index
              Like base-index, but set the starting index for pane numbers.
```