### PR TITLE
Notify control clients of swap-pane

### DIFF
--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -135,6 +135,10 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	server_redraw_window(src_w);
 	server_redraw_window(dst_w);
+	notify_window("window-layout-changed", src_w);
+        if (src_w != dst_w) {
+		notify_window("window-layout-changed", dst_w);
+        }
 
 out:
 	if (window_pop_zoom(src_w))


### PR DESCRIPTION
`swap-pane` should notify control-mode clients of a window layout change.

A user reported that the shortcut for swapping panes didn't work in iTerm2's tmux integration here: https://gitlab.com/gnachman/iterm2/-/issues/10301#note_894044693

