### PR TITLE
Support Sixel transparency

### DIFF
--- a/image-sixel.c
+++ b/image-sixel.c
@@ -434,9 +434,17 @@ sixel_scale(struct sixel_image *si, u_int xpixel, u_int ypixel, u_int ox,
 	new->xpixel = xpixel;
 	new->ypixel = ypixel;
 	new->p2 = si->p2;
+
 	new->set_ra = si->set_ra;
-	new->ra_x = si->ra_x;
-	new->ra_y = si->ra_y;
+	/* clamp to slice end */
+	new->ra_x = si->ra_x < psx ? si->ra_x : psx;
+	new->ra_y = si->ra_y < psy ? si->ra_y : psy;
+	/* subtract slice origin */
+	new->ra_x = new->ra_x > pox ? new->ra_x - pox : 0;
+	new->ra_y = new->ra_y > poy ? new->ra_y - poy : 0;
+	/* resize */
+	new->ra_x = new->ra_x * xpixel / si->xpixel;
+	new->ra_y = new->ra_y * ypixel / si->ypixel;
 
 	for (y = 0; y < tsy; y++) {
 		py = poy + ((double)y * psy / tsy);

--- a/image-sixel.c
+++ b/image-sixel.c
@@ -434,6 +434,9 @@ sixel_scale(struct sixel_image *si, u_int xpixel, u_int ypixel, u_int ox,
 	new->xpixel = xpixel;
 	new->ypixel = ypixel;
 	new->p2 = si->p2;
+	new->set_ra = si->set_ra;
+	new->ra_x = si->ra_x;
+	new->ra_y = si->ra_y;
 
 	for (y = 0; y < tsy; y++) {
 		py = poy + ((double)y * psy / tsy);

--- a/input.c
+++ b/input.c
@@ -2320,6 +2320,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 #ifdef ENABLE_SIXEL
 	struct window		*w;
 	struct sixel_image	*si;
+	u_int			 p2 = 0;
 #endif
 
 	if (wp == NULL)
@@ -2333,7 +2334,11 @@ input_dcs_dispatch(struct input_ctx *ictx)
 #ifdef ENABLE_SIXEL
 	w = wp->window;
 	if (buf[0] == 'q') {
-		si = sixel_parse(buf, len, w->xpixel, w->ypixel);
+		if (input_split(ictx) != 0)
+			return (0);
+		if (ictx->param_list[1].type == INPUT_NUMBER)
+			p2 = ictx->param_list[1].num;
+		si = sixel_parse(buf, len, p2, w->xpixel, w->ypixel);
 		if (si != NULL)
 			screen_write_sixelimage(sctx, si, ictx->cell.cell.bg);
 	}

--- a/input.c
+++ b/input.c
@@ -2320,7 +2320,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 #ifdef ENABLE_SIXEL
 	struct window		*w;
 	struct sixel_image	*si;
-	u_int			 p2 = 0;
+	int			 p2;
 #endif
 
 	if (wp == NULL)
@@ -2336,8 +2336,9 @@ input_dcs_dispatch(struct input_ctx *ictx)
 	if (buf[0] == 'q') {
 		if (input_split(ictx) != 0)
 			return (0);
-		if (ictx->param_list[1].type == INPUT_NUMBER)
-			p2 = ictx->param_list[1].num;
+		p2 = input_get(ictx, 1, 0, 0);
+		if (p2 == -1)
+			p2 = 0;
 		si = sixel_parse(buf, len, p2, w->xpixel, w->ypixel);
 		if (si != NULL)
 			screen_write_sixelimage(sctx, si, ictx->cell.cell.bg);

--- a/tmux.h
+++ b/tmux.h
@@ -3493,7 +3493,7 @@ int		 image_scroll_up(struct screen *, u_int);
 
 /* image-sixel.c */
 #define SIXEL_COLOUR_REGISTERS 1024
-struct sixel_image *sixel_parse(const char *, size_t, u_int, u_int);
+struct sixel_image *sixel_parse(const char *, size_t, u_int, u_int, u_int);
 void		 sixel_free(struct sixel_image *);
 void		 sixel_log(struct sixel_image *);
 void		 sixel_size_in_cells(struct sixel_image *, u_int *, u_int *);


### PR DESCRIPTION
By default, unspecified pixels on Sixel images are opaque. However, when P2 is set to 1, they are left transparent by the terminal. Pass through this parameter.

Additionally, raster attribute dimensions smaller than the actual image size may be specified, which turns unset pixels *outside* the specified rectangle transparent. This is commonly used to crop out some rows of the last sixel of an image (which otherwise would have to align to a multiple of 6).

Instead of sending the actual dimensions of the bitmap, we now pass through the user-specified raster attribute dimensions.

Finally, to avoid collapsing empty sixel lines, we no longer ignore duplicate "-" newline specifiers.

Fixes GitHub issue #3879