### PR TITLE
Add -c option to specify starting directory in which run-shell command

### DIFF
--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -44,8 +44,8 @@ const struct cmd_entry cmd_run_shell_entry = {
 	.name = "run-shell",
 	.alias = "run",
 
-	.args = { "bd:Ct:", 0, 1, cmd_run_shell_args_parse },
-	.usage = "[-bC] [-d delay] " CMD_TARGET_PANE_USAGE " [shell-command]",
+	.args = { "bd:Ct:c:", 0, 2, cmd_run_shell_args_parse },
+	.usage = "[-bC] [-d delay] [-c start-directory]" CMD_TARGET_PANE_USAGE " [shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
 
@@ -145,8 +145,11 @@ cmd_run_shell_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	if (cdata->client != NULL)
 		cdata->client->references++;
-
-	cdata->cwd = xstrdup(server_client_get_cwd(cmdq_get_client(item), s));
+	if (args_has(args, 'c')) {
+		cdata->cwd = xstrdup(args_get(args, 'c'));
+	} else{
+		cdata->cwd = xstrdup(server_client_get_cwd(cmdq_get_client(item), s));
+	}
 
 	cdata->s = s;
 	if (s != NULL)

--- a/tmux.1
+++ b/tmux.1
@@ -6600,6 +6600,7 @@ option.
 .Op Fl bC
 .Op Fl d Ar delay
 .Op Fl t Ar target-pane
+.Op Fl c Ar start-directory
 .Op Ar shell-command
 .Xc
 .D1 Pq alias: Ic run
@@ -6624,6 +6625,11 @@ the command is run in the background.
 waits for
 .Ar delay
 seconds before starting the command.
+If 
+.Fl c
+is given, the current working directory is set to
+.Ar start-directory
+in which command will run.
 If
 .Fl C
 is not given, any output to stdout is displayed in view mode (in the pane


### PR DESCRIPTION
Add -c option to specify starting directory in which run-shell command.  
Associate issure is  [3608](https://github.com/tmux/tmux/issues/3608)