### PR TITLE
Updated paste_buffer automatic buffer handling.

### DIFF
--- a/cmd-choose-tree.c
+++ b/cmd-choose-tree.c
@@ -100,7 +100,7 @@ cmd_choose_tree_exec(struct cmd *self, struct cmdq_item *item)
 	const struct window_mode	*mode;
 
 	if (cmd_get_entry(self) == &cmd_choose_buffer_entry) {
-		if (paste_get_top(NULL) == NULL)
+		if (paste_is_empty())
 			return (CMD_RETURN_NORMAL);
 		mode = &window_buffer_mode;
 	} else if (cmd_get_entry(self) == &cmd_choose_client_entry) {

--- a/paste.c
+++ b/paste.c
@@ -111,6 +111,12 @@ paste_walk(struct paste_buffer *pb)
 	return (RB_NEXT(paste_time_tree, &paste_by_time, pb));
 }
 
+int
+paste_is_empty(void)
+{
+	return RB_ROOT(&paste_by_time)==NULL;
+}
+
 /* Get the most recent automatic buffer. */
 struct paste_buffer *
 paste_get_top(const char **name)
@@ -118,6 +124,10 @@ paste_get_top(const char **name)
 	struct paste_buffer	*pb;
 
 	pb = RB_MIN(paste_time_tree, &paste_by_time);
+
+	while (pb && !pb->automatic)
+		pb = RB_NEXT(paste_time_tree, &paste_by_time, pb);
+
 	if (pb == NULL)
 		return (NULL);
 	if (name != NULL)

--- a/tmux.h
+++ b/tmux.h
@@ -2058,6 +2058,7 @@ u_int		 paste_buffer_order(struct paste_buffer *);
 time_t		 paste_buffer_created(struct paste_buffer *);
 const char	*paste_buffer_data(struct paste_buffer *, size_t *);
 struct paste_buffer *paste_walk(struct paste_buffer *);
+int          paste_is_empty(void);
 struct paste_buffer *paste_get_top(const char **);
 struct paste_buffer *paste_get_name(const char *);
 void		 paste_free(struct paste_buffer *);


### PR DESCRIPTION
Suggested updates based on #3205

- Implement paste_is_empty() boolean
- paste_get_top() always returns an automatic buffer.