### PR TITLE
Add dependabot (github-actions) for dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I added a Dependabot (by GitHub) for automatic (weekly) dependency update check.
Further project configurations are under Settings > Code security and analysis (Dependabot).

[Dependabot GitHub Blog Post](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)