### PR TITLE
Extend format conditionals

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -5633,10 +5633,12 @@ by a
 .Ql } .
 .Pp
 Conditionals are available by prefixing with
-.Ql \&?
-and separating two alternatives with a comma;
-if the specified variable exists and is not zero, the first alternative
-is chosen, otherwise the second is used.
+.Ql \&? .
+For each pair of two arguments, if the variable in the first of the pair exists
+and is not zero, the second of the pair is chosen, otherwise it continues.
+If no condition from paired arguments matches, the default value is chosen.
+If there's an unpaired final argument, that is the default.
+If not, the default is the empty string.
 For example
 .Ql #{?session_attached,attached,not attached}
 will include the string
@@ -5652,6 +5654,12 @@ if
 is enabled, or
 .Ql no
 if not.
+.Ql #{?#{n:window_name},#{window_name} - }
+will include the window name with a dash separator if there is a window name, or
+the empty string if the window name is empty.
+.Ql #{?session_format,format1,window_format,format2,format3}
+will include format1 for a session format, format2 for a window format, or
+format3 for neither a session nor a window format.
 Conditionals can be nested arbitrarily.
 Inside a conditional,
 .Ql \&,

--- a/window-buffer.c
+++ b/window-buffer.c
@@ -44,12 +44,8 @@ static void		 window_buffer_key(struct window_mode_entry *,
 #define WINDOW_BUFFER_DEFAULT_KEY_FORMAT \
 	"#{?#{e|<:#{line},10}," \
 		"#{line}" \
-	"," \
-		"#{?#{e|<:#{line},36},"	\
-	        	"M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
-		"," \
-	        	"" \
-		"}" \
+	",#{e|<:#{line},36},"	\
+		"M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
 	"}"
 
 static const struct menu_item window_buffer_menu_items[] = {

--- a/window-client.c
+++ b/window-client.c
@@ -43,12 +43,8 @@ static void		 window_client_key(struct window_mode_entry *,
 #define WINDOW_CLIENT_DEFAULT_KEY_FORMAT \
 	"#{?#{e|<:#{line},10}," \
 		"#{line}" \
-	"," \
-		"#{?#{e|<:#{line},36},"	\
-	        	"M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
-		"," \
-	        	"" \
-		"}" \
+	",#{e|<:#{line},36},"	\
+		"M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
 	"}"
 
 static const struct menu_item window_client_menu_items[] = {

--- a/window-tree.c
+++ b/window-tree.c
@@ -41,30 +41,24 @@ static void		 window_tree_key(struct window_mode_entry *,
 		"#{?pane_marked,#[reverse],}" \
 		"#{pane_current_command}#{?pane_active,*,}#{?pane_marked,M,}" \
 		"#{?#{&&:#{pane_title},#{!=:#{pane_title},#{host_short}}},: \"#{pane_title}\",}" \
+	",window_format," \
+		"#{?window_marked_flag,#[reverse],}" \
+		"#{window_name}#{window_flags}" \
+		"#{?#{&&:#{==:#{window_panes},1},#{&&:#{pane_title},#{!=:#{pane_title},#{host_short}}}},: \"#{pane_title}\",}" \
 	"," \
-		"#{?window_format," \
-			"#{?window_marked_flag,#[reverse],}" \
-			"#{window_name}#{window_flags}" \
-			"#{?#{&&:#{==:#{window_panes},1},#{&&:#{pane_title},#{!=:#{pane_title},#{host_short}}}},: \"#{pane_title}\",}" \
-		"," \
-			"#{session_windows} windows" \
-			"#{?session_grouped, " \
-				"(group #{session_group}: " \
-				"#{session_group_list})," \
-			"}" \
-			"#{?session_attached, (attached),}" \
+		"#{session_windows} windows" \
+		"#{?session_grouped, " \
+			"(group #{session_group}: " \
+			"#{session_group_list})," \
 		"}" \
+		"#{?session_attached, (attached),}" \
 	"}"
 
 #define WINDOW_TREE_DEFAULT_KEY_FORMAT \
 	"#{?#{e|<:#{line},10}," \
 		"#{line}" \
-	"," \
-		"#{?#{e|<:#{line},36},"	\
-	        	"M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
-		"," \
-	        	"" \
-		"}" \
+	",#{e|<:#{line},36},"	\
+	        "M-#{a:#{e|+:97,#{e|-:#{line},10}}}" \
 	"}"
 
 static const struct menu_item window_tree_menu_items[] = {


### PR DESCRIPTION
1. Add support for `else if`, so `#{?cond1,value1,#{?cond2,value2,else-value}}` can be changed to `#{?cond1,value1,cond2,value2,else-value}`
2. Add default empty string if there's no `else` value, so `#{?cond1,value1,}` can be changed to `#{?cond1,value1}`

This has some degenerate cases that I don't think are particularly useful, but I also don't think it's worth adding code to make them errors:

```
$ tmux display-message -p '#{?}'

$ tmux display-message -p '#{?foo}'
foo
```

And the more useful cases:

```
$ tmux set @true 1
$ tmux set @false 0
$ tmux display-message -p '#{?@true,foo}'
foo
$ tmux display-message -p '#{?@false,foo}'

$ tmux display-message -p '#{?@true,foo,bar}'
foo
$ tmux display-message -p '#{?@false,foo,bar}'
bar
$ tmux display-message -p '#{?@false,foo,@true,bar}'
bar
$ tmux display-message -p '#{?@true,foo,@true,bar}'
foo
$ tmux display-message -p '#{?@false,foo,@false,bar}'

$ tmux display-message -p '#{?@false,foo,@false,bar,default}'
default
```

And expansion still works:

```
$ tmux set @foo bar
$ tmux display-message -p '#{?#{@true},#{@foo}}'
bar
$ tmux display-message -p '#{?#{@false},foo,#{@foo}}'
bar
```

Fixes #4438