### PR TITLE
Document alternate delimiters in regexp prefix

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -5083,6 +5083,15 @@ would change
 .Ql abABab
 into
 .Ql bxBxbx .
+A different delimiter character may also be used, to avoid collisions with
+literal slashes in the pattern.
+For example,
+.Ql s|foo/|bar/|:
+will substitute
+.Ql foo/
+with
+.Ql bar/
+throughout.
 .Pp
 In addition, the last line of a shell command's output may be inserted using
 .Ql #() .


### PR DESCRIPTION
Document the ability to use alternate argument separators with regular expression prefixes mentioned in https://github.com/tmux/tmux/issues/3315#issuecomment-1231752815