### PR TITLE
Add the prompt-cursor-{colour,style} options (issue #4117)

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -207,6 +207,7 @@ const struct options_name_map options_other_names[] = {
 	{ "display-panes-active-color", "display-panes-active-colour" },
 	{ "clock-mode-color", "clock-mode-colour" },
 	{ "cursor-color", "cursor-colour" },
+	{ "prompt-cursor-color", "prompt-cursor-colour" },
 	{ "pane-colors", "pane-colours" },
 	{ NULL, NULL }
 };
@@ -808,11 +809,19 @@ const struct options_table_entry options_table[] = {
 	  .text = "Style of the status line."
 	},
 
-	{ .name = "status-emulate-cursor",
-	  .type = OPTIONS_TABLE_FLAG,
-	  .scope = OPTIONS_TABLE_SERVER,
-	  .default_num = 1,
-	  .text = "Whether to emulate the status line cursor."
+	{ .name = "prompt-cursor-colour",
+	  .type = OPTIONS_TABLE_COLOUR,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = -1,
+	  .text = "Colour of the cursor when in prompt."
+	},
+
+	{ .name = "prompt-cursor-style",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_cursor_style_list,
+	  .default_num = 0,
+	  .text = "Style of the cursor when in prompt."
 	},
 
 	{ .name = "update-environment",

--- a/options-table.c
+++ b/options-table.c
@@ -808,6 +808,13 @@ const struct options_table_entry options_table[] = {
 	  .text = "Style of the status line."
 	},
 
+	{ .name = "status-emulate-cursor",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .default_num = 1,
+	  .text = "Whether to emulate the status line cursor."
+	},
+
 	{ .name = "update-environment",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/server-client.c
+++ b/server-client.c
@@ -2392,23 +2392,33 @@ server_client_reset_state(struct client *c)
 				cy = tty->sy - n;
 		}
 		cx = c->prompt_cursor;
-		if (options_get_number(global_options, "status-emulate-cursor"))
-			mode &= ~MODE_CURSOR;
-	} else if (c->overlay_draw == NULL) {
-		cursor = 0;
-		tty_window_offset(tty, &ox, &oy, &sx, &sy);
-		if (wp->xoff + s->cx >= ox && wp->xoff + s->cx <= ox + sx &&
-		    wp->yoff + s->cy >= oy && wp->yoff + s->cy <= oy + sy) {
-			cursor = 1;
 
-			cx = wp->xoff + s->cx - ox;
-			cy = wp->yoff + s->cy - oy;
+		n = options_get_number(c->session->options, "prompt-cursor-colour");
+		s->default_ccolour = n;
+		n = options_get_number(c->session->options, "prompt-cursor-style");
+		screen_set_cursor_style(n, &s->default_cstyle, &s->default_mode);
+	} else {
+		n = options_get_number(wp->options, "cursor-colour");
+		s->default_ccolour = n;
+		n = options_get_number(wp->options, "cursor-style");
+		screen_set_cursor_style(n, &s->default_cstyle, &s->default_mode);
 
-			if (status_at_line(c) == 0)
-				cy += status_line_size(c);
+		if (c->overlay_draw == NULL) {
+			cursor = 0;
+			tty_window_offset(tty, &ox, &oy, &sx, &sy);
+			if (wp->xoff + s->cx >= ox && wp->xoff + s->cx <= ox + sx &&
+			    wp->yoff + s->cy >= oy && wp->yoff + s->cy <= oy + sy) {
+				cursor = 1;
+
+				cx = wp->xoff + s->cx - ox;
+				cy = wp->yoff + s->cy - oy;
+
+				if (status_at_line(c) == 0)
+					cy += status_line_size(c);
+			}
+			if (!cursor)
+				mode &= ~MODE_CURSOR;
 		}
-		if (!cursor)
-			mode &= ~MODE_CURSOR;
 	}
 	log_debug("%s: cursor to %u,%u", __func__, cx, cy);
 	tty_cursor(tty, cx, cy);

--- a/server-client.c
+++ b/server-client.c
@@ -2392,7 +2392,8 @@ server_client_reset_state(struct client *c)
 				cy = tty->sy - n;
 		}
 		cx = c->prompt_cursor;
-		mode &= ~MODE_CURSOR;
+		if (options_get_number(global_options, "status-emulate-cursor"))
+			mode &= ~MODE_CURSOR;
 	} else if (c->overlay_draw == NULL) {
 		cursor = 0;
 		tty_window_offset(tty, &ox, &oy, &sx, &sy);

--- a/status.c
+++ b/status.c
@@ -646,8 +646,11 @@ status_prompt_set(struct client *c, struct cmd_find_state *fs,
 	c->prompt_type = prompt_type;
 	c->prompt_mode = PROMPT_ENTRY;
 
-	if (~flags & PROMPT_INCREMENTAL)
-		c->tty.flags |= (TTY_NOCURSOR|TTY_FREEZE);
+	if (~flags & PROMPT_INCREMENTAL) {
+		if (options_get_number(global_options, "status-emulate-cursor"))
+			c->tty.flags |= TTY_NOCURSOR;
+		c->tty.flags |= TTY_FREEZE;
+	}
 	c->flags |= CLIENT_REDRAWSTATUS;
 
 	if (flags & PROMPT_INCREMENTAL)
@@ -746,7 +749,8 @@ status_prompt_redraw(struct client *c)
 	format_free(ft);
 
 	memcpy(&cursorgc, &gc, sizeof cursorgc);
-	cursorgc.attr ^= GRID_ATTR_REVERSE;
+	if (options_get_number(global_options, "status-emulate-cursor"))
+		cursorgc.attr ^= GRID_ATTR_REVERSE;
 
 	start = format_width(c->prompt_string);
 	if (start > c->tty.sx)

--- a/status.c
+++ b/status.c
@@ -722,7 +722,7 @@ status_prompt_redraw(struct client *c)
 	struct screen		 old_screen;
 	u_int			 i, lines, offset, left, start, width;
 	u_int			 pcursor, pwidth, promptline;
-	struct grid_cell	 gc, cursorgc;
+	struct grid_cell	 gc;
 	struct format_tree	*ft;
 
 	if (c->tty.sx == 0 || c->tty.sy == 0)
@@ -744,8 +744,6 @@ status_prompt_redraw(struct client *c)
 	else
 		style_apply(&gc, s->options, "message-style", ft);
 	format_free(ft);
-
-	memcpy(&cursorgc, &gc, sizeof cursorgc);
 
 	start = format_width(c->prompt_string);
 	if (start > c->tty.sx)
@@ -791,16 +789,9 @@ status_prompt_redraw(struct client *c)
 		if (width > offset + pwidth)
 			break;
 
-		if (i != c->prompt_index) {
-			utf8_copy(&gc.data, &c->prompt_buffer[i]);
-			screen_write_cell(&ctx, &gc);
-		} else {
-			utf8_copy(&cursorgc.data, &c->prompt_buffer[i]);
-			screen_write_cell(&ctx, &cursorgc);
-		}
+		utf8_copy(&gc.data, &c->prompt_buffer[i]);
+		screen_write_cell(&ctx, &gc);
 	}
-	if (sl->active->cx < screen_size_x(sl->active) && c->prompt_index >= i)
-		screen_write_putc(&ctx, &cursorgc, ' ');
 
 finished:
 	screen_write_stop(&ctx);

--- a/status.c
+++ b/status.c
@@ -646,11 +646,8 @@ status_prompt_set(struct client *c, struct cmd_find_state *fs,
 	c->prompt_type = prompt_type;
 	c->prompt_mode = PROMPT_ENTRY;
 
-	if (~flags & PROMPT_INCREMENTAL) {
-		if (options_get_number(global_options, "status-emulate-cursor"))
-			c->tty.flags |= TTY_NOCURSOR;
+	if (~flags & PROMPT_INCREMENTAL)
 		c->tty.flags |= TTY_FREEZE;
-	}
 	c->flags |= CLIENT_REDRAWSTATUS;
 
 	if (flags & PROMPT_INCREMENTAL)
@@ -749,8 +746,6 @@ status_prompt_redraw(struct client *c)
 	format_free(ft);
 
 	memcpy(&cursorgc, &gc, sizeof cursorgc);
-	if (options_get_number(global_options, "status-emulate-cursor"))
-		cursorgc.attr ^= GRID_ATTR_REVERSE;
 
 	start = format_width(c->prompt_string);
 	if (start > c->tty.sx)

--- a/tmux.1
+++ b/tmux.1
@@ -4357,6 +4357,13 @@ For how to specify
 see the
 .Sx STYLES
 section.
+.It Xo Ic status-emulate-cursor
+.Op Ic on | off
+.Xc
+If enabled (the default), the status line cursor is emulated with reverse-video.
+Otherwise the normal
+.Qq hardware
+cursor is used.
 .It Xo Ic status-position
 .Op Ic top | bottom
 .Xc

--- a/tmux.1
+++ b/tmux.1
@@ -4230,6 +4230,13 @@ Like
 .Ic prefix2
 can be set to
 .Ql None .
+.It Ic prompt-cursor-colour Ar colour
+Set the colour of the cursor in prompt.
+.It Ic prompt-cursor-style Ar style
+Set the style of the cursor in prompt.
+See the
+.Ic cursor-style
+options for available styles.
 .It Xo Ic renumber-windows
 .Op Ic on | off
 .Xc
@@ -4357,13 +4364,6 @@ For how to specify
 see the
 .Sx STYLES
 section.
-.It Xo Ic status-emulate-cursor
-.Op Ic on | off
-.Xc
-If enabled (the default), the status line cursor is emulated with reverse-video.
-Otherwise the normal
-.Qq hardware
-cursor is used.
 .It Xo Ic status-position
 .Op Ic top | bottom
 .Xc


### PR DESCRIPTION
This implements the two options, as discussed in issue #4117:

- `prompt-cursor-colour` cursor colour in prompt, cf. `cursor-colour`
- `prompt-cursor-style` cursor style in prompt, cf. `cursor-style`

At the moment, upstream tmux hides "real" cursor when entering prompt, to instead emulate it. These options make the behaviour unnecessary, so that's been removed.