### PR TITLE
Update extended-keys mode after running reset(1)

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -327,6 +327,8 @@ screen_write_reset(struct screen_write_ctx *ctx)
 	screen_write_scrollregion(ctx, 0, screen_size_y(s) - 1);
 
 	s->mode = MODE_CURSOR | MODE_WRAP;
+	if (options_get_number(global_options, "extended-keys") == 2)
+		s->mode |= MODE_KEXTENDED;
 
 	screen_write_clearscreen(ctx, 8);
 	screen_write_set_cursor(ctx, 0, 0);


### PR DESCRIPTION
This is the same code that was added to screen_reinit() when the "always" value was added to the extended-keys option in 8363c6a.

Fixes GitHub issue #3629.