### PR TITLE
Fix infinite loop in copy mode search-* commands

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -3696,7 +3696,7 @@ window_copy_search(struct window_mode_entry *wme, int direction, int regex)
 	struct screen_write_ctx		 ctx;
 	struct grid			*gd = s->grid;
 	const char			*str = data->searchstr;
-	u_int				 at, endline, fx, fy, start;
+	u_int				 at, endline, fx, fy, start, ssx;
 	int				 cis, found, keys, visible_only;
 	int				 wrapflag;
 
@@ -3723,7 +3723,9 @@ window_copy_search(struct window_mode_entry *wme, int direction, int regex)
 	fx = data->cx;
 	fy = screen_hsize(data->backing) - data->oy + data->cy;
 
-	screen_init(&ss, screen_write_strlen("%s", str), 1, 0);
+	if ((ssx = screen_write_strlen("%s", str)) == 0)
+		return (0);
+	screen_init(&ss, ssx, 1, 0);
 	screen_write_start(&ctx, &ss);
 	screen_write_nputs(&ctx, -1, &grid_default_cell, "%s", str);
 	screen_write_stop(&ctx);


### PR DESCRIPTION
Hello! It is currently possible to enter an infinite loop by attempting to search for a control character in copy mode. Can be tested with `tmux bind -T copy-mode / "send -X search-forward -- '	'"` (that's a tab inside single quotes). This fixes the issue by immediately terminating the search for "0 bytes long" strings. Thanks.