### PR TITLE
Fallback dark gray to gray instead of black in 8-color terminal

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -2880,6 +2880,8 @@ tty_check_fg(struct tty *tty, struct colour_palette *palette,
 				gc->fg &= 7;
 				if (colours >= 16)
 					gc->fg += 90;
+				else if (gc->fg == 0 && gc->bg == 0)
+					gc->fg = 7;
 			}
 		}
 		return;


### PR DESCRIPTION
tmux running in 8-color terminal (for example, Linux virtual console with TERM==linux) passes only 3 bits of color code, so dark gray (color 8) turns to black (color 0) and becomes invisible on black background.

This change maps dark gray (8) to gray (7) if background is black.