### PR TITLE
Add an option prefix-timeout to ignore prefix key after timeout

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -385,6 +385,17 @@ const struct options_table_entry options_table[] = {
 	  .text = "Maximum number of server messages to keep."
 	},
 
+	{ .name = "prefix-timeout",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .minimum = 0,
+	  .maximum = INT_MAX,
+	  .default_num = 0,
+	  .unit = "milliseconds",
+	  .text = "The timeout after pressing the prefix key if no subsequent key is pressed. "
+	             "'0' indicates that the timeout feature is disabled."
+	},
+
 	{ .name = "prompt-history-limit",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_SERVER,

--- a/server-client.c
+++ b/server-client.c
@@ -222,6 +222,16 @@ server_client_set_key_table(struct client *c, const char *name)
 	key_bindings_unref_table(c->keytable);
 	c->keytable = key_bindings_get_table(name, 1);
 	c->keytable->references++;
+	if (gettimeofday(&c->keytable->activity_time, NULL) != 0)
+		fatal("gettimeofday failed");
+}
+
+static uint64_t
+server_client_key_table_activity_diff(struct client *c)
+{
+	struct timeval	diff;
+	timersub(&c->activity_time, &c->keytable->activity_time, &diff);
+	return ((diff.tv_sec * 1000ULL) + (diff.tv_usec / 1000ULL));
 }
 
 /* Get default key table. */
@@ -1867,6 +1877,7 @@ server_client_key_callback(struct cmdq_item *item, void *data)
 	struct key_binding		*bd;
 	int				 xtimeout;
 	uint64_t			 flags;
+	uint64_t			 prefix_delay;
 	struct cmd_find_state		 fs;
 	key_code			 key0, prefix, prefix2;
 
@@ -1961,8 +1972,32 @@ try_again:
 	if (c->flags & CLIENT_REPEAT)
 		log_debug("currently repeating");
 
-	/* Try to see if there is a key binding in the current table. */
 	bd = key_bindings_get(table, key0);
+
+	/*
+	 * If prefix-timeout is enabled and we're in the prefix table, see if the
+	 * timeout has been exceeded. Revert to the root table if so.
+	 */
+	prefix_delay = options_get_number(global_options, "prefix-timeout");
+	if (prefix_delay > 0 && strcmp(table->name, "prefix") == 0 &&
+		server_client_key_table_activity_diff(c) > prefix_delay) {
+		/*
+		 * If repeating is active and this is a repeating binding, ignore the
+		 * timeout.
+		 */
+		if (bd != NULL && (c->flags & CLIENT_REPEAT) &&
+			(bd->flags & KEY_BINDING_REPEAT)) {
+			log_debug("prefix-timeout ignored, repeating is active");
+		} else {
+			log_debug("prefix-timeout exceeded, ignoring prefix key");
+			server_client_set_key_table(c, NULL);
+			first = table = c->keytable;
+			server_status_client(c);
+			goto table_changed;
+		}
+	}
+
+	/* Try to see if there is a key binding in the current table. */
 	if (bd != NULL) {
 		/*
 		 * Key was matched in this table. If currently repeating but a

--- a/tmux.1
+++ b/tmux.1
@@ -4230,6 +4230,15 @@ Like
 .Ic prefix2
 can be set to
 .Ql None .
+.It Ic prefix-timeout Ar time
+Set the time in milliseconds for which
+.Nm
+waits after
+.Ic prefix
+is input before dismissing it.
+Can be set to
+.Ic 0
+to disable timeouts.
 .It Xo Ic renumber-windows
 .Op Ic on | off
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -2016,6 +2016,7 @@ RB_HEAD(key_bindings, key_binding);
 
 struct key_table {
 	const char		*name;
+	struct timeval		 activity_time;
 	struct key_bindings	 key_bindings;
 	struct key_bindings	 default_key_bindings;
 


### PR DESCRIPTION
Hi! This PR introduces the `prefix-timeout` option. When set to non-zero, it defines the amount of milliseconds after the `prefix` key is pressed before it is assumed to have "timed out".

Example config entry:
```
# Use a 5 second prefix key timeout.
set -g prefix-timeout 5000
```

This is my first tmux PR -- happy to iterate on it as much as necessary if you have feedback!