### PR TITLE
Parse input key modifiers as bitflags

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -934,34 +934,12 @@ tty_keys_extended_key(struct tty *tty, const char *buf, size_t len,
 		nkey = number;
 
 	/* Update the modifiers. */
-	switch (modifiers) {
-	case 2:
-		nkey |= KEYC_SHIFT;
-		break;
-	case 3:
-		nkey |= (KEYC_META|KEYC_IMPLIED_META);
-		break;
-	case 4:
-		nkey |= (KEYC_SHIFT|KEYC_META|KEYC_IMPLIED_META);
-		break;
-	case 5:
-		nkey |= KEYC_CTRL;
-		break;
-	case 6:
-		nkey |= (KEYC_SHIFT|KEYC_CTRL);
-		break;
-	case 7:
-		nkey |= (KEYC_META|KEYC_CTRL);
-		break;
-	case 8:
-		nkey |= (KEYC_SHIFT|KEYC_META|KEYC_IMPLIED_META|KEYC_CTRL);
-		break;
-	case 9:
-		nkey |= (KEYC_META|KEYC_IMPLIED_META);
-		break;
-	default:
-		*key = KEYC_NONE;
-		break;
+	if (modifiers > 0) {
+		modifiers--;
+		if (modifiers & 1) nkey |= KEYC_SHIFT;
+		if (modifiers & 2) nkey |= (KEYC_META|KEYC_IMPLIED_META); /* Alt */
+		if (modifiers & 4) nkey |= KEYC_CTRL;
+		if (modifiers & 8) nkey |= (KEYC_META|KEYC_IMPLIED_META); /* Meta */
 	}
 
 	/*


### PR DESCRIPTION
### Problem

When <kbd>NumLock</kbd> or <kbd>CapsLock</kbd> is enabled, `tmux` running inside `kitty` with `modifyOtherKeys` or the kitty keyboard protocol being turned on cannot correctly parse the function-key modifiers (i.e., `<modifiers>` in `CSI 1 ; <modifiers> A`, `CSI 27 ; <modifiers> ; <unicode> ~`, and `CSI <unicode> ; <modifiers> u`, etc.).

kitty-0.20.0 (2021-04-19) has started to include the information of <kbd>NumLock</kbd> and <kbd>CapsLock</kbd> in the function-key modifier (https://github.com/kovidgoyal/kitty/commit/4c644b855649f9de29be4feac89cfeae1b981541). Now, kitty adds [64 and 128 for <kbd>CapsLock</kbd> and <kbd>NumLock</kbd>, respectively](https://github.com/kovidgoyal/kitty/blob/4c2800b294a4b1189a6f0dfaa236f52d5380bb70/kitty/key_encoding.py#L290), to the function-key modifiers. On the other hand, the interpretation of the function-key modifier in tmux is made by [matching with the pre-defined combinations of flags](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L937-L965) rather than by testing for each bitflag. Because of this implementation, tmux fails to parse the function-key modifiers that contain extra flags.

Even if we forget about kitty, the current implementation in `master` actually cannot fully parse [the modifier combinations listed in xterm's code comment](https://github.com/ThomasDickey/xterm-snapshots/blob/master/input.c#L358-L373). Tmux seems to support [Meta (9)](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L959-L961) but somehow does not support other combinations 10-16 involving Meta.

### Solution

We should test each bitflag one by one as in this PR instead of listing all the combinations of the bitflags. I've tested the behavior with kitty-0.25.

### Notes

- kitty-0.24 has stopped the support for `modifyOtherKeys`, but the terminal application can still enable/disable the kitty keyboard protocol by sending `CSI > 1 u` and `CSI < u` enclosed in the tmux pass-through sequence `DCS tmux ; ... ST`.
- In the current implementation of `master`, somehow only Meta modifier in the combination 7 is [missing `KEYC_IMPLIED_META`](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L954). I believe this is a bug because [KEYC_IMPLIED_META seems to be used to distinguish Meta transmitted by `ESC`](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L114-L118) and also because [the combination 7 in another place seems to include `KEYC_IMPLIED_META`](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L258). In this PR, it is naturally handled in a consistent way with other combinations. If there is a special reason that combination 7 should not include `KEYC_IMPLIED_META`, please let me know so I can adjust the PR.
- In the current implementation of `master`, when the modifier is not a known combination, [`KEYC_NONE` is assigned to `*key`](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L963). However, the value seems to be never used and just [overwritten by another value later](https://github.com/tmux/tmux/blob/dc6bc0e95acc04cdf43e869294ecba897a11d850/tty-keys.c#L995), so I just dropped this in this PR. Or, should we ignore all the user inputs that contain unknown modifiers? I think I can adjust the PR also for this if necessary.
