### PR TITLE
Use PATH_MAX instead of MAXPATHLEN.

### DIFF
--- a/osdep-openbsd.c
+++ b/osdep-openbsd.c
@@ -141,7 +141,7 @@ char *
 osdep_get_cwd(int fd)
 {
 	int		name[] = { CTL_KERN, KERN_PROC_CWD, 0 };
-	static char	path[MAXPATHLEN];
+	static char	path[PATH_MAX];
 	size_t		pathlen = sizeof path;
 
 	if ((name[2] = tcgetpgrp(fd)) == -1)


### PR DESCRIPTION
This allows us to drop `sys/param.h` and is in sync with `procname.c` OpenBSD.