### PR TITLE
Add Enter-to-confirm option (-e) to confirm-before command

### DIFF
--- a/cmd-confirm-before.c
+++ b/cmd-confirm-before.c
@@ -41,8 +41,8 @@ const struct cmd_entry cmd_confirm_before_entry = {
 	.name = "confirm-before",
 	.alias = "confirm",
 
-	.args = { "bp:t:", 1, 1, cmd_confirm_before_args_parse },
-	.usage = "[-b] [-p prompt] " CMD_TARGET_CLIENT_USAGE " command",
+	.args = { "bep:t:", 1, 1, cmd_confirm_before_args_parse },
+	.usage = "[-b] [-e] [-p prompt] " CMD_TARGET_CLIENT_USAGE " command",
 
 	.flags = CMD_CLIENT_TFLAG,
 	.exec = cmd_confirm_before_exec
@@ -51,6 +51,7 @@ const struct cmd_entry cmd_confirm_before_entry = {
 struct cmd_confirm_before_data {
 	struct cmdq_item	*item;
 	struct cmd_list		*cmdlist;
+	int			enter_to_confirm;
 };
 
 static enum args_parse_type
@@ -78,6 +79,8 @@ cmd_confirm_before_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (wait)
 		cdata->item = item;
+
+	cdata->enter_to_confirm = args_has(args, 'e');
 
 	if ((prompt = args_get(args, 'p')) != NULL)
 		xasprintf(&new_prompt, "%s ", prompt);
@@ -109,7 +112,7 @@ cmd_confirm_before_callback(struct client *c, void *data, const char *s,
 
 	if (s == NULL || *s == '\0')
 		goto out;
-	if (tolower((u_char)s[0]) != 'y' || s[1] != '\0')
+	if (!(tolower((u_char)s[0]) == 'y' || (cdata->enter_to_confirm && s[0] == '\n')) || s[1] != '\0')
 		goto out;
 	retcode = 0;
 

--- a/status.c
+++ b/status.c
@@ -1431,7 +1431,7 @@ process_key:
 		s = utf8_tocstr(c->prompt_buffer);
 		if (*s != '\0')
 			status_prompt_add_history(s, c->prompt_type);
-		if (c->prompt_inputcb(c, c->prompt_data, s, 1) == 0)
+		if (c->prompt_inputcb(c, c->prompt_data, (*s == '\0')?"\n":s, 1) == 0)
 			status_prompt_clear(c);
 		free(s);
 		break;


### PR DESCRIPTION
I wanted `confirm-before` command to accept other list of characters than the default 'y'. I thought of adding an option that can specify an arbitrary set of characters, but that would probably add unnecessary complexity to the code, and I didn't want to risk adding too much into an unfamiliar codebase.
So I resorted to adding an option to accept [Enter] key as confirmation instead, since that was the effect that I personally wanted to achieve.
As for the things I modified, I modified _cmd-confirm-before.c_ to accept the new (-e) argument option, and a new entry in the `cmd_confirm_before_data` struct so the callback will have access to what the new argument option.  
I also had to modify _status.c_ because it was sending `"\0"` to the `prompt_inputcb` when [Enter] key was pressed. Now, given the `key` is `'\r'` or `'\n'`, and the `prompt_buffer` string is null, it will always send `"\n"`.