### PR TITLE
Use bracketed paste for choose-buffer by default

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6464,7 +6464,7 @@ is replaced by the buffer name in
 and the result executed as a command.
 If
 .Ar template
-is not given, "paste-buffer -b \[aq]%%\[aq]" is used.
+is not given, "paste-buffer -p -b \[aq]%%\[aq]" is used.
 .Pp
 .Fl O
 specifies the initial sort field: one of

--- a/window-buffer.c
+++ b/window-buffer.c
@@ -36,7 +36,7 @@ static void		 window_buffer_key(struct window_mode_entry *,
 			     struct client *, struct session *,
 			     struct winlink *, key_code, struct mouse_event *);
 
-#define WINDOW_BUFFER_DEFAULT_COMMAND "paste-buffer -b '%%'"
+#define WINDOW_BUFFER_DEFAULT_COMMAND "paste-buffer -p -b '%%'"
 
 #define WINDOW_BUFFER_DEFAULT_FORMAT \
 	"#{t/p:buffer_created}: #{buffer_sample}"


### PR DESCRIPTION
The -p option only has any effect if the pane has enabled bracketed paste mode, so this should be safe to use unconditionally.