### PR TITLE
Accept control characters in command-prompt

### DIFF
--- a/status.c
+++ b/status.c
@@ -1262,6 +1262,12 @@ status_prompt_key(struct client *c, key_code key)
 	}
 	key &= ~KEYC_MASK_FLAGS;
 
+	if (c->prompt_flags & PROMPT_SINGLE) {
+		if (key & KEYC_CTRL)
+			key = (key & ~KEYC_CTRL) & 0x1f; 
+		goto append_key;
+	}
+
 	keys = options_get_number(c->session->options, "status-keys");
 	if (keys == MODEKEY_VI) {
 		switch (status_prompt_translate_key(c, key, &key)) {

--- a/status.c
+++ b/status.c
@@ -815,7 +815,8 @@ status_prompt_redraw(struct client *c)
 		    (*c->prompt_buffer[i].data <= 0x1f ||
 		    *c->prompt_buffer[i].data == 0x7f)) {
 			gc.data.data[0] = '^';
-			gc.data.data[1] = *c->prompt_buffer[i].data|0x40;
+			gc.data.data[1] = (*c->prompt_buffer[i].data == 0x7f) ?
+			    '?' : *c->prompt_buffer[i].data|0x40;
 			gc.data.size = gc.data.have = 2;
 			gc.data.width = 2;
 		} else
@@ -1274,7 +1275,14 @@ status_prompt_key(struct client *c, key_code key)
 
 	if (c->prompt_flags & PROMPT_SINGLE || quotenext) {
 		quotenext = 0;
-		key &= (key & KEYC_CTRL) ? 0x1f : 0xff;
+		if ((key & KEYC_MASK_KEY) == KEYC_BSPACE)
+			key = 0x7f;
+		else if ((key & KEYC_MASK_KEY) > 0x7f) {
+			if (!KEYC_IS_UNICODE(key))
+				return (0);
+			key &= KEYC_MASK_KEY;
+		} else
+			key &= (key & KEYC_CTRL) ? 0x1f : KEYC_MASK_KEY;
 		goto append_key;
 	}
 

--- a/status.c
+++ b/status.c
@@ -1252,7 +1252,6 @@ status_prompt_key(struct client *c, key_code key)
 	size_t			 size, idx;
 	struct utf8_data	 tmp;
 	int			 keys, word_is_separators;
-	static int		 quotenext = 0;
 
 	if (c->prompt_flags & PROMPT_KEY) {
 		keystring = key_string_lookup_key(key, 0);
@@ -1273,8 +1272,9 @@ status_prompt_key(struct client *c, key_code key)
 	}
 	key &= ~KEYC_MASK_FLAGS;
 
-	if (c->prompt_flags & PROMPT_SINGLE || quotenext) {
-		quotenext = 0;
+	if (c->prompt_flags & PROMPT_SINGLE ||
+	    c->prompt_flags & PROMPT_QUOTENEXT) {
+		c->prompt_flags &= ~PROMPT_QUOTENEXT;
 		if ((key & KEYC_MASK_KEY) == KEYC_BSPACE)
 			key = 0x7f;
 		else if ((key & KEYC_MASK_KEY) > 0x7f) {
@@ -1509,7 +1509,7 @@ process_key:
 			prefix = '+';
 		goto changed;
 	case 'v'|KEYC_CTRL:
-		quotenext = 1;
+		c->prompt_flags |= PROMPT_QUOTENEXT;
 		break;
 	default:
 		goto append_key;

--- a/tmux.h
+++ b/tmux.h
@@ -1971,6 +1971,7 @@ struct client {
 #define PROMPT_NOFORMAT 0x8
 #define PROMPT_KEY 0x10
 #define PROMPT_ACCEPT 0x20
+#define PROMPT_QUOTENEXT 0x40
 	int			 prompt_flags;
 	enum prompt_type	 prompt_type;
 	int			 prompt_cursor;


### PR DESCRIPTION
Hello!

As I mentioned in PR #4201, limitations of the command prompt make the new tab feature somewhat hard to use. This solves the issue:

- `command-prompt -1` now accepts input without processing it first.
- Otherwise, control characters can now be input with Ctrl-V Ctrl-<Key> (and Ctrl-V Tab, Ctrl-V Esc, etc.).

Thanks.