### PR TITLE
Don't revert to black block cursor in popup

### DIFF
--- a/popup.c
+++ b/popup.c
@@ -691,6 +691,7 @@ popup_display(int flags, enum box_lines lines, struct cmdq_item *item, u_int px,
 	pd->border_cell.attr = 0;
 
 	screen_init(&pd->s, jx, jy, 0);
+	screen_set_default_cursor(&pd->s, global_w_options);
 	colour_palette_init(&pd->palette);
 	colour_palette_from_option(&pd->palette, global_w_options);
 


### PR DESCRIPTION
Hi!

This is a small patch to use cursor-colour and cursor-style from options in popup.

Thanks.