### PR TITLE
Use only the definition of getpeerucred if available

### DIFF
--- a/compat/getpeereid.c
+++ b/compat/getpeereid.c
@@ -38,9 +38,6 @@ getpeereid(int s, uid_t *uid, gid_t *gid)
 	*gid = uc.gid;
 	return (0);
 #elif defined(HAVE_GETPEERUCRED)
-int
-getpeereid(int s, uid_t *uid, gid_t *gid)
-{
         ucred_t *ucred = NULL;
 
         if (getpeerucred(s, &ucred) == -1)
@@ -51,7 +48,6 @@ getpeereid(int s, uid_t *uid, gid_t *gid)
                 return (-1);
         ucred_free(ucred);
         return (0);
-}
 #else
 	return (getuid());
 #endif


### PR DESCRIPTION
f97d784f172a10e0444ad93bb536ee0428613aa7 did not compile because of the
redeclaration of `getpeereid()` when `HAVE_GETPEERUCRED` is defined.
f97d784f172a10e0444ad93bb536ee0428613aa7 can now be considered tested on
Solaris :).