### PR TITLE
Install the mdoc format man page on illumos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -926,8 +926,13 @@ case "$host_os" in
 				MANFORMAT=mdoc
 				;;
 			*)
-				# Solaris 2.0 to 11.3 use AT&T nroff.
-				MANFORMAT=man
+				if test `uname -o 2>/dev/null` = illumos; then
+					# illumos uses mandoc
+					MANFORMAT=mdoc
+				else
+					# Solaris 2.0 to 11.3 use AT&T nroff.
+					MANFORMAT=man
+				fi
 				;;
 		esac
 		;;


### PR DESCRIPTION
illumos uses mandoc to render man pages and therefore needs the mdoc format page installed as-is. As an OpenSolaris derivative it contains solaris in the host triple, so an additional check against `uname -o` is required to differentiate.