### PR TITLE
Fix a memory leak when executing fzf-tmux

### DIFF
--- a/cmd-parse.y
+++ b/cmd-parse.y
@@ -1086,7 +1086,8 @@ cmd_parse_from_arguments(struct args_value *values, u_int count,
 				arg->type = CMD_PARSE_STRING;
 				arg->string = copy;
 				TAILQ_INSERT_TAIL(&cmd->arguments, arg, entry);
-			}
+			} else
+			  free(copy);
 		} else if (values[i].type == ARGS_COMMANDS) {
 			arg = xcalloc(1, sizeof *arg);
 			arg->type = CMD_PARSE_PARSED_COMMANDS;


### PR DESCRIPTION
If we execute fzf-tmux inside tmux session, there is a memory leak in cmd_parse_from_arguments().

Here is memory leak information:

```
=================================================================
==367944==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 2 byte(s) in 1 object(s) allocated from:
    #0 0x4855e4 in strdup (/usr/local/bin/tmux+0x4855e4)
    #1 0x84d104 in xstrdup /home/japin/Codes/tmux/xmalloc.c:93:12
    #2 0x5170d8 in cmd_parse_from_arguments /home/japin/Codes/tmux/cmd-parse.y:1075:11
    #3 0x4e10df in client_main /home/japin/Codes/tmux/client.c:267:8
    #4 0x768190 in main /home/japin/Codes/tmux/tmux.c:519:7
    #5 0x7fe9db1fe082 in __libc_start_main /build/glibc-SzIz7B/glibc-2.31/csu/../csu/libc-start.c:308:16

SUMMARY: AddressSanitizer: 2 byte(s) leaked in 1 allocation(s).
```