### PR TITLE
Fix a case of failure to overwrite sixel image cells

### DIFF
--- a/image.c
+++ b/image.c
@@ -150,6 +150,21 @@ image_check_area(struct screen *s, u_int px, u_int py, u_int nx, u_int ny)
 }
 
 int
+image_intersect_area(struct screen *s, u_int px, u_int py, u_int nx, u_int ny)
+{
+	struct image	*im;
+
+	TAILQ_FOREACH(im, &s->images, entry) {
+		if (py + ny <= im->py || py >= im->py + im->sy)
+			continue;
+		if (px + nx <= im->px || px >= im->px + im->sx)
+			continue;
+		return (1);
+	}
+	return (0);
+}
+
+int
 image_scroll_up(struct screen *s, u_int lines)
 {
 	struct image		*im, *im1;

--- a/screen-write.c
+++ b/screen-write.c
@@ -2022,6 +2022,10 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	if (skip) {
 		if (s->cx >= gl->cellsize)
 			skip = grid_cells_equal(gc, &grid_default_cell);
+#ifdef ENABLE_SIXEL
+		else if (image_intersect_area(s, s->cx, s->cy, width, 1))
+			skip = 0;
+#endif
 		else {
 			gce = &gl->celldata[s->cx];
 			if (gce->flags & GRID_FLAG_EXTENDED)

--- a/tmux.h
+++ b/tmux.h
@@ -3561,6 +3561,7 @@ int		 image_free_all(struct screen *);
 struct image	*image_store(struct screen *, struct sixel_image *);
 int		 image_check_line(struct screen *, u_int, u_int);
 int		 image_check_area(struct screen *, u_int, u_int, u_int, u_int);
+int		 image_intersect_area(struct screen *, u_int, u_int, u_int, u_int);
 int		 image_scroll_up(struct screen *, u_int);
 
 /* image-sixel.c */


### PR DESCRIPTION
When the cell to be overwritten contained part of an image, no update would be issued if the backing cell character appeared unchanged.

We address this by issuing cell updates when the cell intersects with an image, allowing images to e.g. be reliably erased with spaces.

I chose to add a new function `image_intersect_area()` instead of adding a bool argument to `image_check_area()` to make image removal optional, since we can break out of the loop early in the pure intersection case. I've no idea if this affects performance at all, though - conceivably it could have an impact if the maximum number of concurrent images is increased in the future.

This was prompted by https://github.com/hpjansson/chafa/issues/241, which contains some examples and analysis (big thanks to @niksingh710!).