### PR TITLE
Add compatibility for older systemd

### DIFF
--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -107,6 +107,11 @@ systemd_move_pid_to_new_cgroup(pid_t pid, char **cause)
 		xasprintf(cause, "failed to generate uuid: %s", strerror(-r));
 		goto finish;
 	}
+
+	#ifndef SD_ID128_UUID_FORMAT_STR
+	#define SD_ID128_UUID_FORMAT_STR "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+	#endif
+
 	xasprintf(&name, "tmux-spawn-" SD_ID128_UUID_FORMAT_STR ".scope",
 	    SD_ID128_FORMAT_VAL(uuid));
 	r = sd_bus_message_append(m, "s", name);


### PR DESCRIPTION
In the version of systemd on my system (Rocky Linux 8), there is no SD_ID128_UUID_FORMAT_STR macro.

This PR shims it in so that tmux can be built with --enable-systemd on versions without that macro.