### PR TITLE
Fix uninitialized variable warnings

### DIFF
--- a/format-draw.c
+++ b/format-draw.c
@@ -1141,7 +1141,7 @@ format_trim_right(const char *expanded, u_int limit)
 	char			*copy, *out;
 	const char		*cp = expanded, *end;
 	u_int			 width = 0, total_width, skip, n;
-	u_int			 leading_width, copy_width;
+	u_int			 leading_width, copy_width = 0;
 	struct utf8_data	 ud;
 	enum utf8_state		 more;
 

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1157,7 +1157,7 @@ static int
 tty_keys_clipboard(__unused struct tty *tty, const char *buf, size_t len,
     size_t *size)
 {
-	size_t	 end, terminator, needed;
+	size_t	 end, terminator = 0, needed;
 	char	*copy, *out;
 	int	 outlen;
 


### PR DESCRIPTION
This PR fixes uninitialized warnings below.

```
format-draw.c: In function ‘format_trim_right’:
format-draw.c:1161:17: warning: ‘copy_width’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1161 |      copy_width -= (skip - width);
      |      ~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```
```
tty-keys.c: In function ‘tty_keys_next’:
tty-keys.c:1201:14: warning: ‘terminator’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 1201 |  *size = end + terminator;
      |          ~~~~^~~~~~~~~~~~
tty-keys.c:1160:15: note: ‘terminator’ was declared here
 1160 |  size_t  end, terminator, needed;
      |               ^~~~~~~~~~
```

## Environment
- gcc 9.3.0 