### PR TITLE
Fix answer to CSI winops sequence to report window size

### DIFF
--- a/input.c
+++ b/input.c
@@ -1899,7 +1899,7 @@ input_csi_dispatch_winops(struct input_ctx *ictx)
 			}
 			break;
 		case 18:
-			input_reply(ictx, "\033[8;%u;%ut", x, y);
+			input_reply(ictx, "\033[8;%u;%ut", y, x);
 			break;
 		default:
 			log_debug("%s: unknown '%c'", __func__, ictx->ch);


### PR DESCRIPTION
The answer should report window height, then window width. This is a
regression introduced in 3bbd66c0137f.