### PR TITLE
Properly detect mouse SGR button release events and rapid clicks of different buttons

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -644,7 +644,10 @@ server_client_check_mouse(struct client *c, struct key_event *event)
 				log_debug("triple-click at %u,%u", x, y);
 				goto have_event;
 			}
-		} else {
+		}
+
+		/* DOWN is the only remaining event type. */
+		if (type == NOTYPE) {
 			type = DOWN;
 			x = m->x, y = m->y, b = m->b;
 			log_debug("down at %u,%u", x, y);

--- a/server-client.c
+++ b/server-client.c
@@ -622,6 +622,8 @@ server_client_check_mouse(struct client *c, struct key_event *event)
 	} else if (MOUSE_RELEASE(m->b)) {
 		type = UP;
 		x = m->x, y = m->y, b = m->lb;
+		if (m->sgr_type == 'm')
+			b = m->sgr_b;
 		log_debug("up at %u,%u", x, y);
 	} else {
 		if (c->flags & CLIENT_DOUBLECLICK) {


### PR DESCRIPTION
I'm trying to implement mouse chording in another application, and stumbled upon two issues which resulted in valid mouse events being dropped by tmux.

- Mouse release events (SGR or otherwise) are only detected on the last clicked button, preventing underlying applications from maintaining accurate mouse state
- Clicking two different buttons in succession would sometimes result in the second button press being undetected due to the double-click timeout

These two commits fix those issues. In my testing, all mouse events emitted by suckless st 0.9.1 are now properly detected and passed to the underlying application. Theoretically, this improved state tracking means that mouse chording could be implemented within a tmux binding... But I haven't tested that.