### PR TITLE
Fix tmux cgroup not stopping bash and hanging the shutdown

### DIFF
--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -145,6 +145,17 @@ systemd_move_pid_to_new_cgroup(pid_t pid, char **cause)
 	}
 
 	/*
+	 * Make sure that the session shells are terminated with
+	 * SIGHUP since bash and friends tend to ignore SIGTERM
+	 */
+	r = sd_bus_message_append(m, "(sv)", "SendSIGHUP", "b", 1);
+	if (r < 0) {
+		xasprintf(cause, "failed to append to properties: %s",
+		    strerror(-r));
+		goto finish;
+	}
+
+	/*
 	 * Inherit the slice from the parent process, or default to
 	 * "app-tmux.slice" if that fails.
 	 */


### PR DESCRIPTION
Fixes #3905, which only seems to happen with Gnome (I tried i3 and the problem didn't occur).

I'm not an expert on systemd but I have been troubleshooting #3905 for a couple days, and I wanted to check how other projects where doing it. I then searched across Github and came across a few projects that set this flag to true, and the explanation seems to be related to the problem in #3905.

Some projects that do this are:
- https://github.com/vodik/envoy/blob/50c069f0603af267d647fe3172ccac2e008a4825/src/dbus.c#L56
- https://github.com/elogind/elogind/blob/0368f9796bce721f5471d0fea5665dedefd4daca/src/login/logind-dbus.c#L4532

I gave it a try locally and it seems to solve the issue.