### PR TITLE
show stderr from `run-shell` commands, not just stdout

### DIFF
--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -44,8 +44,8 @@ const struct cmd_entry cmd_run_shell_entry = {
 	.name = "run-shell",
 	.alias = "run",
 
-	.args = { "bd:Ct:c:", 0, 1, cmd_run_shell_args_parse },
-	.usage = "[-bC] [-c start-directory] [-d delay] " CMD_TARGET_PANE_USAGE
+	.args = { "bd:Ct:Es:c:", 0, 1, cmd_run_shell_args_parse },
+	.usage = "[-bCE] [-c start-directory] [-d delay] " CMD_TARGET_PANE_USAGE
 	         " [shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
@@ -157,6 +157,9 @@ cmd_run_shell_exec(struct cmd *self, struct cmdq_item *item)
 		cdata->cwd = xstrdup(args_get(args, 'c'));
 	else
 		cdata->cwd = xstrdup(server_client_get_cwd(c, s));
+
+	if (args_has(args, 'E'))
+		cdata->flags |= JOB_SHOWSTDERR;
 
 	cdata->s = s;
 	if (s != NULL)

--- a/tmux.h
+++ b/tmux.h
@@ -2428,6 +2428,7 @@ typedef void (*job_free_cb) (void *);
 #define JOB_KEEPWRITE 0x2
 #define JOB_PTY 0x4
 #define JOB_DEFAULTSHELL 0x8
+#define JOB_SHOWSTDERR 0x10
 struct job	*job_run(const char *, int, char **, struct environ *,
 		     struct session *, const char *, job_update_cb,
 		     job_complete_cb, job_free_cb, void *, int, int, int);


### PR DESCRIPTION
when commands fail, they often print error messages to stderr. previously, failures were quite hard to debug because tmux would hide stderr.

before:
```
; tmux run-shell 'echo oops >&2; exit 1'
'echo oops >&2; exit 1' returned 1
```

after:
```
; tmux run-shell 'echo oops >&2; exit 1'
oops
'echo oops >&2; exit 1' returned 1
```