### PR TITLE
Add support for popups to control mode

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -432,7 +432,16 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 		w = tty->sx;
 	if (h > tty->sy)
 		h = tty->sy;
-	if (!cmd_display_menu_get_position(tc, item, args, &px, &py, w, h))
+	if (tc->flags & CLIENT_CONTROL) {
+		/* Control clients may not have a window size, so provide a
+		 * reasonable default so popups can still work. */
+		if (w == 0)
+			w = 80;
+		if (h == 0)
+			h = 25;
+                px = 0;
+                py = 0;
+	} else if (!cmd_display_menu_get_position(tc, item, args, &px, &py, w, h))
 		return (CMD_RETURN_NORMAL);
 
 	value = args_get(args, 'b');
@@ -498,5 +507,7 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 	free(cwd);
 	free(title);
 	cmd_free_argv(argc, argv);
+	if (tc->flags & CLIENT_CONTROL)
+		return (CMD_RETURN_NORMAL);
 	return (CMD_RETURN_WAIT);
 }

--- a/control-notify.c
+++ b/control-notify.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "tmux.h"
 
@@ -259,4 +260,58 @@ control_notify_paste_buffer_deleted(const char *name)
 
 		control_write(c, "%%paste-buffer-deleted %s", name);
 	}
+}
+
+void
+control_notify_popup_created(struct popup_data *pd)
+{
+	struct evbuffer	*message;
+
+	if (!CONTROL_SHOULD_NOTIFY_CLIENT(pd->c))
+		return;
+
+	message = evbuffer_new();
+	if (message == NULL)
+		fatalx("out of memory");
+
+	evbuffer_add_printf(message,"%%popup-created ^%u %ux%u,%u,%u : ", pd->id,
+		      pd->px, pd->py, pd->sx, pd->sy);
+	control_escape(message, pd->title, strlen(pd->title));
+	control_write_buffer(pd->c, message);
+	evbuffer_free(message);
+}
+
+void
+control_notify_popup_closed(struct popup_data *pd)
+{
+	if (!CONTROL_SHOULD_NOTIFY_CLIENT(pd->c))
+		return;
+	control_write(pd->c, "%%popup-closed ^%u", pd->id);
+}
+
+void
+control_notify_popup_changed(struct popup_data *pd)
+{
+	struct evbuffer	*message;
+
+	if (!CONTROL_SHOULD_NOTIFY_CLIENT(pd->c))
+		return;
+
+	message = evbuffer_new();
+	if (message == NULL)
+		fatalx("out of memory");
+
+	evbuffer_add_printf(message,"%%popup-changed ^%u %ux%u,%u,%u : ", pd->id,
+		      pd->px, pd->py, pd->sx, pd->sy);
+	control_escape(message, pd->title, strlen(pd->title));
+	control_write_buffer(pd->c, message);
+	evbuffer_free(message);
+}
+
+void
+control_notify_popup_status(struct popup_data *pd)
+{
+	if (!CONTROL_SHOULD_NOTIFY_CLIENT(pd->c))
+		return;
+	control_write(pd->c, "%%popup-status ^%u %d", pd->id, pd->status);
 }

--- a/window.c
+++ b/window.c
@@ -1054,7 +1054,7 @@ window_pane_read_callback(__unused struct bufferevent *bufev, void *data)
 	log_debug("%%%u has %zu bytes", wp->id, size);
 	TAILQ_FOREACH(c, &clients, entry) {
 		if (c->session != NULL && (c->flags & CLIENT_CONTROL))
-			control_write_output(c, wp);
+			control_write_output(c, wp, NULL, &wp->offset);
 	}
 	input_parse_pane(wp);
 	bufferevent_disable(wp->event, EV_READ);


### PR DESCRIPTION
This was prompted by [a request](https://gitlab.com/gnachman/iterm2/-/issues/12149) from an iTerm2 user.

A few thoughts:
* The concept of popup size is not well defined in control mode. The popup could be shown in a modal dialog, for example. I tried to find a compromise since a control mide client might want to display the popup in a TUI.
* I need to pass an optional wp. It's normally a u_int but I used int so I could use -1 for "invalid". Maybe there's a better way to do this that I missed.
* popup_append belongs with other string handling code, but I couldn't find a good home for it.
