### PR TITLE
added an option to repeat the last search backwards, assigned to the …

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -3206,6 +3206,12 @@ int	 mode_tree_key(struct mode_tree_data *, struct client *, key_code *,
 void	 mode_tree_run_command(struct client *, struct cmd_find_state *,
 	     const char *, const char *);
 
+/* mode-tree search direction */
+enum search_dir {
+    SEARCH_FORWARD,
+    SEARCH_BACKWARD
+};
+
 /* window-buffer.c */
 extern const struct window_mode window_buffer_mode;
 


### PR DESCRIPTION
this should address #3866, I've added an option to repeat the last search but backwards using the 'N' key as requested and for that I wrote a function that traverses the tree backwards, I've also added a new field to 'mode_tree_data' which controls the search direction (which is flipped when the user pushes the respective key).