### PR TITLE
Don't copy padding cells into the selection

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -4263,6 +4263,8 @@ window_copy_match_at_cursor(struct window_copy_mode_data *data)
 			buf = xrealloc(buf, len + 2);
 			buf[len] = '\t';
 			len++;
+		} else if (gc.flags & GRID_FLAG_PADDING) {
+			/* nothing to do */
 		} else {
 			buf = xrealloc(buf, len + gc.data.size + 1);
 			memcpy(buf + len, gc.data.data, gc.data.size);


### PR DESCRIPTION
Tmux represents tab padding using '!' padding markers. Most commands check `GRID_FLAG_PADDING` and know not to render these. However, regex searching did not respect the padding flag.

Steps to reproduce the issue this fixes:
1. `tmux set -g mode-flags vi`
2. `printf '\tfoo`
3. `C-b [ ?\sfoo<Enter>` (enter copy mode, search for "whitespace foo", copy the selection)
4. `C-b ]` (or any other method of pasting the current selection)

before this PR, that will show `	!!!!!!!foo` instead of `	foo`.