### PR TITLE
Support building with jemalloc memory allocator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -548,6 +548,24 @@ if test "x$found_malloc_trim" = xyes; then
 	AC_DEFINE(HAVE_MALLOC_TRIM)
 fi
 
+# Build against jemalloc if requested
+AC_ARG_ENABLE(
+	jemalloc,
+	AS_HELP_STRING(--enable-jemalloc, use jemalloc if it is installed)
+)
+if test "x$enable_jemalloc" = xyes; then
+	PKG_CHECK_MODULES(
+		JEMALLOC,
+		jemalloc,
+		[
+			AM_CPPFLAGS="$JEMALLOC_CFLAGS $AM_CPPFLAGS"
+			CPPFLAGS="$AM_CPPFLAGS $SAVED_CPPFLAGS"
+			LIBS="$LIBS $JEMALLOC_LIBS"
+		],
+		AC_MSG_ERROR("jemalloc not found")
+	)
+fi
+
 # Check for CMSG_DATA. On some platforms like HP-UX this requires UNIX 95
 # (_XOPEN_SOURCE and _XOPEN_SOURCE_EXTENDED) (see xopen_networking(7)). On
 # others, UNIX 03 (_XOPEN_SOURCE 600, see standards(7) on Solaris).


### PR DESCRIPTION
When `history-limit` is set to a large value, tmux can use lots of resident memory (sometimes in the GBs). On glibc-based systems, memory is returned to the system mostly when tmux calls `malloc_trim()` from an hourly cleanup timer. By contrast, jemalloc returns memory to the system almost immediately after closing a large pane (or exiting its copy mode), and supports nice improvements like using THP on Linux, etc.

Closes: #4029