### PR TITLE
Change 'g' and 'G' to go to top and bottom of menu respectively.

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -326,24 +326,24 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 	case 'g':
 	case KEYC_PPAGE:
 	case '\002': /* C-b */
-		if (md->choice > 5)
-			md->choice -= 5;
-		else
-			md->choice = 0;
-		while (md->choice != count && (name == NULL || *name == '-'))
+		md->choice = 0;
+		name = menu->items[md->choice].name;
+		while (md->choice != count && (name == NULL || *name == '-')) {
 			md->choice++;
+			name = menu->items[md->choice].name;
+		}
 		if (md->choice == count)
 			md->choice = -1;
 		c->flags |= CLIENT_REDRAWOVERLAY;
 		break;
 	case 'G':
 	case KEYC_NPAGE:
-		if (md->choice > count - 6)
-			md->choice = count - 1;
-		else
-			md->choice += 5;
-		while (md->choice != -1 && (name == NULL || *name == '-'))
+		md->choice = count -1;
+		name = menu->items[md->choice].name;
+		while (md->choice != -1 && (name == NULL || *name == '-')) {
 			md->choice--;
+			name = menu->items[md->choice].name;
+		}
 		c->flags |= CLIENT_REDRAWOVERLAY;
 		break;
 	case '\006': /* C-f */

--- a/menu.c
+++ b/menu.c
@@ -323,24 +323,59 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 		} while ((name == NULL || *name == '-') && md->choice != old);
 		c->flags |= CLIENT_REDRAWOVERLAY;
 		return (0);
-	case 'g':
 	case KEYC_PPAGE:
 	case '\002': /* C-b */
+		if (md->choice < 6) 
+			md->choice = 0;
+		else {
+			i = 5;
+			while (i > 0) {
+				md->choice--;
+				name = menu->items[md->choice].name;
+				if (md->choice != 0 && (name != NULL && *name != '-')) 
+					i--;
+				else if (md->choice == 0)
+					break;
+			}
+		}
+		c->flags |= CLIENT_REDRAWOVERLAY;
+		break;
+	case KEYC_NPAGE:
+		if (md->choice > count - 6) {
+			md->choice = count - 1;	
+			name = menu->items[md->choice].name;
+		} else {
+			i = 5;
+			while (i > 0) {
+				md->choice++;
+				name = menu->items[md->choice].name;
+				if (md->choice != count - 1 && (name != NULL && *name != '-'))
+					i--;
+				else if (md->choice == count - 1)
+					break;
+			}
+		}
+		while(name == NULL || *name == '-') {
+			md->choice--;
+			name = menu->items[md->choice].name;
+		}
+		c->flags |= CLIENT_REDRAWOVERLAY;
+		break;
+	case 'g':
+	case KEYC_HOME:
 		md->choice = 0;
 		name = menu->items[md->choice].name;
-		while (md->choice != count && (name == NULL || *name == '-')) {
+		while (name == NULL || *name == '-') {
 			md->choice++;
 			name = menu->items[md->choice].name;
 		}
-		if (md->choice == count)
-			md->choice = -1;
 		c->flags |= CLIENT_REDRAWOVERLAY;
 		break;
 	case 'G':
-	case KEYC_NPAGE:
-		md->choice = count -1;
+	case KEYC_END:
+		md->choice = count - 1;
 		name = menu->items[md->choice].name;
-		while (md->choice != -1 && (name == NULL || *name == '-')) {
+		while (name == NULL || *name == '-') {
 			md->choice--;
 			name = menu->items[md->choice].name;
 		}


### PR DESCRIPTION
### Proposed changes
Menu navigation with 'g','G', PageUp and PageDown will go to the top or bottom
of a menu.

### Current behavior
Currently these keys increment or decrement menu selections by five.
These movements do not handle navigating over menu separators in every use case. 
This can result in navigation by values other than five, or a menu with seemingly 
nothing selected.


https://user-images.githubusercontent.com/84802637/182046894-e742ef22-fd00-422e-b83b-8eb2d99626d3.mp4


### New behavior
Navigation with the aforementioned keys will simply either go to the top of the menu or the bottom.
We also now account for all cases where the choices are separators and not actual options (even if the last
item in a menu is a separator).

https://user-images.githubusercontent.com/84802637/182046907-fdb10703-50af-4eb0-876a-cafc0210f0d1.mp4
