### PR TITLE
Fix own fallback implementation of `getpeereid()`

### DIFF
--- a/compat/getpeereid.c
+++ b/compat/getpeereid.c
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 
 #include <stdio.h>
+#include <unistd.h>
 
 #ifdef HAVE_UCRED_H
 #include <ucred.h>
@@ -49,6 +50,8 @@ getpeereid(int s, uid_t *uid, gid_t *gid)
         ucred_free(ucred);
         return (0);
 #else
-	return (getuid());
+	*uid = geteuid();
+	*gid = getegid();
+	return (0);
 #endif
 }


### PR DESCRIPTION
Use `geteuid()` & `getegid()` (including `<unistd.h>`) to set uid & gid in
the out parameters, so they are set to callers. Also return 0, since
those functions do not fail.

Fixes commit 8bcd392ee79996f828fd40c52198071ec0f273dd.