### PR TITLE
Don't notify when unzooming windows from window_destroy()

### DIFF
--- a/cmd-display-panes.c
+++ b/cmd-display-panes.c
@@ -246,7 +246,7 @@ cmd_display_panes_key(struct client *c, void *data, struct key_event *event)
 	wp = window_pane_at_index(w, index);
 	if (wp == NULL)
 		return (1);
-	window_unzoom(w);
+	window_unzoom(w, 1);
 
 	xasprintf(&expanded, "%%%u", wp->id);
 

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -87,7 +87,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (args_has(args, 'Z')) {
 		if (w->flags & WINDOW_ZOOMED)
-			window_unzoom(w);
+			window_unzoom(w, 1);
 		else
 			window_zoom(wp);
 		server_redraw_window(w);

--- a/popup.c
+++ b/popup.c
@@ -345,7 +345,7 @@ popup_make_pane(struct popup_data *pd, enum layout_type type)
 	u_int			 hlimit;
 	const char		*shell;
 
-	window_unzoom(w);
+	window_unzoom(w, 1);
 
 	lc = layout_split_pane(wp, type, -1, 0);
 	hlimit = options_get_number(s->options, "history-limit");

--- a/resize.c
+++ b/resize.c
@@ -40,7 +40,7 @@ resize_window(struct window *w, u_int sx, u_int sy, int xpixel, int ypixel)
 	/* If the window is zoomed, unzoom. */
 	zoomed = w->flags & WINDOW_ZOOMED;
 	if (zoomed)
-		window_unzoom(w);
+		window_unzoom(w, 1);
 
 	/* Resize the layout first. */
 	layout_resize(w, sx, sy);

--- a/server-fn.c
+++ b/server-fn.c
@@ -488,6 +488,6 @@ server_check_unattached(void)
 void
 server_unzoom_window(struct window *w)
 {
-	if (window_unzoom(w) == 0)
+	if (window_unzoom(w, 1) == 0)
 		server_redraw_window(w);
 }

--- a/tmux.h
+++ b/tmux.h
@@ -3070,7 +3070,7 @@ struct window_pane *window_add_pane(struct window *, struct window_pane *,
 void		 window_resize(struct window *, u_int, u_int, int, int);
 void		 window_pane_send_resize(struct window_pane *, u_int, u_int);
 int		 window_zoom(struct window_pane *);
-int		 window_unzoom(struct window *);
+int		 window_unzoom(struct window *, int);
 int		 window_push_zoom(struct window *, int, int);
 int		 window_pop_zoom(struct window *);
 void		 window_lost_pane(struct window *, struct window_pane *);

--- a/window.c
+++ b/window.c
@@ -338,7 +338,7 @@ window_destroy(struct window *w)
 {
 	log_debug("window @%u destroyed (%d references)", w->id, w->references);
 
-	window_unzoom(w);
+	window_unzoom(w, 0);
 	RB_REMOVE(windows, &windows, w);
 
 	if (w->layout_root != NULL)
@@ -673,7 +673,7 @@ window_zoom(struct window_pane *wp)
 }
 
 int
-window_unzoom(struct window *w)
+window_unzoom(struct window *w, int notify)
 {
 	struct window_pane	*wp;
 
@@ -690,7 +690,9 @@ window_unzoom(struct window *w)
 		wp->saved_layout_cell = NULL;
 	}
 	layout_fix_panes(w, NULL);
-	notify_window("window-layout-changed", w);
+
+	if (notify)
+		notify_window("window-layout-changed", w);
 
 	return (0);
 }
@@ -704,7 +706,7 @@ window_push_zoom(struct window *w, int always, int flag)
 		w->flags |= WINDOW_WASZOOMED;
 	else
 		w->flags &= ~WINDOW_WASZOOMED;
-	return (window_unzoom(w) == 0);
+	return (window_unzoom(w, 1) == 0);
 }
 
 int


### PR DESCRIPTION
Since commit 36e1ac65560, window_destroy() calls window_unzoom() but the latter emits a 'window-layout-changed' notification with the window which is about to be freed. This results in the callback later dereferencing a freed window, or a double-free.

Closes: #3857.