### PR TITLE
Bugfix: w maybe notdefined without ENABLE_SIXEL

### DIFF
--- a/input.c
+++ b/input.c
@@ -2293,7 +2293,6 @@ input_dcs_dispatch(struct input_ctx *ictx)
 
 	if (wp == NULL)
 		return (0);
-	w = wp->window;
 
 	if (ictx->flags & INPUT_DISCARD) {
 		log_debug("%s: %zu bytes (discard)", __func__, len);
@@ -2301,6 +2300,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 	}
 
 #ifdef ENABLE_SIXEL
+	w = wp->window;
 	if (buf[0] == 'q') {
 		si = sixel_parse(buf, len, w->xpixel, w->ypixel);
 		if (si != NULL)


### PR DESCRIPTION
This issue is introduced in 605bf21ff225c68d21577a94d423e9ec16158cdb

fix the issue of the below build error: 

```bash
make
...
input.c:2296:2: error: use of undeclared identifier 'w'
        w = wp->window;
        ^
1 warning and 1 error generated.
make: *** [input.o] Error 1
```

