### PR TITLE
Use DEC mode 2026 for Sync terminal feature

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6823,7 +6823,7 @@ capability.
 .It Em \&Sxl
 Indicates that the terminal supports SIXEL.
 .It Em \&Sync
-Start (parameter is 1) or end (parameter is 2) a synchronized update.
+Start (parameter is 1) or end (parameter is 0) a synchronized update.
 .It Em \&Tc
 Indicate that the terminal supports the
 .Ql direct colour

--- a/tty-features.c
+++ b/tty-features.c
@@ -226,7 +226,7 @@ static const struct tty_feature tty_feature_strikethrough = {
 
 /* Terminal supports synchronized updates. */
 static const char *const tty_feature_sync_capabilities[] = {
-	"Sync=\\EP=%p1%ds\\E\\\\",
+	"Sync=\\E[?2026%?%p1%{1}%-%tl%eh%;",
 	NULL
 };
 static const struct tty_feature tty_feature_sync = {


### PR DESCRIPTION
The ESC P = %p1 s ST sequence is an iTerm2 extension to enable or
disable synchronized output. However, some effort has been made recently
to "standardize" (as much as anything can be standardized in this world)
on using DEC mode 2026 for this feature instead [1]. iTerm2 also
supports this mode and even recommends its use over its own extension
[2].

As far as I can tell the only other terminal emulator that uses iTerm2's
extension is kitty, but they copied it from tmux. So if tmux changes to
use DEC mode 2026 then that would make a strong case for kitty to change
as well.

[1]: https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036
[2]: https://gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec#decsetdecreset
