### PR TITLE
tmux.h: Don't pack pointer-containing struct grid_line

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -677,7 +677,7 @@ struct grid_line {
 	struct grid_extd_entry	*extddata;
 
 	int			 flags;
-} __packed;
+};
 
 /* Entire grid of cells. */
 struct grid {


### PR DESCRIPTION
On CHERI, and thus Arm's prototype Morello architecture, C language
pointers are represented as hardware capabilities, which have bounds,
permissions and other metadata to enforce spatial memory safety and,
importantly, have an associated non-addressable tag bit to enforce the
validity of every capability (that is, the only way to construct a
capability with the tag bit set is by deriving a new capability as a
subset of an existing valid capability, and any action such as
overwriting the capability in memory with an arbitrary bit pattern will
clear the tag, rendering it no longer valid). There is one tag bit per
capability-sized word of memory, and thus capabilities must be stored at
aligned locations otherwise they cannot be tagged (load/store capability
instructions will take an alignment fault, and memcpy will silently drop
the tag). This therefore means that capabilities cannot be stored in
structs that use the GNU packed attribute (unless care is taken to
ensure they will be aligned at run time), which is intended to be used
when mapping hardware data structure layouts to C structs, not in
general purpose code.

Thus, since struct grid_line contains pointers, remove __packed from its
definition, increasing the portability of the code whilst adding no
space overhead on 32-bit architectures and only 8 bytes of overhead on
64-bit architectures (which, if that is genuinely a concern, can be
entirely mitigated by reordering the fields). This will also make the
code faster on architectures that don't natively support unaligned
acceses and currently have to use byte loads/stores to reconstruct the
multi-byte values.
