### PR TITLE
treat C1 control characters as being zero width

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -248,7 +248,14 @@ utf8_width(struct utf8_data *ud, int *width)
 	 * to the terminal without tmux.
 	 */
 	if (*width < 0) {
+#ifdef HAVE_UTF8PROC
 		*width = 1;
+#else
+		/* C1 control characters are non-printable, so they are always
+		 * zero width. (This is true of C0 control characters as well,
+		 * but they are handled separately from text already.) */
+		*width = (wc >= 0x80 && wc <= 0x9f) ? 0 : 1;
+#endif
 		return (UTF8_DONE);
 	}
 #endif


### PR DESCRIPTION
wcwidth uses -1 to mean both "this character is not printable" and "this
character is unknown", which means that always using a default of 1
gives incorrect results for control characters (they are not printable,
so they should have a width of 0, not 1). we don't have to care about C0
control characters here, because they are never treated as text, but C1
control characters are, and so we should use the correct values for
them.

this is only an issue with wcwidth - utf8proc returns useful values here
already.

this fixes #3002.

another option here could be to drop C1 control characters entirely, so that they never show up as text in the first place? that feels more actually correct, but also more invasive, and i'm not sure what the implications of that might be.