### PR TITLE
Add 'pane_unseen_input' format

### DIFF
--- a/format.c
+++ b/format.c
@@ -1885,6 +1885,18 @@ format_cb_pane_input_off(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for pane_unseen_changes. */
+static void *
+format_cb_pane_unseen_input(struct format_tree *ft)
+{
+	if (ft->wp != NULL) {
+		if (ft->wp->flags & PANE_UNSEEN_CHANGES)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
 /* Callback for pane_last. */
 static void *
 format_cb_pane_last(struct format_tree *ft)
@@ -2952,6 +2964,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_tty", FORMAT_TABLE_STRING,
 	  format_cb_pane_tty
+	},
+	{ "pane_unseen_changes", FORMAT_TABLE_STRING,
+	  format_cb_pane_unseen_input
 	},
 	{ "pane_width", FORMAT_TABLE_STRING,
 	  format_cb_pane_width

--- a/input.c
+++ b/input.c
@@ -971,6 +971,10 @@ input_parse_buffer(struct window_pane *wp, u_char *buf, size_t len)
 	window_update_activity(wp->window);
 	wp->flags |= PANE_CHANGED;
 
+	/* new input while there is a mode */
+	if (!TAILQ_EMPTY(&wp->modes))
+		wp->flags |= PANE_UNSEEN_CHANGES;
+
 	/* NULL wp if there is a mode set as don't want to update the tty. */
 	if (TAILQ_EMPTY(&wp->modes))
 		screen_write_start_pane(sctx, wp, &wp->base);

--- a/tmux.1
+++ b/tmux.1
@@ -5242,6 +5242,7 @@ The following variables are available, where appropriate:
 .It Li "pane_id" Ta "#D" Ta "Unique pane ID"
 .It Li "pane_in_mode" Ta "" Ta "1 if pane is in a mode"
 .It Li "pane_index" Ta "#P" Ta "Index of pane"
+.It Li "pane_unseen_changes" Ta "" Ta "1 if there were changes in pane while in mode"
 .It Li "pane_input_off" Ta "" Ta "1 if input to pane is disabled"
 .It Li "pane_last" Ta "" Ta "1 if last pane"
 .It Li "pane_left" Ta "" Ta "Left of pane"

--- a/tmux.h
+++ b/tmux.h
@@ -1046,6 +1046,7 @@ struct window_pane {
 #define PANE_STATUSDRAWN 0x400
 #define PANE_EMPTY 0x800
 #define PANE_STYLECHANGED 0x1000
+#define PANE_UNSEEN_CHANGES 0x2000
 
 	int		 argc;
 	char	       **argv;

--- a/window.c
+++ b/window.c
@@ -1130,6 +1130,7 @@ window_pane_reset_mode(struct window_pane *wp)
 
 	next = TAILQ_FIRST(&wp->modes);
 	if (next == NULL) {
+		wp->flags &= ~PANE_UNSEEN_CHANGES;
 		log_debug("%s: no next mode", __func__);
 		wp->screen = &wp->base;
 	} else {


### PR DESCRIPTION
This commit introduces a new pane_unseen_input format. When a pane has seen input while it was in some mode, it sets the flags to PANE_UNSEEN_INPUT. It is cleared when exiting the mode.