### PR TITLE
Fix copy-mode-test-emacs.sh

### DIFF
--- a/regress/copy-mode-test-emacs.sh
+++ b/regress/copy-mode-test-emacs.sh
@@ -42,14 +42,14 @@ $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "words\n        Indented")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "words\n        Indented")" ] || exit 1
 
 # Test that `next-word` wraps around un-indented line breaks.
 $TMUX send-keys -X next-word
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "line\n")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "line\n")" ] || exit 1
 
 # Test that `next-word-end` treats periods as letters.
 $TMUX send-keys -X next-word
@@ -63,14 +63,14 @@ $TMUX send-keys -X previous-word
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "line...\n")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "line...\n")" ] || exit 1
 
 # Test that `previous-space` and `next-space` treat periods as letters.
 $TMUX send-keys -X previous-space
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-space
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "line...\n")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "line...\n")" ] || exit 1
 
 # Test that `next-word` and `next-word-end` treat other symbols as letters.
 $TMUX send-keys -X begin-selection
@@ -87,7 +87,7 @@ $TMUX send-keys -X previous-word
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "\$ym_bols[]{}\n ")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "\$ym_bols[]{}\n ")" ] || exit 1
 
 # Test that `next-word-end` treats digits as letters
 $TMUX send-keys -X next-word-end

--- a/regress/copy-mode-test-vi.sh
+++ b/regress/copy-mode-test-vi.sh
@@ -41,14 +41,14 @@ $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "words\n        Indented")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "words\n        Indented")" ] || exit 1
 
 # Test that `next-word` wraps around un-indented line breaks.
 $TMUX send-keys -X next-word
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "line\nA")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "line\nA")" ] || exit 1
 
 # Test that `next-word-end` does not treat periods as letters.
 $TMUX send-keys -X next-word
@@ -69,7 +69,7 @@ $TMUX send-keys -X previous-space
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-space
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "line...\n.")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "line...\n.")" ] || exit 1
 
 # Test that `next-word` and `next-word-end` do not treat other symbols as letters.
 $TMUX send-keys -X begin-selection
@@ -85,7 +85,7 @@ $TMUX send-keys -X next-space
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-space
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(echo -e "\$ym_bols[]{}\n ?")" ] || exit 1
+[ "$($TMUX show-buffer)" = "$(printf "\$ym_bols[]{}\n ?")" ] || exit 1
 
 # Test that `next-word-end` treats digits as letters
 $TMUX send-keys -X next-word-end


### PR DESCRIPTION
The commands in the test script of the form `echo -e "..." ` was treating -e as a string resulting in the test script to fail. This PR fixes this by replacing `echo -e` with `printf`