### PR TITLE
Resolve the symlinks for source-file command

### DIFF
--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -121,6 +121,16 @@ cmd_source_file_done(struct client *c, const char *path, int error,
 static void
 cmd_source_file_add(struct cmd_source_file_data *cdata, const char *path)
 {
+	char resolved[PATH_MAX];
+
+	if (realpath(path, resolved) == NULL) {
+		log_debug("%s: realpath(\"%s\") failed: %s", __func__,
+			path, strerror(errno));
+		return;
+	} else {
+		path = resolved;
+	}
+
 	log_debug("%s: %s", __func__, path);
 	cdata->files = xreallocarray(cdata->files, cdata->nfiles + 1,
 	    sizeof *cdata->files);


### PR DESCRIPTION
Hi,

I find the `source-file` command cannot resolve the symlink file, here is an example:

```
$ ls -al .tmux.conf
lrwxr-xr-x  1 japin  staff  15 Sep 28  2020 .tmux.conf -> .tmux/tmux.conf
$ ls -al .tmux/tmux.conf .tmux/personal.conf
-rw-r--r--  1 japin  staff    65 Oct 11 10:03 .tmux/personal.conf
-rw-r--r--  1 japin  staff  4971 Oct 11 09:09 .tmux/tmux.conf
```

And the `tmux.conf` contains:

```
source -F "#{d:current_file}/personal.conf"
bind R source-file ~/.tmux.conf \; display "Reload config ..."
```

When starting the server, it works fine.  However, if I try to reload the config, the `#{d:current_file}/personal.conf` is converted to `~/personal.conf`, not `~/.tmux/personal.conf`. Since `~/.tmux.conf` is a symlink, and `source-file` command does not resolve the real path, which causes no such file error.