### PR TITLE
vi copy mode: Do not skip matched text under cursor in new search

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -3638,18 +3638,9 @@ window_copy_search(struct window_mode_entry *wme, int direction, int regex)
 		 * after the term the cursor is currently on when searching
 		 * forward.
 		 */
-		if (keys == MODEKEY_VI) {
-			if (data->searchmark != NULL)
-				window_copy_move_after_search_mark(data, &fx,
-				    &fy, wrapflag);
-			else {
-				/*
-				 * When there are no search marks, start the
-				 * search after the current cursor position.
-				 */
-				window_copy_move_right(s, &fx, &fy, wrapflag);
-			}
-		}
+		if (keys == MODEKEY_VI)
+			window_copy_move_right(s, &fx, &fy, wrapflag);
+
 		endline = gd->hsize + gd->sy - 1;
 	}
 	else {


### PR DESCRIPTION
Hey there!

This PR contains a fix for what I believe to be a bug introduced in 28cd956729c13f8f66e26d438592df9c9930e7b8:

If you perform a new search after searching for something, and the new search term is a substring of what's already matched under the cursor, the current matched text is not considered as the first match, but the last one.

It's a bit easier to explain with an example reproducing the issue:
1. Have a tmux pane where the word __test__ appears at least twice on different lines
2. Enter vi copy mode and search for __.*test__ (`/` key - tmux `send-keys -X search-forward ".*test"`)
3. After the cursor moves to the beginning of the highlighted match, search for __test__ (tmux `send-keys -X search-forward "test"`)
4. The cursor moves to the next line highlighting __test__ instead of to the one highlighted on the current line, despite the cursor being positioned at the beginning of the line on the prior step

This PR changes the result of step 4 above, so that the cursor moves to the __test__ highlighted on the current line, like it actually happens on vi, as apparently intended on 28cd956729c13f8f66e26d438592df9c9930e7b8.

Prior tmux releases (3.1c and below) have a different vi copy mode search behavior (removing the conditional on [line 3671](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/window-copy.c#L3671) appears to return the old behavior). That's why I believe this is a bug.

Let me know what you think 😀 
