### PR TITLE
add `pane-border-indent` option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac
 
-AC_INIT([tmux], next-3.4)
+AC_INIT([tmux], andrey-3.4)
 AC_PREREQ([2.60])
 
 AC_CONFIG_AUX_DIR(etc)

--- a/format-draw.c
+++ b/format-draw.c
@@ -717,7 +717,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 					   RIGHT,
 					   ABSOLUTE_CENTRE };
 	int			 focus_start = -1, focus_end = -1;
-	int			 list_state = -1, fill = -1, even;
+	int			 list_state = -1, pad = 0, fill = -1, even;
 	enum style_align	 list_align = STYLE_ALIGN_DEFAULT;
 	struct grid_cell	 gc, current_default;
 	struct style		 sy, saved_sy;
@@ -834,6 +834,10 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 			sy.gc.bg = base->bg;
 			sy.gc.fg = base->fg;
 		}
+
+		/* If this style has padding, store it for later. */
+		if (sy.pad > 0)
+			pad = sy.pad;
 
 		/* If this style has a fill colour, store it for later. */
 		if (sy.fill != 8)
@@ -970,6 +974,15 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	TAILQ_FOREACH(fr, &frs, entry) {
 		log_debug("%s: range %d|%u is %s %u-%u", __func__, fr->type,
 		    fr->argument, names[fr->index], fr->start, fr->end);
+	}
+
+	if (pad > 0) {
+		log_debug("%s: pad greater than 0 %d", __func__, pad);
+		// uncertain what i'd have to change here
+		ocx += pad;
+		available -= pad;
+		focus_start += pad;
+		focus_end -= pad;
 	}
 
 	/* Clear the available area. */

--- a/options-table.c
+++ b/options-table.c
@@ -1043,6 +1043,15 @@ const struct options_table_entry options_table[] = {
 	  .text = "Format of text in the pane status lines."
 	},
 
