### PR TITLE
Assorted changes to make bash completion easier

### DIFF
--- a/cmd-command-prompt.c
+++ b/cmd-command-prompt.c
@@ -44,7 +44,7 @@ const struct cmd_entry cmd_command_prompt_entry = {
 
 	.args = { "1bFkiI:Np:t:T:", 0, 1, cmd_command_prompt_args_parse },
 	.usage = "[-1bFkiN] [-I inputs] [-p prompts] " CMD_TARGET_CLIENT_USAGE
-		 " [-T type] [template]",
+		 " [-T prompt-type] [template]",
 
 	.flags = CMD_CLIENT_TFLAG,
 	.exec = cmd_command_prompt_exec

--- a/cmd-confirm-before.c
+++ b/cmd-confirm-before.c
@@ -42,7 +42,7 @@ const struct cmd_entry cmd_confirm_before_entry = {
 	.alias = "confirm",
 
 	.args = { "bc:p:t:y", 1, 1, cmd_confirm_before_args_parse },
-	.usage = "[-by] [-c confirm_key] [-p prompt] " CMD_TARGET_CLIENT_USAGE
+	.usage = "[-by] [-c confirm-key] [-p prompt] " CMD_TARGET_CLIENT_USAGE
 		 " command",
 
 	.flags = CMD_CLIENT_TFLAG,

--- a/cmd-set-environment.c
+++ b/cmd-set-environment.c
@@ -35,7 +35,7 @@ const struct cmd_entry cmd_set_environment_entry = {
 	.alias = "setenv",
 
 	.args = { "Fhgrt:u", 1, 2, NULL },
-	.usage = "[-Fhgru] " CMD_TARGET_SESSION_USAGE " name [value]",
+	.usage = "[-Fhgru] " CMD_TARGET_SESSION_USAGE " variable [value]",
 
 	.target = { 't', CMD_FIND_SESSION, CMD_FIND_CANFAIL },
 

--- a/cmd-show-environment.c
+++ b/cmd-show-environment.c
@@ -39,7 +39,7 @@ const struct cmd_entry cmd_show_environment_entry = {
 	.alias = "showenv",
 
 	.args = { "hgst:", 0, 1, NULL },
-	.usage = "[-hgs] " CMD_TARGET_SESSION_USAGE " [name]",
+	.usage = "[-hgs] " CMD_TARGET_SESSION_USAGE " [variable]",
 
 	.target = { 't', CMD_FIND_SESSION, CMD_FIND_CANFAIL },
 

--- a/cmd-show-prompt-history.c
+++ b/cmd-show-prompt-history.c
@@ -32,7 +32,7 @@ const struct cmd_entry cmd_show_prompt_history_entry = {
 	.alias = "showphist",
 
 	.args = { "T:", 0, 0, NULL },
-	.usage = "[-T type]",
+	.usage = "[-T prompt-type]",
 
 	.flags = CMD_AFTERHOOK,
 	.exec = cmd_show_prompt_history_exec
@@ -43,7 +43,7 @@ const struct cmd_entry cmd_clear_prompt_history_entry = {
 	.alias = "clearphist",
 
 	.args = { "T:", 0, 0, NULL },
-	.usage = "[-T type]",
+	.usage = "[-T prompt-type]",
 
 	.flags = CMD_AFTERHOOK,
 	.exec = cmd_show_prompt_history_exec

--- a/tmux.1
+++ b/tmux.1
@@ -23,7 +23,7 @@
 .Sh SYNOPSIS
 .Nm tmux
 .Bk -words
-.Op Fl 2CDlNuVv
+.Op Fl 2CDhlNuVv
 .Op Fl c Ar shell-command
 .Op Fl f Ar file
 .Op Fl L Ar socket-name
@@ -156,6 +156,8 @@ command may be used to load a file later.
 .Nm
 shows any error messages from commands in configuration files in the first
 session created, and continues to process the rest of the configuration file.
+.It Fl h
+Print usage information and exit.
 .It Fl L Ar socket-name
 .Nm
 stores the server socket in a directory under
@@ -6386,7 +6388,7 @@ Commands to alter and view the environment are:
 .It Xo Ic set-environment
 .Op Fl Fhgru
 .Op Fl t Ar target-session
-.Ar name Op Ar value
+.Ar variable Op Ar value
 .Xc
 .D1 Pq alias: Ic setenv
 Set or unset an environment variable.

--- a/tmux.c
+++ b/tmux.c
@@ -43,20 +43,20 @@ const char	*socket_path;
 int		 ptm_fd = -1;
 const char	*shell_command;
 
-static __dead void	 usage(void);
+static __dead void	 usage(int);
 static char		*make_label(const char *, char **);
 
 static int		 areshell(const char *);
 static const char	*getshell(void);
 
 static __dead void
-usage(void)
+usage(int status)
 {
-	fprintf(stderr,
-	    "usage: %s [-2CDlNuVv] [-c shell-command] [-f file] [-L socket-name]\n"
+	fprintf(status ? stderr : stdout,
+	    "usage: %s [-2CDhlNuVv] [-c shell-command] [-f file] [-L socket-name]\n"
 	    "            [-S socket-path] [-T features] [command [flags]]\n",
 	    getprogname());
-	exit(1);
+	exit(status);
 }
 
 static const char *
@@ -379,7 +379,7 @@ main(int argc, char **argv)
 		environ_set(global_environ, "PWD", 0, "%s", cwd);
 	expand_paths(TMUX_CONF, &cfg_files, &cfg_nfiles, 1);
 
-	while ((opt = getopt(argc, argv, "2c:CDdf:lL:NqS:T:uUvV")) != -1) {
+	while ((opt = getopt(argc, argv, "2c:CDdf:hlL:NqS:T:uUvV")) != -1) {
 		switch (opt) {
 		case '2':
 			tty_add_features(&feat, "256", ":,");
@@ -408,6 +408,8 @@ main(int argc, char **argv)
 			cfg_files[cfg_nfiles++] = xstrdup(optarg);
 			cfg_quiet = 0;
 			break;
+		case 'h':
+			usage(0);
 		case 'V':
 			printf("tmux %s\n", getversion());
 			exit(0);
@@ -437,16 +439,16 @@ main(int argc, char **argv)
 			log_add_level();
 			break;
 		default:
-			usage();
+			usage(1);
 		}
 	}
 	argc -= optind;
 	argv += optind;
 
 	if (shell_command != NULL && argc != 0)
-		usage();
+		usage(1);
 	if ((flags & CLIENT_NOFORK) && argc != 0)
-		usage();
+		usage(1);
 
 	if ((ptm_fd = getptmfd()) == -1)
 		err(1, "getptmfd");


### PR DESCRIPTION
I'm working on a bash completion script to include in the bash-completion repo itself. To (hopefully) reduce the maintenance burden, I'm trying to parse tmux's usage output as much as possible rather than hard-code any commands or options. These are some changes that I think will make that easier.

* Change `-T type` to `-T prompt-type` in usage output to match the man page.

* Change `-c confirm_key` to `-c confirm-key` to match the man page.

* Make environment variable names consistent with `variable` instead of a mix of `variable` and `name`.

* Add a documented way to get the top-level usage message, instead of needing to rely on an error of some sort.

I can split this up if you want some of those but not others. Or feel free to split it if that would be easier.