### PR TITLE
Allow searching wrapped lines to be enabled through configuration

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -383,6 +383,14 @@ const struct options_table_entry options_table[] = {
 	  .text = "Maximum number of commands to keep in history."
 	},
 
+	{ .name = "search-wrapped-lines",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_num = 0,
+	  .text = "Whether to include full wrapped lines when searching for "
+		  "text in copy mode."
+	},
+
 	{ .name = "set-clipboard",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/tmux.1
+++ b/tmux.1
@@ -3797,6 +3797,17 @@ each client.
 .It Ic prompt-history-limit Ar number
 Set the number of history items to save in the history file for each type of
 command prompt.
+.It Xo Ic search-wrapped-lines
+.Op Ic on | off
+.Xc
+Defines how
+.Nm
+handles wrapped lines when searching in copy mode.
+.Pp
+When disabled (the default) lines are truncated, performance is faster, some
+matches may be missing.
+.Pp
+When enabled lines are read in full, performance is slower, all matches found.
 .It Xo Ic set-clipboard
 .Op Ic on | external | off
 .Xc

--- a/window-copy.c
+++ b/window-copy.c
@@ -3615,10 +3615,12 @@ window_copy_search_jump(struct window_mode_entry *wme, struct grid *gd,
     int direction, int regex)
 {
 	u_int			 i, px, sx, ssize = 1;
-	int			 found = 0, cflags = REG_EXTENDED;
+	int			 search_wrapped, found = 0, cflags = REG_EXTENDED;
 	char			*sbuf;
 	regex_t			 reg;
 	struct grid_line	*gl;
+
+	search_wrapped = options_get_number(global_options, "search-wrapped-lines");
 
 	if (regex) {
 		sbuf = xmalloc(ssize);
@@ -3636,7 +3638,7 @@ window_copy_search_jump(struct window_mode_entry *wme, struct grid *gd,
 	if (direction) {
 		for (i = fy; i <= endline; i++) {
 			gl = grid_get_line(gd, i);
-			if (i != endline && gl->flags & GRID_LINE_WRAPPED)
+			if (search_wrapped == 0 && i != endline && gl->flags & GRID_LINE_WRAPPED)
 				continue;
 			if (regex) {
 				found = window_copy_search_lr_regex(gd,
@@ -3652,7 +3654,7 @@ window_copy_search_jump(struct window_mode_entry *wme, struct grid *gd,
 	} else {
 		for (i = fy + 1; endline < i; i--) {
 			gl = grid_get_line(gd, i - 1);
-			if (i != endline && gl->flags & GRID_LINE_WRAPPED)
+			if (search_wrapped == 0 && i != endline && gl->flags & GRID_LINE_WRAPPED)
 				continue;
 			if (regex) {
 				found = window_copy_search_rl_regex(gd,


### PR DESCRIPTION
## Details

This resolves issue [3864](https://github.com/tmux/tmux/issues/3864) by adding a new opt-in (off by default) flag `search-wrapped-lines`.

Enabling this flag will cause searches to scan the entirety of wrapped lines at the cost of slower speeds. This is especially true with regexes as described in the original issue [3675](https://github.com/tmux/tmux/issues/3675).

I figured it would make sense to keep the default behavior as is, rather than the other way around, but was 50/50.

If there is anything else you would like me to test / information to add please lmk! I've been using TMUX for most of my career, really love this tool, and appreciate all the effort being put in here!

If you had an entirely different approach involving optimizing performance rather than this kind of forked behavior, or something else entirely that's completely understandable.

## Testing

Was able to confirm locally that setting `set -g search-wrapped-lines on` slows down regex searches while finding all matches in wrapped text.

Removing this setting seems to lead to the current behavior, faster searches but missing matches in long lines of wrapped text.