+	{ .name = "pane-border-indent",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .minimum = 0,
+	  .maximum = USHRT_MAX,
+	  .default_num = 2,
+	  .text = "Indent of the pane border."
+	},
+
 	{ .name = "pane-border-indicators",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -301,7 +301,7 @@ screen_redraw_check_cell(struct client *c, u_int px, u_int py, int pane_status,
 	struct window		*w = c->session->curw->window;
 	struct window_pane	*wp, *active;
 	int			 border;
-	u_int			 right, line;
+	u_int			 right, line, indent;
 
 	*wpp = NULL;
 
@@ -309,6 +309,8 @@ screen_redraw_check_cell(struct client *c, u_int px, u_int py, int pane_status,
 		return (CELL_OUTSIDE);
 	if (px == w->sx || py == w->sy) /* window border */
 		return (screen_redraw_type_of_cell(c, px, py, pane_status));
+
+	indent = options_get_number(w->options, "pane-border-indent");
 
 	if (pane_status != PANE_STATUS_OFF) {
 		active = wp = server_client_get_pane(c);
@@ -320,9 +322,9 @@ screen_redraw_check_cell(struct client *c, u_int px, u_int py, int pane_status,
 				line = wp->yoff - 1;
 			else
 				line = wp->yoff + wp->sy;
-			right = wp->xoff + 2 + wp->status_size - 1;
+			right = wp->xoff + indent + wp->status_size - 1;
 
-			if (py == line && px >= wp->xoff + 2 && px <= right)
+			if (py == line && px >= wp->xoff + indent && px <= right)
 				return (CELL_INSIDE);
 
 		next1:
@@ -382,7 +384,7 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	struct format_tree	*ft;
 	char			*expanded;
 	int			 pane_status = rctx->pane_status;
-	u_int			 width, i, cell_type, px, py;
+	u_int			 width, i, cell_type, px, py, indent;
 	struct screen_write_ctx	 ctx;
 	struct screen		 old;
 
@@ -396,10 +398,12 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	fmt = options_get_string(wp->options, "pane-border-format");
 
 	expanded = format_expand_time(ft, fmt);
-	if (wp->sx < 4)
+
+	indent = options_get_number(w->options, "pane-border-indent");
+	if (wp->sx < 2 * indent)
 		wp->status_size = width = 0;
 	else
-		wp->status_size = width = wp->sx - 4;
+		wp->status_size = width = wp->sx - 2 * indent;
 
 	memcpy(&old, &wp->status_screen, sizeof old);
 	screen_init(&wp->status_screen, width, 1, 0);
@@ -408,7 +412,7 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	screen_write_start(&ctx, &wp->status_screen);
 
 	for (i = 0; i < width; i++) {
-		px = wp->xoff + 2 + i;
+		px = wp->xoff + indent + i;
 		if (rctx->pane_status == PANE_STATUS_TOP)
 			py = wp->yoff - 1;
 		else
@@ -443,9 +447,11 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 	struct tty		*tty = &c->tty;
 	struct window_pane	*wp;
 	struct screen		*s;
-	u_int			 i, x, width, xoff, yoff, size;
+	u_int			 i, x, width, xoff, yoff, size, indent;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
+
+	indent = options_get_number(w->options, "pane-border-indent");
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
 		if (!window_pane_visible(wp))
@@ -457,7 +463,7 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 			yoff = wp->yoff - 1;
 		else
 			yoff = wp->yoff + wp->sy;
-		xoff = wp->xoff + 2;
+		xoff = wp->xoff + indent;
 
 		if (xoff + size <= ctx->ox ||
 		    xoff >= ctx->ox + ctx->sx ||

--- a/style.c
+++ b/style.c
@@ -33,6 +33,7 @@ static struct style style_default = {
 	{ { { ' ' }, 0, 1, 1 }, 0, 0, 8, 8, 0, 0 },
 	0,
 
+	2,
 	8,
 	STYLE_ALIGN_DEFAULT,
 	STYLE_LIST_OFF,
@@ -186,6 +187,11 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 				sy->align = STYLE_ALIGN_ABSOLUTE_CENTRE;
 			else
 				goto error;
+		} else if (end > 4 && strncasecmp(tmp, "pad=", 4) == 0) {
+			value = strtol(tmp + 4, NULL, 10);
+			if (errno == ERANGE)
+				goto error;
+			sy->pad = value;
 		} else if (end > 5 && strncasecmp(tmp, "fill=", 5) == 0) {
 			if ((value = colour_fromstring(tmp + 5)) == -1)
 				goto error;
@@ -301,6 +307,11 @@ style_tostring(struct style *sy)
 		else if (sy->default_type == STYLE_DEFAULT_POP)
 			tmp = "pop-default";
 		off += xsnprintf(s + off, sizeof s - off, "%s%s", comma, tmp);
+		comma = ",";
+	}
+	if (sy->pad != 2) {
+		off += xsnprintf(s + off, sizeof s - off, "%spad=%d", comma,
+		    sy->pad);
 		comma = ",";
 	}
 	if (sy->fill != 8) {

--- a/tmux.h
+++ b/tmux.h
@@ -835,6 +835,7 @@ struct style {
 	struct grid_cell	gc;
 	int			ignore;
 
+	int			pad;
 	int			fill;
 	enum style_align	align;
 	enum style_list		list;


### PR DESCRIPTION
Hi there - this patch removes the hardcoded 2's in `screen-redraw.c` and makes them customizable through a new `pane-border-indent` option. I've been running this patch for a few years but have been a bit reluctant opening a PR with it because of this comment from a related issue https://github.com/tmux/tmux/issues/2028#issuecomment-569234413:

> We are moving away from having options for every little thing, so I don't want pane-border-indent, it needs to be expressed in the style, which would also allow it to be used in other contexts.

I'd love to know if your thoughts have since changed and if you'd be open to an option like this. I tried achieving border indentation using a style directive like mentioned in the comment, but I wasn't successful because the hardcoded 2's got in the way regardless.

Please let me know what you think!

---

Here's a demo using the following config:

```tmux
set -g pane-border-status bottom
set -g pane-border-style ""
set -g pane-active-border-style ""
set -g pane-border-format "#[#{?#{pane_active},bg=red fill=red,bg=blue fill=blue}]"
set -g pane-border-indent 0
```

With default indentation:

<img width="500" src="https://github.com/tmux/tmux/assets/9457739/2331c736-2277-4b93-837b-9b985bac5b78">
<br><br>

With zero indent:

<img width="500" src="https://github.com/tmux/tmux/assets/9457739/40581b0a-a976-45b8-bcf7-60a9517bccfd">