### PR TITLE
compat/systemd: Fix a build error and a warning with clang-15

### DIFF
--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -16,6 +16,7 @@
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <string.h>
 #include <sys/types.h>
 #include <sys/un.h>
 

--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -30,7 +30,7 @@ systemd_create_socket(int flags, char **cause)
 	int			fds;
 	int			fd;
 	struct sockaddr_un	sa;
-	int			addrlen = sizeof sa;
+	socklen_t		addrlen = sizeof sa;
 
 	fds = sd_listen_fds(0);
 	if (fds > 1) { /* too many file descriptors */


### PR DESCRIPTION
Building with clang-15 emitted the following error and warning:
```
compat/systemd.c:46:47: warning: passing 'int *' to parameter of type 'socklen_t *' (aka 'unsigned int *')
      converts between pointers to integer types with different sign [-Wpointer-sign]
                if (getsockname(fd, (struct sockaddr *)&sa, &addrlen) == -1)
                                                            ^~~~~~~~
/usr/x86_64-pc-linux-musl/include/sys/socket.h:391:73: note: passing argument to parameter here
int getsockname (int, struct sockaddr *__restrict, socklen_t *__restrict);
                                                                        ^
compat/systemd.c:56:49: error: call to undeclared library function 'strerror' with type 'char *(int)'; ISO C99 and
      later do not support implicit function declarations [-Wimplicit-function-declaration]
                xasprintf(cause, "systemd socket error (%s)", strerror(errno));
                                                              ^
compat/systemd.c:56:49: note: include the header <string.h> or explicitly provide a declaration for 'strerror'
1 warning and 1 error generated.
```

This PR fixes both