### PR TITLE
#3164 [input-keys] input_key_get_mouse: saturate coordinates at max supported value

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -581,6 +581,12 @@ enum tty_code_code {
 #define MOTION_MOUSE_MODES (MODE_MOUSE_BUTTON|MODE_MOUSE_ALL)
 #define CURSOR_MODES (MODE_CURSOR|MODE_CURSOR_BLINKING|MODE_CURSOR_VERY_VISIBLE)
 
+/* X10 Mouse protocol support */
+#define X10_MOUSE_PARAM_CAP 0x100
+#define X10_MOUSE_BTN_OFFSET 0x20
+#define X10_MOUSE_POS_OFFSET 0x21
+#define X10_MOUSE_CLAMP_TO_PARAM(p) ((((uint)p) < (uint)X10_MOUSE_PARAM_CAP) ? (p) : (X10_MOUSE_PARAM_CAP-1))
+
 /* A single UTF-8 character. */
 typedef u_int utf8_char;
 

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1061,17 +1061,17 @@ tty_keys_mouse(struct tty *tty, const char *buf, size_t len, size_t *size,
 		log_debug("%s: mouse input: %.*s", c->name, (int)*size, buf);
 
 		/* Check and return the mouse input. */
-		if (b < 32)
+		if (b < X10_MOUSE_BTN_OFFSET)
 			return (-1);
-		b -= 32;
-		if (x >= 33)
-			x -= 33;
-		else
-			x = 256 - x;
-		if (y >= 33)
-			y -= 33;
-		else
-			y = 256 - y;
+
+		b = b - X10_MOUSE_BTN_OFFSET;
+
+		/*
+		 * This is deliberately different from our behavior in `input_key_get_mouse`
+		 * The overflow behavior is kept for backward compatibility with 2756d12
+		 */
+		x = (x + X10_MOUSE_PARAM_CAP - X10_MOUSE_POS_OFFSET) % X10_MOUSE_PARAM_CAP;
+		x = (y + X10_MOUSE_PARAM_CAP - X10_MOUSE_POS_OFFSET) % X10_MOUSE_PARAM_CAP;
 	} else if (buf[2] == '<') {
 		/* Read the three inputs. */
 		*size = 3;


### PR DESCRIPTION
This fixes #3164 
I was going to make a unit test for this but couldn't figure out any existing framework for that in the project.