### PR TITLE
Add display-message -C flag to update pane while message is displayed

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -315,11 +315,11 @@ alerts_set_message(struct winlink *wl, const char *type, const char *option)
 		if (visual == VISUAL_OFF)
 			continue;
 		if (c->session->curw == wl) {
-			status_message_set(c, -1, 1, 0, "%s in current window",
-			    type);
+			status_message_set(c, -1, 1, 0, 0,
+			    "%s in current window", type);
 		} else {
-			status_message_set(c, -1, 1, 0, "%s in window %d", type,
-			    wl->idx);
+			status_message_set(c, -1, 1, 0, 0,
+			    "%s in window %d", type, wl->idx);
 		}
 	}
 }

--- a/cmd-display-message.c
+++ b/cmd-display-message.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_display_message_entry = {
 	.name = "display-message",
 	.alias = "display",
 
-	.args = { "ac:d:lINpt:F:v", 0, 1, NULL },
-	.usage = "[-aIlNpv] [-c target-client] [-d delay] [-F format] "
+	.args = { "ac:d:lINCpt:F:v", 0, 1, NULL },
+	.usage = "[-aIlNCpv] [-c target-client] [-d delay] [-F format] "
 		 CMD_TARGET_PANE_USAGE " [message]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
@@ -69,6 +69,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	const char		*template;
 	char			*msg, *cause;
 	int			 delay = -1, flags, Nflag = args_has(args, 'N');
+	int			Cflag = args_has(args, 'C');
 	struct format_tree	*ft;
 	u_int			 count = args_count(args);
 	struct evbuffer		*evb;
@@ -150,7 +151,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 		server_client_print(tc, 0, evb);
 		evbuffer_free(evb);
 	} else if (tc != NULL)
-		status_message_set(tc, delay, 0, Nflag, "%s", msg);
+		status_message_set(tc, delay, 0, Nflag, Cflag, "%s", msg);
 	free(msg);
 
 	format_free(ft);

--- a/cmd-if-shell.c
+++ b/cmd-if-shell.c
@@ -157,7 +157,7 @@ cmd_if_shell_callback(struct job *job)
 	if (cmdlist == NULL) {
 		if (cdata->item == NULL) {
 			*error = toupper((u_char)*error);
-			status_message_set(c, -1, 1, 0, "%s", error);
+			status_message_set(c, -1, 1, 0, 0, "%s", error);
 		} else
 			cmdq_error(cdata->item, "%s", error);
 		free(error);

--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -114,8 +114,8 @@ cmd_list_keys_print_notes(struct cmdq_item *item, struct args *args,
 			note = xstrdup(bd->note);
 		tmp = utf8_padcstr(key, keywidth + 1);
 		if (args_has(args, '1') && tc != NULL) {
-			status_message_set(tc, -1, 1, 0, "%s%s%s", prefix, tmp,
-			    note);
+			status_message_set(tc, -1, 1, 0, 0, "%s%s%s", prefix,
+			    tmp, note);
 		} else
 			cmdq_print(item, "%s%s%s", prefix, tmp, note);
 		free(tmp);
@@ -298,8 +298,8 @@ cmd_list_keys_exec(struct cmd *self, struct cmdq_item *item)
 			free(cp);
 
 			if (args_has(args, '1') && tc != NULL) {
-				status_message_set(tc, -1, 1, 0, "bind-key %s",
-				    tmp);
+				status_message_set(tc, -1, 1, 0, 0,
+				    "bind-key %s", tmp);
 			} else
 				cmdq_print(item, "bind-key %s", tmp);
 			free(key);

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -892,7 +892,7 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 		c->retval = 1;
 	} else {
 		*msg = toupper((u_char) *msg);
-		status_message_set(c, -1, 1, 0, "%s", msg);
+		status_message_set(c, -1, 1, 0, 0, "%s", msg);
 	}
 
 	free(msg);

--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -204,7 +204,7 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 	if (cmdlist == NULL) {
 		if (cdata->item == NULL) {
 			*error = toupper((u_char)*error);
-			status_message_set(c, -1, 1, 0, "%s", error);
+			status_message_set(c, -1, 1, 0, 0, "%s", error);
 		} else
 			cmdq_error(cdata->item, "%s", error);
 		free(error);

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -1297,7 +1297,7 @@ mode_tree_run_command(struct client *c, struct cmd_find_state *fs,
 		if (status == CMD_PARSE_ERROR) {
 			if (c != NULL) {
 				*error = toupper((u_char)*error);
-				status_message_set(c, -1, 1, 0, "%s", error);
+				status_message_set(c, -1, 1, 0, 0, "%s", error);
 			}
 			free(error);
 		}

--- a/status.c
+++ b/status.c
@@ -470,7 +470,7 @@ status_redraw(struct client *c)
 /* Set a status line message. */
 void
 status_message_set(struct client *c, int delay, int ignore_styles,
-    int ignore_keys, const char *fmt, ...)
+    int ignore_keys, int continue_output, const char *fmt, ...)
 {
 	struct timeval	 tv;
 	va_list		 ap;
@@ -514,7 +514,9 @@ status_message_set(struct client *c, int delay, int ignore_styles,
 		c->message_ignore_keys = ignore_keys;
 	c->message_ignore_styles = ignore_styles;
 
-	c->tty.flags |= (TTY_NOCURSOR|TTY_FREEZE);
+	if (!continue_output)
+	    c->tty.flags |= TTY_FREEZE;
+	c->tty.flags |= TTY_NOCURSOR;
 	c->flags |= CLIENT_REDRAWSTATUS;
 }
 

--- a/tmux.1
+++ b/tmux.1
@@ -6767,6 +6767,9 @@ option is used; a delay of zero waits for a key press.
 .Ql N
 ignores key presses and closes only after the delay expires.
 If
+.Fl C
+given, pane will continue to be updated while message is displayed.
+If
 .Fl l
 is given,
 .Ar message

--- a/tmux.h
+++ b/tmux.h
@@ -2891,7 +2891,7 @@ struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);
 int	 status_redraw(struct client *);
-void printflike(5, 6) status_message_set(struct client *, int, int, int,
+void printflike(6, 7) status_message_set(struct client *, int, int, int, int,
 	     const char *, ...);
 void	 status_message_clear(struct client *);
 int	 status_message_redraw(struct client *);

--- a/window-customize.c
+++ b/window-customize.c
@@ -1000,7 +1000,7 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 
 fail:
 	*cause = toupper((u_char)*cause);
-	status_message_set(c, -1, 1, 0, "%s", cause);
+	status_message_set(c, -1, 1, 0, 0, "%s", cause);
 	free(cause);
 	return (0);
 }
@@ -1203,7 +1203,7 @@ window_customize_set_command_callback(struct client *c, void *itemdata,
 
 fail:
 	*error = toupper((u_char)*error);
-	status_message_set(c, -1, 1, 0, "%s", error);
+	status_message_set(c, -1, 1, 0, 0, "%s", error);
 	free(error);
 	return (0);
 }


### PR DESCRIPTION
Add a `-C` flag to prevent display-message from freezing tty and continue updating pane while message is still being displayed. This should benefit scripts that give real-time background feedback in status line without distrupting output of interactive applications that dynamically update screen.

Fixes #4362.