### PR TITLE
Allow gifting sessions to tmux (tmux -g + add-window -s)

### DIFF
--- a/client.c
+++ b/client.c
@@ -230,7 +230,7 @@ client_exit(void)
 /* Client main loop. */
 int
 client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
-    int feat)
+    int feat, int gift_fd)
 {
 	struct cmd_parse_result	*pr;
 	struct msg_command	*data;
@@ -388,7 +388,7 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 		size += sizeof *data;
 
 		/* Send the command. */
-		if (proc_send(client_peer, msg, -1, data, size) != 0) {
+		if (proc_send(client_peer, msg, gift_fd, data, size) != 0) {
 			fprintf(stderr, "failed to send command\n");
 			free(data);
 			return (1);

--- a/tmux.1
+++ b/tmux.1
@@ -3078,7 +3078,7 @@ the
 option.
 .Tg neww
 .It Xo Ic new-window
-.Op Fl abdkPS
+.Op Fl abdksPS
 .Op Fl c Ar start-directory
 .Op Fl e Ar environment
 .Op Fl F Ar format
@@ -3124,6 +3124,14 @@ is not specified, the value of the
 option is used.
 .Fl c
 specifies the working directory in which the new window is created.
+.Pp
+If
+.Fl s ,
+instead of executing a command,
+the gifted file descriptor
+.Pq Nm Fl g ,
+which must be an open pseudoterminal master,
+is adopted and controlled in the new window.
 .Pp
 When the shell command completes, the window closes.
 See the

--- a/tmux.1
+++ b/tmux.1
@@ -26,6 +26,7 @@
 .Op Fl 2CDlNuVv
 .Op Fl c Ar shell-command
 .Op Fl f Ar file
+.Op Fl g Ar fd
 .Op Fl L Ar socket-name
 .Op Fl S Ar socket-path
 .Op Fl T Ar features
@@ -133,6 +134,14 @@ With
 .Fl D ,
 .Ar command
 may not be specified.
+.It Fl g Ar fd
+Gift
+.Ar fd
+to the server, alongside the executed command.
+This is only useful when paired with
+.Ic new-window Fl s
+to reparent another terminal emulator's session into
+.Nm .
 .It Fl f Ar file
 Specify an alternative configuration file.
 By default,

--- a/tmux.c
+++ b/tmux.c
@@ -53,7 +53,7 @@ static __dead void
 usage(void)
 {
 	fprintf(stderr,
-	    "usage: %s [-2CDlNuVv] [-c shell-command] [-f file] [-L socket-name]\n"
+	    "usage: %s [-2CDlNuVv] [-c shell-command] [-f file] [-g fd] [-L socket-name]\n"
 	    "            [-S socket-path] [-T features] [command [flags]]\n",
 	    getprogname());
 	exit(1);
@@ -352,7 +352,7 @@ main(int argc, char **argv)
 	char					*path = NULL, *label = NULL;
 	char					*cause, **var;
 	const char				*s, *cwd;
-	int					 opt, keys, feat = 0, fflag = 0;
+	int					 opt, keys, feat = 0, fflag = 0, gift_fd = -1;
 	uint64_t				 flags = 0;
 	const struct options_table_entry	*oe;
 	u_int					 i;
@@ -379,7 +379,7 @@ main(int argc, char **argv)
 		environ_set(global_environ, "PWD", 0, "%s", cwd);
 	expand_paths(TMUX_CONF, &cfg_files, &cfg_nfiles, 1);
 
-	while ((opt = getopt(argc, argv, "2c:CDdf:lL:NqS:T:uUvV")) != -1) {
+	while ((opt = getopt(argc, argv, "2c:CDdf:lL:NqS:T:uUvVg:")) != -1) {
 		switch (opt) {
 		case '2':
 			tty_add_features(&feat, "256", ":,");
@@ -435,6 +435,9 @@ main(int argc, char **argv)
 			break;
 		case 'v':
 			log_add_level();
+			break;
+		case 'g':
+			gift_fd = atoi(optarg);
 			break;
 		default:
 			usage();
@@ -534,5 +537,5 @@ main(int argc, char **argv)
 	free(label);
 
 	/* Pass control to the client. */
-	exit(client_main(osdep_event_init(), argc, argv, flags, feat));
+	exit(client_main(osdep_event_init(), argc, argv, flags, feat, gift_fd));
 }

--- a/tmux.h
+++ b/tmux.h
@@ -2182,6 +2182,8 @@ struct spawn_context {
 #define SPAWN_FULLSIZE 0x20
 #define SPAWN_EMPTY 0x40
 #define SPAWN_ZOOM 0x80
+
+	int	*steal_master_fd;
 };
 
 /* Mode tree sort order. */
@@ -2734,7 +2736,7 @@ void printflike(2, 3) cmdq_error(struct cmdq_item *, const char *, ...);
 void	cmd_wait_for_flush(void);
 
 /* client.c */
-int	client_main(struct event_base *, int, char **, uint64_t, int);
+int	client_main(struct event_base *, int, char **, uint64_t, int, int);
 
 /* key-bindings.c */
 struct key_table *key_bindings_get_table(const char *, int);


### PR DESCRIPTION
`tmux -g 4 -- whatever-command ...` runs `whatever-command...` but also sends fd 4 to the server with it.

This allows for `tmux -g 4 -- new-window -s` to, instead of opening a new pty, reuse the master sent alongside with the command.

I usually have the fore-thought to start a very long job in tmux, but not always, and when it stings it stings (what sparked this particular instance is a like-ten-minute VM settle/poweroff/boot/restore/continue cycle).

st+iso14755, adding this to iso14755():
```c
	if (us && !strcmp(us, "totmux\n") && !fork()) {
		snprintf(codepoint, sizeof(codepoint), "%d", cmdfd);
		_exit(execlp("tmux", "tmux", "-g", codepoint, "--", "new-window", "-s", (char *)NULL));
		return;
	}
```
cooperatively gifts the session to tmux. [Demo](https://101010.pl/@nabijaczleweli/113551201086443574):

https://github.com/user-attachments/assets/e106494c-d95e-4044-b5ba-19d4389d6294

On systems that allow dup-from-remote-process, this can be used to steal any session from any terminal emulator. This example can be used on Linux:
```c
#define _GNU_SOURCE
#include <sys/syscall.h>
#include <unistd.h>
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <stdlib.h>
#include <err.h>
#include <dirent.h>

int main(int argc, char ** argv) {
	if (argc != 2 && argc != 3 && argc != 4)
		fprintf(stderr, "usage: %1$s xterm-pid xterm-/dev/ptmx-fd [./tmux]\n"
		                "       %1$s xterm-pid\n", argv[0]);

	pid_t pid = atoi(argv[1]);
	int pidfd = syscall(SYS_pidfd_open, pid, 0);
	if (pidfd == -1)
		err(1, "pidfd_open(%d)", pid);

	if (!argv[2]) {
		char path[128], *name;
		sprintf(path, "/proc/%d/fd", pid);
		DIR *fds = opendir(path);
		if (!fds)
			err(1, "opendir(%s)", path);

		int ret = 1;
		for(struct dirent *ent; (ent = readdir(fds));) {
			int mfd = syscall(SYS_pidfd_getfd, pidfd, atoi(ent->d_name), 0);
			if((name = ptsname(mfd))) {
				printf("%s\t%s\n", ent->d_name, name);
				ret = 0;
			}
			close(mfd);
		}
		return ret;
	}

	int rfd = atoi(argv[2]);
	int mfd = syscall(SYS_pidfd_getfd, pidfd, rfd, 0);
	if (mfd == -1)
		err(1, "pidfd_getfd(%d)", rfd);

	fprintf(stderr, "Stole %d's fd %d %s\n", pid, rfd, ptsname(mfd));

	const char * tmux = argv[3] ?: "tmux";
	char mfds[32];
	sprintf(mfds, "%d", mfd);
	fprintf(stderr, "execl(%s -g %s -- new-window -s)\n", tmux, mfds);

	fcntl(mfd, F_SETFD, 0);
	execlp(tmux, tmux, "-g", mfds, "--", "new-window", "-s", (char*)0);
	return -1;
}
```

To steal a session from st or gnome-terminal (which hosts all masters in a single gnome-terminal-server process, so the listing mode is useful there). [Demo](https://101010.pl/@nabijaczleweli/113551092840876376):

https://github.com/user-attachments/assets/6ba85b23-9c9d-44fb-9b7d-4c6fd19b387b