### PR TITLE
Fix terminfo library name for NetBSD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,7 @@ fi
 if test "x$found_ncurses" = xno; then
 	AC_SEARCH_LIBS(
 		setupterm,
-		[tinfo ncurses ncursesw],
+		[tinfo terminfo ncurses ncursesw],
 		found_ncurses=yes,
 		found_ncurses=no
 	)


### PR DESCRIPTION
Fixes configure step - curses library was not found before this change because setupterm is in libterminfo on NetBSD.