### PR TITLE
Add cursor-colour option

### DIFF
--- a/input.c
+++ b/input.c
@@ -2442,7 +2442,7 @@ input_top_bit_set(struct input_ctx *ictx)
 }
 
 /* Parse colour from OSC. */
-static int
+int
 input_osc_parse_colour(const char *p)
 {
 	double	 c, m, y, k = 0;

--- a/options-table.c
+++ b/options-table.c
@@ -187,6 +187,7 @@ const struct options_name_map options_other_names[] = {
 	{ "display-panes-color", "display-panes-colour" },
 	{ "display-panes-active-color", "display-panes-active-colour" },
 	{ "clock-mode-color", "clock-mode-colour" },
+	{ "cursor-color", "cursor-colour" },
 	{ "pane-colors", "pane-colours" },
 	{ NULL, NULL }
 };
@@ -232,6 +233,13 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "",
 	  .text = "Shell command run when text is copied. "
 		  "If empty, no command is run."
+	},
+
+	{ .name = "cursor-colour",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .default_num = -1,
+	  .text = "Colour of the cursor."
 	},
 
 	{ .name = "default-terminal",

--- a/options.c
+++ b/options.c
@@ -1111,8 +1111,14 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows) {
 			if (w->active == NULL)
 				continue;
-			if (options_get_number(w->options, "automatic-rename"))
+			int option = options_get_number(w->options, name);
 				w->active->flags |= PANE_CHANGED;
+		}
+	}
+	if (strcmp(name, "cursor-colour") == 0) {
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
+			wp->screen->default_ccolour =
+			options_get_number(wp->options, name);
 		}
 	}
 	if (strcmp(name, "key-table") == 0) {

--- a/options.c
+++ b/options.c
@@ -1111,7 +1111,7 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows) {
 			if (w->active == NULL)
 				continue;
-			int option = options_get_number(w->options, name);
+			if (options_get_number(w->options, name))
 				w->active->flags |= PANE_CHANGED;
 		}
 	}

--- a/screen.c
+++ b/screen.c
@@ -81,7 +81,8 @@ screen_init(struct screen *s, u_int sx, u_int sy, u_int hlimit)
 	s->path = NULL;
 
 	s->cstyle = SCREEN_CURSOR_DEFAULT;
-	s->ccolour = xstrdup("");
+	s->ccolour = -1;
+	s->default_ccolour = -1;
 	s->tabs = NULL;
 	s->sel = NULL;
 
@@ -125,7 +126,6 @@ screen_free(struct screen *s)
 	free(s->tabs);
 	free(s->path);
 	free(s->title);
-	free(s->ccolour);
 
 	if (s->write_list != NULL)
 		screen_write_free_list(s);
@@ -191,8 +191,7 @@ screen_set_cursor_style(struct screen *s, u_int style)
 void
 screen_set_cursor_colour(struct screen *s, const char *colour)
 {
-	free(s->ccolour);
-	s->ccolour = xstrdup(colour);
+	s->ccolour = input_osc_parse_colour(colour);
 }
 
 /* Set screen title. */

--- a/tmux.1
+++ b/tmux.1
@@ -4416,6 +4416,9 @@ The alternate screen feature preserves the contents of the window when an
 interactive application starts and restores it on exit, so that any output
 visible before the application starts reappears unchanged after it exits.
 .Pp
+.It Ic cursor-colour Ar colour
+Set the colour of the cursor.
+.Pp
 .It Ic pane-colours[] Ar colour
 The default colour palette.
 Each entry in the array defines the colour

