### PR TITLE
Notify control-mode clients of changes to paste buffers.

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -234,3 +234,16 @@ control_notify_session_window_changed(struct session *s)
 		    s->curw->window->id);
 	}
 }
+
+void
+control_notify_paste_changed(const char *name)
+{
+	struct client	*c;
+
+	TAILQ_FOREACH(c, &clients, entry) {
+		if (!CONTROL_SHOULD_NOTIFY_CLIENT(c))
+			continue;
+
+		control_write(c, "%%paste-changed %s", name);
+	}
+}

--- a/notify.c
+++ b/notify.c
@@ -32,6 +32,7 @@ struct notify_entry {
 	struct session		*session;
 	struct window		*window;
 	int			 pane;
+	const char		*paste_name;
 };
 
 static struct cmdq_item *
@@ -149,6 +150,8 @@ notify_callback(struct cmdq_item *item, void *data)
 		control_notify_session_closed(ne->session);
 	if (strcmp(ne->name, "session-window-changed") == 0)
 		control_notify_session_window_changed(ne->session);
+	if (strcmp(ne->name, "paste-changed") == 0)
+		control_notify_paste_changed(ne->paste_name);
 
 	notify_insert_hook(item, ne);
 
@@ -164,6 +167,9 @@ notify_callback(struct cmdq_item *item, void *data)
 
 	format_free(ne->formats);
 	free((void *)ne->name);
+	if (ne->paste_name != NULL) {
+		free((void *)ne->paste_name);
+	}
 	free(ne);
 
 	return (CMD_RETURN_NORMAL);
@@ -171,7 +177,7 @@ notify_callback(struct cmdq_item *item, void *data)
 
 static void
 notify_add(const char *name, struct cmd_find_state *fs, struct client *c,
-    struct session *s, struct window *w, struct window_pane *wp)
+    struct session *s, struct window *w, struct window_pane *wp, const char *paste_name)
 {
 	struct notify_entry	*ne;
 	struct cmdq_item	*item;
@@ -187,6 +193,7 @@ notify_add(const char *name, struct cmd_find_state *fs, struct client *c,
 	ne->session = s;
 	ne->window = w;
 	ne->pane = (wp != NULL ? wp->id : -1);
+	ne->paste_name = (paste_name != NULL) ? xstrdup(paste_name) : NULL;
 
 	ne->formats = format_create(NULL, NULL, 0, FORMAT_NOJOBS);
 	format_add(ne->formats, "hook", "%s", name);
@@ -248,7 +255,7 @@ notify_client(const char *name, struct client *c)
 	struct cmd_find_state	fs;
 
 	cmd_find_from_client(&fs, c, 0);
-	notify_add(name, &fs, c, NULL, NULL, NULL);
+	notify_add(name, &fs, c, NULL, NULL, NULL, NULL);
 }
 
 void
@@ -260,7 +267,7 @@ notify_session(const char *name, struct session *s)
 		cmd_find_from_session(&fs, s, 0);
 	else
 		cmd_find_from_nothing(&fs, 0);
-	notify_add(name, &fs, NULL, s, NULL, NULL);
+	notify_add(name, &fs, NULL, s, NULL, NULL, NULL);
 }
 
 void
@@ -269,7 +276,7 @@ notify_winlink(const char *name, struct winlink *wl)
 	struct cmd_find_state	fs;
 
 	cmd_find_from_winlink(&fs, wl, 0);
-	notify_add(name, &fs, NULL, wl->session, wl->window, NULL);
+	notify_add(name, &fs, NULL, wl->session, wl->window, NULL, NULL);
 }
 
 void
@@ -278,7 +285,7 @@ notify_session_window(const char *name, struct session *s, struct window *w)
 	struct cmd_find_state	fs;
 
 	cmd_find_from_session_window(&fs, s, w, 0);
-	notify_add(name, &fs, NULL, s, w, NULL);
+	notify_add(name, &fs, NULL, s, w, NULL, NULL);
 }
 
 void
@@ -287,7 +294,7 @@ notify_window(const char *name, struct window *w)
 	struct cmd_find_state	fs;
 
 	cmd_find_from_window(&fs, w, 0);
-	notify_add(name, &fs, NULL, NULL, w, NULL);
+	notify_add(name, &fs, NULL, NULL, w, NULL, NULL);
 }
 
 void
@@ -296,5 +303,13 @@ notify_pane(const char *name, struct window_pane *wp)
 	struct cmd_find_state	fs;
 
 	cmd_find_from_pane(&fs, wp, 0);
-	notify_add(name, &fs, NULL, NULL, NULL, wp);
+	notify_add(name, &fs, NULL, NULL, NULL, wp, NULL);
+}
+
+void
+notify_paste(const char *paste_name)
+{
+  	struct cmd_find_state fs;
+	cmd_find_clear_state(&fs, 0);
+	notify_add("paste-changed", &fs, NULL, NULL, NULL, NULL, paste_name);
 }

--- a/paste.c
+++ b/paste.c
@@ -206,6 +206,8 @@ paste_add(const char *prefix, char *data, size_t size)
 	pb->order = paste_next_order++;
 	RB_INSERT(paste_name_tree, &paste_by_name, pb);
 	RB_INSERT(paste_time_tree, &paste_by_time, pb);
+
+        notify_paste(pb->name);
 }
 
 /* Rename a paste buffer. */
@@ -252,6 +254,9 @@ paste_rename(const char *oldname, const char *newname, char **cause)
 	pb->automatic = 0;
 
 	RB_INSERT(paste_name_tree, &paste_by_name, pb);
+
+        notify_paste(oldname);
+        notify_paste(newname);
 
 	return (0);
 }
@@ -301,6 +306,8 @@ paste_set(char *data, size_t size, const char *name, char **cause)
 	RB_INSERT(paste_name_tree, &paste_by_name, pb);
 	RB_INSERT(paste_time_tree, &paste_by_time, pb);
 
+        notify_paste(name);
+
 	return (0);
 }
 
@@ -311,6 +318,8 @@ paste_replace(struct paste_buffer *pb, char *data, size_t size)
 	free(pb->data);
 	pb->data = data;
 	pb->size = size;
+
+        notify_paste(pb->name);
 }
 
 /* Convert start of buffer into a nice string. */

--- a/tmux.h
+++ b/tmux.h
@@ -2154,6 +2154,7 @@ void	notify_winlink(const char *, struct winlink *);
 void	notify_session_window(const char *, struct session *, struct window *);
 void	notify_window(const char *, struct window *);
 void	notify_pane(const char *, struct window_pane *);
+void	notify_paste(const char *);
 
 /* options.c */
 struct options	*options_create(struct options *);
@@ -3175,6 +3176,7 @@ void	control_notify_session_renamed(struct session *);
 void	control_notify_session_created(struct session *);
 void	control_notify_session_closed(struct session *);
 void	control_notify_session_window_changed(struct session *);
+void	control_notify_paste_changed(const char *paste_name);
 
 /* session.c */
 extern struct sessions sessions;


### PR DESCRIPTION
Sends %paste-changed <name> when a paste buffer is modified.

This is motivated by the desire to support neovim's copy-to-tmux feature in iTerm2's tmux integration. More background here: https://gitlab.com/gnachman/iterm2/-/issues/10530