### PR TITLE
Fix minor typos in regress configs

### DIFF
--- a/regress/conf/2eae5d47049c1f6d0bef3db4e171aed7.conf
+++ b/regress/conf/2eae5d47049c1f6d0bef3db4e171aed7.conf
@@ -12,7 +12,7 @@ set-window-option -g pane-base-index 1
 unbind ^B
 bind ^B select-pane -t :.+
 
-# Reload config wtih a key
+# Reload config with a key
 bind-key r source-file ~/.tmux.conf \; display "Config reloaded!"
 
 # Mouse works as expected

--- a/regress/conf/a46e6e84cd1071105aa807256dbc158d.conf
+++ b/regress/conf/a46e6e84cd1071105aa807256dbc158d.conf
@@ -24,7 +24,7 @@ set-option -g default-terminal 'screen-256color'
 # allow Vim to receive focus events from terminal window
 set-option -g focus-events on
 
-# allow Vim to recieve modifier keys: Shift, Control, Alt
+# allow Vim to receive modifier keys: Shift, Control, Alt
 set-window-option -g xterm-keys on
 
 # prevent tmux from catching modifier keys meant for Vim

--- a/regress/conf/ad21dbb0893240563ddfdd954b9903a1.conf
+++ b/regress/conf/ad21dbb0893240563ddfdd954b9903a1.conf
@@ -552,7 +552,7 @@ setw -g status-keys       emacs
 # Changelog: https://github.com/tmux/tmux/blob/master/CHANGES
 
 # style colors: default, black, red, green, yellow, blue, magenta, cyan, white,
-#               colour0-colour255, hexdecimal RGB string '#ffffff'
+#               colour0-colour255, hexadecimal RGB string '#ffffff'
 # Use $SCRIPTS/bash/256-colors.sh to figure out the color number you want
 # style attributes: none, bold/bright, dim, underscore, blink, reverse, hidden,
 #                   or italics

--- a/regress/conf/b9f0ce1976ec62ec60dc5da7dd92c160.conf
+++ b/regress/conf/b9f0ce1976ec62ec60dc5da7dd92c160.conf
@@ -1,6 +1,6 @@
-# none of these attempts worked, to bind keys, except sometimes during the sesssion. Oh well.
+# none of these attempts worked, to bind keys, except sometimes during the session. Oh well.
 # I thought maybe that was because F1 is handled differently in a console than in X, but
-# even just C-1 didnt work.  Using just "a" or "x" as the key did, but not yet sure why not "C-".
+# even just C-1 didn't work.  Using just "a" or "x" as the key did, but not yet sure why not "C-".
 #bind-key -T root C-1 attach-session -t$0
 #But this one works now, only picks the wrong one? Mbe need2understand what "$1" or $0 mean, better,
 #but with the stub maybe this doesn't matter:
@@ -47,7 +47,7 @@ select-window -t :=3
 #$3 for email (mutt)
 new-session sula
 new-window sula ; send-keys mutt Enter
-#nah, probly betr not?:
+#nah, probably better not?:
 #send-keys -l z
 #send-keys -l "thepassifdecide"
 #send-keys Enter

--- a/regress/conf/e2661d67d0d45a8647fb95de76ec8174.conf
+++ b/regress/conf/e2661d67d0d45a8647fb95de76ec8174.conf
@@ -63,7 +63,7 @@ bind N command-prompt -p hosts: 'run-shell -b "bash -c \"~/lbin/nw %% >/dev/null
 #05:59 < Celti> annihilannic: I believe the #{pane_in_mode} format does what you want
 #05:59 < Celti> put it in your statusline
 #05:59 < Celti> annihilannic: No, my mistake, I should have read farther down, you want #{pane_synchronized}
-# only works in tmux 2.0?, higher than 1.6.3 anyawy
+# only works in tmux 2.0?, higher than 1.6.3 anyway
 set-option -g window-status-format         ' #I:#W#F#{?pane_synchronized,S,}'
 #set-option -g window-status-current-format ' #I:#W#{?pane_synchronized,[sync],}#F'
 # to highlight in red when sync is on... not sure why I did this with set-window-option instead of set-option, perhaps


### PR DESCRIPTION
found by [codespell](https://github.com/codespell-project/codespell).