### PR TITLE
Enable formats for some commands.

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -848,6 +848,41 @@ args_strtonum(struct args *args, u_char flag, long long minval,
 	return (ll);
 }
 
+/* Convert an argument value to a number, and expand formats. */
+long long
+args_strtonum_and_expand(struct args *args, u_char flag, long long minval,
+    long long maxval, struct cmdq_item *item, char **cause)
+{
+	const char		*errstr;
+	char			*formatted;
+	long long		 ll;
+	struct args_entry	*entry;
+	struct args_value	*value;
+
+	if ((entry = args_find(args, flag)) == NULL) {
+		*cause = xstrdup("missing");
+		return (0);
+	}
+	value = TAILQ_LAST(&entry->values, args_values);
+	if (value == NULL ||
+	    value->type != ARGS_STRING ||
+	    value->string == NULL) {
+		*cause = xstrdup("missing");
+		return (0);
+	}
+
+	formatted = format_single_from_target(item, value->string);
+	ll = strtonum(formatted, minval, maxval, &errstr);
+	free(formatted);
+	if (errstr != NULL) {
+		*cause = xstrdup(errstr);
+		return (0);
+	}
+
+	*cause = NULL;
+	return (ll);
+}
+
 /* Convert an argument to a number which may be a percentage. */
 long long
 args_percentage(struct args *args, u_char flag, long long minval,
@@ -895,6 +930,73 @@ args_string_percentage(const char *value, long long minval, long long maxval,
 		}
 	} else {
 		ll = strtonum(value, minval, maxval, &errstr);
+		if (errstr != NULL) {
+			*cause = xstrdup(errstr);
+			return (0);
+		}
+	}
+
+	*cause = NULL;
+	return (ll);
+}
+
+/*
+ * Convert an argument to a number which may be a percentage, and expand
+ * formats.
+ */
+long long
+args_percentage_and_expand(struct args *args, u_char flag, long long minval,
+    long long maxval, long long curval, struct cmdq_item *item, char **cause)
+{
+	const char		*value;
+	struct args_entry	*entry;
+
+	if ((entry = args_find(args, flag)) == NULL) {
+		*cause = xstrdup("missing");
+		return (0);
+	}
+	value = TAILQ_LAST(&entry->values, args_values)->string;
+	return (args_string_percentage_and_expand(value, minval, maxval, curval,
+		    item, cause));
+}
+
+/*
+ * Convert a string to a number which may be a percentage, and expand formats.
+ */
+long long
+args_string_percentage_and_expand(const char *value, long long minval,
+    long long maxval, long long curval, struct cmdq_item *item, char **cause)
+{
+	const char	*errstr;
+	long long	 ll;
+	size_t		 valuelen = strlen(value);
+	char		*copy, *f;
+
+	if (value[valuelen - 1] == '%') {
+		copy = xstrdup(value);
+		copy[valuelen - 1] = '\0';
+
+		f = format_single_from_target(item, copy);
+		ll = strtonum(f, 0, 100, &errstr);
+		free(f);
+		free(copy);
+		if (errstr != NULL) {
+			*cause = xstrdup(errstr);
+			return (0);
+		}
+		ll = (curval * ll) / 100;
+		if (ll < minval) {
+			*cause = xstrdup("too small");
+			return (0);
+		}
+		if (ll > maxval) {
+			*cause = xstrdup("too large");
+			return (0);
+		}
+	} else {
+		f = format_single_from_target(item, value);
+		ll = strtonum(f, minval, maxval, &errstr);
+		free(f);
 		if (errstr != NULL) {
 			*cause = xstrdup(errstr);
 			return (0);

--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_capture_pane_entry = {
 	.name = "capture-pane",
 	.alias = "capturep",
 
-	.args = { "ab:CeE:JNpPqS:t:", 0, 0, NULL },
-	.usage = "[-aCeJNpPq] " CMD_BUFFER_USAGE " [-E end-line] "
+	.args = { "ab:CeE:FJNpPqS:t:", 0, 0, NULL },
+	.usage = "[-aCeFJNpPq] " CMD_BUFFER_USAGE " [-E end-line] "
 		 "[-S start-line] " CMD_TARGET_PANE_USAGE,
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -133,7 +133,11 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	if (Sflag != NULL && strcmp(Sflag, "-") == 0)
 		top = 0;
 	else {
-		n = args_strtonum(args, 'S', INT_MIN, SHRT_MAX, &cause);
+		if (args_has(args, 'F')) {
+			n = args_strtonum_and_expand(args, 'S', INT_MIN,
+				SHRT_MAX, item, &cause);
+		} else
+			n = args_strtonum(args, 'S', INT_MIN, SHRT_MAX, &cause);
 		if (cause != NULL) {
 			top = gd->hsize;
 			free(cause);
@@ -149,7 +153,11 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	if (Eflag != NULL && strcmp(Eflag, "-") == 0)
 		bottom = gd->hsize + gd->sy - 1;
 	else {
-		n = args_strtonum(args, 'E', INT_MIN, SHRT_MAX, &cause);
+		if (args_has(args, 'F')) {
+			n = args_strtonum_and_expand(args, 'E', INT_MIN,
+				SHRT_MAX, item, &cause);
+		} else
+			n = args_strtonum(args, 'E', INT_MIN, SHRT_MAX, &cause);
 		if (cause != NULL) {
 			bottom = gd->hsize + gd->sy - 1;
 			free(cause);

--- a/cmd-send-keys.c
+++ b/cmd-send-keys.c
@@ -151,7 +151,11 @@ cmd_send_keys_exec(struct cmd *self, struct cmdq_item *item)
 	char				*cause = NULL;
 
 	if (args_has(args, 'N')) {
-		np = args_strtonum(args, 'N', 1, UINT_MAX, &cause);
+		if (args_has(args, 'F')) {
+			np = args_strtonum_and_expand(args, 'N', 1, UINT_MAX,
+				 item, &cause);
+		} else
+			np = args_strtonum(args, 'N', 1, UINT_MAX, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "repeat count %s", cause);
 			free(cause);

--- a/tmux.1
+++ b/tmux.1
@@ -2015,7 +2015,7 @@ but a different format may be specified with
 .Fl F .
 .Tg capturep
 .It Xo Ic capture-pane
-.Op Fl aepPqCJN
+.Op Fl aepPqCFJN
 .Op Fl b Ar buffer-name
 .Op Fl E Ar end-line
 .Op Fl S Ar start-line
@@ -2059,6 +2059,8 @@ to
 is the start of the history and to
 .Fl E
 the end of the visible pane.
+.Fl F
+expands formats in arguments where appropriate.
 The default is to capture only the visible contents of the pane.
 .It Xo
 .Ic choose-client
@@ -2338,7 +2340,7 @@ zooms the pane.
 This command works only if at least one client is attached.
 .Tg joinp
 .It Xo Ic join-pane
-.Op Fl bdfhv
+.Op Fl bdfFhv
 .Op Fl l Ar size
 .Op Fl s Ar src-pane
 .Op Fl t Ar dst-pane
@@ -2359,6 +2361,8 @@ option causes
 .Ar src-pane
 to be joined to left of or above
 .Ar dst-pane .
+.Fl F
+expands formats in arguments where appropriate.
 .Pp
 If
 .Fl s
@@ -2928,7 +2932,7 @@ the command behaves like
 .Ic last-window .
 .Tg splitw
 .It Xo Ic split-window
-.Op Fl bdfhIvPZ
+.Op Fl bdfGhIvPZ
 .Op Fl c Ar start-directory
 .Op Fl e Ar environment
 .Op Fl l Ar size
@@ -2966,6 +2970,8 @@ or full window width (with
 instead of splitting the active pane.
 .Fl Z
 zooms if the window is not zoomed, or keeps it zoomed if already zoomed.
+.Fl G
+expands formats in arguments where appropriate.
 .Pp
 An empty
 .Ar shell-command

--- a/tmux.h
+++ b/tmux.h
@@ -2383,10 +2383,16 @@ struct args_value *args_first_value(struct args *, u_char);
 struct args_value *args_next_value(struct args_value *);
 long long	 args_strtonum(struct args *, u_char, long long, long long,
 		     char **);
+long long	 args_strtonum_and_expand(struct args *, u_char, long long,
+		     long long, struct cmdq_item *, char **);
 long long	 args_percentage(struct args *, u_char, long long,
 		     long long, long long, char **);
 long long	 args_string_percentage(const char *, long long, long long,
 		     long long, char **);
+long long	 args_percentage_and_expand(struct args *, u_char, long long,
+		     long long, long long, struct cmdq_item *, char **);
+long long	 args_string_percentage_and_expand(const char *, long long,
+		     long long, long long, struct cmdq_item *, char **);
 
 /* cmd-find.c */
 int		 cmd_find_target(struct cmd_find_state *, struct cmdq_item *,


### PR DESCRIPTION
- The following commands have been updated:
send-keys: -N
capture-pane: -S, -E
split-window: -l
join-pane: -l
- Also, join-pane did not properly compute the size if -f was given (it
always used the target pane). This has now been fixed.
- Minor refactoring to avoid code duplication and make the logic easier to
follow.