### PR TITLE
Add new function window_copy_get_current_offset

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -3293,6 +3293,8 @@ void		 window_copy_pagedown(struct window_pane *, int, int);
 void		 window_copy_start_drag(struct client *, struct mouse_event *);
 char		*window_copy_get_word(struct window_pane *, u_int, u_int);
 char		*window_copy_get_line(struct window_pane *, u_int);
+int		 window_copy_get_current_offset(struct window_pane *, u_int *,
+		     u_int *);
 
 /* window-option.c */
 extern const struct window_mode window_customize_mode;

--- a/window-copy.c
+++ b/window-copy.c
@@ -48,7 +48,7 @@ static void	window_copy_redraw_selection(struct window_mode_entry *, u_int);
 static void	window_copy_redraw_lines(struct window_mode_entry *, u_int,
 		    u_int);
 static void	window_copy_redraw_screen(struct window_mode_entry *);
- static void	window_copy_write_line(struct window_mode_entry *,
+static void	window_copy_write_line(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int);
 static void	window_copy_write_lines(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int, u_int);

--- a/window-copy.c
+++ b/window-copy.c
@@ -48,7 +48,7 @@ static void	window_copy_redraw_selection(struct window_mode_entry *, u_int);
 static void	window_copy_redraw_lines(struct window_mode_entry *, u_int,
 		    u_int);
 static void	window_copy_redraw_screen(struct window_mode_entry *);
-static void	window_copy_write_line(struct window_mode_entry *,
+ static void	window_copy_write_line(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int);
 static void	window_copy_write_lines(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int, u_int);
@@ -4188,6 +4188,27 @@ window_copy_write_one(struct window_mode_entry *wme,
 	}
 }
 
+int
+window_copy_get_current_offset(struct window_pane *wp, u_int *offset,
+    u_int *size)
+{
+        struct window_mode_entry	*wme;
+	struct window_copy_mode_data	*data;
+	u_int				 hsize;
+
+        wme = TAILQ_FIRST(&wp->modes);
+        data = wme->data;
+        if (data == NULL)
+                return (0);
+        
+        hsize = screen_hsize(data->backing);
+
+        *offset = hsize - data->oy;
+        *size = hsize;
+
+        return (1);
+}
+                                
 static void
 window_copy_write_line(struct window_mode_entry *wme,
     struct screen_write_ctx *ctx, u_int py)


### PR DESCRIPTION
Add new function to get the current offset of the position (in lines) and size (also in lines) of the pane in copy mode.