### PR TITLE
updates configuration files docs

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -140,7 +140,9 @@ By default,
 loads the system configuration file from
 .Pa @SYSCONFDIR@/tmux.conf ,
 if present, then looks for a user configuration file at
-.Pa ~/.tmux.conf .
+.Pa ~/.tmux.conf 
+or
+.Pa ~/.config/tmux/tmux.conf .
 .Pp
 The configuration file is a set of
 .Nm
@@ -6628,6 +6630,10 @@ options.
 .Bl -tag -width "@SYSCONFDIR@/tmux.confXXX" -compact
 .It Pa ~/.tmux.conf
 Default
+.Nm
+configuration file.
+.It Pa ~/.config/tmux/tmux.conf
+User-specific
 .Nm
 configuration file.
 .It Pa @SYSCONFDIR@/tmux.conf


### PR DESCRIPTION
## Summary

As can be noticed from the changelog for [version 3.1](https://raw.githubusercontent.com/tmux/tmux/3.1/CHANGES) and by comparing [version 3.1 with version 3.0](https://github.com/tmux/tmux/compare/3.0...3.1#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afR16) a configuration file located at `~/.config/tmux/tmux.conf` is supported, but this option is not documented on the [man page](https://man.openbsd.org/tmux.1#FILES). I took a look at the [master](https://github.com/tmux/tmux/blob/master/tmux.1#L6627) and [3.3rc](https://github.com/tmux/tmux/blob/3.3-rc/tmux.1#L6437) versions of the file to make sure it wasn't already included on later versions.

This pull request is a proposal for inclusion of the aforementioned file. Thank you in advance!

## Test Evidence

Documentation changes were tested with `nroff -mdoc tmux.1 | less`.
![20220101153521](https://user-images.githubusercontent.com/29714040/147857746-1b8c6171-6daf-4797-85b8-398efd744e39.png)
![20220101153506](https://user-images.githubusercontent.com/29714040/147857748-7e60c776-3fee-4c92-89e5-d94d7fa05cfb.png)