### PR TITLE
Check result of fdopen

### DIFF
--- a/popup.c
+++ b/popup.c
@@ -787,6 +787,8 @@ popup_editor(struct client *c, const char *buf, size_t len,
 	if (fd == -1)
 		return (-1);
 	f = fdopen(fd, "w");
+	if (f == NULL)
+		return (-1);
 	if (fwrite(buf, len, 1, f) != 1) {
 		fclose(f);
 		return (-1);


### PR DESCRIPTION
`fdopen` can fail for various reasons, e.g. if there is not enough memory. If `fdopen` fails, it returns `NULL`, which previously would have caused a segmentation fault in `fwrite`.

This issue was found by using the GCC static analyzer, which can be enabled using the `-fanalyzer` flag:
```
CFLAGS=-fanalyzer ./configure && make -j
```