### PR TITLE
WIP: Add none border-lines style

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -299,7 +299,7 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	u_int			 px, py, i, count = args_count(args);
 	struct options		*o = target->s->curw->window->options;
 	struct options_entry	*oe;
-	u_short			 bw;
+	u_int			 bw;
 
 	if (tc->overlay_draw != NULL)
 		return (CMD_RETURN_NORMAL);
@@ -368,7 +368,7 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 		}
 	}
 
-	bw = ((lines != BOX_LINES_NONE) ? 2 : 2);
+	bw = ((lines != BOX_LINES_NONE) ? 2 : 0);
 	if (!cmd_display_menu_get_position(tc, item, args, &px, &py,
 	    menu->width + 2 + bw, menu->count + bw)) {
 		menu_free(menu);

--- a/menu.c
+++ b/menu.c
@@ -187,7 +187,7 @@ menu_check_cb(__unused struct client *c, void *data, u_int px, u_int py,
 {
 	struct menu_data	*md = data;
 	struct menu		*menu = md->menu;
-	u_short			 bw;
+	u_int			 bw;
 
 	bw = (md->border_lines != BOX_LINES_NONE) ? 2 : 0;
 	server_client_overlay_range(md->px, md->py, menu->width + 2 + bw,
@@ -204,7 +204,7 @@ menu_draw_cb(struct client *c, void *data,
 	struct menu		*menu = md->menu;
 	struct screen_write_ctx	 ctx;
 	u_int			 i, bx, px = md->px, py = md->py;
-	u_short			 bw;
+	u_int			 bw;
 
 	if (md->border_lines != BOX_LINES_NONE) {
 		bw = 2;
@@ -259,7 +259,7 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 	struct cmdq_state		*state;
 	enum cmd_parse_status		 status;
 	char				*error;
-	u_short				 bw;
+	u_int				 bw;
 
 	if (KEYC_IS_MOUSE(event->key)) {
 		if (md->flags & MENU_NOMOUSE) {
@@ -478,9 +478,8 @@ menu_prepare(struct menu *menu, int flags, int starting_choice,
 	int			 choice;
 	const char		*name;
 	struct options		*o = c->session->curw->window->options;
-	u_short			 bw;
+	u_int			 bw;
 
-	u_short two = 2;
 	bw = (lines != BOX_LINES_NONE) ? 2 : 0;
 	if (c->tty.sx < menu->width + 2 + bw || c->tty.sy < menu->count + bw)
 		return (NULL);
@@ -504,7 +503,8 @@ menu_prepare(struct menu *menu, int flags, int starting_choice,
 
 	if (fs != NULL)
 		cmd_find_copy_state(&md->fs, fs);
-	screen_init(&md->s, menu->width + 2 + bw, menu->count + two, 0);
+	// TODO: Should menu->count really be + 2 for border-line none?
+	screen_init(&md->s, menu->width + 2 + bw, menu->count + 2, 0);
 	if (~md->flags & MENU_NOMOUSE)
 		md->s.mode |= (MODE_MOUSE_ALL|MODE_MOUSE_BUTTON);
 	md->s.mode &= ~MODE_CURSOR;

--- a/screen-write.c
+++ b/screen-write.c
@@ -702,7 +702,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu, int choice,
 	const struct grid_cell	*gc = &default_gc;
 	u_int			 cx, cy, co, i, j, width = menu->width;
 	const char		*name;
-	u_short			 bw;
+	u_int			 bw;
 
 	cx = s->cx;
 	cy = s->cy;

--- a/tmux.1
+++ b/tmux.1
@@ -6071,6 +6071,7 @@ the default is
 .Ql y .
 .Tg menu
 .It Xo Ic display-menu
+.Op Fl B
 .Op Fl O
 .Op Fl b Ar border-lines
 .Op Fl c Ar target-client
@@ -6104,6 +6105,11 @@ If the name begins with a hyphen (-), then the item is disabled (shown dim) and
 may not be chosen.
 The name may be empty for a separator line, in which case both the key and
 command should be omitted.
+.Pp
+.Fl B
+sets menu-border-lines to none regardless of any session options and the
+.Fl b
+flag.
 .Pp
 .Fl b
 sets the type of characters used for drawing menu borders.


### PR DESCRIPTION
🚧 This is a work-in-progress follow-up PR on #3650 that attempts to add the `none` border-lines style.

@nicm: I assume there are off-by-one errors when calculating the width and height of the menu and I may have missed some code that does `+ 4` for the width or `+ 2` for the height when figuring out the size and position of the menu.
Maybe the changes in this PR so far help you identify other sections where changes are needed or issues with the code I've written.
I think it might be helpful to get another pair of eyes on this 👀

<details><summary>Test using <code>test_menu_border_lines_none.sh</code></summary>

```sh
#!/bin/ksh

clear
echo "# Expect double tmux border lines menu when styled using arguments"
echo "% ./tmux menu -x 0 -y 1 -b padded -S bg=orange -T Padded border '' '' -bar '' '' '' baz '' ''"
./tmux menu -x 0 -y 1 -b padded -S bg=orange -T Padded border '' '' -bar '' '' '' baz '' ''

clear
set -A size $(stty size)
awk -vc=× -vr=${size[0]} -vl=${size[1]} 'BEGIN{for(i=0;i<r;i++) for(j=0;j<l;j++) printf c}'
echo -e "# Expect no tmux border lines menu with -B even when styled using arguments"
echo "% ./tmux menu -x 0 -y 1 -B -b double -S bg=green -T Menu Title no '' '' -border '' '' '' baz '' ''"
./tmux menu -x 0 -y 1 -B -b double -S bg=green -T Menu Title '' '' -'no border' '' '' '' baz '' ''

clear
set -A size $(stty size)
awk -vc=× -vr=${size[0]} -vl=${size[1]} 'BEGIN{for(i=0;i<r;i++) for(j=0;j<l;j++) printf c}'
echo -e "# Expect no tmux title or border lines menu with -B even when styled using arguments"
echo "% ./tmux menu -x 0 -y 1 -B -b double -S bg=green 'No title' '' '' -no '' '' '' border '' ''"
./tmux menu -x 0 -y 1 -B -b double -S bg=green 'No title' '' '' -no '' '' '' border '' ''
```

</details>

| Description | Screenshot |
| --- | --- |
| 👍 `padded` border-style | ![image](https://github.com/tmux/tmux/assets/16507/1ea5694f-5281-4ba4-870e-8daf796cdd7b)
| 🙅 `none` with title: there seems to be one additional row at the very end of the menu and one additional column on the right | ![image](https://github.com/tmux/tmux/assets/16507/090b17d2-e7ae-489d-984a-86335ce082de)
| 🙅 `none` without title: there seems to be two additional row at the very end of the menu and one additional column on the right | ![image](https://github.com/tmux/tmux/assets/16507/9e7c876a-678f-422c-a65d-508cec31b7e4)




