### PR TITLE
Explain what it means when an issue is closed

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,3 +77,8 @@ The log files are:
 - `tmux-out*.log`: output log file.
 
 Please attach the log files to your issue.
+
+## What does it mean if an issue is closed?
+
+All it means is that work on the issue is not planned for the near future. See
+the issue's comments to find out if contributions would be welcome.


### PR DESCRIPTION
When looking through various issues, I think I've seen a few times where I think people misunderstood the intent of closing an issue. Maybe this (or something similar) will help that happen less often? I'm not sure though, and I don't have any experience running an issue tracker for a large open source community, so feel free to ignore this if this won't help.