### PR TITLE
tty: Pass unrequested OSC 52 sequence to client

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -747,6 +747,7 @@ tty_keys_next(struct tty *tty)
 	switch (tty_keys_clipboard(tty, buf, len, &size)) {
 	case 0:		/* yes */
 		key = KEYC_UNKNOWN;
+	case -2:	/* yes, but leave it to the foreground program. */
 		goto complete_key;
 	case -1:	/* no, or not valid */
 		break;
@@ -1340,7 +1341,7 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 
 	/* If we did not request this, ignore it. */
 	if (~tty->flags & TTY_OSC52QUERY)
-		return (0);
+		return (-2);
 	tty->flags &= ~TTY_OSC52QUERY;
 	evtimer_del(&tty->clipboard_timer);
 


### PR DESCRIPTION
Problem:

An OSC 52 escape sequence received outside a designated TTY_OSC52QUERY is not passed on to the client application. For example, a program running inside the tmux sends the OSC 52 escape sequence to the host terminal. The host terminal writes data content to tmux to response the request, but tmux ignores the data in tty_keys_clipboard because the TTY_OSC52QUERY wasn't set, so the client program never receives the data.

Solution:

Add a tty_keys_clipboard return code `-2` as a "leave it to the foreground program" indicator.