### PR TITLE
tmux list-commands: expand command prefixes 

### DIFF
--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -321,6 +321,29 @@ out:
 	return (CMD_RETURN_NORMAL);
 }
 
+static void
+cmd_list_single_command(const struct cmd_entry *entry, struct format_tree *ft, const char *template, struct cmdq_item *item) {
+	const char *s;
+	char			 *line;
+
+	format_add(ft, "command_list_name", "%s", entry->name);
+	if (entry->alias != NULL)
+		s = entry->alias;
+	else
+		s = "";
+	format_add(ft, "command_list_alias", "%s", s);
+	if (entry->usage != NULL)
+		s = entry->usage;
+	else
+		s = "";
+	format_add(ft, "command_list_usage", "%s", s);
+
+	line = format_expand(ft, template);
+	if (*line != '\0')
+		cmdq_print(item, "%s", line);
+	free(line);
+}
+
 static enum cmd_retval
 cmd_list_keys_commands(struct cmd *self, struct cmdq_item *item)
 {
@@ -328,8 +351,7 @@ cmd_list_keys_commands(struct cmd *self, struct cmdq_item *item)
 	const struct cmd_entry	**entryp;
 	const struct cmd_entry	 *entry;
 	struct format_tree	 *ft;
-	const char		 *template, *s, *command;
-	char			 *line;
+	const char		 *template,  *command;
 
 	if ((template = args_get(args, 'F')) == NULL) {
 		template = "#{command_list_name}"
@@ -349,22 +371,7 @@ cmd_list_keys_commands(struct cmd *self, struct cmdq_item *item)
 		    strcmp(entry->alias, command) != 0)))
 		    continue;
 
-		format_add(ft, "command_list_name", "%s", entry->name);
-		if (entry->alias != NULL)
-			s = entry->alias;
-		else
-			s = "";
-		format_add(ft, "command_list_alias", "%s", s);
-		if (entry->usage != NULL)
-			s = entry->usage;
-		else
-			s = "";
-		format_add(ft, "command_list_usage", "%s", s);
-
-		line = format_expand(ft, template);
-		if (*line != '\0')
-			cmdq_print(item, "%s", line);
-		free(line);
+		cmd_list_single_command(entry, ft, template, item);
 	}
 
 	format_free(ft);

--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -352,6 +352,7 @@ cmd_list_keys_commands(struct cmd *self, struct cmdq_item *item)
 	const struct cmd_entry	 *entry;
 	struct format_tree	 *ft;
 	const char		 *template,  *command;
+	char *cause;
 
 	if ((template = args_get(args, 'F')) == NULL) {
 		template = "#{command_list_name}"
@@ -363,15 +364,16 @@ cmd_list_keys_commands(struct cmd *self, struct cmdq_item *item)
 	format_defaults(ft, NULL, NULL, NULL, NULL);
 
 	command = args_string(args, 0);
-	for (entryp = cmd_table; *entryp != NULL; entryp++) {
-		entry = *entryp;
-		if (command != NULL &&
-		    (strcmp(entry->name, command) != 0 &&
-		    (entry->alias == NULL ||
-		    strcmp(entry->alias, command) != 0)))
-		    continue;
-
-		cmd_list_single_command(entry, ft, template, item);
+	if (command == NULL) {
+		for (entryp = cmd_table; *entryp != NULL; entryp++) {
+			entry = *entryp;
+			cmd_list_single_command(entry, ft, template, item);
+		}
+	} else {
+		entry = cmd_find(command, &cause);
+		if (entry != NULL) {
+			cmd_list_single_command(entry, ft, template, item);
+		}
 	}
 
 	format_free(ft);

--- a/cmd.c
+++ b/cmd.c
@@ -444,7 +444,7 @@ cmd_get_alias(const char *name)
 }
 
 /* Look up a command entry by name. */
-static const struct cmd_entry *
+const struct cmd_entry *
 cmd_find(const char *name, char **cause)
 {
 	const struct cmd_entry	**loop, *entry, *found = NULL;

--- a/tmux.h
+++ b/tmux.h
@@ -2612,6 +2612,7 @@ long long	 args_string_percentage_and_expand(const char *, long long,
 		     long long, long long, struct cmdq_item *, char **);
 
 /* cmd-find.c */
+const struct cmd_entry *cmd_find(const char *name, char **cause);
 int		 cmd_find_target(struct cmd_find_state *, struct cmdq_item *,
 		     const char *, enum cmd_find_type, int);
 struct client	*cmd_find_best_client(struct session *);


### PR DESCRIPTION
Make `tmux lscm split` equivalent to `tmux lscm splitw`, since
`tmux split` is equivalent to `tmux splitw`.

Fixes https://github.com/tmux/tmux/issues/4341

This required making a previously-static function public.

-------

I am a little uncomfortable that the `cause` variable may be allocated but never freed, but it seem that it's not freed anywhere else either (that I could find), so I hope that's OK.

On second thought, whether it's OK depends on whether it's allocated by the client (I'm guessing it's short-lived in the `tmux lscm` case) or by the server. In any case, let me know if I should change it. I could add a special-case to `cmd_find` when `**cause` is NULL, and pass NULL to it.


-------

I am not a C programmer, let me know if there are any novice issues or if there are some conventions I'm violating. I'm not sure how to format the code either, and whether there is a command to automatically reformat my code correctly.

I also didn't see any place to add tests for this.