### PR TITLE
man: clarify the section on `new-session -A/-D/-X`

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -1281,18 +1281,17 @@ behave like
 .Ic attach-session
 if
 .Ar session-name
-already exists; in this case,
+already exists; in this case, additional
 .Fl D
-behaves like
-.Fl d
-to
-.Ic attach-session ,
 and
 .Fl X
-behaves like
+flags behave like
+.Fl d
+and
 .Fl x
 to
-.Ic attach-session .
+.Ic attach-session
+respectively.
 .Pp
 If
 .Fl t


### PR DESCRIPTION
The docs weren't clear, whether the -D and -X flags should follow -A or if they already imply that -A is given. This edit covers the real behaviour (that -A is still required)