### PR TITLE
Uint64 client flags

### DIFF
--- a/client.c
+++ b/client.c
@@ -452,11 +452,12 @@ client_send_identify(const char *ttynam, const char *termname, char **caps,
 {
 	char	**ss;
 	size_t	  sslen;
-	int	  fd, flags = client_flags;
+	int	  fd;
+	uint64_t  flags = client_flags;
 	pid_t	  pid;
 	u_int	  i;
 
-	proc_send(client_peer, MSG_IDENTIFY_FLAGS, -1, &flags, sizeof flags);
+	proc_send(client_peer, MSG_IDENTIFY_LONGFLAGS, -1, &flags, sizeof flags);
 	proc_send(client_peer, MSG_IDENTIFY_LONGFLAGS, -1, &client_flags,
 	    sizeof client_flags);
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -496,8 +496,8 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 }
 
 /* Update status line and change flags if unchanged. */
-static int
-screen_redraw_update(struct client *c, int flags)
+static uint64_t
+screen_redraw_update(struct client *c, uint64_t flags)
 {
 	struct window			*w = c->session->curw->window;
 	struct window_pane		*wp;
@@ -567,7 +567,7 @@ void
 screen_redraw_screen(struct client *c)
 {
 	struct screen_redraw_ctx	ctx;
-	int				flags;
+	uint64_t			flags;
 
 	if (c->flags & CLIENT_SUSPENDED)
 		return;

--- a/server-client.c
+++ b/server-client.c
@@ -2935,7 +2935,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 	const char	*data, *home;
 	size_t		 datalen;
 	int		 feat;
-	uint		 flags;
+	int		 flags;
 	uint64_t	 longflags;
 	char		*name;
 

--- a/server-client.c
+++ b/server-client.c
@@ -1866,7 +1866,8 @@ server_client_key_callback(struct cmdq_item *item, void *data)
 	struct timeval			 tv;
 	struct key_table		*table, *first;
 	struct key_binding		*bd;
-	int				 xtimeout, flags;
+	int				 xtimeout;
+        uint64_t			 flags;
 	struct cmd_find_state		 fs;
 	key_code			 key0, prefix, prefix2;
 
@@ -2565,7 +2566,8 @@ server_client_check_redraw(struct client *c)
 	struct tty		*tty = &c->tty;
 	struct window		*w = c->session->curw->window;
 	struct window_pane	*wp;
-	int			 needed, flags, mode = tty->mode, new_flags = 0;
+	int			 needed, flags, mode = tty->mode;
+        uint64_t		 new_cflags = 0;
 	int			 redraw;
 	u_int			 bit = 0;
 	struct timeval		 tv = { .tv_usec = 1000 };
@@ -2599,7 +2601,7 @@ server_client_check_redraw(struct client *c)
 			}
 		}
 		if (needed)
-			new_flags |= CLIENT_REDRAWPANES;
+			new_cflags |= CLIENT_REDRAWPANES;
 	}
 	if (needed && (left = EVBUFFER_LENGTH(tty->out)) != 0) {
 		log_debug("%s: redraw deferred (%zu left)", c->name, left);
@@ -2622,15 +2624,15 @@ server_client_check_redraw(struct client *c)
 					 * If more that 64 panes, give up and
 					 * just redraw the window.
 					 */
-					new_flags &= CLIENT_REDRAWPANES;
-					new_flags |= CLIENT_REDRAWWINDOW;
+					new_cflags &= CLIENT_REDRAWPANES;
+					new_cflags |= CLIENT_REDRAWWINDOW;
 					break;
 				}
 			}
 			if (c->redraw_panes != 0)
 				c->flags |= CLIENT_REDRAWPANES;
 		}
-		c->flags |= new_flags;
+		c->flags |= new_cflags;
 		return;
 	} else if (needed)
 		log_debug("%s: redraw needed", c->name);
@@ -2932,7 +2934,8 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 {
 	const char	*data, *home;
 	size_t		 datalen;
-	int		 flags, feat;
+	int		 feat;
+	uint		 flags;
 	uint64_t	 longflags;
 	char		*name;
 

--- a/server-client.c
+++ b/server-client.c
@@ -2934,8 +2934,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 {
 	const char	*data, *home;
 	size_t		 datalen;
-	int		 feat;
-	int		 flags;
+	int		 flags,feat;
 	uint64_t	 longflags;
 	char		*name;
 

--- a/server-client.c
+++ b/server-client.c
@@ -2934,7 +2934,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 {
 	const char	*data, *home;
 	size_t		 datalen;
-	int		 flags,feat;
+	int		 flags, feat;
 	uint64_t	 longflags;
 	char		*name;
 

--- a/server.c
+++ b/server.c
@@ -103,7 +103,7 @@ server_check_marked(void)
 
 /* Create server socket. */
 int
-server_create_socket(int flags, char **cause)
+server_create_socket(uint64_t flags, char **cause)
 {
 	struct sockaddr_un	sa;
 	size_t			size;
@@ -172,7 +172,7 @@ server_tidy_event(__unused int fd, __unused short events, __unused void *data)
 
 /* Fork new server. */
 int
-server_start(struct tmuxproc *client, int flags, struct event_base *base,
+server_start(struct tmuxproc *client, uint64_t flags, struct event_base *base,
     int lockfd, char *lockfile)
 {
 	int		 fd;

--- a/tmux.h
+++ b/tmux.h
@@ -2742,11 +2742,11 @@ void	 server_clear_marked(void);
 int	 server_is_marked(struct session *, struct winlink *,
 	     struct window_pane *);
 int	 server_check_marked(void);
-int	 server_start(struct tmuxproc *, int, struct event_base *, int, char *);
+int	 server_start(struct tmuxproc *, uint64_t, struct event_base *, int, char *);
 void	 server_update_socket(void);
 void	 server_add_accept(int);
 void printflike(1, 2) server_add_message(const char *, ...);
-int	 server_create_socket(int, char **);
+int	 server_create_socket(uint64_t flags, char **cause);
 
 /* server-client.c */
 RB_PROTOTYPE(client_windows, client_window, entry, server_client_window_cmp);

--- a/tmux.h
+++ b/tmux.h
@@ -2746,7 +2746,7 @@ int	 server_start(struct tmuxproc *, uint64_t, struct event_base *, int, char *)
 void	 server_update_socket(void);
 void	 server_add_accept(int);
 void printflike(1, 2) server_add_message(const char *, ...);
-int	 server_create_socket(uint64_t flags, char **cause);
+int	 server_create_socket(uint64_t, char **);
 
 /* server-client.c */
 RB_PROTOTYPE(client_windows, client_window, entry, server_client_window_cmp);


### PR DESCRIPTION
This cleans up several cases where the struct client flags or variables using this field were not uint64_t.  

In server_client_check_redraw in server_client.c, changed new_flags to new_cflags for clarity because the variable flags was also used in this function but for the tty->flags. 

I noticed in server_client_dispatch_identify, flags is signed int but didn't change it, it doesn't seem like it's used now that flags is passed in with MSG_IDENTIFY_LONGFLAGS instead of MSG_IDENTIFY_FLAGS.  I left that case and that signed integer var in the code along with the MSG_IDENTIFY_FLAGS case.  Should that case be deleted now completely?

