### PR TITLE
Include (n)curses for workaround detection

### DIFF
--- a/tty-features.c
+++ b/tty-features.c
@@ -21,6 +21,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(HAVE_CURSES_H)
+#include <curses.h>
+#elif defined(HAVE_NCURSES_H)
+#include <ncurses.h>
+#endif
+
 #include "tmux.h"
 
 /*


### PR DESCRIPTION
The relevant #if in tty_feature_hyperlinks_capabilities would otherwise fail silently.

This is a follow-up fix for https://github.com/tmux/tmux/pull/3240 prompted by @nicm's [comment](https://github.com/tmux/tmux/pull/3240#issuecomment-1186274909).