### PR TITLE
don't store 0-width cells as extended

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -84,7 +84,7 @@ grid_need_extended_cell(const struct grid_cell_entry *gce,
 		return (1);
 	if (gc->attr > 0xff)
 		return (1);
-	if (gc->data.size != 1 || gc->data.width != 1)
+	if (gc->data.size > 1 || gc->data.width > 1)
 		return (1);
 	if ((gc->fg & COLOUR_FLAG_RGB) || (gc->bg & COLOUR_FLAG_RGB))
 		return (1);


### PR DESCRIPTION
Continuing the discussion in PR #4201. I am becoming less convinced that storing tabs as non-extended cells is at all a good idea. However, just storing padding cells as non-extended seems to be a large improvement already. This small patch does that.

Thanks.