### PR TITLE
compat: Fix clang compiler error in Android

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -289,6 +289,11 @@ void		 explicit_bzero(void *, size_t);
 int		 getdtablecount(void);
 #endif
 
+#ifndef HAVE_GETDTABLESIZE
+/* getdtablesize.c */
+int		 getdtablesize(void);
+#endif
+
 #ifndef HAVE_CLOSEFROM
 /* closefrom.c */
 void		 closefrom(int);

--- a/compat/htonll.c
+++ b/compat/htonll.c
@@ -14,6 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <arpa/inet.h>
 #include <sys/types.h>
 
 #include "compat.h"

--- a/compat/ntohll.c
+++ b/compat/ntohll.c
@@ -14,6 +14,7 @@
  * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <arpa/inet.h>
 #include <sys/types.h>
 
 #include "compat.h"

--- a/compat/setproctitle.c
+++ b/compat/setproctitle.c
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 
 #include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "compat.h"


### PR DESCRIPTION

    This includes some missing headers and function declaration and fixes
    the following compiler errors.
    
    ../compat/htonll.c:27:9: error: call to undeclared function 'htonl'
       27 |     b = htonl (v & 0xffffffff);
          |         ^
    
    ../compat/ntohll.c:27:9: error: call to undeclared function 'ntohl'
       27 |     b = ntohl (v & 0xffffffff);
          |         ^
    
    ../compat/setproctitle.c:39:47: error: call to undeclared function 'getprogname'
       39 |         used = snprintf(name, sizeof name, "%s: %s", getprogname(), title);
          |                                                      ^
    
    ../compat/imsg.c:82:9: error: call to undeclared function 'getdtablesize'
       82 |             >= getdtablesize()) {
          |                ^