--- a/tmux.h
+++ b/tmux.h
@@ -780,7 +780,8 @@ struct screen {
 	u_int				 cy;	  /* cursor y */
 
 	enum screen_cursor_style	 cstyle;  /* cursor style */
-	char				*ccolour; /* cursor colour */
+	int				 ccolour; /* cursor colour */
+	int				 default_ccolour;
 
 	u_int				 rupper;  /* scroll region top */
 	u_int				 rlower;  /* scroll region bottom */
@@ -1277,7 +1278,7 @@ struct tty {
 	u_int		 cx;
 	u_int		 cy;
 	enum screen_cursor_style cstyle;
-	char		*ccolour;
+	int		 ccolour;
 
 	int		 oflag;
 	u_int		 oox;
@@ -2602,6 +2603,7 @@ void	 recalculate_sizes_now(int);
 struct input_ctx *input_init(struct window_pane *, struct bufferevent *,
 	     struct colour_palette *);
 void	 input_free(struct input_ctx *);
+int	 input_osc_parse_colour(const char *);
 void	 input_reset(struct input_ctx *, int);
 struct evbuffer *input_pending(struct input_ctx *);
 void	 input_parse_pane(struct window_pane *);

--- a/tty.c
+++ b/tty.c
@@ -38,7 +38,7 @@ static int	tty_client_ready(struct client *);
 
 static void	tty_set_italics(struct tty *);
 static int	tty_try_colour(struct tty *, int, const char *);
-static void	tty_force_cursor_colour(struct tty *, const char *);
+static void	tty_force_cursor_colour(struct tty *, int);
 static void	tty_cursor_pane(struct tty *, const struct tty_ctx *, u_int,
 		    u_int);
 static void	tty_cursor_pane_unless_wrap(struct tty *,
@@ -105,7 +105,7 @@ tty_init(struct tty *tty, struct client *c)
 	tty->client = c;
 
 	tty->cstyle = SCREEN_CURSOR_DEFAULT;
-	tty->ccolour = xstrdup("");
+	tty->ccolour = -1;
 
 	if (tcgetattr(c->fd, &tty->tio) != 0)
 		return (-1);
@@ -341,8 +341,8 @@ tty_start_tty(struct tty *tty)
 	tty->flags |= TTY_STARTED;
 	tty_invalidate(tty);
 
-	if (*tty->ccolour != '\0')
-		tty_force_cursor_colour(tty, "");
+	if (tty->ccolour != -1)
+		tty_force_cursor_colour(tty, -1);
 
 	tty->mouse_drag_flag = 0;
 	tty->mouse_drag_update = NULL;
@@ -406,7 +406,7 @@ tty_stop_tty(struct tty *tty)
 	}
 	if (tty->mode & MODE_BRACKETPASTE)
 		tty_raw(tty, tty_term_string(tty->term, TTYC_DSBP));
-	if (*tty->ccolour != '\0')
+	if (tty->ccolour != -1)
 		tty_raw(tty, tty_term_string(tty->term, TTYC_CR));
 
 	tty_raw(tty, tty_term_string(tty->term, TTYC_CNORM));
@@ -451,7 +451,6 @@ void
 tty_free(struct tty *tty)
 {
 	tty_close(tty);
-	free(tty->ccolour);
 }
 
 void
@@ -650,24 +649,38 @@ tty_set_title(struct tty *tty, const char *title)
 }
 
 static void
-tty_force_cursor_colour(struct tty *tty, const char *ccolour)
+tty_force_cursor_colour(struct tty *tty, int c)
 {
-	if (*ccolour == '\0')
+	u_char	r, g, b;
+	char	s[13] = "";
+
+	if (c != -1)
+		c = colour_force_rgb(c);
+	if (c == tty->ccolour)
+		return;
+	if (c == -1)
 		tty_putcode(tty, TTYC_CR);
-	else
-		tty_putcode_ptr1(tty, TTYC_CS, ccolour);
-	free(tty->ccolour);
-	tty->ccolour = xstrdup(ccolour);
+	else {
+		colour_split_rgb(c, &r, &g, &b);
+		xsnprintf(s, sizeof s, "rgb:%02hhx/%02hhx/%02hhx", r, g, b);
+		tty_putcode_ptr1(tty, TTYC_CS, s);
+	}
+	tty->ccolour = c;
 }
 
 static void
 tty_update_cursor(struct tty *tty, int mode, int changed, struct screen *s)
 {
-	enum screen_cursor_style cstyle;
+	enum screen_cursor_style	cstyle;
+	int				ccolour;
 
 	/* Set cursor colour if changed. */
-	if (s != NULL && strcmp(s->ccolour, tty->ccolour) != 0)
-		tty_force_cursor_colour(tty, s->ccolour);
+	if (s != NULL) {
+		ccolour = s->ccolour;
+		if (s->ccolour == -1)
+			ccolour = s->default_ccolour;
+		tty_force_cursor_colour(tty, ccolour);
+	}
 
 	/* If cursor is off, set as invisible. */
 	if (~mode & MODE_CURSOR) {


### PR DESCRIPTION
To test:
* Build and run tmux: `./tmux -vv -f/dev/null -Ltest`
* Set the different colours for the cursor: `./tmux set cursor-colour $(awk 'BEGIN{srand();printf ("#%x%x%x", rand()*255, rand()*255, rand()*255)}')` (see below)

ℹ️ If the changes in this PR are applied the **Options for default cursor colour.** item can be removed from the [Contribution — Small things](https://github.com/tmux/tmux/wiki/Contributing#small-things) wiki page

<details><summary><code>test_cursor_colour.sh</code></summary>

```
#!/bin/ksh

echo "Cursor should be default. Enter to continue"; read
./tmux set cursor-colour crimson
echo "Cursor should be crimson. Enter to continue"; read
echo -en "\033]12;pink\a"
echo "Cursor should be pink. Enter to continue"; read
echo -en "\033]12;#ff00ff\a"
echo "Cursor should be #ff00ff. Enter to continue"; read
echo -en "\033]112\a"
echo "Cursor should be crimson again. Enter to continue"; read
./tmux set -u cursor-colour
echo "Cursor should be default again. Enter to continue"; read
```

</details>