### PR TITLE
Fix handling of UTF-32 code points in extended key sequences

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -3316,6 +3316,7 @@ void		 session_renumber_windows(struct session *);
 
 /* utf8.c */
 enum utf8_state	 utf8_towc (const struct utf8_data *, wchar_t *);
+enum utf8_state	 utf8_fromwc(wchar_t wc, struct utf8_data *);
 int		 utf8_in_table(wchar_t, const wchar_t *, u_int);
 utf8_char	 utf8_build_one(u_char);
 enum utf8_state	 utf8_from_data(const struct utf8_data *, utf8_char *);

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -911,6 +911,8 @@ tty_keys_extended_key(struct tty *tty, const char *buf, size_t len,
 	cc_t		 bspace;
 	key_code	 nkey;
 	key_code	 onlykey;
+	struct utf8_data ud;
+	utf8_char        uc;
 
 	*size = 0;
 
@@ -959,6 +961,15 @@ tty_keys_extended_key(struct tty *tty, const char *buf, size_t len,
 		nkey = KEYC_BSPACE;
 	else
 		nkey = number;
+
+	/* Convert UTF-32 codepoint into internal representation. */
+	if (nkey & ~0x7f) {
+		if (utf8_fromwc(nkey, &ud) == UTF8_DONE &&
+		    utf8_from_data(&ud, &uc) == UTF8_DONE)
+			nkey = uc;
+		else
+			return (-1);
+	}
 
 	/* Update the modifiers. */
 	if (modifiers > 0) {


### PR DESCRIPTION
As suggested, I'm breaking off pieces from #4038 to make it smaller. Once this is merged, I will rebase #4038.

This fix ensures that UTF-32 codepoints in incoming extended key sequences are converted into internal representation. `utf8_fromwc` is implemented for both `--with-utf8proc` and `--without-utf8proc` build variants.