### PR TITLE
Introduce Nobr terminfo extension

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6433,6 +6433,10 @@ These are set automatically if the
 capability is present.
 .It Em \&Hls
 Set or clear a hyperlink annotation.
+.It Em \&Nobr
+Tell
+.Nm
+that the terminal does not use bright colors for bold display.
 .It Em \&Rect
 Tell
 .Nm

--- a/tmux.h
+++ b/tmux.h
@@ -515,6 +515,7 @@ enum tty_code_code {
 	TTYC_KUP6,
 	TTYC_KUP7,
 	TTYC_MS,
+	TTYC_NOBR,
 	TTYC_OL,
 	TTYC_OP,
 	TTYC_RECT,

--- a/tty-features.c
+++ b/tty-features.c
@@ -271,6 +271,17 @@ static const struct tty_feature tty_feature_rectfill = {
 	TERM_DECFRA
 };
 
+/* Terminal does not use bright colors for bold display. */
+static const char *tty_feature_nobr_capabilities[] = {
+	"Nobr",
+	NULL
+};
+static const struct tty_feature tty_feature_nobr = {
+	"nobr",
+	tty_feature_nobr_capabilities,
+	0
+};
+
 /* Use builtin function keys only. */
 static const char *tty_feature_ignorefkeys_capabilities[] = {
 	"kf0@",
@@ -358,6 +369,7 @@ static const struct tty_feature *tty_features[] = {
 	&tty_feature_ignorefkeys,
 	&tty_feature_margins,
 	&tty_feature_mouse,
+	&tty_feature_nobr,
 	&tty_feature_osc7,
 	&tty_feature_overline,
 	&tty_feature_rectfill,

--- a/tty-term.c
+++ b/tty-term.c
@@ -250,6 +250,7 @@ static const struct tty_term_code_entry tty_term_codes[] = {
 	[TTYC_KUP6] = { TTYCODE_STRING, "kUP6" },
 	[TTYC_KUP7] = { TTYCODE_STRING, "kUP7" },
 	[TTYC_MS] = { TTYCODE_STRING, "Ms" },
+	[TTYC_NOBR] = { TTYCODE_STRING, "Nobr" },
 	[TTYC_OL] = { TTYCODE_STRING, "ol" },
 	[TTYC_OP] = { TTYCODE_STRING, "op" },
 	[TTYC_RECT] = { TTYCODE_STRING, "Rect" },

--- a/tty.c
+++ b/tty.c
@@ -2690,12 +2690,12 @@ tty_check_fg(struct tty *tty, struct colour_palette *palette,
 
 	/*
 	 * Perform substitution if this pane has a palette. If the bright
-	 * attribute is set, use the bright entry in the palette by changing to
-	 * the aixterm colour.
+	 * attribute is set and Nobr is not enabled, use the bright entry in the
+	 * palette by changing to the aixterm colour
 	 */
 	if (~gc->flags & GRID_FLAG_NOPALETTE) {
 		c = gc->fg;
-		if (c < 8 && gc->attr & GRID_ATTR_BRIGHT)
+		if (c < 8 && gc->attr & GRID_ATTR_BRIGHT && !tty_term_has(tty->term, TTYC_NOBR))
 			c += 90;
 		if ((c = colour_palette_get(palette, c)) != -1)
 			gc->fg = c;


### PR DESCRIPTION
To match terminal not using bright colors for bold display.
Fix #3275