### PR TITLE
Fix SIXEL images not being processed

### DIFF
--- a/input.c
+++ b/input.c
@@ -2259,6 +2259,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 	if (ictx->flags & INPUT_DISCARD) {
 		log_debug("%s: %zu bytes (discard)", __func__, len);
 		return (0);
+	}
 #ifdef ENABLE_SIXEL
 	if (buf[0] == 'q') {
 		si = sixel_parse(buf, len, w->xpixel, w->ypixel);
@@ -2266,7 +2267,6 @@ input_dcs_dispatch(struct input_ctx *ictx)
 			screen_write_sixelimage(sctx, si, ictx->cell.cell.bg);
 	}
 #endif
-	}
 
 	allow_passthrough = options_get_number(wp->options, "allow-passthrough");
 	if (!allow_passthrough)


### PR DESCRIPTION
A simple brace error. 
Code calling SIXEL parsing function was falling under an `if` statement discarding the input.