### PR TITLE
Show menu key when shorter than 1/4 of tty width

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -89,22 +89,25 @@ menu_add_item(struct menu *menu, const struct menu_item *item,
 		keylen = strlen(key) + 3; /* 3 = space and two brackets */
 
 		/*
-		 * Only add the key if there is space for the entire item text
-		 * and the key.
+		 * Add the key if it is shorter than a quarter of the available
+		 * space or there is space for the entire item text and the key.
 		 */
-		if (keylen >= max_width || slen >= max_width - keylen)
+		if (keylen <= max_width / 4)
+			max_width -= keylen;
+		else if (keylen >= max_width || slen >= max_width - keylen)
 			key = NULL;
 	}
 
-	if (key != NULL)
-		xasprintf(&name, "%s#[default] #[align=right](%s)", s, key);
-	else {
-		if (slen > max_width) {
-			max_width--;
-			suffix = ">";
-		}
-		xasprintf(&name, "%.*s%s", (int)max_width, s, suffix);
+	if (slen > max_width) {
+		max_width--;
+		suffix = ">";
 	}
+	if (key != NULL)
+		xasprintf(&name, "%.*s%s#[default] #[align=right](%s)",
+		    (int)max_width, s, suffix, key);
+	else
+		xasprintf(&name, "%.*s%s", (int)max_width, s, suffix);
+
 	new_item->name = name;
 	free(s);
 


### PR DESCRIPTION
@nicm, I liked your idea of showing the menu
> key if it would take up less than a quarter of the available space

(see [comment on issue #2933](https://github.com/tmux/tmux/issues/2933#issuecomment-950141608)) and thought I'd follow up on it with a quick PR.

To test:

* Build and run tmux `./tmux -vv -f/dev/null -Ltest`
* Show a narrow menu with a long key, e..g `C-M-Left`
* Show a wide menu with a short key, e.g. `d` (see `test_menu_width.sh` below`)

<details><summary><code>test_menu_width.sh</code></summary>

```
#!/bin/ksh

clear; echo "\$ ./tmux menu 123 '' '' '-456' '' '' 789 'C-M-Left' clock-mode"
./tmux menu 123 '' '' '-456' '' '' 789 'C-M-Left' clock-mode

clear; echo "\$./tmux menu 123 '' '' '-456' '' '' xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
'd' clock-mode"
./tmux menu 123 '' '' '-456' '' '' xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx 'd' clock-mode
```

</details>

| terminal width | narrow menu | wide menu |
| --- | --- | --- |
| wide | ![image](https://user-images.githubusercontent.com/16507/139861960-dd8caba4-ca0b-4cbe-9563-eb7a80e10040.png) | ![image](https://user-images.githubusercontent.com/16507/139862007-afe09fdc-3e2b-4542-aa63-3dc32e889929.png)|
| narrow | ![image](https://user-images.githubusercontent.com/16507/139862117-0bffa32d-60f2-4a50-a793-2e2a147a19eb.png) | ![image](https://user-images.githubusercontent.com/16507/139862135-8ac4a3c7-b564-4cf7-9929-606a041649f6.png)|
| unreasonable 😆  | ![image](https://user-images.githubusercontent.com/16507/139862172-fcd85133-57ba-4573-911f-b4ee0f27b8b9.png)| ![image](https://user-images.githubusercontent.com/16507/139862189-6afc382b-1fa1-4894-9b07-c7161bae8c45.png)|


