### PR TITLE
Use silent makefile rules by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR(etc)
 AC_CONFIG_LIBOBJ_DIR(compat)
 AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_SILENT_RULES([yes])
 
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
This makes compiler warnings more visible. The original behavior can be enabled by adding V=1 to the make command line.