### PR TITLE
compat/systemd: Add missing includes

### DIFF
--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -24,7 +24,9 @@
 #include <systemd/sd-login.h>
 #include <systemd/sd-id128.h>
 
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "tmux.h"
 


### PR DESCRIPTION
Fixes the following build errors (with musl libc and LLVM toolchain):
```
compat/systemd.c:111:2: error: call to undeclared library function 'free' with type 'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  111 |         free(name);
      |         ^
compat/systemd.c:111:2: note: include the header <stdlib.h> or explicitly provide a declaration for 'free'
compat/systemd.c:134:15: error: call to undeclared function 'getpid'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  134 |         parent_pid = getpid();
      |                      ^
2 errors generated.
```