### PR TITLE
mode-tree: Only align window and pane indexes

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -3354,6 +3354,7 @@ struct mode_tree_item *mode_tree_add(struct mode_tree_data *,
 	     const char *, int);
 void	 mode_tree_draw_as_parent(struct mode_tree_item *);
 void	 mode_tree_no_tag(struct mode_tree_item *);
+void	 mode_tree_align(struct mode_tree_item *, int);
 void	 mode_tree_remove(struct mode_tree_data *, struct mode_tree_item *);
 void	 mode_tree_draw(struct mode_tree_data *);
 int	 mode_tree_key(struct mode_tree_data *, struct client *, key_code *,

--- a/window-tree.c
+++ b/window-tree.c
@@ -300,6 +300,7 @@ window_tree_build_pane(struct session *s, struct winlink *wl,
 {
 	struct window_tree_modedata	*data = modedata;
 	struct window_tree_itemdata	*item;
+	struct mode_tree_item		*mti;
 	char				*name, *text;
 	u_int				 idx;
 	struct format_tree		*ft;
@@ -318,9 +319,11 @@ window_tree_build_pane(struct session *s, struct winlink *wl,
 	xasprintf(&name, "%u", idx);
 	format_free(ft);
 
-	mode_tree_add(data->data, parent, item, (uint64_t)wp, name, text, -1);
+	mti = mode_tree_add(data->data, parent, item, (uint64_t)wp, name, text,
+	    -1);
 	free(text);
 	free(name);
+	mode_tree_align(mti, 1);
 }
 
 static int
@@ -375,6 +378,7 @@ window_tree_build_window(struct session *s, struct winlink *wl,
 	    expanded);
 	free(text);
 	free(name);
+	mode_tree_align(mti, 1);
 
 	if ((wp = TAILQ_FIRST(&wl->window->panes)) == NULL)
 		goto empty;


### PR DESCRIPTION
Fixes #4442