### PR TITLE
Spread cells more evenly

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -1101,7 +1101,7 @@ layout_spread_cell(struct window *w, struct layout_cell *parent)
 {
 	struct layout_cell	*lc;
 	struct style		*sb_style = &w->active->scrollbar_style;
-	u_int			 number, each, size, this;
+	u_int			 number, each, size, this, remainder;
 	int			 change, changed, status, scrollbars;
 
 	number = 0;
@@ -1130,20 +1130,31 @@ layout_spread_cell(struct window *w, struct layout_cell *parent)
 	each = (size - (number - 1)) / number;
 	if (each == 0)
 		return (0);
+	/*
+	 * Remaining space after assigning that which can be evenly
+	 * distributed.
+	 */
+	remainder = size - (number * (each + 1)) + 1;
 
 	changed = 0;
 	TAILQ_FOREACH (lc, &parent->cells, entry) {
-		if (TAILQ_NEXT(lc, entry) == NULL)
-			each = size - ((each + 1) * (number - 1));
 		change = 0;
 		if (parent->type == LAYOUT_LEFTRIGHT) {
 			change = each - (int)lc->sx;
+			if (remainder > 0) {
+				change++;
+				remainder--;
+			}
 			layout_resize_adjust(w, lc, LAYOUT_LEFTRIGHT, change);
 		} else if (parent->type == LAYOUT_TOPBOTTOM) {
 			if (layout_add_horizontal_border(w, lc, status))
 				this = each + 1;
 			else
 				this = each;
+			if (remainder > 0) {
+				this++;
+				remainder--;
+			}
 			change = this - (int)lc->sy;
 			layout_resize_adjust(w, lc, LAYOUT_TOPBOTTOM, change);
 		}


### PR DESCRIPTION
Previously when spreading out cells, the space that could be evenly
distributed was, with any remaining space assigned to the last cell.

Update the code to instead spread the remaining N lines/columns evenly
across the first N cells (one each).

This is a significant improvement when layouting large numbers of cells,
since the remaining space grows linearly with the number of cells. For
example, with 20 windows, up to 19 lines/columns would be assigned to
the last cell (which is quite noticable).
