### PR TITLE
Added dockerfile and script for building/running in container.

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,26 @@
+FROM debian:stable
+
+RUN apt update && apt install -y \
+gcc \
+bison \
+autoconf \
+pkgconf \
+make \
+libevent-dev \
+libncurses-dev
+
+RUN useradd app
+
+RUN mkdir /tmux-bin
+RUN chown app:app /tmux-bin
+
+RUN mkdir /tmux
+RUN chown app:app /tmux
+
+WORKDIR /tmux
+
+USER app
+
+ENV PATH="$PATH:/tmux-bin"
+
+CMD [ "bash" ]

--- a/run-container.sh
+++ b/run-container.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -o pipefail
+
+function output_help() {
+	echo &&
+	echo "'build': build repo for container, build products persistently located in host repo" 1>&2 &&
+	echo &&
+	echo "'interactive' (default): automatically calls 'build', afterwards open interactive bash to the container. From there, you can use the built tmux executable from within the container. It's automatically put in the PATH, so you can simply write 'tmux ...' to use the built executable." 1>&2
+	echo &&
+	echo "'cmd': run the argument that follows as a command in bash from within the container. Automatically builds tmux for the container, just like 'interactive'."
+}
+
+function assert_arg_count() {
+	if [ "$1" -eq "$2" ]
+	then
+		return
+	fi
+
+	echo "$0: ERROR: invalid number of arguments for subcommand" 1>&2 && output_help
+	exit 1
+}
+
+function do_in_new_container() {
+	image_name="$(pwd | sed 's/\///' | sed 's/\//__/g')" &&
+	docker build -t "$image_name" . &&
+	docker run -it --rm -v .:/tmux "$image_name" "$@"
+}
+
+function do_subcommand() {
+	subcommand=$1
+	shift
+	case "$subcommand" in
+
+		build)
+			assert_arg_count $# 0 &&
+
+			do_in_new_container bash -c './autogen.sh && ./configure && make' ||
+			exit 1
+		;;
+
+		interactive|'')
+			assert_arg_count $# 0 &&
+
+			# prerequisites
+			do_subcommand build &&
+
+			do_in_new_container bash -c 'ln -s /tmux/tmux /tmux-bin/tmux && bash' ||
+
+			exit 1
+		;;
+
+		cmd)
+			# NOTE: I want to be able to use more than 1 arg for this, but bash -c doesn't like that for some reason.
+			assert_arg_count $# 1 &&
+
+			# prerequisites
+			do_subcommand build &&
+
+			do_in_new_container bash -c "$1" ||
+
+			exit 1
+		;;
+
+		*)
+			echo "$0: ERROR: subcommand invalid" 1>&2 && output_help
+			exit 1
+		;;
+
+	esac
+}
+
+do_subcommand "$@"


### PR DESCRIPTION
Below is the commit message of the single commit that this pull request consists of. Maybe I overdid it and wrote too much. Sorry. This pull request may be a little bit rough around the edges, but it seems to work nicely. I would like to know whether this feature is useful or not. If it is useful, what should I improve upon before it can be merged? I also find it unsatisfying that it's so detached from the build system, but I'm no autotools expert and I'm not exactly sure what the best way to integrate it more into the build system would be, so advice about that would be appreciated as well.

If you already have tmux installed on your system, testing your changes can be a little annoying. This fixes that. It also is a fixed environment which is the same for everyone, which can be useful as well.

IMPORTANT NOTE: Make sure to clean repo between switching from building/using tmux in container and on host or vice versa. Build products stay around and aren't recognized as belonging to different target. SO YOU NEED TO CLEAN BUILD WHEN SWITCHING!!!!

You can do:

sudo docker build -t some-individual-name .
sudo docker run -it --rm -v .:/tmux some-individual-name bash -c './autogen.sh && ./configure && make'

OR you can use the small helper script like so:

sudo ./run-container.sh interactive --> build for container, start bash
sudo ./run-container.sh build --> build for container
sudo ./run-container.sh cmd 'command' --> execute arbitrary cmd in container

You can use the cmd subcommand like so for example:

sudo ./run-container.sh cmd 'make -C regress' --> run regression tests

NOTE: I know you can test tmux on host systems with tmux already installed if you just change the unix socket that the client uses, but maybe this docker container commit will be useful to someone. If it isn't, just scrap it.