### PR TITLE
Add literal flag to display-message

### DIFF
--- a/cmd-display-message.c
+++ b/cmd-display-message.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_display_message_entry = {
 	.name = "display-message",
 	.alias = "display",
 
-	.args = { "ac:d:INpt:F:v", 0, 1, NULL },
-	.usage = "[-aINpv] [-c target-client] [-d delay] [-F format] "
+	.args = { "ac:d:lINpt:F:v", 0, 1, NULL },
+	.usage = "[-aIlNpv] [-c target-client] [-d delay] [-F format] "
 		 CMD_TARGET_PANE_USAGE " [message]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
@@ -67,7 +67,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	struct winlink		*wl = target->wl;
 	struct window_pane	*wp = target->wp;
 	const char		*template;
-	char			*msg, *cause;
+	char			*cause, *msg;
 	int			 delay = -1, flags;
 	struct format_tree	*ft;
 	u_int			 count = args_count(args);
@@ -132,7 +132,11 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_NORMAL);
 	}
 
-	msg = format_expand_time(ft, template);
+	if (args_has(args, 'l'))
+		msg = xstrdup(template);
+	else
+		msg = format_expand_time(ft, template);
+
 	if (cmdq_get_client(item) == NULL)
 		cmdq_error(item, "%s", msg);
 	else if (args_has(args, 'p'))

--- a/tmux.1
+++ b/tmux.1
@@ -5890,7 +5890,7 @@ The following keys are also available:
 .El
 .Tg display
 .It Xo Ic display-message
-.Op Fl aINpv
+.Op Fl aIlNpv
 .Op Fl c Ar target-client
 .Op Fl d Ar delay
 .Op Fl t Ar target-pane
@@ -5912,7 +5912,11 @@ is not given, the
 option is used; a delay of zero waits for a key press.
 .Ql N
 ignores key presses and closes only after the delay expires.
-The format of
+If
+.Fl l
+is given, the
+.Ar message
+is printed literally. Otherwise, the format of
 .Ar message
 is described in the
 .Sx FORMATS


### PR DESCRIPTION
Addresses #3371 

Adds a `-l` flag to `display-message` that causes it to print what is supplied literally. I think need this for my tests that use `display-message` to print key bindings.

This doesn't contain documentation as I'm not really familiar w/ the syntax of the docs or how to test them, so I didn't want to mess that up. 