### PR TITLE
Improve const-correctness.

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -344,7 +344,7 @@ key_bindings_init_done(__unused struct cmdq_item *item, __unused void *data)
 void
 key_bindings_init(void)
 {
-	static const char *defaults[] = {
+	static const char * const defaults[] = {
 		/* Prefix keys. */
 		"bind -N 'Send the prefix key' C-b { send-prefix }",
 		"bind -N 'Rotate through the panes' C-o { rotate-window }",

--- a/tty-features.c
+++ b/tty-features.c
@@ -43,12 +43,12 @@
 /* A named terminal feature. */
 struct tty_feature {
 	const char	 *name;
-	const char	**capabilities;
+	const char * const *capabilities;
 	int		  flags;
 };
 
 /* Terminal has xterm(1) title setting. */
-static const char *tty_feature_title_capabilities[] = {
+static const char * const tty_feature_title_capabilities[] = {
 	"tsl=\\E]0;", /* should be using TS really */
 	"fsl=\\a",
 	NULL
@@ -60,7 +60,7 @@ static const struct tty_feature tty_feature_title = {
 };
 
 /* Terminal has OSC 7 working directory. */
-static const char *tty_feature_osc7_capabilities[] = {
+static const char * const tty_feature_osc7_capabilities[] = {
 	"Swd=\\E]7;",
 	"fsl=\\a",
 	NULL
@@ -72,7 +72,7 @@ static const struct tty_feature tty_feature_osc7 = {
 };
 
 /* Terminal has mouse support. */
-static const char *tty_feature_mouse_capabilities[] = {
+static const char * const tty_feature_mouse_capabilities[] = {
 	"kmous=\\E[M",
 	NULL
 };
@@ -83,7 +83,7 @@ static const struct tty_feature tty_feature_mouse = {
 };
 
 /* Terminal can set the clipboard with OSC 52. */
-static const char *tty_feature_clipboard_capabilities[] = {
+static const char * const tty_feature_clipboard_capabilities[] = {
 	"Ms=\\E]52;%p1%s;%p2%s\\a",
 	NULL
 };
@@ -94,7 +94,7 @@ static const struct tty_feature tty_feature_clipboard = {
 };
 
 /* Terminal supports OSC 8 hyperlinks. */
-static const char *tty_feature_hyperlinks_capabilities[] = {
+static const char * const tty_feature_hyperlinks_capabilities[] = {
 #if defined (__OpenBSD__) || (defined(NCURSES_VERSION_MAJOR) && \
 	(NCURSES_VERSION_MAJOR > 5 || \
 	(NCURSES_VERSION_MAJOR == 5 && NCURSES_VERSION_MINOR > 8)))
@@ -113,7 +113,7 @@ static const struct tty_feature tty_feature_hyperlinks = {
  * terminals with RGB have versions that do not allow setting colours from the
  * 256 palette.
  */
-static const char *tty_feature_rgb_capabilities[] = {
+static const char * const tty_feature_rgb_capabilities[] = {
 	"AX",
 	"setrgbf=\\E[38;2;%p1%d;%p2%d;%p3%dm",
 	"setrgbb=\\E[48;2;%p1%d;%p2%d;%p3%dm",
@@ -128,7 +128,7 @@ static const struct tty_feature tty_feature_rgb = {
 };
 
 /* Terminal supports 256 colours. */
-static const char *tty_feature_256_capabilities[] = {
+static const char * const tty_feature_256_capabilities[] = {
 	"AX",
 	"setab=\\E[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m",
 	"setaf=\\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m",
@@ -141,7 +141,7 @@ static const struct tty_feature tty_feature_256 = {
 };
 
 /* Terminal supports overline. */
-static const char *tty_feature_overline_capabilities[] = {
+static const char * const tty_feature_overline_capabilities[] = {
 	"Smol=\\E[53m",
 	NULL
 };
@@ -152,7 +152,7 @@ static const struct tty_feature tty_feature_overline = {
 };
 
 /* Terminal supports underscore styles. */
-static const char *tty_feature_usstyle_capabilities[] = {
+static const char * const tty_feature_usstyle_capabilities[] = {
 	"Smulx=\\E[4::%p1%dm",
 	"Setulc=\\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m",
 	"ol=\\E[59m",
@@ -165,7 +165,7 @@ static const struct tty_feature tty_feature_usstyle = {
 };
 
 /* Terminal supports bracketed paste. */
-static const char *tty_feature_bpaste_capabilities[] = {
+static const char * const tty_feature_bpaste_capabilities[] = {
 	"Enbp=\\E[?2004h",
 	"Dsbp=\\E[?2004l",
 	NULL
@@ -177,7 +177,7 @@ static const struct tty_feature tty_feature_bpaste = {
 };
 
 /* Terminal supports focus reporting. */
-static const char *tty_feature_focus_capabilities[] = {
+static const char * const tty_feature_focus_capabilities[] = {
 	"Enfcs=\\E[?1004h",
 	"Dsfcs=\\E[?1004l",
 	NULL
@@ -189,7 +189,7 @@ static const struct tty_feature tty_feature_focus = {
 };
 
 /* Terminal supports cursor styles. */
-static const char *tty_feature_cstyle_capabilities[] = {
+static const char * const tty_feature_cstyle_capabilities[] = {
 	"Ss=\\E[%p1%d q",
 	"Se=\\E[2 q",
 	NULL
@@ -201,7 +201,7 @@ static const struct tty_feature tty_feature_cstyle = {
 };
 
 /* Terminal supports cursor colours. */
-static const char *tty_feature_ccolour_capabilities[] = {
+static const char * const tty_feature_ccolour_capabilities[] = {
 	"Cs=\\E]12;%p1%s\\a",
 	"Cr=\\E]112\\a",
 	NULL
@@ -213,7 +213,7 @@ static const struct tty_feature tty_feature_ccolour = {
 };
 
 /* Terminal supports strikethrough. */
-static const char *tty_feature_strikethrough_capabilities[] = {
+static const char * const tty_feature_strikethrough_capabilities[] = {
 	"smxx=\\E[9m",
 	NULL
 };
@@ -224,7 +224,7 @@ static const struct tty_feature tty_feature_strikethrough = {
 };
 
 /* Terminal supports synchronized updates. */
-static const char *tty_feature_sync_capabilities[] = {
+static const char * const tty_feature_sync_capabilities[] = {
 	"Sync=\\EP=%p1%ds\\E\\\\",
 	NULL
 };
@@ -235,7 +235,7 @@ static const struct tty_feature tty_feature_sync = {
 };
 
 /* Terminal supports extended keys. */
-static const char *tty_feature_extkeys_capabilities[] = {
+static const char * const tty_feature_extkeys_capabilities[] = {
 	"Eneks=\\E[>4;1m",
 	"Dseks=\\E[>4m",
 	NULL
@@ -247,7 +247,7 @@ static const struct tty_feature tty_feature_extkeys = {
 };
 
 /* Terminal supports DECSLRM margins. */
-static const char *tty_feature_margins_capabilities[] = {
+static const char * const tty_feature_margins_capabilities[] = {
 	"Enmg=\\E[?69h",
 	"Dsmg=\\E[?69l",
 	"Clmg=\\E[s",
@@ -261,7 +261,7 @@ static const struct tty_feature tty_feature_margins = {
 };
 
 /* Terminal supports DECFRA rectangle fill. */
-static const char *tty_feature_rectfill_capabilities[] = {
+static const char * const tty_feature_rectfill_capabilities[] = {
 	"Rect",
 	NULL
 };
@@ -272,7 +272,7 @@ static const struct tty_feature tty_feature_rectfill = {
 };
 
 /* Use builtin function keys only. */
-static const char *tty_feature_ignorefkeys_capabilities[] = {
+static const char * const tty_feature_ignorefkeys_capabilities[] = {
 	"kf0@",
 	"kf1@",
 	"kf2@",
@@ -346,7 +346,7 @@ static const struct tty_feature tty_feature_ignorefkeys = {
 };
 
 /* Available terminal features. */
-static const struct tty_feature *tty_features[] = {
+static const struct tty_feature * const tty_features[] = {
 	&tty_feature_256,
 	&tty_feature_bpaste,
 	&tty_feature_ccolour,
@@ -421,7 +421,7 @@ int
 tty_apply_features(struct tty_term *term, int feat)
 {
 	const struct tty_feature	 *tf;
-	const char			**capability;
+	const char	         * const *capability;
 	u_int				  i;
 
 	if (feat == 0)
@@ -453,7 +453,7 @@ tty_apply_features(struct tty_term *term, int feat)
 void
 tty_default_features(int *feat, const char *name, u_int version)
 {
-	static struct {
+	static const struct {
 		const char	*name;
 		u_int		 version;
 		const char	*features;


### PR DESCRIPTION
Constify a number of static pointer arrays and static structs which results
in ~1000 bytes moved from the data (rw) to the text (ro) section.

Before:
 $ size tmux
   text	   data	    bss	    dec	    hex	filename
 853211	   8984	  30256	 892451	  d9e23	tmux

After:
 $ size tmux
   text	   data	    bss	    dec	    hex	filename
 854235	   7944	  30256	 892435	  d9e13	tmux