### PR TITLE
cmd-paste-buffer: don't paste into dead panes

### DIFF
--- a/cmd-paste-buffer.c
+++ b/cmd-paste-buffer.c
@@ -54,6 +54,11 @@ cmd_paste_buffer_exec(struct cmd *self, struct cmdq_item *item)
 	size_t			 seplen, bufsize;
 	int			 bracket = args_has(args, 'p');
 
+	if (window_pane_exited(wp)) {
+		cmdq_error(item, "target pane has exited");
+		return (CMD_RETURN_ERROR);
+	}
+
 	bufname = NULL;
 	if (args_has(args, 'b'))
 		bufname = args_get(args, 'b');

--- a/cmd-pipe-pane.c
+++ b/cmd-pipe-pane.c
@@ -68,7 +68,7 @@ cmd_pipe_pane_exec(struct cmd *self, struct cmdq_item *item)
 	sigset_t			 set, oldset;
 
 	/* Do nothing if pane is dead. */
-	if (wp->fd == -1 || (wp->flags & PANE_EXITED)) {
+	if (window_pane_exited(wp)) {
 		cmdq_error(item, "target pane has exited");
 		return (CMD_RETURN_ERROR);
 	}

--- a/tmux.h
+++ b/tmux.h
@@ -3096,6 +3096,7 @@ int		 window_pane_key(struct window_pane *, struct client *,
 		     struct session *, struct winlink *, key_code,
 		     struct mouse_event *);
 int		 window_pane_visible(struct window_pane *);
+int		 window_pane_exited(struct window_pane *);
 u_int		 window_pane_search(struct window_pane *, const char *, int,
 		     int);
 const char	*window_printable_flags(struct winlink *, int);

--- a/window.c
+++ b/window.c
@@ -1214,6 +1214,12 @@ window_pane_visible(struct window_pane *wp)
 	return (wp == wp->window->active);
 }
 
+int
+window_pane_exited(struct window_pane *wp)
+{
+	return (wp->fd == -1 || (wp->flags & PANE_EXITED));
+}
+
 u_int
 window_pane_search(struct window_pane *wp, const char *term, int regex,
     int ignore)


### PR DESCRIPTION
From Debian bug#1063237:

> I've run into this:
> 
>      $ tmux set-option -g remain-on-exit \; new-session -d false
>      $ tmux set-buffer x \; paste-buffer
>      server exited unexpectedly
> 
> Backtrace:
> 
>      #0  0xf7ea662b in bufferevent_write (bufev=0x0, data=0x5745f730, size=1) at ./bufferevent.c:454
>      #1  0x5659d0a6 in cmd_paste_buffer_exec (self=0x57442f20, item=0x574751d0) at ./cmd-paste-buffer.c:98
>      #2  0x5659e892 in cmdq_fire_command (item=0x574751d0) at ./cmd-queue.c:647
>      #3  cmdq_next (c=0x57480b00) at ./cmd-queue.c:763
>      #4  0x565ee113 in server_loop () at ./server.c:270
>      #5  0x565da562 in proc_loop (tp=0x57438580, loopcb=0x565ee0b0 <server_loop>) at ./proc.c:222
>      #6  0x565ee96c in server_start (client=0x57437d00, flags=402718720, base=0x57437600, lockfd=5, lockfile=0x57437950 "") at ./server.c:251
>      #7  0x5658e72b in client_connect (flags=<optimized out>, path=0x57437500 "/tmp/tmux-1000/default", base=0x57437600) at ./client.c:164
>      #8  client_main (base=0x57437600, argc=7, argv=0xfffed398, flags=<optimized out>, feat=0) at ./client.c:287
>      #9  0x56589432 in main (argc=7, argv=<optimized out>) at ./tmux.c:519