### PR TITLE
Changed tmux has-session -t <session> to NOT accept prefixes.

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -58,7 +58,7 @@ const struct cmd_entry cmd_has_session_entry = {
 	.args = { "t:", 0, 0, NULL },
 	.usage = CMD_TARGET_SESSION_USAGE,
 
-	.target = { 't', CMD_FIND_SESSION, 0 },
+	.target = { 't', CMD_FIND_SESSION, CMD_FIND_EXACT_SESSION },
 
 	.flags = 0,
 	.exec = cmd_new_session_exec


### PR DESCRIPTION
I assume has-session is mainly an automation tool. In that case, accepting prefixes for session names makes little sense. Consider following situation:

tmux list-sessions:
	- testsession: etc...

tmux has-session -t test --> returns TRUE

WHEREAS:

tmux list-sessions:
	- testsession: etc...
	- testsess: etc...

tmux has-session -t test --> returns FALSE

CONCLUSION:

has-session behavior is context-dependent and makes no sense, given that all we were originally looking for is a session named 'test'.

If this is meant to be used in automation, I figure it should be reliable.

So I added CMD_FIND_EXACT_SESSION in the flags for the .target field in cmd_has_session_entry, which prevents this behavior and searches for the session as given, without doing prefix stuff.

Tested it, works great, fixes the issue, everythings fine, at least on my machine.