### PR TITLE
Add checking for yacc existence

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,10 +268,8 @@ if test "x$found_libevent" = xno; then
 fi
 
 # Look for yacc.
-AC_CHECK_PROG(found_yacc, yacc, yes, no)
-if test "x$found_yacc" = xno; then
-	AC_MSG_ERROR("yacc not found")
-fi
+$YACC &>/dev/null
+AS_IF([ test $? == 127 ], [AC_MSG_ERROR("yacc not found")])
 
 # Look for ncurses or curses. Try pkg-config first then directly for the
 # library.

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,12 @@ if test "x$found_libevent" = xno; then
 	AC_MSG_ERROR("libevent not found")
 fi
 
+# Look for yacc.
+AC_CHECK_PROG(found_yacc, yacc, yes, no)
+if test "x$found_yacc" = xno; then
+	AC_MSG_ERROR("yacc not found")
+fi
+
 # Look for ncurses or curses. Try pkg-config first then directly for the
 # library.
 PKG_CHECK_MODULES(

--- a/configure.ac
+++ b/configure.ac
@@ -268,8 +268,10 @@ if test "x$found_libevent" = xno; then
 fi
 
 # Look for yacc.
-$YACC &>/dev/null
-AS_IF([ test $? == 127 ], [AC_MSG_ERROR("yacc not found")])
+AC_CHECK_PROG(found_yacc, $YACC, yes, no)
+if test "x$found_yacc" = xno; then
+	AC_MSG_ERROR("yacc not found")
+fi
 
 # Look for ncurses or curses. Try pkg-config first then directly for the
 # library.


### PR DESCRIPTION
Hi there, I've found that if there is no bison/byacc installed, it still successes without errors in the configuration stage, and only in make stage that the errors related to something like **unknown command yacc** show.
I think it's better to check yacc existence in the configuration stage? 

I've tested on my machine which is Ubuntu 20.04. If there is no bison/byacc, an error shows in the configuration stage, otherwise it passes if bison or byacc installed.

Thanks for your efforts.