### PR TITLE
Pass terminal data on socket on Cygwin platforms

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -69,6 +69,11 @@
 #define __weak __attribute__ ((__weak__))
 #endif
 
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
+#define WIN32_PLATFORM
+#define TTY_OVER_SOCKET
+#endif
+
 #ifndef ECHOPRT
 #define ECHOPRT 0
 #endif

--- a/tmux-protocol.h
+++ b/tmux-protocol.h
@@ -68,6 +68,11 @@ enum msgtype {
 	MSG_WRITE_READY,
 	MSG_WRITE_CLOSE,
 	MSG_READ_CANCEL
+#ifdef TTY_OVER_SOCKET
+	,
+	MSG_TTY_READ,
+	MSG_TTY_WRITE
+#endif
 };
 
 /*

--- a/tmux.h
+++ b/tmux.h
@@ -2461,6 +2461,11 @@ void	tty_cmd_sixelimage(struct tty *, const struct tty_ctx *);
 void	tty_cmd_syncstart(struct tty *, const struct tty_ctx *);
 void	tty_default_colours(struct grid_cell *, struct window_pane *);
 
+#ifdef TTY_OVER_SOCKET
+int		tty_attach_stdin_to_socket(struct tty *, struct tmuxpeer *);
+int		tty_attach_out_to_socket(struct tty *, struct client *);
+#endif
+
 /* tty-term.c */
 extern struct tty_terms tty_terms;
 u_int		 tty_term_ncodes(void);


### PR DESCRIPTION
On Cygwin and MSYS2 use a controlling pty for the server client handler
instead of passing a file descriptor over the socket which is not
possible on Cygwin platforms.

Attach an event to STDIN on the client, passing data from it to the
server and attach an event to the pty out_fd on the server client
handler and pass data from it to the client.

This fixes this issue:

https://github.com/microsoft/terminal/issues/5132

which also applies to other Windows terminals.

I am also including some patches that are included in the MSYS2
and Cygwin tmux packages in this pull request.