### PR TITLE
Rename header guards on compat/queue.h

### DIFF
--- a/compat/queue.h
+++ b/compat/queue.h
@@ -32,8 +32,8 @@
  *	@(#)queue.h	8.5 (Berkeley) 8/20/94
  */
 
-#ifndef	_SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#ifndef	_COMPAT_QUEUE_H_
+#define	_COMPAT_QUEUE_H_
 
 /*
  * This file defines five types of data structures: singly-linked lists,
@@ -530,4 +530,4 @@ struct {								\
 	}								\
 } while (0)
 
-#endif	/* !_SYS_QUEUE_H_ */
+#endif	/* !_COMPAT_QUEUE_H_ */


### PR DESCRIPTION
Some platforms (…macOS) have a <sys/queue.h> but it isn't full-featured enough to have all the functionality we need (e.g. TAILQ_REPLACE). This means the configure check fails and we fall back to our compatibility header, but if *someone else* happens to include the system header first then it will activate the _SYS_QUEUE_H_ header guard and ours will not define anything. Since we can't really control whether the system header is included or not (it is pulled in transitively) we probably should just rename ours so it doesn't conflict.