### PR TITLE
Support moving the prompt for command on different status line. Githu…

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -42,7 +42,7 @@ static const char *options_table_status_list[] = {
 	"off", "on", "2", "3", "4", "5", NULL
 };
 static const char *options_table_status_prompt_line_list[] = {
-	"0", "1", "2", "3", "4", "5", NULL
+	"0", "1", "2", "3", "4", NULL
 };
 static const char *options_table_status_keys_list[] = {
 	"emacs", "vi", NULL

--- a/options-table.c
+++ b/options-table.c
@@ -628,7 +628,7 @@ const struct options_table_entry options_table[] = {
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .choices = options_table_status_prompt_line_list,
-	  .default_num = 1,
+	  .default_num = 0,
 	  .text = "Line number of status prompt"
 	},
 

--- a/options-table.c
+++ b/options-table.c
@@ -41,6 +41,9 @@ static const char *options_table_clock_mode_style_list[] = {
 static const char *options_table_status_list[] = {
 	"off", "on", "2", "3", "4", "5", NULL
 };
+static const char *options_table_status_prompt_line_list[] = {
+	"0", "1", "2", "3", "4", "5", NULL
+};
 static const char *options_table_status_keys_list[] = {
 	"emacs", "vi", NULL
 };
@@ -620,6 +623,13 @@ const struct options_table_entry options_table[] = {
 	  .choices = options_table_status_list,
 	  .default_num = 1,
 	  .text = "Number of lines in the status line."
+	},
+	{ .name = "status-prompt-line",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_status_prompt_line_list,
+	  .default_num = 1,
+	  .text = "Line number of status prompt"
 	},
 
 	{ .name = "status-bg",

--- a/status.c
+++ b/status.c
@@ -263,12 +263,12 @@ status_line_size(struct client *c)
 	return (s->statuslines);
 }
 
-/* Get the prompt line number for client's session. 1 means at the bottom. */
+/* Get the prompt line number for client's session. 0 means topmost line of the status */
 u_int
 status_prompt_line_at(struct client *c)
 {
 	if (c->flags & (CLIENT_STATUSOFF|CLIENT_CONTROL))
-		return (1);
+		return (0);
 	return (options_get_number(global_s_options, "status-prompt-line"));
 }
 

--- a/status.c
+++ b/status.c
@@ -718,8 +718,8 @@ status_prompt_redraw(struct client *c)
 	screen_init(sl->active, c->tty.sx, lines, 0);
 
 	promptline = status_prompt_line_at(c);
-	if (promptline <= 1 || promptline > lines)
-		promptline = 1;
+	if (promptline > (lines - 1))
+		promptline = lines - 1;
 
 	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
 	if (c->prompt_mode == PROMPT_COMMAND)
@@ -737,12 +737,12 @@ status_prompt_redraw(struct client *c)
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-	screen_write_cursormove(&ctx, 0, lines - promptline, 0);
+	screen_write_cursormove(&ctx, 0, promptline, 0);
 	for (offset = 0; offset < c->tty.sx; offset++)
 		screen_write_putc(&ctx, &gc, ' ');
-	screen_write_cursormove(&ctx, 0, lines - promptline, 0);
+	screen_write_cursormove(&ctx, 0, promptline, 0);
 	format_draw(&ctx, &gc, start, c->prompt_string, NULL, 0);
-	screen_write_cursormove(&ctx, start, lines - promptline, 0);
+	screen_write_cursormove(&ctx, start, promptline, 0);
 
 	left = c->tty.sx - start;
 	if (left == 0)

--- a/tmux.1
+++ b/tmux.1
@@ -3971,6 +3971,9 @@ gives a status line one row in height;
 or
 .Ic 5
 more rows.
+.It Xo Ic status-prompt-line
+.Xc
+By default prompt is displayed at the bottom of the screen. By specifing a number between 0 and (status - 1). Prompt can be displayed on different status lines, where 0 is the topmost line of status.
 .It Ic status-format[] Ar format
 Specify the format to be used for each line of the status line.
 The default builds the top status line from the various individual status

--- a/tmux.h
+++ b/tmux.h
@@ -2689,6 +2689,7 @@ void	 status_timer_start_all(void);
 void	 status_update_cache(struct session *);
 int	 status_at_line(struct client *);
 u_int	 status_line_size(struct client *);
+u_int	 status_prompt_line_at(struct client *);
 struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);


### PR DESCRIPTION
- added an option 'status-prompt-line' (when status is set to 5, status-prompt-line can range from 1-5 where 5 is the bottom of the screen. 
- default value of status-prompt-line is 1

```
 set-option -g status 5
 set-option -g status-prompt-line 3
```
puts status prompt on the 3rd line from the bottom.

![prompt](https://user-images.githubusercontent.com/74096215/188328322-763241b7-da38-46b5-96cf-dfdfc2e5f407.gif)