### PR TITLE
Remove ~/.tmux.conf repetition from -f option in manual

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -140,10 +140,9 @@ By default,
 loads the system configuration file from
 .Pa @SYSCONFDIR@/tmux.conf ,
 if present, then looks for a user configuration file at
-.Pa \[ti]/.tmux.conf,
-.Pa $XDG_CONFIG_HOME/tmux/tmux.conf
+.Pa \[ti]/.tmux.conf
 or
-.Pa \[ti]/.tmux.conf .
+.Pa $XDG_CONFIG_HOME/tmux/tmux.conf .
 .Pp
 The configuration file is a set of
 .Nm


### PR DESCRIPTION
The manual of -f option describes the procedure for searching for the configuration file. The ~/.tmux.conf is there twice.