### PR TITLE
tmux lscm: add some forgotten spaces after `CMD_TARGET_PANE_USAGE`

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -41,7 +41,7 @@ const struct cmd_entry cmd_display_menu_entry = {
 	.args = { "b:c:C:H:s:S:MOt:T:x:y:", 1, -1, cmd_display_menu_args_parse },
 	.usage = "[-MO] [-b border-lines] [-c target-client] "
 		 "[-C starting-choice] [-H selected-style] [-s style] "
-		 "[-S border-style] " CMD_TARGET_PANE_USAGE "[-T title] "
+		 "[-S border-style] " CMD_TARGET_PANE_USAGE " [-T title] "
 		 "[-x position] [-y position] name key command ...",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -58,7 +58,7 @@ const struct cmd_entry cmd_display_popup_entry = {
 	.usage = "[-BCE] [-b border-lines] [-c target-client] "
 		 "[-d start-directory] [-e environment] [-h height] "
 		 "[-s style] [-S border-style] " CMD_TARGET_PANE_USAGE
-		 "[-T title] [-w width] [-x position] [-y position] "
+		 " [-T title] [-w width] [-x position] [-y position] "
 		 "[shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -42,7 +42,7 @@ const struct cmd_entry cmd_split_window_entry = {
 	.args = { "bc:de:fF:hIl:p:Pt:vZ", 0, -1, NULL },
 	.usage = "[-bdefhIPvZ] [-c start-directory] [-e environment] "
 		 "[-F format] [-l size] " CMD_TARGET_PANE_USAGE
-		 "[shell-command]",
+		 " [shell-command]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 


### PR DESCRIPTION
Previously, `tmux lscm splitw` did not have a space between `[-t target-pane]` and `[shell-command]`.