### PR TITLE
correct repeated preset layout name.

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -375,7 +375,8 @@ pane.
 Arrange panes in one of the seven preset layouts:
 even-horizontal, even-vertical,
 main-horizontal, main-horizontal-mirrored,
-main-vertical, main-vertical, or tiled.
+main-vertical, main-vertical-mirrored,
+or tiled.
 .It Space
 Arrange the current window in the next preset layout.
 .It M-n


### PR DESCRIPTION
`main-vertical` is written twice, and `main-vertical-mirrored` is not mentioned here.