### PR TITLE
Update example_tmux.conf

### DIFF
--- a/example_tmux.conf
+++ b/example_tmux.conf
@@ -14,7 +14,7 @@ set -g status-bg red
 %endif
 
 # Enable RGB colour if running in xterm(1)
-set-option -sa terminal-overrides ",xterm*:Tc"
+set-option -sa terminal-features ",xterm*:RGB"
 
 # Change the default $TERM to tmux-256color
 set -g default-terminal "tmux-256color"


### PR DESCRIPTION
Use `terminal-features` instead of `terminal-overrides` to enable truecolor support.