### PR TITLE
Removed redundant config file location from man page

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -140,10 +140,9 @@ By default,
 loads the system configuration file from
 .Pa @SYSCONFDIR@/tmux.conf ,
 if present, then looks for a user configuration file at
-.Pa \[ti]/.tmux.conf,
-.Pa $XDG_CONFIG_HOME/tmux/tmux.conf
+.Pa \[ti]/.tmux.conf
 or
-.Pa \[ti]/.tmux.conf .
+.Pa $XDG_CONFIG_HOME/tmux/tmux.conf .
 .Pp
 The configuration file is a set of
 .Nm


### PR DESCRIPTION
The ~/.tmux.conf location was listed twice, so I just removed the second one.