### PR TITLE
Increase the buffer size on style_tostring() to avoid truncation.

### DIFF
--- a/style.c
+++ b/style.c
@@ -242,7 +242,7 @@ style_tostring(struct style *sy)
 	int			 off = 0;
 	const char		*comma = "", *tmp = "";
 	static char		 s[256];
-	char			 b[16];
+	char			 b[21];
 
 	*s = '\0';
 


### PR DESCRIPTION
Line 278 performs an snprintf of "user|%s" to variable b, which currently is 16 bytes. However, the string being written is style.range_string, which is itself 16 bytes. Therefore, to avoid truncation, the type of b must be char b[21], to fit 16 from range_string plus 5 from "user|".

This is not a buffer overflow security bug since snprintf truncates instead of overflowing. Still nice to avoid truncation, though.