### PR TITLE
Fix underline default value in extended cell check

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -88,7 +88,7 @@ grid_need_extended_cell(const struct grid_cell_entry *gce,
 		return (1);
 	if ((gc->fg & COLOUR_FLAG_RGB) || (gc->bg & COLOUR_FLAG_RGB))
 		return (1);
-	if (gc->us != 0) /* only supports 256 or RGB */
+	if (gc->us != 8) /* only supports 256 or RGB */
 		return (1);
 	if (gc->link != 0)
 		return (1);


### PR DESCRIPTION
Commit 84936b832f7a changed the default value for underline from 0 to 8 but did not update the check in `grid_need_extended_cell()` accordingly, resulting in tmux always using extended cells for the default cell.

This makes tmux use approximately x4 more memory than 3.3a for scrollback history, which is very visible for users with large `history-limit` values when entering copy mode (see https://bugs.debian.org/1073981).

Also, tmux is generally much slower at accepting large output.

Check for the new default value when deciding if an extended cell should be allocated.

Tested with `history-limit' set to 2000000 and cat'ing a large text file:
* Current HEAD (c07e856d24): 3.2GB resident memory
* With this patch: 715MB resident memory