### PR TITLE
arguments: handle invalid states

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -108,6 +108,7 @@ args_value_as_string(struct args_value *value)
 	case ARGS_STRING:
 		return (value->string);
 	}
+	fatalx("unexpected argument type");
 }
 
 /* Create an empty arguments set. */
@@ -753,6 +754,7 @@ args_make_commands(struct args_command_state *state, int argc, char **argv,
 	case CMD_PARSE_SUCCESS:
 		return (pr->cmdlist);
 	}
+	fatalx("invalid parse return state");
 }
 
 /* Free commands state. */


### PR DESCRIPTION
Since C enums are not strongly typed enough, any actual value can occur
(at least without whole-program analysis), so explicitly handle invalid
states as crashes instead of undefined behavior.

---
I *think* `fatalx` makes sense here, but may that is too harsh (since if they happen, we're in UB anyways by falling off the end of a function not returning `void`).