### PR TITLE
Add options and arguments to display-menu to set menu style

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -38,8 +38,8 @@ const struct cmd_entry cmd_display_menu_entry = {
 	.name = "display-menu",
 	.alias = "menu",
 
-	.args = { "c:t:S:OT:x:y:", 1, -1, cmd_display_menu_args_parse },
-	.usage = "[-O] [-c target-client] [-S starting-choice] "
+	.args = { "c:t:s:S:OT:x:y:", 1, -1, cmd_display_menu_args_parse },
+	.usage = "[-O] [-c target-client] [-s style] [-S starting-choice] "
 		 CMD_TARGET_PANE_USAGE " [-T title] [-x position] "
 		 "[-y position] name key command ...",
 
@@ -289,6 +289,7 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	struct menu		*menu = NULL;
 	struct menu_item	 menu_item;
 	const char		*key, *name;
+	const char		*style = args_get(args, 's');
 	char			*title, *cause;
 	int			 flags = 0, starting_choice = 0;
 	u_int			 px, py, i, count = args_count(args);
@@ -356,8 +357,8 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 		flags |= MENU_STAYOPEN;
 	if (!event->m.valid)
 		flags |= MENU_NOMOUSE;
-	if (menu_display(menu, flags, starting_choice, item, px, py, tc, target,
-	    NULL, NULL) != 0)
+	if (menu_display(menu, flags, starting_choice, item, px, py, tc, style,
+	    target, NULL, NULL) != 0)
 		return (CMD_RETURN_NORMAL);
 	return (CMD_RETURN_WAIT);
 }

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -962,7 +962,7 @@ mode_tree_display_menu(struct mode_tree_data *mtd, struct client *c, u_int x,
 		x -= (menu->width + 4) / 2;
 	else
 		x = 0;
-	if (menu_display(menu, 0, 0, NULL, x, y, c, NULL,
+	if (menu_display(menu, 0, 0, NULL, x, y, c, NULL, NULL,
 	    mode_tree_menu_callback, mtm) != 0)
 		menu_free(menu);
 }

--- a/options-table.c
+++ b/options-table.c
@@ -326,6 +326,15 @@ const struct options_table_entry options_table[] = {
 		  "Empty does not write a history file."
 	},
 
+	{ .name = "menu-style",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .flags = OPTIONS_TABLE_IS_STYLE,
+	  .default_str = "default",
+	  .separator = ",",
+	  .text = "Default style of menu."
+	},
+
 	{ .name = "message-limit",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/popup.c
+++ b/popup.c
@@ -574,7 +574,7 @@ menu:
 		x = m->x - (pd->menu->width + 4) / 2;
 	else
 		x = 0;
-	pd->md = menu_prepare(pd->menu, 0, 0, NULL, x, m->y, c, NULL,
+	pd->md = menu_prepare(pd->menu, 0, 0, NULL, x, m->y, c, NULL, NULL,
 	    popup_menu_done, pd);
 	c->flags |= CLIENT_REDRAWOVERLAY;
 

--- a/status.c
+++ b/status.c
@@ -1765,7 +1765,7 @@ status_prompt_complete_list_menu(struct client *c, char **list, u_int size,
 		offset = 0;
 
 	if (menu_display(menu, MENU_NOMOUSE|MENU_TAB, 0, NULL, offset,
-	    py, c, NULL, status_prompt_menu_callback, spm) != 0) {
+	    py, c, NULL, NULL, status_prompt_menu_callback, spm) != 0) {
 		menu_free(menu);
 		free(spm);
 		return (0);
@@ -1858,7 +1858,7 @@ status_prompt_complete_window_menu(struct client *c, struct session *s,
 		offset = 0;
 
 	if (menu_display(menu, MENU_NOMOUSE|MENU_TAB, 0, NULL, offset,
-	    py, c, NULL, status_prompt_menu_callback, spm) != 0) {
+	    py, c, NULL, NULL, status_prompt_menu_callback, spm) != 0) {
 		menu_free(menu);
 		free(spm);
 		return (NULL);

--- a/tmux.1
+++ b/tmux.1
@@ -4076,6 +4076,13 @@ The default is to run
 .Xr lock 1
 with
 .Fl np .
+.It Ic menu-style Ar style
+Set the menu style.
+See the
+.Sx STYLES
+section on how to specify
+.Ar style .
+Attributes are ignored.
 .It Ic message-command-style Ar style
 Set status line message command style.
 This is used for the command prompt with
@@ -4543,20 +4550,18 @@ Attributes are ignored.
 .Pp
 .It Ic popup-style Ar style
 Set the popup style.
-For how to specify
-.Ar style ,
-see the
+See the
 .Sx STYLES
-section.
+section on how to specify
+.Ar style .
 Attributes are ignored.
 .Pp
 .It Ic popup-border-style Ar style
 Set the popup border style.
-For how to specify
-.Ar style ,
-see the
+See the
 .Sx STYLES
-section.
+section on how to specify
+.Ar style .
 Attributes are ignored.
 .Pp
 .It Ic popup-border-lines Ar type
@@ -6032,6 +6037,7 @@ the default is
 .It Xo Ic display-menu
 .Op Fl O
 .Op Fl c Ar target-client
+.Op Fl s Ar style
 .Op Fl t Ar target-pane
 .Op Fl S Ar starting-choice
 .Op Fl T Ar title
@@ -6060,9 +6066,14 @@ may not be chosen.
 The name may be empty for a separator line, in which case both the key and
 command should be omitted.
 .Pp
+.Fl s
+sets the style for the menu (see
+.Sx STYLES ) .
+.Pp
 .Fl T
 is a format for the menu title (see
 .Sx FORMATS ) .
+.Pp
 .Fl S
 sets the menu item selected by default, if the menu is not bound to a mouse key
 binding.
@@ -6173,13 +6184,13 @@ forwards any input read from stdin to the empty pane given by
 .Tg popup
 .It Xo Ic display-popup
 .Op Fl BCE
-.Op Fl b Ar border-lines
+.Op Fl b Ar type
 .Op Fl c Ar target-client
 .Op Fl d Ar start-directory
 .Op Fl e Ar environment
 .Op Fl h Ar height
 .Op Fl s Ar style
-.Op Fl S Ar border-style
+.Op Fl S Ar style
 .Op Fl t Ar target-pane
 .Op Fl T Ar title
 .Op Fl w Ar width
@@ -6231,7 +6242,7 @@ option is ignored.
 See
 .Ic popup-border-lines
 for possible values for
-.Ar border-lines .
+.Ar type .
 .Pp
 .Fl s
 sets the style for the popup and

--- a/tmux.h
+++ b/tmux.h
@@ -2894,10 +2894,11 @@ void	 screen_write_putc(struct screen_write_ctx *, const struct grid_cell *,
 	     u_char);
 void	 screen_write_fast_copy(struct screen_write_ctx *, struct screen *,
 	     u_int, u_int, u_int, u_int);
-void	 screen_write_hline(struct screen_write_ctx *, u_int, int, int);
+void	 screen_write_hline(struct screen_write_ctx *, u_int, int, int,
+             const struct grid_cell *);
 void	 screen_write_vline(struct screen_write_ctx *, u_int, int, int);
 void	 screen_write_menu(struct screen_write_ctx *, struct menu *, int,
-	     const struct grid_cell *);
+	     const struct grid_cell *, const struct grid_cell *);
 void	 screen_write_box(struct screen_write_ctx *, u_int, u_int,
              enum box_lines, const struct grid_cell *, const char *);
 void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
@@ -3310,11 +3311,11 @@ void		 menu_add_item(struct menu *, const struct menu_item *,
 		    struct cmd_find_state *);
 void		 menu_free(struct menu *);
 struct menu_data *menu_prepare(struct menu *, int, int, struct cmdq_item *,
-		    u_int, u_int, struct client *, struct cmd_find_state *,
-		    menu_choice_cb, void *);
+		    u_int, u_int, struct client *, const char *,
+		    struct cmd_find_state *, menu_choice_cb, void *);
 int		 menu_display(struct menu *, int, int, struct cmdq_item *,
-		    u_int, u_int, struct client *, struct cmd_find_state *,
-		    menu_choice_cb, void *);
+		    u_int, u_int, struct client *, const char *,
+		    struct cmd_find_state *, menu_choice_cb, void *);
 struct screen	*menu_mode_cb(struct client *, void *, u_int *, u_int *);
 void		 menu_check_cb(struct client *, void *, u_int, u_int, u_int,
 		    struct overlay_ranges *);

--- a/window-client.c
+++ b/window-client.c
@@ -242,7 +242,7 @@ window_client_draw(__unused void *modedata, void *itemdata,
 		screen_write_cursormove(ctx, cx, cy + 2, 0);
 	else
 		screen_write_cursormove(ctx, cx, cy + sy - 1 - lines, 0);
-	screen_write_hline(ctx, sx, 0, 0);
+	screen_write_hline(ctx, sx, 0, 0, NULL);
 
 	if (at != 0)
 		screen_write_cursormove(ctx, cx, cy, 0);


### PR DESCRIPTION
This PR adds styling to `display-menu` and is a follow-up PR of #2947.

To test:
* Build and run tmux `./tmux -vv -f/dev/null -Ltest`
* Set `menu-style` options and display menu (see `test_menu_style.sh` below)
* Use `-s` argument when displaying a menu (see `test_menu_style.sh` below)

👉 **NOTA BENE:** There are several `TODO:` comments in the code that should to be clarified prior applying the changes. 

<details><summary><code>test_menu_style.sh</code></summary>

```sh
#!/bin/ksh

clear
echo "# Expect default tmux menu when unstyled"
echo "% ./tmux -T Unstyled foo '' '' -bar '' '' '' baz '' ''"
./tmux set -gw menu-style fg=default,bg=default
./tmux menu -T Unstyled foo '' '' -bar '' '' '' baz '' ''

clear
echo "# Expect tmux menu to be orange on red when styled via tmux options, e.g.:"
echo "% ./tmux set -gw menu-style fg=orange,bg=red"
./tmux set -gw menu-style fg=orange,bg=red
echo "% ./tmux menu -T 'Styled' '#[fg=cyan,bg=blue]using' '' '' Options '' '' '' -bar '' ''"
./tmux menu -T 'Styled' '#[fg=cyan,bg=blue]using' '' '' Options '' '' '' -bar '' ''

clear
echo "# Expect tmux menu to be red on orange when styled via tmux arguments overriding previously set options, e.g.:"
echo "% ./tmux menu -T 'Styled' -s fg=red,bg=orange using '' '' Arguments '' '' '' -bar '' ''"
./tmux menu -T 'Styled' -s fg=red,bg=orange using '' '' Arguments '' '' '' -bar '' ''

clear
echo "# Expect tmux completions menu to also be styled from tmux options"
echo '# Enter `<prefix>:display<tab><tab>`  where <prefix> is your tmux prefix key; ^B by default'
```

</details>

| | |
| --- | --- |
| Unstyled | <img width=80% src=https://github.com/tmux/tmux/assets/16507/3b48ff26-4068-431e-a80e-57c0a6ee3b04>
| Styled using Options | <img width=80% src=https://github.com/tmux/tmux/assets/16507/bf179b2c-e606-4032-836e-73dd1ef0ba3e> <img width=80% src=https://github.com/tmux/tmux/assets/16507/3b33ef56-203a-4133-b0e5-95f0beb03a24>
| Styled using Arguments | !<img width=80% src=https://github.com/tmux/tmux/assets/16507/352a1d20-e061-4b6e-88b0-9aa4729e4a17>


