### PR TITLE
Fix read of uninitialized memory for non-PTY jobs

### DIFF
--- a/job.c
+++ b/job.c
@@ -181,7 +181,7 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e,
 	environ_free(env);
 	free(argv0);
 
-	job = xmalloc(sizeof *job);
+	job = xcalloc(1, sizeof *job);
 	job->state = JOB_RUNNING;
 	job->flags = flags;
 
@@ -190,7 +190,8 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e,
 	else
 		job->cmd = cmd_stringify_argv(argc, argv);
 	job->pid = pid;
-	strlcpy(job->tty, tty, sizeof job->tty);
+	if (flags & JOB_PTY)
+		strlcpy(job->tty, tty, sizeof job->tty);
 	job->status = 0;
 
 	LIST_INSERT_HEAD(&all_jobs, job, entry);


### PR DESCRIPTION
Before this change, this command:

```
valgrind --log-file=valgrind.log tmux -f /dev/null start-server \; run true \; kill-server
```

Gave these errors:

```
==3477== Conditional jump or move depends on uninitialised value(s)
==3477==    at 0x484E5BE: strlcpy (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3477==    by 0x167D28: job_run (job.c:193)
==3477==    by 0x14002D: cmd_run_shell_timer (cmd-run-shell.c:196)
==3477==    by 0x48B724D: ??? (in /usr/lib/x86_64-linux-gnu/libevent_core-2.1.so.7.0.1)
==3477==    by 0x48B793E: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent_core-2.1.so.7.0.1)
==3477==    by 0x17A766: proc_loop (proc.c:213)
==3477==    by 0x18EEF3: server_start (server.c:253)
==3477==    by 0x12D872: client_connect (client.c:164)
==3477==    by 0x12D872: client_main (client.c:295)
==3477==    by 0x128307: main (tmux.c:537)
==3477==
==3477== Conditional jump or move depends on uninitialised value(s)
==3477==    at 0x484E677: strlcpy (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3477==    by 0x167D28: job_run (job.c:193)
==3477==    by 0x14002D: cmd_run_shell_timer (cmd-run-shell.c:196)
==3477==    by 0x48B724D: ??? (in /usr/lib/x86_64-linux-gnu/libevent_core-2.1.so.7.0.1)
==3477==    by 0x48B793E: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent_core-2.1.so.7.0.1)
==3477==    by 0x17A766: proc_loop (proc.c:213)
==3477==    by 0x18EEF3: server_start (server.c:253)
==3477==    by 0x12D872: client_connect (client.c:164)
==3477==    by 0x12D872: client_main (client.c:295)
==3477==    by 0x128307: main (tmux.c:537)
```

Addresses #4421