### PR TITLE
account for scrollbar width when drawing pane-border-status

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -434,9 +434,14 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	struct format_tree	*ft;
 	char			*expanded;
 	int			 pane_status = rctx->pane_status;
+	int			 pane_scrollbars = rctx->pane_scrollbars;
+	int			 sb_w = 0;
 	u_int			 width, i, cell_type, px, py;
 	struct screen_write_ctx	 ctx;
 	struct screen		 old;
+
+	if (window_pane_show_scrollbar(wp, pane_scrollbars))
+		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 
 	ft = format_create(c, NULL, FORMAT_PANE|wp->id, FORMAT_STATUS);
 	format_defaults(ft, c, c->session, c->session->curw, wp);
@@ -451,7 +456,7 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	if (wp->sx < 4)
 		wp->status_size = width = 0;
 	else
-		wp->status_size = width = wp->sx - 4;
+		wp->status_size = width = wp->sx + sb_w - 2;
 
 	memcpy(&old, &wp->status_screen, sizeof old);
 	screen_init(&wp->status_screen, width, 1, 0);


### PR DESCRIPTION
I noticed this the other day, when scrollbars and pane-border-status both are enabled, the pane-border isn't properly coloured all the way across when the pane is not the active pane.  Some example images:

![Screenshot 2025-02-22 152752](https://github.com/user-attachments/assets/d272f0f1-1ee7-4929-a1b3-800d8a89939a)

![Screenshot 2025-02-22 152709](https://github.com/user-attachments/assets/15037f04-b49f-4ca3-b98b-9a27628aa025)

1. I added taking into account the width of the scrollbar if enabled, but this wasn't enough!
2. Instead of subtracting 4 characters, I had to reduce that to 2

n.b. sb_w is 0 when scrollbars are disabled.

I was a bit surprised I had to change the 4 to a 2 but it didn't seem to break things in the cases I tested.  Leaving it at 4 for me leaves a single character at the end of the border unchanged when you switch panes.  If this breaks something please let me know!
