### PR TITLE
Warning fixes

### DIFF
--- a/format.c
+++ b/format.c
@@ -3813,7 +3813,7 @@ format_build_modifiers(struct format_expand_state *es, const char **s,
 		argc = 0;
 
 		/* Single argument with no wrapper character. */
-		if (!ispunct(cp[1]) || cp[1] == '-') {
+		if (!ispunct((unsigned char)cp[1]) || cp[1] == '-') {
 			end = format_skip(cp + 1, ":;");
 			if (end == NULL)
 				break;

--- a/hyperlinks.c
+++ b/hyperlinks.c
@@ -42,7 +42,7 @@
 
 #define MAX_HYPERLINKS 5000
 
-static uint64_t hyperlinks_next_external_id = 1;
+static long long hyperlinks_next_external_id = 1;
 static u_int global_hyperlinks_count;
 
 struct hyperlinks_uri {

--- a/input.c
+++ b/input.c
@@ -2842,7 +2842,7 @@ input_reply_clipboard(struct bufferevent *bev, const char *buf, size_t len,
     const char *end)
 {
 	char	*out = NULL;
-	size_t	 outlen = 0;
+	int	 outlen = 0;
 
 	if (buf != NULL && len != 0) {
 		outlen = 4 * ((len + 2) / 3) + 1;

--- a/notify.c
+++ b/notify.c
@@ -193,7 +193,7 @@ notify_add(const char *name, struct cmd_find_state *fs, struct client *c,
 	ne->client = c;
 	ne->session = s;
 	ne->window = w;
-	ne->pane = (wp != NULL ? wp->id : -1);
+	ne->pane = (wp != NULL ? (int)wp->id : -1);
 	ne->pbname = (pbname != NULL ? xstrdup(pbname) : NULL);
 
 	ne->formats = format_create(NULL, NULL, 0, FORMAT_NOJOBS);
@@ -240,7 +240,7 @@ notify_hook(struct cmdq_item *item, const char *name)
 	ne.client = cmdq_get_client(item);
 	ne.session = target->s;
 	ne.window = target->w;
-	ne.pane = (target->wp != NULL ? target->wp->id : -1);
+	ne.pane = (target->wp != NULL ? (int)target->wp->id : -1);
 
 	ne.formats = format_create(NULL, NULL, 0, FORMAT_NOJOBS);
 	format_add(ne.formats, "hook", "%s", name);

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1160,7 +1160,7 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 {
 	struct client		*c = tty->client;
 	struct window_pane	*wp;
-	size_t			 end, terminator, needed;
+	size_t			 end, terminator = 0, needed;
 	char			*copy, *out;
 	int			 outlen;
 	u_int			 i;

--- a/tty-term.c
+++ b/tty-term.c
@@ -674,7 +674,7 @@ tty_term_read_list(const char *name, int fd, char ***caps, u_int *ncaps,
 	const struct tty_term_code_entry	*ent;
 	int					 error, n;
 	u_int					 i;
-	const char				*s;
+	const char				*s = NULL;
 	char					 tmp[11];
 
 	if (setupterm((char *)name, fd, &error) != OK) {


### PR DESCRIPTION
This fixes most warnings with the default compiler warning flags when building on NetBSD.
The remaining one is:
```
../format.c: In function ‘format_find’:
../format.c:3572:5: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
 3572 |     strftime(s, sizeof s, time_format, &tm);
      |     ^~~~~~~~
../format.c: In function ‘format_expand1’:
../format.c:4750:3: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
 4750 |   if (strftime(expanded, sizeof expanded, fmt, &es->tm) == 0) {
      |   ^~
```