### PR TITLE
capture-pane -e support hyperlink

### DIFF
--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -177,7 +177,7 @@ cmd_capture_pane_history(struct args *args, struct cmdq_item *item,
 	buf = NULL;
 	for (i = top; i <= bottom; i++) {
 		line = grid_string_cells(gd, 0, i, sx, &gc, with_codes,
-		    escape_c0, !join_lines && !no_trim);
+		    escape_c0, !join_lines && !no_trim, wp->screen);
 		linelen = strlen(line);
 
 		buf = cmd_capture_pane_append(buf, len, line, linelen);

--- a/grid-view.c
+++ b/grid-view.c
@@ -231,5 +231,5 @@ grid_view_string_cells(struct grid *gd, u_int px, u_int py, u_int nx)
 	px = grid_view_x(gd, px);
 	py = grid_view_y(gd, py);
 
-	return (grid_string_cells(gd, px, py, nx, NULL, 0, 0, 0));
+	return (grid_string_cells(gd, px, py, nx, NULL, 0, 0, 0, NULL));
 }

--- a/tmux.h
+++ b/tmux.h
@@ -2774,7 +2774,7 @@ void	 grid_clear_lines(struct grid *, u_int, u_int, u_int);
 void	 grid_move_lines(struct grid *, u_int, u_int, u_int, u_int);
 void	 grid_move_cells(struct grid *, u_int, u_int, u_int, u_int, u_int);
 char	*grid_string_cells(struct grid *, u_int, u_int, u_int,
-	     struct grid_cell **, int, int, int);
+	     struct grid_cell **, int, int, int, struct screen *);
 void	 grid_duplicate_lines(struct grid *, u_int, struct grid *, u_int,
 	     u_int);
 void	 grid_reflow(struct grid *, u_int);


### PR DESCRIPTION
#3240 follow-up feature
Now `capture-pane -e` support OSC 8 hyperlinks and paste these hyperlinks via `paste-buffer` correctly.