### PR TITLE
Add prefix3 and prefix4

### DIFF
--- a/cmd-send-keys.c
+++ b/cmd-send-keys.c
@@ -47,8 +47,8 @@ const struct cmd_entry cmd_send_prefix_entry = {
 	.name = "send-prefix",
 	.alias = NULL,
 
-	.args = { "2t:", 0, 0, NULL },
-	.usage = "[-2] " CMD_TARGET_PANE_USAGE,
+	.args = { "234t:", 0, 0, NULL },
+	.usage = "[-2|-3|-4] " CMD_TARGET_PANE_USAGE,
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 
@@ -188,7 +188,11 @@ cmd_send_keys_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	if (cmd_get_entry(self) == &cmd_send_prefix_entry) {
-		if (args_has(args, '2'))
+		if (args_has(args, '4'))
+			key = options_get_number(s->options, "prefix4");
+		else if (args_has(args, '3'))
+			key = options_get_number(s->options, "prefix3");
+		else if (args_has(args, '2'))
 			key = options_get_number(s->options, "prefix2");
 		else
 			key = options_get_number(s->options, "prefix");

--- a/options-table.c
+++ b/options-table.c
@@ -565,6 +565,20 @@ const struct options_table_entry options_table[] = {
 	  .text = "A second prefix key."
 	},
 
+	{ .name = "prefix3",
+	  .type = OPTIONS_TABLE_KEY,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = KEYC_NONE,
+	  .text = "A third prefix key."
+	},
+
+	{ .name = "prefix4",
+	  .type = OPTIONS_TABLE_KEY,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = KEYC_NONE,
+	  .text = "A fourth prefix key."
+	},
+
 	{ .name = "renumber-windows",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/server-client.c
+++ b/server-client.c
@@ -1296,7 +1296,9 @@ table_changed:
 	 */
 	key0 = (key & (KEYC_MASK_KEY|KEYC_MASK_MODIFIERS));
 	if ((key0 == (key_code)options_get_number(s->options, "prefix") ||
-	    key0 == (key_code)options_get_number(s->options, "prefix2")) &&
+	    key0 == (key_code)options_get_number(s->options, "prefix2") ||
+	    key0 == (key_code)options_get_number(s->options, "prefix3") ||
+	    key0 == (key_code)options_get_number(s->options, "prefix4")) &&
 	    strcmp(table->name, "prefix") != 0) {
 		server_client_set_key_table(c, "prefix");
 		server_status_client(c);


### PR DESCRIPTION
https://github.com/tmux/tmux/commit/535286c05aee55c0127cdabada8e54582905ef8e says "People who want three prefix keys are out of luck :-)."

I want four prefix keys!
 - `C-\` and `M-\` on UK English keyboards (`\` is between left shift and 'z' https://en.wikipedia.org/wiki/File:KB_United_Kingdom.svg)
 - `C-z` and `M-z` on US English keyboards which I use much more rarely (to retain the muscle memory for prefix/prefix2 https://en.wikipedia.org/wiki/File:KB_United_States-NoAltGr.svg)

I've lightly tested and both the send-prefix arguments and using them as prefixes seems to work.

Note: I didn't add error handling for when people try and pass multiple arguments to `send-prefix`, instead it'll just silently use the highest prefix number passed (e.g. `send-prefix -2 -3` will just send `prefix4`).