### PR TITLE
Add option to set whether to scroll on display clear

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -1080,6 +1080,14 @@ const struct options_table_entry options_table[] = {
 	          "remain-on-exit is enabled."
 	},
 
+	{ .name = "scroll-on-clear",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .default_num = 1,
+	  .text = "Whether the contents of the screen should be scrolled into"
+		  "history when clearing the whole screen."
+	},
+
 	{ .name = "synchronize-panes",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,

--- a/screen-write.c
+++ b/screen-write.c
@@ -1427,7 +1427,8 @@ screen_write_clearendofscreen(struct screen_write_ctx *ctx, u_int bg)
 	ttyctx.bg = bg;
 
 	/* Scroll into history if it is enabled and clearing entire screen. */
-	if (s->cx == 0 && s->cy == 0 && (gd->flags & GRID_HISTORY))
+	if (s->cx == 0 && s->cy == 0 && (gd->flags & GRID_HISTORY) &&
+	    options_get_number(ctx->wp->options, "scroll-on-clear"))
 		grid_view_clear_history(gd, bg);
 	else {
 		if (s->cx <= sx - 1)

--- a/tmux.1
+++ b/tmux.1
@@ -4479,6 +4479,12 @@ Set the text shown at the bottom of exited panes when
 .Ic remain-on-exit
 is enabled.
 .Pp
+.It Xo Ic scroll-on-clear
+.Op Ic on | off
+.Xc
+When the entire screen is cleared and this option is on (the default), scroll
+the contents of the screen into history before clearing it.
+.Pp
 .It Xo Ic synchronize-panes
 .Op Ic on | off
 .Xc


### PR DESCRIPTION
Github issue 3090. When clearing the whole display, tmux scrolls the
lines into the history. In some cases (e.g., zsh) this may result in
many extraneous lines being added to the history, so allow the user to
disable this using the new option 'scroll-on-clear'.