### PR TITLE
Preserve paste buffer selection when deleting last buffer

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -261,19 +261,21 @@ mode_tree_up(struct mode_tree_data *mtd, int wrap)
 	}
 }
 
-void
+int
 mode_tree_down(struct mode_tree_data *mtd, int wrap)
 {
 	if (mtd->current == mtd->line_size - 1) {
 		if (wrap) {
 			mtd->current = 0;
 			mtd->offset = 0;
-		}
+		} else
+			return (0);
 	} else {
 		mtd->current++;
 		if (mtd->current > mtd->offset + mtd->height - 1)
 			mtd->offset++;
 	}
+	return (1);
 }
 
 void *

--- a/tmux.h
+++ b/tmux.h
@@ -3187,7 +3187,7 @@ int	 mode_tree_set_current(struct mode_tree_data *, uint64_t);
 void	 mode_tree_each_tagged(struct mode_tree_data *, mode_tree_each_cb,
 	     struct client *, key_code, int);
 void	 mode_tree_up(struct mode_tree_data *, int);
-void	 mode_tree_down(struct mode_tree_data *, int);
+int	   mode_tree_down(struct mode_tree_data *, int);
 struct mode_tree_data *mode_tree_start(struct window_pane *, struct args *,
 	     mode_tree_build_cb, mode_tree_draw_cb, mode_tree_search_cb,
 	     mode_tree_menu_cb, mode_tree_height_cb, mode_tree_key_cb, void *,

--- a/window-buffer.c
+++ b/window-buffer.c
@@ -409,7 +409,14 @@ window_buffer_do_delete(void *modedata, void *itemdata,
 	struct paste_buffer		*pb;
 
 	if (item == mode_tree_get_current(data->data))
-		mode_tree_down(data->data, 0);
+		if (!mode_tree_down(data->data, 0))
+			/* If we were unable to select the item further down we are at
+			 * the end of the list. Move one element up instead, to make
+			 * sure that we preserve a valid selection or we risk having the
+			 * tree build logic reset it to the first item.
+			 */
+			mode_tree_up(data->data, 0);
+
 	if ((pb = paste_get_name(item->name)) != NULL)
 		paste_free(pb);
 }


### PR DESCRIPTION
When in buffer selection mode, selecting the last buffer and deleting it, the first buffer in the list is selected. This behavior seems counter intuitive. It also does not really appear to be intended: we deliberate invoke mode_tree_down() with the 'wrap' flag set to false so as to *not* wrap selection around to the beginning. Yet, that is ultimately happening because the selection effectively gets invalidated (after all, we delete the selected element).
Adjust the logic so that we preserve the selection: when we fail to select the element below the current one (because it is the last one already), select the one above it instead.