### PR TITLE
Align line names in choose-tree

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -66,6 +66,7 @@ struct mode_tree_data {
 	u_int			  line_size;
 
 	u_int			  depth;
+	u_int			  maxdepth;
 
 	u_int			  width;
 	u_int			  height;
@@ -196,6 +197,8 @@ mode_tree_build_lines(struct mode_tree_data *mtd,
 	int			 flat = 1;
 
 	mtd->depth = depth;
+	if (depth > mtd->maxdepth)
+		mtd->maxdepth = depth;
 	TAILQ_FOREACH(mti, mtl, entry) {
 		mtd->line_list = xreallocarray(mtd->line_list,
 		    mtd->line_size + 1, sizeof *mtd->line_list);
@@ -528,6 +531,7 @@ mode_tree_build(struct mode_tree_data *mtd)
 	TAILQ_INIT(&mtd->saved);
 
 	mode_tree_clear_lines(mtd);
+	mtd->maxdepth = 0;
 	mode_tree_build_lines(mtd, &mtd->children, 0);
 
 	if (mtd->line_list != NULL && tag == UINT64_MAX)
@@ -659,6 +663,7 @@ mode_tree_draw(struct mode_tree_data *mtd)
 	const char		*tag, *symbol;
 	size_t			 size, n;
 	int			 keylen, pad;
+	int			 namelen[mtd->maxdepth + 1];
 
 	if (mtd->line_size == 0)
 		return;
@@ -680,6 +685,15 @@ mode_tree_draw(struct mode_tree_data *mtd)
 			continue;
 		if ((int)mti->keylen + 3 > keylen)
 			keylen = mti->keylen + 3;
+	}
+
+	for (i = 0; i < mtd->maxdepth + 1; i++)
+		namelen[i] = 0;
+	for (i = 0; i < mtd->line_size; i++) {
+		line = &mtd->line_list[i];
+		mti = line->item;
+		if ((int)strlen(mti->name) > namelen[line->depth])
+			namelen[line->depth] = strlen(mti->name);
 	}
 
 	for (i = 0; i < mtd->line_size; i++) {
@@ -731,8 +745,9 @@ mode_tree_draw(struct mode_tree_data *mtd)
 			tag = "*";
 		else
 			tag = "";
-		xasprintf(&text, "%-*s%s%s%s%s", keylen, key, start, mti->name,
-		    tag, (mti->text != NULL) ? ": " : "" );
+		xasprintf(&text, "%-*s%s%*s%s%s", keylen, key, start,
+		    namelen[line->depth], mti->name, tag,
+		    (mti->text != NULL) ? ": " : "" );
 		width = utf8_cstrwidth(text);
 		if (width > w)
 			width = w;


### PR DESCRIPTION
Fixes #4354

Here's the relevant part of `choose-tree` with this patch, showing single- and double-digit numbers aligned.
```
(0)   -  0: 11 windows (attached)
(1)   ├─> -  0: [tmux]*Z
(2)   │   ├─>  0: bash: "dseomn@c4a97db9ab28:~"
(3)   │   ├─>  1: bash: "dseomn@c4a97db9ab28:~"
(4)   │   ├─>  2: bash: "dseomn@c4a97db9ab28:~"
(5)   │   ├─>  3: bash: "dseomn@c4a97db9ab28:~"
(6)   │   ├─>  4: bash: "dseomn@c4a97db9ab28:~"
(7)   │   ├─>  5: bash: "dseomn@c4a97db9ab28:~"
(8)   │   ├─>  6: bash: "dseomn@c4a97db9ab28:~"
(9)   │   ├─>  7: bash: "dseomn@c4a97db9ab28:~"
(M-a) │   ├─>  8: bash*: "dseomn@c4a97db9ab28:~"
(M-b) │   ├─>  9: bash: "dseomn@c4a97db9ab28:~"
(M-c) │   ├─> 10: bash: "dseomn@c4a97db9ab28:~"
(M-d) │   ├─> 11: bash: "dseomn@c4a97db9ab28:~"
(M-e) │   └─> 12: bash: "dseomn@c4a97db9ab28:~"
(M-f) ├─>    1: bash: "dseomn@c4a97db9ab28:~"
(M-g) ├─>    2: bash: "dseomn@c4a97db9ab28:~"
(M-h) ├─>    3: bash: "dseomn@c4a97db9ab28:~"
(M-i) ├─>    4: bash: "dseomn@c4a97db9ab28:~"
(M-j) ├─>    5: bash: "dseomn@c4a97db9ab28:~"
(M-k) ├─>    6: bash: "dseomn@c4a97db9ab28:~"
(M-l) ├─>    7: bash: "dseomn@c4a97db9ab28:~"
(M-m) ├─>    8: bash: "dseomn@c4a97db9ab28:~"
(M-n) ├─>    9: bash: "dseomn@c4a97db9ab28:~"
(M-o) └─>   10: bash-: "dseomn@c4a97db9ab28:~"
(M-p) -  2: 1 windows
(M-q) └─>  0: bash*: "dseomn@c4a97db9ab28:~"
(M-r) -  3: 1 windows
(M-s) └─>  0: bash*: "dseomn@c4a97db9ab28:~"
(M-t) -  4: 1 windows
(M-u) └─>  0: bash*: "dseomn@c4a97db9ab28:~"
(M-v) -  5: 1 windows
(M-w) └─>  0: bash*: "dseomn@c4a97db9ab28:~"
(M-x) -  6: 1 windows
(M-y) └─>  0: bash*: "dseomn@c4a97db9ab28:~"
(M-z) -  7: 1 windows
      └─>  0: bash*: "dseomn@c4a97db9ab28:~"
      -  8: 1 windows
      └─>  0: bash*: "dseomn@c4a97db9ab28:~"
      -  9: 1 windows
      └─>  0: bash*: "dseomn@c4a97db9ab28:~"
      - 10: 1 windows
      └─>  0: bash*: "dseomn@c4a97db9ab28:~"
      - 11: 1 windows
      └─>  0: bash*: "dseomn@c4a97db9ab28:~"
```