### PR TITLE
Added to .gitignore to ignore vim swapfiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmux.1.*
 cmd-parse.c
 fuzz/*-fuzzer
 .dirstamp
+.*.swp


### PR DESCRIPTION
My vim swapfiles come up in git status, which is annoying. I figure other people probably have the same problem. Added a line to the .gitignore. Maybe it's worth putting in the upstream.