### PR TITLE
Stopped ignoring error on client command parse.

### DIFF
--- a/client.c
+++ b/client.c
@@ -266,8 +266,11 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 			if (cmd_list_any_have(pr->cmdlist, CMD_STARTSERVER))
 				flags |= CLIENT_STARTSERVER;
 			cmd_list_free(pr->cmdlist);
-		} else
+		} else {
+			fprintf(stderr, "%s\n", pr->error);
 			free(pr->error);
+			return 1;
+		}
 		args_free_values(values, argc);
 		free(values);
 	}


### PR DESCRIPTION
It's always been kind of strange how tmux doesn't tell you the issues in the arguments unless it can connect to a server or start a server or whatever.

Like if you do:

    tmux thisdoesntexist

and there's no server, it'll just say can't connect to server instead of telling you that you messed up the cmdline.

I understand it from a software architecture perspective. The server parses the command, and if a connection can't be established then that is the first error that happens and as such it's reasonable that it's the error that is reported.

But it strays from almost every other command-line tool I've ever used. I just figure maybe it's worth doing in a more expected way, principle of least astonishment and such.

I can imagine 1 or 2 edge cases where it might be of miniscule importance to have this. Like if you write a script with a tmux command but don't have a server running. Then you're going to get "can't connect to server" when you test it. If you only test it once and then save it for a rainy day when you do happen to have a server running, you expect it to work. But it might not because once the server is up you find out you misspelled the command in your script. Then you have to go back and change it, which is extra work.

None of this matters that much. I mainly just want to ask what the policy is about this. Personally I think I would find it slightly better if the error were to be reported early instead of late, but I could see why you would make the opposite case.

I think optimally, we would parse it on the client, report errors early, and then forward the parsed cmd structure to the server, that way the server doesn't have to parse again.

This PR doesn't contain that. I wanted to ask what the policy is on this. If you agree with me, I would be interested in seeing what I can do about removing the client/server redundancy in the way that I mentioned above.