### PR TITLE
Adds Yacc as a dependency.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,8 +16,12 @@ page](https://github.com/libevent/libevent/releases/latest).
 from [this page](https://invisible-mirror.net/archives/ncurses/).
 - yacc available from [tuhs.org](https://www.tuhs.org/cgi-bin/utree.pl?file=V6/usr/source/yacc)
 
-To build tmux, a C compiler (for example gcc or clang), make, pkg-config and a
-suitable yacc (yacc or bison) are needed.
+To build tmux you will need: 
+
+- a C compiler (for example gcc or clang)
+- make
+- pkg-config
+- a suitable yacc (yacc or bison)
 
 ## Installation
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -14,7 +14,6 @@ tmux depends on
 page](https://github.com/libevent/libevent/releases/latest).
 - [ncurses](https://www.gnu.org/software/ncurses/), available
 from [this page](https://invisible-mirror.net/archives/ncurses/).
-- yacc available from [tuhs.org](https://www.tuhs.org/cgi-bin/utree.pl?file=V6/usr/source/yacc)
 
 To build tmux you will need: 
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -8,11 +8,13 @@ This release runs on OpenBSD, FreeBSD, NetBSD, Linux, macOS and Solaris.
 
 ## Dependencies
 
-tmux depends on [libevent](https://libevent.org) 2.x, available from [this
-page](https://github.com/libevent/libevent/releases/latest).
+tmux depends on 
 
-It also depends on [ncurses](https://www.gnu.org/software/ncurses/), available
+- [libevent](https://libevent.org) 2.x, available from [this
+page](https://github.com/libevent/libevent/releases/latest).
+- [ncurses](https://www.gnu.org/software/ncurses/), available
 from [this page](https://invisible-mirror.net/archives/ncurses/).
+- yacc available from [tuhs.org](https://www.tuhs.org/cgi-bin/utree.pl?file=V6/usr/source/yacc)
 
 To build tmux, a C compiler (for example gcc or clang), make, pkg-config and a
 suitable yacc (yacc or bison) are needed.


### PR DESCRIPTION
As reference in https://github.com/tmux/tmux/issues/2396 (closed as stale), Yacc is a dependency for compiling Tmux. This PR: 

1. Adds `yacc` to the list of dependencies.
2. Organizes the dependencies in an unordered list.

The link to download yacc was taken from the [Wikipedia article](https://en.wikipedia.org/wiki/Yacc). There may be a better location to point people to, but I can't find anything else.