### PR TITLE
Add missing time.h include

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <termios.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "tmux.h"


### PR DESCRIPTION
This fixes compilation with gcc 14.1:

tty.c: In function ‘tty_send_requests’:
tty.c:382:30: error: implicit declaration of function ‘time’ [-Wimplicit-function-declaration]
  382 |         tty->last_requests = time (NULL);
      |                              ^~~~
tty.c:34:1: note: ‘time’ is defined in header ‘<time.h>’; this is probably fixable by adding ‘#include <time.h>’
   33 | #include "tmux.h"
  +++ |+#include <time.h>
   34 |
make: *** [Makefile:844: tty.o] Error 1