### PR TITLE
man: clarify usage of '&&' and '||' operators

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4889,7 +4889,7 @@ otherwise by
 .Ql ||
 and
 .Ql &&
-evaluate to true if either or both of two comma-separated alternatives are
+evaluate to true if either or all of the comma-separated alternatives are
 true, for example
 .Ql #{||:#{pane_in_mode},#{alternate_on}} .
 .Pp


### PR DESCRIPTION
The manual said that '&&' and '||' work with two arguments, but they can actually can take three and more