### PR TITLE
tty_keys_clipboard: Fix size calculation

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1212,7 +1212,7 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 	}
 	if (end == len)
 		return (1);
-	*size = end + terminator;
+	*size = end + 1;
 
 	/* Skip the initial part. */
 	buf += 5;


### PR DESCRIPTION
When parsing for both terminators '\007' and '\033\\', the index `end` consistently points to the final character of the terminator. Therefore, the size calculation should be simplified to `end + 1` instead of `end + size-of-terminators`.