### PR TITLE
Add hook command-error

### DIFF
--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -664,9 +664,17 @@ cmdq_fire_command(struct cmdq_item *item)
 
 out:
 	item->client = saved;
-	if (retval == CMD_RETURN_ERROR)
+	if (retval == CMD_RETURN_ERROR) {
+		fsp = NULL;
+		if (cmd_find_valid_state(&item->target))
+			fsp = &item->target;
+		else if (cmd_find_valid_state(&item->state->current))
+			fsp = &item->state->current;
+		else if (cmd_find_from_client(&fs, item->client, 0) == 0)
+			fsp = &fs;
+		cmdq_insert_hook(fsp ? fsp->s : NULL, item, fsp, "command-error");
 		cmdq_guard(item, "error", flags);
-	else
+	} else
 		cmdq_guard(item, "end", flags);
 	return (retval);
 }

--- a/options-table.c
+++ b/options-table.c
@@ -1325,6 +1325,7 @@ const struct options_table_entry options_table[] = {
 	OPTIONS_TABLE_HOOK("client-focus-out", ""),
 	OPTIONS_TABLE_HOOK("client-resized", ""),
 	OPTIONS_TABLE_HOOK("client-session-changed", ""),
+	OPTIONS_TABLE_HOOK("command-error", ""),
 	OPTIONS_TABLE_PANE_HOOK("pane-died", ""),
 	OPTIONS_TABLE_PANE_HOOK("pane-exited", ""),
 	OPTIONS_TABLE_PANE_HOOK("pane-focus-in", ""),

--- a/tmux.1
+++ b/tmux.1
@@ -4883,6 +4883,13 @@ layout after every
 set-hook -g after-split-window "selectl even-vertical"
 .Ed
 .Pp
+If a command fails for whatever reason, there is a hook named
+.Ql command-error
+that you can you. For example you could run a shell command when a command fails with the following:
+.Bd -literal -offset indent
+set-hook -g command-error "run-shell \\"notify-send 'a tmux command failed'\\""
+.Ed
+.Pp
 All the notifications listed in the
 .Sx CONTROL MODE
 section are hooks (without any arguments), except


### PR DESCRIPTION
I found this useful to have when an error happened, but none of the other hooks fired (as an error happened). Potentially others will find this useful?