### PR TITLE
fix mouse scrolling in alternate mode

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -441,7 +441,10 @@ key_bindings_init(void)
 		"bind -n MouseDrag1Pane { if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { copy-mode -M } }",
 
 		/* Mouse wheel up on pane. */
-		"bind -n WheelUpPane { if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { copy-mode -e } }",
+		"bind -n WheelUpPane { if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { if -F '#{alternate_on}' { send-keys -N 3 Up } { copy-mode -e } } }",
+
+		/* Mouse wheel down on pane. */
+		"bind -n WheelDownPane { if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { if -F '#{alternate_on}' { send-keys -N 3 Down} } }",
 
 		/* Mouse button 2 down on pane. */
 		"bind -n MouseDown2Pane { select-pane -t=; if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { paste -p } }",


### PR DESCRIPTION
terminal emulators are supposed to translate mouse scroll events to arrow keys when the alternate screen buffer is active. you can verify this locally with `tput smcup` (*outside* tmux, in e.g. kitty, gnome-terminal, xterm). in this mode, scrolling will move up and down in the shell history.

tmux previously didn't do this, which broke programs like `less` which don't capture mouse events.

you can test this PR as follows:
1. start a new tmux server with this branch with a default config, e.g. `./tmux -L new-session -f /dev/null`
2. enable mouse support (`C-b :set mouse on`)
3. run any program which has more than the height of a pane in output and pipe it to less, e.g. `stty --help | less`
4. scroll down and then up with the mouse

before this PR, scrolling down will do nothing and scrolling up will enter copy mode. after this PR, scrolling up and down passes the up and down keys through to less.

fixes https://github.com/tmux/tmux/issues/3705