### PR TITLE
tmux.1: tweak docs for new-session's -d and -D params to match behaviour

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1235,14 +1235,14 @@ Lock all clients attached to
 Create a new session with name
 .Ar session-name .
 .Pp
-The new session is attached to the current terminal unless
+The new session is attached to the current terminal, unless
 .Fl d
 is given.
 .Ar window-name
 and
 .Ar shell-command
 are the name of and shell command to execute in the initial window.
-With
+When creating a detached session with
 .Fl d ,
 the initial size comes from the global
 .Ic default-size


### PR DESCRIPTION
The `-d` and `-D` params to `new-session`, as described in the tmux man page, seem to conflict with the observed behaviour (and with itself).

They are described as following:

> The new session is attached to the current terminal unless -d is given. window-name and shell-command are the name of and shell command to execute in the initial window.  With -d, the initial size comes from the global default-size option; -x and -y can be used to specify a different size.

[later on in the same file]

> The -A flag makes new-session behave like attach-session if session-name already exists; in this case, -D behaves like -d to attach-session, and -X behaves like -x to attach-session.

In practice, the `-d` param creates a detached session:

```
photon ~ % tmux new-session -d -s detached
photon ~ % tmux list-sessions | grep detached
detached: 1 windows (created Thu Aug 25 14:00:24 2022)
photon ~ % tmux kill-session -t detached
```

(and it appears that `-D` will use `default-size`.)

OTOH, it looks like the other attach-session-ish parameters are in capitals (i.e. `-A` and `-X`), so it's possible the docs may illustrate the intended behaviour after all?