### PR TITLE
✨(format): Add `pane_current_command_pid` format variable for macOS

### DIFF
--- a/format.c
+++ b/format.c
@@ -840,6 +840,24 @@ format_cb_current_command(struct format_tree *ft)
 	return (value);
 }
 
+// relies on osdep_get_pid which is only implemented for macOS
+#ifdef __APPLE__
+/* Callback for pane_current_command_pid */
+static void *
+format_cb_current_command_pid(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+	char			 *value;
+
+	if (wp == NULL || wp->shell == NULL)
+		return (NULL);
+
+	pid_t pid = osdep_get_pid(wp->fd);
+	asprintf(&value, "%d", pid);
+	return value;
+}
+#endif
+
 /* Callback for pane_current_path. */
 static void *
 format_cb_current_path(struct format_tree *ft)
@@ -2866,6 +2884,11 @@ static const struct format_table_entry format_table[] = {
 	{ "pane_current_command", FORMAT_TABLE_STRING,
 	  format_cb_current_command
 	},
+	#ifdef __APPLE__
+	{ "pane_current_command_pid", FORMAT_TABLE_STRING,
+	  format_cb_current_command_pid
+	},
+	#endif
 	{ "pane_current_path", FORMAT_TABLE_STRING,
 	  format_cb_current_path
 	},

--- a/osdep-darwin.c
+++ b/osdep-darwin.c
@@ -29,11 +29,20 @@
 
 char			*osdep_get_name(int, char *);
 char			*osdep_get_cwd(int);
+pid_t			osdep_get_pid(int);
 struct event_base	*osdep_event_init(void);
 
 #ifndef __unused
 #define __unused __attribute__ ((__unused__))
 #endif
+
+pid_t
+osdep_get_pid(int fd)
+{
+	pid_t				pid;
+	pid = tcgetpgrp(fd);
+	return pid;
+}
 
 char *
 osdep_get_name(int fd, __unused char *tty)

--- a/tmux.h
+++ b/tmux.h
@@ -3272,6 +3272,9 @@ int		 utf8_cstrhas(const char *, const struct utf8_data *);
 /* osdep-*.c */
 char		*osdep_get_name(int, char *);
 char		*osdep_get_cwd(int);
+#ifdef __APPLE__
+pid_t		osdep_get_pid(int);
+#endif
 struct event_base *osdep_event_init(void);
 
 /* log.c */


### PR DESCRIPTION
✨(format): Add `pane_current_command_pid` format variable for macOS

Summary: Tmux currently has format variables for:
- `pane_pid`: _pid_ of the _first_ pane process
- `current_command_name`: _name_ of the _current_ pane process

But there's no way to get the _pid_ of the _current_ pane process.  This would
be helpful for something like getting the full name of the current process:

```
#(ps -p #{???} -o command=)
```

This commit adds the `pane_current_command_pid` format variable to do exactly
that.

Test Plan:
```sh
$ tmux
$ nvim tmux.c # or any other long-running command of your choosing
# run tmux exec command
:display-message '#(ps -p #{pane_current_command_pid} -o command=)'
nvim tmux.c
```

Question for reviewers:
- should we add an additional format specifier called
`pane_current_command_full_name` or something that does what I just described?
- I know this patch will likely get rejected due to only supporting macOS.  I
will accept patches to add support for other platforms, and will add the
patches myself as I use other platforms in my day-to-day

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/tmux/tmux/pull/3471).
* __->__ #3471
