### PR TITLE
Since xstrdup() calls fatalx() if strdup returns NULL, it will crash …

### DIFF
--- a/popup.c
+++ b/popup.c
@@ -803,7 +803,7 @@ popup_editor(struct client *c, const char *buf, size_t len,
 
 	xasprintf(&cmd, "%s %s", editor, path);
 	if (popup_display(POPUP_INTERNAL|POPUP_CLOSEEXIT, BOX_LINES_DEFAULT,
-	    NULL, px, py, sx, sy, NULL, cmd, 0, NULL, _PATH_TMP, NULL, c, NULL,
+	    NULL, px, py, sx, sy, NULL, cmd, 0, NULL, _PATH_TMP, "", c, NULL,
 	    NULL, NULL, popup_editor_close_cb, pe) != 0) {
 		popup_editor_free(pe);
 		free(cmd);


### PR DESCRIPTION
…if str is NULL. The call to popup_display sets the title parameter to NULL and causes tmux to crash after xstrdup is called on title in popup_display. The bug was added in commit acba07629ebf2dc2f0c316f110493e720b30757c in GitHub issue 2941. The intention was to have the owner of the title string free the string while keeping a copy in popup, but it was likely assumed that title was not a NULL string as cmd_display_exec_cmd in cmd-display-menu.c calls popup_display with title as a non-NULL string.