### PR TITLE
Better tab handling near the end of the line

### DIFF
--- a/input.c
+++ b/input.c
@@ -1230,9 +1230,16 @@ input_c0_dispatch(struct input_ctx *ictx)
 		screen_write_backspace(sctx);
 		break;
 	case '\011':	/* HT */
-		/* Don't tab beyond the end of the line. */
-		if (s->cx >= screen_size_x(s) - 1)
-			break;
+		/* Tab on the next line if too close to the end. */
+		if (screen_size_x(s) == 1 || s->cx >= screen_size_x(s) - 2) {
+			screen_write_linefeed(sctx, 1, ictx->cell.cell.bg);
+			screen_write_carriagereturn(sctx);
+			if (screen_size_x(s) == 1) {
+				screen_write_linefeed(sctx, 1, ictx->cell.cell.bg);
+				screen_write_carriagereturn(sctx);
+				break;
+			}
+		}
 
 		/* Find the next tab point, or use the last column if none. */
 		do {


### PR DESCRIPTION
Hello!

Currently horizontal tabs input when cursor is at the end of the line are ignored, and when cursor is on the penultimate cell, it just gets moved right once. The result is that in these cases tab does not create any spacing between characters.

This changes the behaviour to be more like it is in xterm:

- If the cursor it too close to the end of the line (last, or penultimate cell), tab instead moves the cursor starting from the beginning of the next line
- In case of a 1 column-wide screen, tab is represented by moving further down an additional line

I am not exactly sure if that might cause problems in terminal raw mode, though as far as I know, most applications requiring raw mode do their own tab handling.

Thanks.