### PR TITLE
add copy-mode -d arg to page down

### DIFF
--- a/cmd-copy-mode.c
+++ b/cmd-copy-mode.c
@@ -30,8 +30,8 @@ const struct cmd_entry cmd_copy_mode_entry = {
 	.name = "copy-mode",
 	.alias = NULL,
 
-	.args = { "eHMs:t:uq", 0, 0, NULL },
-	.usage = "[-eHMuq] [-s src-pane] " CMD_TARGET_PANE_USAGE,
+	.args = { "eHMs:t:udq", 0, 0, NULL },
+	.usage = "[-eHMudq] [-s src-pane] " CMD_TARGET_PANE_USAGE,
 
 	.source =  { 's', CMD_FIND_PANE, 0 },
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -91,6 +91,9 @@ cmd_copy_mode_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	if (args_has(args, 'u'))
 		window_copy_pageup(wp, 0);
+
+	if (args_has(args, 'd'))
+                window_copy_pagedown(wp, 0, args_has(args, 'e'));
 
 	return (CMD_RETURN_NORMAL);
 }

--- a/tmux.1
+++ b/tmux.1
@@ -2110,14 +2110,17 @@ The synopsis for the
 command is:
 .Bl -tag -width Ds
 .It Xo Ic copy-mode
-.Op Fl eHMqu
+.Op Fl eHMqud
 .Op Fl s Ar src-pane
 .Op Fl t Ar target-pane
 .Xc
-Enter copy mode.
+Enter copy mode (if not already in it).
 The
 .Fl u
 option scrolls one page up.
+The
+.Fl d
+option scrolls one page down.
 .Fl M
 begins a mouse drag (only valid if bound to a mouse key binding, see
 .Sx MOUSE SUPPORT ) .
@@ -2140,6 +2143,7 @@ This is intended to allow fast scrolling through a pane's history, for
 example with:
 .Bd -literal -offset indent
 bind PageUp copy-mode -eu
+bind PageDown copy-mode -ed
 .Ed
 .El
 .Pp

--- a/tmux.h
+++ b/tmux.h
@@ -3267,6 +3267,7 @@ void printflike(3, 4) window_copy_add(struct window_pane *, int, const char *,
 void printflike(3, 0) window_copy_vadd(struct window_pane *, int, const char *,
 		     va_list);
 void		 window_copy_pageup(struct window_pane *, int);
+void		 window_copy_pagedown(struct window_pane *, int, int);
 void		 window_copy_start_drag(struct client *, struct mouse_event *);
 char		*window_copy_get_word(struct window_pane *, u_int, u_int);
 char		*window_copy_get_line(struct window_pane *, u_int);

--- a/window-copy.c
+++ b/window-copy.c
@@ -41,7 +41,7 @@ static void	window_copy_resize(struct window_mode_entry *, u_int, u_int);
 static void	window_copy_formats(struct window_mode_entry *,
 		    struct format_tree *);
 static void	window_copy_pageup1(struct window_mode_entry *, int);
-static int	window_copy_pagedown(struct window_mode_entry *, int, int);
+static int	window_copy_pagedown1(struct window_mode_entry *, int, int);
 static void	window_copy_next_paragraph(struct window_mode_entry *);
 static void	window_copy_previous_paragraph(struct window_mode_entry *);
 static void	window_copy_redraw_selection(struct window_mode_entry *, u_int);
@@ -646,8 +646,17 @@ window_copy_pageup1(struct window_mode_entry *wme, int half_page)
 	window_copy_redraw_screen(wme);
 }
 
+void
+window_copy_pagedown(struct window_pane *wp, int half_page, int scroll_exit)
+{
+	if (window_copy_pagedown1(TAILQ_FIRST(&wp->modes), half_page, scroll_exit)) {
+		window_pane_reset_mode(wp);
+		return;
+	}
+}
+
 static int
-window_copy_pagedown(struct window_mode_entry *wme, int half_page,
+window_copy_pagedown1(struct window_mode_entry *wme, int half_page,
     int scroll_exit)
 {
 	struct window_copy_mode_data	*data = wme->data;
@@ -1347,7 +1356,7 @@ window_copy_cmd_halfpage_down(struct window_copy_cmd_state *cs)
 	u_int				 np = wme->prefix;
 
 	for (; np != 0; np--) {
-		if (window_copy_pagedown(wme, 1, data->scroll_exit))
+		if (window_copy_pagedown1(wme, 1, data->scroll_exit))
 			return (WINDOW_COPY_CMD_CANCEL);
 	}
 	return (WINDOW_COPY_CMD_NOTHING);
@@ -1361,7 +1370,7 @@ window_copy_cmd_halfpage_down_and_cancel(struct window_copy_cmd_state *cs)
 	u_int				 np = wme->prefix;
 
 	for (; np != 0; np--) {
-		if (window_copy_pagedown(wme, 1, 1))
+		if (window_copy_pagedown1(wme, 1, 1))
 			return (WINDOW_COPY_CMD_CANCEL);
 	}
 	return (WINDOW_COPY_CMD_NOTHING);
@@ -1789,7 +1798,7 @@ window_copy_cmd_page_down(struct window_copy_cmd_state *cs)
 	u_int				 np = wme->prefix;
 
 	for (; np != 0; np--) {
-		if (window_copy_pagedown(wme, 0, data->scroll_exit))
+		if (window_copy_pagedown1(wme, 0, data->scroll_exit))
 			return (WINDOW_COPY_CMD_CANCEL);
 	}
 	return (WINDOW_COPY_CMD_NOTHING);
@@ -1802,7 +1811,7 @@ window_copy_cmd_page_down_and_cancel(struct window_copy_cmd_state *cs)
 	u_int				 np = wme->prefix;
 
 	for (; np != 0; np--) {
-		if (window_copy_pagedown(wme, 0, 1))
+		if (window_copy_pagedown1(wme, 0, 1))
 			return (WINDOW_COPY_CMD_CANCEL);
 	}
 	return (WINDOW_COPY_CMD_NOTHING);


### PR DESCRIPTION
Add a '-d' option to copy-mode for consistency.  Though this is not strictly necessary since you can use `send -X page-down`, this just adds consistency so you can bind NPage and PPage to copy-mode commands.

Also added clarification that the copy-mode command not only gets you into copy mode but it also functions in copy mode, as in, to scroll up and down.