### PR TITLE
Add a flag in confirm-before to select the confirmation key

### DIFF
--- a/cmd-confirm-before.c
+++ b/cmd-confirm-before.c
@@ -52,8 +52,8 @@ const struct cmd_entry cmd_confirm_before_entry = {
 struct cmd_confirm_before_data {
 	struct cmdq_item	*item;
 	struct cmd_list		*cmdlist;
-    u_char              confirm_key;
-    int                 default_yes;
+        u_char                  confirm_key;
+        int                     default_yes;
 };
 
 static enum args_parse_type
@@ -71,7 +71,7 @@ cmd_confirm_before_exec(struct cmd *self, struct cmdq_item *item)
 	struct client			*tc = cmdq_get_target_client(item);
 	struct cmd_find_state		*target = cmdq_get_target(item);
 	char				*new_prompt;
-    const char          *confirm_key_ptr;
+        const char                      *confirm_key_ptr;
 	const char			*prompt, *cmd;
 	int				 wait = !args_has(args, 'b');
 
@@ -83,18 +83,18 @@ cmd_confirm_before_exec(struct cmd *self, struct cmdq_item *item)
 	if (wait)
 		cdata->item = item;
 
-    cdata->default_yes = args_has(args, 'y');
+        cdata->default_yes = args_has(args, 'y');
 
-    if ((confirm_key_ptr = args_get(args, 'c')) != NULL){
-        if(confirm_key_ptr[1] == '\0' &&
-                confirm_key_ptr[0] > 31 && confirm_key_ptr[0] < 127)
-            cdata->confirm_key = confirm_key_ptr[0];
-        else
-         return (CMD_RETURN_ERROR);
-    }
-    else {
-        cdata->confirm_key = 'y';
-    }
+        if ((confirm_key_ptr = args_get(args, 'c')) != NULL){
+            if(confirm_key_ptr[1] == '\0' &&
+                    confirm_key_ptr[0] > 31 && confirm_key_ptr[0] < 127)
+                cdata->confirm_key = confirm_key_ptr[0];
+            else
+                return (CMD_RETURN_ERROR);
+        }
+        else {
+            cdata->confirm_key = 'y';
+        }
 
 	if ((prompt = args_get(args, 'p')) != NULL)
 		xasprintf(&new_prompt, "%s ", prompt);

--- a/cmd-confirm-before.c
+++ b/cmd-confirm-before.c
@@ -127,7 +127,8 @@ cmd_confirm_before_callback(struct client *c, void *data, const char *s,
 
 	if (s == NULL)
 		goto out;
-	if (s[0] != cdata->confirm_key && (s[0] != '\0' || !cdata->default_yes))
+	if (s[0] != cdata->confirm_key &&
+                        (s[0] != '\0' || !cdata->default_yes))
 		goto out;
 	retcode = 0;
 

--- a/cmd-confirm-before.c
+++ b/cmd-confirm-before.c
@@ -41,8 +41,9 @@ const struct cmd_entry cmd_confirm_before_entry = {
 	.name = "confirm-before",
 	.alias = "confirm",
 
-	.args = { "bp:t:", 1, 1, cmd_confirm_before_args_parse },
-	.usage = "[-b] [-p prompt] " CMD_TARGET_CLIENT_USAGE " command",
+	.args = { "byc:p:t:", 1, 1, cmd_confirm_before_args_parse },
+	.usage = "[-b] [-y] [-c confirm_key] [-p prompt] "
+        CMD_TARGET_CLIENT_USAGE " command",
 
 	.flags = CMD_CLIENT_TFLAG,
 	.exec = cmd_confirm_before_exec
@@ -51,6 +52,8 @@ const struct cmd_entry cmd_confirm_before_entry = {
 struct cmd_confirm_before_data {
 	struct cmdq_item	*item;
 	struct cmd_list		*cmdlist;
+    u_char              confirm_key;
+    int                 default_yes;
 };
 
 static enum args_parse_type
@@ -68,6 +71,7 @@ cmd_confirm_before_exec(struct cmd *self, struct cmdq_item *item)
 	struct client			*tc = cmdq_get_target_client(item);
 	struct cmd_find_state		*target = cmdq_get_target(item);
 	char				*new_prompt;
+    const char          *confirm_key_ptr;
 	const char			*prompt, *cmd;
 	int				 wait = !args_has(args, 'b');
 
@@ -79,11 +83,25 @@ cmd_confirm_before_exec(struct cmd *self, struct cmdq_item *item)
 	if (wait)
 		cdata->item = item;
 
+    cdata->default_yes = args_has(args, 'y');
+
+    if ((confirm_key_ptr = args_get(args, 'c')) != NULL){
+        if(confirm_key_ptr[1] == '\0' &&
+                confirm_key_ptr[0] > 31 && confirm_key_ptr[0] < 127)
+            cdata->confirm_key = confirm_key_ptr[0];
+        else
+         return (CMD_RETURN_ERROR);
+    }
+    else {
+        cdata->confirm_key = 'y';
+    }
+
 	if ((prompt = args_get(args, 'p')) != NULL)
 		xasprintf(&new_prompt, "%s ", prompt);
 	else {
 		cmd = cmd_get_entry(cmd_list_first(cdata->cmdlist))->name;
-		xasprintf(&new_prompt, "Confirm '%s'? (y/n) ", cmd);
+		xasprintf(&new_prompt, "Confirm '%s'? (%c/n) ",
+                cmd, cdata->confirm_key);
 	}
 
 	status_prompt_set(tc, target, new_prompt, NULL,
@@ -107,9 +125,9 @@ cmd_confirm_before_callback(struct client *c, void *data, const char *s,
 	if (c->flags & CLIENT_DEAD)
 		goto out;
 
-	if (s == NULL || *s == '\0')
+	if (s == NULL)
 		goto out;
-	if (tolower((u_char)s[0]) != 'y' || s[1] != '\0')
+	if (s[0] != cdata->confirm_key && (s[0] != '\0' || !cdata->default_yes))
 		goto out;
 	retcode = 0;
 

--- a/tmux.1
+++ b/tmux.1
@@ -5833,7 +5833,7 @@ until it is dismissed.
 changes the default answer of the prompt to y.
 .Fl c
 changes the confirmation key from the default 'y' to the key specified by
-.Ar confirm_key,
+.Ar confirm_key ,
 which is a single visible ascii character.
 .Tg menu
 .It Xo Ic display-menu

--- a/tmux.1
+++ b/tmux.1
@@ -5807,6 +5807,8 @@ until it is dismissed.
 .Tg confirm
 .It Xo Ic confirm-before
 .Op Fl b
+.Op Fl y
+.Op Fl c Ar confirm_key
 .Op Fl p Ar prompt
 .Op Fl t Ar target-client
 .Ar command
@@ -5827,6 +5829,12 @@ With
 .Fl b ,
 the prompt is shown in the background and the invoking client does not exit
 until it is dismissed.
+.Fl y
+changes the default answer of the prompt to y.
+.Fl c
+changes the confirmation key from the default 'y' to the key specified by
+.Ar confirm_key,
+which is a single visible ascii character.
 .Tg menu
 .It Xo Ic display-menu
 .Op Fl O


### PR DESCRIPTION
Hi, I wanted to be able to confirm the prompt of `confirm-before` without entering any character (only hitting enter), I then saw [pr #3496](https://github.com/tmux/tmux/pull/3496), that implements the behavior but only for enter key, so I implemented a more general solution per [nicm comment](https://github.com/tmux/tmux/pull/3496#issuecomment-1484736723).

I am still not sure of a couple of things:
- where should we place the `DEFAULT_CONFIRM_KEYCODE`, and if there is a macro for the keycode of 'y' that we can use instead.
- Do we still need the check of `s[1] != '\0'` in `cmd_confirm_before_callback`?