### PR TITLE
Default to vlock on Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ dist_EXTRA_tmux_SOURCES = compat/*.[ch]
 AM_CPPFLAGS += @XOPEN_DEFINES@ \
 	-DTMUX_VERSION='"@VERSION@"' \
 	-DTMUX_CONF='"$(sysconfdir)/tmux.conf:~/.tmux.conf:$$XDG_CONFIG_HOME/tmux/tmux.conf:~/.config/tmux/tmux.conf"' \
+	-DTMUX_LOCK_CMD='"@DEFAULT_LOCK_CMD@"' \
 	-DTMUX_TERM='"@DEFAULT_TERM@"'
 
 # Additional object files.

--- a/configure.ac
+++ b/configure.ac
@@ -936,6 +936,19 @@ AM_CONDITIONAL(IS_HPUX, test "x$PLATFORM" = xhpux)
 AM_CONDITIONAL(IS_HAIKU, test "x$PLATFORM" = xhaiku)
 AM_CONDITIONAL(IS_UNKNOWN, test "x$PLATFORM" = xunknown)
 
+# Set the default lock command
+DEFAULT_LOCK_CMD="lock -np"
+AC_MSG_CHECKING(lock-command)
+if test "x$PLATFORM" = xlinux ; then
+	AC_CHECK_PROG(found_vlock, vlock, yes, no)
+	if test "x$found_vlock" = xyes; then
+		DEFAULT_LOCK_CMD="vlock"
+	fi
+fi
+AC_MSG_RESULT($DEFAULT_LOCK_CMD)
+AC_SUBST(DEFAULT_LOCK_CMD)
+
+
 # Save our CFLAGS/CPPFLAGS/LDFLAGS for the Makefile and restore the old user
 # variables.
 AC_SUBST(AM_CPPFLAGS)

--- a/options-table.c
+++ b/options-table.c
@@ -530,7 +530,7 @@ const struct options_table_entry options_table[] = {
 	{ .name = "lock-command",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "lock -np",
+	  .default_str = TMUX_LOCK_CMD,
 	  .text = "Shell command to run to lock a client."
 	},
 

--- a/tmux.h
+++ b/tmux.h
@@ -81,6 +81,9 @@ struct winlink;
 #ifndef TMUX_TERM
 #define TMUX_TERM "screen"
 #endif
+#ifndef TMUX_LOCK_CMD
+#define TMUX_LOCK_CMD "lock -np"
+#endif
 
 /* Minimum layout cell size, NOT including border lines. */
 #define PANE_MINIMUM 1


### PR DESCRIPTION
The default lock command is 'lock -np', which isn't available on Linux.  The standard answer is to set the lock command in a conf file to 'vlock', but that requires the user to do this manually.

This tests if vlock is available in the build environment so Linux distributions can optionally package tmux with a requirement on vlock and have the command work by default.