### PR TITLE
fix grid_reader_cursor_* functions moving over tabs

### DIFF
--- a/grid-reader.c
+++ b/grid-reader.c
@@ -242,7 +242,7 @@ grid_reader_cursor_next_word(struct grid_reader *gr, const char *separators)
 	}
 	while (grid_reader_handle_wrap(gr, &xx, &yy) &&
 	    ((width = grid_reader_in_set(gr, WHITESPACE))))
-		gr->cx += n;
+		gr->cx += width;
 }
 
 /* Move cursor to the end of the next word. */
@@ -441,7 +441,9 @@ grid_reader_cursor_back_to_indentation(struct grid_reader *gr)
 		xx = grid_line_length(gr->gd, py);
 		for (px = 0; px < xx; px++) {
 			grid_get_cell(gr->gd, px, py, &gc);
-			if (gc.data.size != 1 || *gc.data.data != ' ') {
+			if ((gc.data.size != 1 || *gc.data.data != ' ') &&
+			    ~gc.flags & GRID_FLAG_TAB &&
+			    ~gc.flags & GRID_FLAG_PADDING) {
 				gr->cx = px;
 				gr->cy = py;
 				return;

--- a/grid-reader.c
+++ b/grid-reader.c
@@ -180,24 +180,7 @@ grid_reader_handle_wrap(struct grid_reader *gr, u_int *xx, u_int *yy)
 int
 grid_reader_in_set(struct grid_reader *gr, const char *set)
 {
-	struct grid_cell	gc;
-
-	grid_get_cell(gr->gd, gr->cx, gr->cy, &gc);
-	if (gc.flags & GRID_FLAG_PADDING)
-		return (0);
-	if (gc.flags & GRID_FLAG_TAB && strchr(set, '\t'))
-		return (gc.data.width);
-	return (utf8_cstrhas(set, &gc.data));
-}
-
-/* Check if character under cursor is padding. */
-static int
-grid_reader_is_padding(struct grid_reader *gr)
-{
-	struct grid_cell	gc;
-
-	grid_get_cell(gr->gd, gr->cx, gr->cy, &gc);
-	return (gc.flags & GRID_FLAG_PADDING);
+	return (grid_in_set(gr->gd, gr->cx, gr->cy, set));
 }
 
 /* Move cursor to the start of the next word. */
@@ -298,13 +281,11 @@ grid_reader_cursor_previous_word(struct grid_reader *gr, const char *separators,
 	int	oldx, oldy, at_eol, word_is_letters;
 
 	/* Move back to the previous word character. */
-	if (already || grid_reader_in_set(gr, WHITESPACE) ||
-	    grid_reader_is_padding(gr)) {
+	if (already || grid_reader_in_set(gr, WHITESPACE)) {
 		for (;;) {
 			if (gr->cx > 0) {
 				gr->cx--;
-				if (!grid_reader_in_set(gr, WHITESPACE) &&
-				    !grid_reader_is_padding(gr)) {
+				if (!grid_reader_in_set(gr, WHITESPACE)) {
 					word_is_letters =
 					    !grid_reader_in_set(gr, separators);
 					break;
@@ -320,8 +301,7 @@ grid_reader_cursor_previous_word(struct grid_reader *gr, const char *separators,
 					oldx = gr->cx;
 					gr->cx--;
 					at_eol = grid_reader_in_set(gr,
-					    WHITESPACE) ||
-					    grid_reader_is_padding(gr);
+					    WHITESPACE);
 					gr->cx = oldx;
 					if (at_eol) {
 						word_is_letters = 0;
@@ -348,7 +328,6 @@ grid_reader_cursor_previous_word(struct grid_reader *gr, const char *separators,
 		if (gr->cx > 0)
 			gr->cx--;
 	} while (!grid_reader_in_set(gr, WHITESPACE) &&
-	    !grid_reader_is_padding(gr) &&
 	    word_is_letters != grid_reader_in_set(gr, separators));
 	gr->cx = oldx;
 	gr->cy = oldy;

--- a/grid.c
+++ b/grid.c
@@ -1566,16 +1566,20 @@ grid_line_length(struct grid *gd, u_int py)
 int
 grid_in_set(struct grid *gd, u_int px, u_int py, const char *set)
 {
-	struct grid_cell	gc;
+	struct grid_cell	gc, tmp_gc;
 	u_int			pxx;
 
 	grid_get_cell(gd, px, py, &gc);
 	if (strchr(set, '\t')) {
-		pxx = px;
-		while (pxx > 0 && gc.flags & GRID_FLAG_PADDING)
-			grid_get_cell(gd, --pxx, py, &gc);
-		if (gc.flags & GRID_FLAG_TAB)
-			return (gc.data.width - (px - pxx));
+		if (gc.flags & GRID_FLAG_PADDING) {
+			pxx = px;
+			do
+				grid_get_cell(gd, --pxx, py, &tmp_gc);
+			while (pxx > 0 && tmp_gc.flags & GRID_FLAG_PADDING);
+			if (tmp_gc.flags & GRID_FLAG_TAB)
+				return (tmp_gc.data.width - (px - pxx));
+		} else if (gc.flags & GRID_FLAG_TAB)
+			return (gc.data.width);
 	}
 	if (gc.flags & GRID_FLAG_PADDING)
 		return (0);

--- a/grid.c
+++ b/grid.c
@@ -1561,3 +1561,23 @@ grid_line_length(struct grid *gd, u_int py)
 	}
 	return (px);
 }
+
+/* Check if character is in set. */
+int
+grid_in_set(struct grid *gd, u_int px, u_int py, const char *set)
+{
+	struct grid_cell	gc;
+	u_int			pxx;
+
+	grid_get_cell(gd, px, py, &gc);
+	if (strchr(set, '\t')) {
+		pxx = px;
+		while (pxx > 0 && gc.flags & GRID_FLAG_PADDING)
+			grid_get_cell(gd, --pxx, py, &gc);
+		if (gc.flags & GRID_FLAG_TAB)
+			return (gc.data.width - (px - pxx));
+	}
+	if (gc.flags & GRID_FLAG_PADDING)
+		return (0);
+	return (utf8_cstrhas(set, &gc.data));
+}

--- a/tmux.h
+++ b/tmux.h
@@ -614,7 +614,7 @@ enum tty_code_code {
 };
 
 /* Character classes. */
-#define WHITESPACE " "
+#define WHITESPACE "\t "
 
 /* Mode keys. */
 #define MODEKEY_EMACS 0

--- a/tmux.h
+++ b/tmux.h
@@ -2988,6 +2988,7 @@ void	 grid_reflow(struct grid *, u_int);
 void	 grid_wrap_position(struct grid *, u_int, u_int, u_int *, u_int *);
 void	 grid_unwrap_position(struct grid *, u_int *, u_int *, u_int, u_int);
 u_int	 grid_line_length(struct grid *, u_int);
+int	 grid_in_set(struct grid *, u_int, u_int, const char *);
 
 /* grid-reader.c */
 void	 grid_reader_start(struct grid_reader *, struct grid *, u_int, u_int);

--- a/window-copy.c
+++ b/window-copy.c
@@ -5033,14 +5033,8 @@ window_copy_in_set(struct window_mode_entry *wme, u_int px, u_int py,
     const char *set)
 {
 	struct window_copy_mode_data	*data = wme->data;
-	struct grid_cell		 gc;
 
-	grid_get_cell(data->backing->grid, px, py, &gc);
-	if (gc.flags & GRID_FLAG_PADDING)
-		return (0);
-	if (gc.flags & GRID_FLAG_TAB && strchr(set, '\t'))
-		return (gc.data.width);
-	return (utf8_cstrhas(set, &gc.data));
+	return (grid_in_set(data->backing->grid, px, py, set));
 }
 
 static u_int

--- a/window-copy.c
+++ b/window-copy.c
@@ -5038,6 +5038,8 @@ window_copy_in_set(struct window_mode_entry *wme, u_int px, u_int py,
 	grid_get_cell(data->backing->grid, px, py, &gc);
 	if (gc.flags & GRID_FLAG_PADDING)
 		return (0);
+	if (gc.flags & GRID_FLAG_TAB && strchr(set, '\t'))
+		return (gc.data.width);
 	return (utf8_cstrhas(set, &gc.data));
 }
 


### PR DESCRIPTION
Hello!

This fixes next-word, next-word-end and previous-word not working correctly on lines with tabs.

Thanks.