### PR TITLE
create list of last visited panes for each window

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -582,7 +582,7 @@ cmd_find_get_pane_with_window(struct cmd_find_state *fs, const char *pane)
 
 	/* Try special characters. */
 	if (strcmp(pane, "!") == 0) {
-		fs->wp = fs->w->last;
+		fs->wp = TAILQ_FIRST(&fs->w->last_visited_panes);
 		if (fs->wp == NULL)
 			return (-1);
 		return (0);

--- a/cmd-select-pane.c
+++ b/cmd-select-pane.c
@@ -98,7 +98,11 @@ cmd_select_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct options_entry	*o;
 
 	if (entry == &cmd_last_pane_entry || args_has(args, 'l')) {
-		lastwp = w->last;
+		lastwp = TAILQ_FIRST(&w->last_visited_panes);
+		/*
+		 * check for no last pane found in case the other pane
+		 * was spawned without being visited (e.g., split-window -d)
+		 */
 		if (lastwp == NULL && window_count_panes(w) == 2) {
 			lastwp = TAILQ_PREV(w->active, window_panes, entry);
 			if (lastwp == NULL)

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -128,10 +128,8 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 			window_set_active_pane(dst_w, src_wp, 1);
 	}
 	if (src_w != dst_w) {
-		if (src_w->last == src_wp)
-			src_w->last = NULL;
-		if (dst_w->last == dst_wp)
-			dst_w->last = NULL;
+		window_pane_stack_remove(&src_w->last_visited_panes, src_wp);
+		window_pane_stack_remove(&dst_w->last_visited_panes, dst_wp);
 		colour_palette_from_option(&src_wp->palette, src_wp->options);
 		colour_palette_from_option(&dst_wp->palette, dst_wp->options);
 	}

--- a/format.c
+++ b/format.c
@@ -1902,7 +1902,7 @@ static void *
 format_cb_pane_last(struct format_tree *ft)
 {
 	if (ft->wp != NULL) {
-		if (ft->wp == ft->wp->window->last)
+		if (ft->wp == TAILQ_FIRST(&ft->wp->window->last_visited_panes))
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}

--- a/spawn.c
+++ b/spawn.c
@@ -113,6 +113,7 @@ spawn_window(struct spawn_context *sc, char **cause)
 		window_pane_resize(sc->wp0, w->sx, w->sy);
 
 		layout_init(w, sc->wp0);
+		w->active = NULL;
 		window_set_active_pane(w, sc->wp0, 0);
 	}
 

--- a/tmux.h
+++ b/tmux.h
@@ -1052,6 +1052,7 @@ struct window_pane {
 #define PANE_EMPTY 0x800
 #define PANE_STYLECHANGED 0x1000
 #define PANE_UNSEENCHANGES 0x2000
+#define PANE_VISITED 0x4000
 
 	int		 argc;
 	char	       **argv;
@@ -1096,7 +1097,8 @@ struct window_pane {
 	int		 border_gc_set;
 	struct grid_cell border_gc;
 
-	TAILQ_ENTRY(window_pane) entry;
+	TAILQ_ENTRY(window_pane) entry;  /* link in list of all panes */
+	TAILQ_ENTRY(window_pane) sentry; /* link in list of last visited */
 	RB_ENTRY(window_pane) tree_entry;
 };
 TAILQ_HEAD(window_panes, window_pane);
@@ -1117,7 +1119,7 @@ struct window {
 	struct timeval		 activity_time;
 
 	struct window_pane	*active;
-	struct window_pane	*last;
+	struct window_panes 	 last_visited_panes;
 	struct window_panes	 panes;
 
 	int			 lastlayout;
@@ -1170,6 +1172,7 @@ struct winlink {
 #define WINLINK_ACTIVITY 0x2
 #define WINLINK_SILENCE 0x4
 #define WINLINK_ALERTFLAGS (WINLINK_BELL|WINLINK_ACTIVITY|WINLINK_SILENCE)
+#define WINLINK_VISITED 0x8
 
 	RB_ENTRY(winlink) entry;
 	TAILQ_ENTRY(winlink) wentry;
@@ -3045,6 +3048,10 @@ struct window_pane *window_pane_find_up(struct window_pane *);
 struct window_pane *window_pane_find_down(struct window_pane *);
 struct window_pane *window_pane_find_left(struct window_pane *);
 struct window_pane *window_pane_find_right(struct window_pane *);
+void		 window_pane_stack_push(struct window_panes *,
+		     struct window_pane *);
+void		 window_pane_stack_remove(struct window_panes *,
+		     struct window_pane *);
 void		 window_set_name(struct window *, const char *);
 void		 window_add_ref(struct window *, const char *);
 void		 window_remove_ref(struct window *, const char *);

--- a/window.c
+++ b/window.c
@@ -246,6 +246,7 @@ winlink_stack_push(struct winlink_stack *stack, struct winlink *wl)
 
 	winlink_stack_remove(stack, wl);
 	TAILQ_INSERT_HEAD(stack, wl, sentry);
+	wl->flags |= WINLINK_VISITED;
 }
 
 void
@@ -256,11 +257,9 @@ winlink_stack_remove(struct winlink_stack *stack, struct winlink *wl)
 	if (wl == NULL)
 		return;
 
-	TAILQ_FOREACH(wl2, stack, sentry) {
-		if (wl2 == wl) {
-			TAILQ_REMOVE(stack, wl, sentry);
-			return;
-		}
+	if (wl->flags & WINLINK_VISITED) {
+		TAILQ_REMOVE(stack, wl, sentry);
+		wl->flags &= ~WINLINK_VISITED;
 	}
 }
 
@@ -310,6 +309,7 @@ window_create(u_int sx, u_int sy, u_int xpixel, u_int ypixel)
 	w->flags = 0;
 
 	TAILQ_INIT(&w->panes);
+	TAILQ_INIT(&w->last_visited_panes);
 	w->active = NULL;
 
 	w->lastlayout = -1;
@@ -519,18 +519,23 @@ window_pane_update_focus(struct window_pane *wp)
 int
 window_set_active_pane(struct window *w, struct window_pane *wp, int notify)
 {
+	struct window_pane *lastwp;
+
 	log_debug("%s: pane %%%u", __func__, wp->id);
 
 	if (wp == w->active)
 		return (0);
-	w->last = w->active;
+	lastwp = w->active;
+
+	window_pane_stack_remove(&w->last_visited_panes, wp);
+	window_pane_stack_push(&w->last_visited_panes, lastwp);
 
 	w->active = wp;
 	w->active->active_point = next_active_point++;
 	w->active->flags |= PANE_CHANGED;
 
 	if (options_get_number(global_options, "focus-events")) {
-		window_pane_update_focus(w->last);
+		window_pane_update_focus(lastwp);
 		window_pane_update_focus(w->active);
 	}
 
@@ -753,21 +758,22 @@ window_lost_pane(struct window *w, struct window_pane *wp)
 	if (wp == marked_pane.wp)
 		server_clear_marked();
 
+	window_pane_stack_remove(&w->last_visited_panes, wp);
 	if (wp == w->active) {
-		w->active = w->last;
-		w->last = NULL;
+		w->active = TAILQ_FIRST(&w->last_visited_panes);
 		if (w->active == NULL) {
 			w->active = TAILQ_PREV(wp, window_panes, entry);
 			if (w->active == NULL)
 				w->active = TAILQ_NEXT(wp, entry);
 		}
 		if (w->active != NULL) {
+			window_pane_stack_remove(&w->last_visited_panes,
+						 w->active);
 			w->active->flags |= PANE_CHANGED;
 			notify_window("window-pane-changed", w);
 			window_update_focus(w);
 		}
-	} else if (wp == w->last)
-		w->last = NULL;
+	}
 }
 
 void
@@ -850,6 +856,11 @@ void
 window_destroy_panes(struct window *w)
 {
 	struct window_pane	*wp;
+
+	while (!TAILQ_EMPTY(&w->last_visited_panes)) {
+		wp = TAILQ_FIRST(&w->last_visited_panes);
+		window_pane_stack_remove(&w->last_visited_panes, wp);
+	}
 
 	while (!TAILQ_EMPTY(&w->panes)) {
 		wp = TAILQ_FIRST(&w->panes);
@@ -1486,6 +1497,29 @@ window_pane_find_right(struct window_pane *wp)
 	best = window_pane_choose_best(list, size);
 	free(list);
 	return (best);
+}
+
+void
+window_pane_stack_push(struct window_panes *stack, struct window_pane *wp)
+{
+	if (wp == NULL)
+		return;
+
+	window_pane_stack_remove(stack, wp);
+	TAILQ_INSERT_HEAD(stack, wp, sentry);
+	wp->flags |= PANE_VISITED;
+}
+
+void
+window_pane_stack_remove(struct window_panes *stack, struct window_pane *wp)
+{
+	if (wp == NULL)
+		return;
+
+	if (wp->flags & PANE_VISITED) {
+		TAILQ_REMOVE(stack, wp, sentry);
+		wp->flags &= ~PANE_VISITED;
+	}
 }
 
 /* Clear alert flags for a winlink */


### PR DESCRIPTION
This commit changes the "last-pane" feature to use a stack-like list of the visited panes in each window. This is so that it is easy to use the last-pane command to visit previously visited panes even when the most recently visited pane is deleted.

This is partially addressed by https://github.com/tmux/tmux/pull/1377 (0c94c3fbee3df39293de8b7fd957392251113a74).
That commit is helpful but I use layouts with 4+ panes frequently enough that I run into this when there are 3+ panes after deleting one.

A limitation of the solution here is that panes that are created without being visited are not added to the stack.
This is addressed for the 2-pane case by leaving in the solution from PR 1377.
While this commit does not address the issue for 3+ panes, this is not addressed for the last-window stack either so I think this acceptable.
A complete solution could add panes to the bottom of the stack if they are created without being visited (although that would not be very stacklike ;)). This could work for windows too.
