### PR TITLE
don't hang indefinitely if a spawned process fails to close a file descriptor

### DIFF
--- a/job.c
+++ b/job.c
@@ -360,14 +360,13 @@ job_check_died(pid_t pid, int status)
 
 	job->status = status;
 
-	if (job->state == JOB_CLOSED) {
-		if (job->completecb != NULL)
-			job->completecb(job);
-		job_free(job);
-	} else {
+	if (job->state != JOB_CLOSED) {
 		job->pid = -1;
 		job->state = JOB_DEAD;
 	}
+	if (job->completecb != NULL)
+		job->completecb(job);
+	job_free(job);
 }
 
 /* Get job status. */


### PR DESCRIPTION
previously, the following command would hang indefinitely:
```
tmux start-server \; run-shell "echo foo | xclip -in"
```

this is because xclip did not close stdout, as mentioned in the debugging tips on [the Arch wiki](https://wiki.archlinux.org/title/Tmux#On_Xorg). tmux's server logs showed the following:
```
1732109791.150539 job_run: cmd=echo foo | xclip -in, cwd=/home/jyn/src/tmux, shell=/bin/sh
1732109791.150664 run job 0x5b1a098b6ec0: echo foo | xclip -in, pid 277372
1732109791.150669 cmdq_next <global>: empty
1732109791.150671 cmdq_next </dev/pts/10>: waiting
1732109791.150675 job write 0x5b1a098b6ec0: echo foo | xclip -in, pid 277372, output left 0
1732109791.150678 cmdq_next <global>: empty
1732109791.150679 cmdq_next </dev/pts/10>: waiting
1732109791.153375 server_signal: Child exited
1732109791.153383 job died 0x5b1a098b6ec0: echo foo | xclip -in, pid 277372
1732109791.153386 cmdq_next <global>: empty
1732109791.153389 cmdq_next </dev/pts/10>: waiting
```

and the client would only stop waiting once the xclip process was killed:
```
; killall xclip
1732110364.224235 job error 0x62b57a099ea0: echo foo | xclip -in -selection clipboard >/dev/null, pid -1
1732110364.224249 free job 0x62b57a099ea0: echo foo | xclip -in -selection clipboard >/dev/null
1732110364.224252 unref client 0x62b57a0c2310 (4 references)
1732110364.224265 cmdq_next <global>: empty
1732110364.224268 cmdq_next </dev/pts/13>: enter
1732110364.224270 cmdq_next </dev/pts/13>: [run-shell/0x62b57a0c2210] (0), flags 1
1732110364.224272 unref client 0x62b57a0c2310 (3 references)
1732110364.224278 cmdq_next </dev/pts/13>: [server_client_command_done/0x62b57a0ba980] (1), flags 0
1732110364.224280 unref client 0x62b57a0c2310 (2 references)
1732110364.224283 cmdq_next </dev/pts/13>: exit (empty)
```

this changes that "free job" logic to run whenever the process dies, even if `job_error_callback` wasnn't called.