### PR TITLE
Fix memory leak in format_find

### DIFF
--- a/format.c
+++ b/format.c
@@ -3564,12 +3564,12 @@ found:
 	}
 	if (modifiers & FORMAT_QUOTE_SHELL) {
 		saved = found;
-		found = xstrdup(format_quote_shell(saved));
+		found = format_quote_shell(saved);
 		free(saved);
 	}
 	if (modifiers & FORMAT_QUOTE_STYLE) {
 		saved = found;
-		found = xstrdup(format_quote_style(saved));
+		found = format_quote_style(saved);
 		free(saved);
 	}
 	return (found);


### PR DESCRIPTION
`format_quote_{shell,style}` already `xmalloc`s a new string, so the `xstrdup` isn't necessary.

The leak is small, but after a couple of months tmux had the biggest memory consumption on my server.