### PR TITLE
[WIP] [Help needed] Support terminals which have more than 256 colors in their colortable

### DIFF
--- a/colour.c
+++ b/colour.c
@@ -137,7 +137,7 @@ colour_tostring(int c)
 	}
 
 	if (c & COLOUR_FLAG_256) {
-		xsnprintf(s, sizeof s, "colour%u", c & 0xff);
+		xsnprintf(s, sizeof s, "colour%u", c & 0xffff);
 		return (s);
 	}
 
@@ -203,13 +203,13 @@ colour_fromstring(const char *s)
 	}
 
 	if (strncasecmp(s, "colour", (sizeof "colour") - 1) == 0) {
-		n = strtonum(s + (sizeof "colour") - 1, 0, 255, &errstr);
+		n = strtonum(s + (sizeof "colour") - 1, 0, 0xffff, &errstr);
 		if (errstr != NULL)
 			return (-1);
 		return (n | COLOUR_FLAG_256);
 	}
 	if (strncasecmp(s, "color", (sizeof "color") - 1) == 0) {
-		n = strtonum(s + (sizeof "color") - 1, 0, 255, &errstr);
+		n = strtonum(s + (sizeof "color") - 1, 0, 0xffff, &errstr);
 		if (errstr != NULL)
 			return (-1);
 		return (n | COLOUR_FLAG_256);
@@ -1029,8 +1029,8 @@ colour_palette_set(struct colour_palette *p, int n, int c)
 
 	if (c != -1 && p->palette == NULL) {
 		if (p->palette == NULL)
-			p->palette = xcalloc(256, sizeof *p->palette);
-		for (i = 0; i < 256; i++)
+			p->palette = xcalloc(0xffff, sizeof *p->palette);
+		for (i = 0; i < 0xffff; i++)
 			p->palette[i] = -1;
 	}
 	p->palette[n] = c;

--- a/grid.c
+++ b/grid.c
@@ -63,11 +63,11 @@ grid_store_cell(struct grid_cell_entry *gce, const struct grid_cell *gc,
 {
 	gce->flags = (gc->flags & ~GRID_FLAG_CLEARED);
 
-	gce->data.fg = gc->fg & 0xff;
+	gce->data.fg = gc->fg & 0xffff;
 	if (gc->fg & COLOUR_FLAG_256)
 		gce->flags |= GRID_FLAG_FG256;
 
-	gce->data.bg = gc->bg & 0xff;
+	gce->data.bg = gc->bg & 0xffff;
 	if (gc->bg & COLOUR_FLAG_256)
 		gce->flags |= GRID_FLAG_BG256;
 
@@ -739,7 +739,7 @@ grid_string_cells_fg(const struct grid_cell *gc, int *values)
 	if (gc->fg & COLOUR_FLAG_256) {
 		values[n++] = 38;
 		values[n++] = 5;
-		values[n++] = gc->fg & 0xff;
+		values[n++] = gc->fg & 0xffff;
 	} else if (gc->fg & COLOUR_FLAG_RGB) {
 		values[n++] = 38;
 		values[n++] = 2;
@@ -788,7 +788,7 @@ grid_string_cells_bg(const struct grid_cell *gc, int *values)
 	if (gc->bg & COLOUR_FLAG_256) {
 		values[n++] = 48;
 		values[n++] = 5;
-		values[n++] = gc->bg & 0xff;
+		values[n++] = gc->bg & 0xffff;
 	} else if (gc->bg & COLOUR_FLAG_RGB) {
 		values[n++] = 48;
 		values[n++] = 2;
@@ -837,7 +837,7 @@ grid_string_cells_us(const struct grid_cell *gc, int *values)
 	if (gc->us & COLOUR_FLAG_256) {
 		values[n++] = 58;
 		values[n++] = 5;
-		values[n++] = gc->us & 0xff;
+		values[n++] = gc->us & 0xffff;
 	} else if (gc->us & COLOUR_FLAG_RGB) {
 		values[n++] = 58;
 		values[n++] = 2;

--- a/input.c
+++ b/input.c
@@ -1914,7 +1914,7 @@ input_csi_dispatch_sgr_256_do(struct input_ctx *ictx, int fgbg, int c)
 {
 	struct grid_cell	*gc = &ictx->cell.cell;
 
-	if (c == -1 || c > 255) {
+	if (c == -1 || c > (0xffff-1)) {
 		if (fgbg == 38)
 			gc->fg = 8;
 		else if (fgbg == 48)

--- a/tty.c
+++ b/tty.c
@@ -2858,9 +2858,9 @@ tty_try_colour(struct tty *tty, int colour, const char *type)
 
 	if (colour & COLOUR_FLAG_256) {
 		if (*type == '3' && tty_term_has(tty->term, TTYC_SETAF))
-			tty_putcode1(tty, TTYC_SETAF, colour & 0xff);
+			tty_putcode1(tty, TTYC_SETAF, colour & 0xffff);
 		else if (tty_term_has(tty->term, TTYC_SETAB))
-			tty_putcode1(tty, TTYC_SETAB, colour & 0xff);
+			tty_putcode1(tty, TTYC_SETAB, colour & 0xffff);
 		return (0);
 	}
 


### PR DESCRIPTION
In this draft PR we attempt to support color terminals which have more than 256 colors in their colortable. The plan is:
* [x] Support options `color256` .. `color65535`
* [ ] Allow tmux to issue `\033[38;5;XXXX` -like commands to terminals where XXXX is not limited to be within the 0..255 range.

The motivation for this work is the following:
1. We want to add support for custom terminal-side colors in order to refer to them from various client-side configs. 
2. In particular, we want to enable different per-client color themes to co-exist in the tmux runtime. In order to do this we plan to ask clients to configure their `color256`..`colorXXXX` to match the specific parts of the UI and then use these names in a tmux session configuration.

Now, Vim already supports this feature (e.g. we can freely use `:highlight LineNR ctermbg=260` where 260 is the index in the extended color table of a terminal) and we already have this working in Simple terminal (the changes are trivial, see this [patch](https://github.com/grwlf/st/commit/9b8a6c1c73fb3f93491d5d48fc8e4d77f1d4a473))

Unfortunately, the tmux part of the story is in half-working state. The current version is able to display the right colors in PS1 (if configured like `PS1="\n\[\033[38;5;260;1m\][\u@\h \w ]\\$\[\033[0m\] "`) but the statusline colors are displayed incorrectly.

Advice or comments are highly welcome! 