### PR TITLE
man page: fix typo for `save-buffer`

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -7068,7 +7068,8 @@ If
 .Ar path
 is
 .Ql - ,
-the contents are read from stdin.
+the contents are written to stdout, like
+.Ic show-buffer .
 .It Xo Ic set-buffer
 .Op Fl aw
 .Op Fl b Ar buffer-name


### PR DESCRIPTION
Feel free to treat this as a (minor) docs bug report or as a PR.

As an aside, I think a command like `read-buffer` might be nice to have. It would be easier to discover than `load-buffer -`.