### PR TITLE
Fix options ordering in tmux.1

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -5166,13 +5166,6 @@ visible before the application starts reappears unchanged after it exits.
 .It Ic cursor-colour Ar colour
 Set the colour of the cursor.
 .Pp
-.It Ic pane-colours[] Ar colour
-The default colour palette.
-Each entry in the array defines the colour
-.Nm
-uses when the colour with that index is requested.
-The index may be from zero to 255.
-.Pp
 .It Ic cursor-style Ar style
 Set the style of the cursor.
 Available styles are:
@@ -5183,6 +5176,13 @@ Available styles are:
 .Ic underline ,
 .Ic blinking-bar ,
 .Ic bar .
+.Pp
+.It Ic pane-colours[] Ar colour
+The default colour palette.
+Each entry in the array defines the colour
+.Nm
+uses when the colour with that index is requested.
+The index may be from zero to 255.
 .Pp
 .It Xo Ic remain-on-exit
 .Op Ic on | off | failed


### PR DESCRIPTION
Switch `pane-colors[]` and `cursor-style` to be options in alphabetical order.