### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[{*.c,*.h,Makefile.am,configure.ac}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
In #1799 it is made clear that contributors should make sure that their editor is configured to use a tab width of 8. This file can help with that; it configures supported editors to have just that.

It is also used by Github for displaying the appropriate width in the browser.

I tried to be conservative with the file patterns used (for now only `*.c`, `*.h`, `Makefile.am` and `configure.ac` are set to have an indent style of tabs and a width of 8. But this list can of course be extended, or other [properties](https://editorconfig.org/#file-format-details) can be added.