### PR TITLE
Fix SIGCHLD with libevent signalfd backend

### DIFF
--- a/client.c
+++ b/client.c
@@ -516,7 +516,7 @@ client_exec(const char *shell, const char *shellcmd)
 		xasprintf(&argv0, "%s", name);
 	setenv("SHELL", shell, 1);
 
-	proc_clear_signals(client_proc, 1);
+	proc_clear_signals(client_proc);
 
 	setblocking(STDIN_FILENO, 1);
 	setblocking(STDOUT_FILENO, 1);

--- a/cmd-pipe-pane.c
+++ b/cmd-pipe-pane.c
@@ -132,7 +132,7 @@ cmd_pipe_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	case 0:
 		/* Child process. */
-		proc_clear_signals(server_proc, 1);
+		proc_clear_signals(server_proc);
 		sigprocmask(SIG_SETMASK, &oldset, NULL);
 		close(pipe_fd[0]);
 

--- a/job.c
+++ b/job.c
@@ -119,7 +119,7 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e, struct sessio
 		}
 		goto fail;
 	case 0:
-		proc_clear_signals(server_proc, 1);
+		proc_clear_signals(server_proc);
 		sigprocmask(SIG_SETMASK, &oldset, NULL);
 
 		if ((cwd == NULL || chdir(cwd) != 0) &&

--- a/proc.c
+++ b/proc.c
@@ -265,7 +265,7 @@ proc_set_signals(struct tmuxproc *tp, void (*signalcb)(int))
 }
 
 void
-proc_clear_signals(struct tmuxproc *tp, int defaults)
+proc_clear_signals(struct tmuxproc *tp)
 {
 	struct sigaction	sa;
 
@@ -286,17 +286,17 @@ proc_clear_signals(struct tmuxproc *tp, int defaults)
 	signal_del(&tp->ev_sigusr2);
 	signal_del(&tp->ev_sigwinch);
 
-	if (defaults) {
-		sigaction(SIGINT, &sa, NULL);
-		sigaction(SIGQUIT, &sa, NULL);
-		sigaction(SIGHUP, &sa, NULL);
-		sigaction(SIGCHLD, &sa, NULL);
-		sigaction(SIGCONT, &sa, NULL);
-		sigaction(SIGTERM, &sa, NULL);
-		sigaction(SIGUSR1, &sa, NULL);
-		sigaction(SIGUSR2, &sa, NULL);
-		sigaction(SIGWINCH, &sa, NULL);
-	}
+	/* Restore defaults, since signal_del() not always capable of restoring the
+	 * defaults, due to SIG_IGN (i.e. for SIGCHLD) */
+	sigaction(SIGINT, &sa, NULL);
+	sigaction(SIGQUIT, &sa, NULL);
+	sigaction(SIGHUP, &sa, NULL);
+	sigaction(SIGCHLD, &sa, NULL);
+	sigaction(SIGCONT, &sa, NULL);
+	sigaction(SIGTERM, &sa, NULL);
+	sigaction(SIGUSR1, &sa, NULL);
+	sigaction(SIGUSR2, &sa, NULL);
+	sigaction(SIGWINCH, &sa, NULL);
 }
 
 struct tmuxpeer *

--- a/server.c
+++ b/server.c
@@ -190,7 +190,7 @@ server_start(struct tmuxproc *client, int flags, struct event_base *base,
 			return (fd);
 		}
 	}
-	proc_clear_signals(client, 0);
+	proc_clear_signals(client);
 	server_client_flags = flags;
 
 	if (event_reinit(base) != 0)

--- a/spawn.c
+++ b/spawn.c
@@ -428,7 +428,7 @@ spawn_pane(struct spawn_context *sc, char **cause)
 		_exit(1);
 
 	/* Clean up file descriptors and signals and update the environment. */
-	proc_clear_signals(server_proc, 1);
+	proc_clear_signals(server_proc);
 	closefrom(STDERR_FILENO + 1);
 	sigprocmask(SIG_SETMASK, &oldset, NULL);
 	log_close();

--- a/tmux.h
+++ b/tmux.h
@@ -2071,7 +2071,7 @@ struct tmuxproc *proc_start(const char *);
 void	proc_loop(struct tmuxproc *, int (*)(void));
 void	proc_exit(struct tmuxproc *);
 void	proc_set_signals(struct tmuxproc *, void(*)(int));
-void	proc_clear_signals(struct tmuxproc *, int);
+void	proc_clear_signals(struct tmuxproc *);
 struct tmuxpeer *proc_add_peer(struct tmuxproc *, int,
 	    void (*)(struct imsg *, void *), void *);
 void	proc_remove_peer(struct tmuxpeer *);


### PR DESCRIPTION
Without this patch with signalfd() backend it works incorrectly, this is
what proc_clear_signals() does:

    6674  rt_sigprocmask(SIG_UNBLOCK, [CHLD], NULL, 8) = 0
    6674  rt_sigaction(SIGCHLD, {sa_handler=SIG_IGN, sa_mask=[CHLD], sa_flags=SA_RESTORER|SA_RESTART, sa_restorer=0x7ffff7c78ab0}, NULL, 8) = 0
    6674  close(6<signalfd:[CHLD]>)         = 0

And this is what proc_set_signals() does:

    6674  rt_sigaction(SIGCHLD, NULL, {sa_handler=SIG_IGN, sa_mask=[CHLD], sa_flags=SA_RESTORER|SA_RESTART, sa_restorer=0x7ffff7c78ab0}, 8) = 0
    6674  rt_sigprocmask(SIG_BLOCK, [CHLD], NULL, 8) = 0
    6674  signalfd4(-1, [CHLD], 8, SFD_CLOEXEC|SFD_NONBLOCK) = 6<signalfd:[CHLD]>

Pay attention to the SIG_IGN.

And also one more patch for the client, that calls waitpid in a loop to avoid loosing any childs.

**P.S. I'm going to disable signalfd backend in libevent by default, since there are some trickery, which will break some existing programs. Also note, that there was not stable release with signalfd enabled.**