### PR TITLE
Allow making key bindings repeatable without a command

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -201,6 +201,8 @@ key_bindings_add(const char *name, key_code key, const char *note, int repeat,
 				free((void *)bd->note);
 				bd->note = xstrdup(note);
 			}
+			if (repeat)
+				bd->flags |= KEY_BINDING_REPEAT;
 		}
 		return;
 	}

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -197,11 +197,10 @@ key_bindings_add(const char *name, key_code key, const char *note, int repeat,
 	bd = key_bindings_get(table, key & ~KEYC_MASK_FLAGS);
 	if (cmdlist == NULL) {
 		if (bd != NULL) {
-			free((void *)bd->note);
-			if (note != NULL)
+			if (note != NULL) {
+				free((void *)bd->note);
 				bd->note = xstrdup(note);
-			else
-				bd->note = NULL;
+			}
 		}
 		return;
 	}

--- a/tmux.1
+++ b/tmux.1
@@ -3732,6 +3732,13 @@ attaches a note to the key (shown with
 .Ic list-keys
 .Fl N ) ,
 which can be cleared by passing an empty string.
+The
+.Fl r
+and
+.Fl N
+flags can be used without
+.Ar command
+to alter an existing binding.
 .Pp
 To view the default bindings and possible commands, see the
 .Ic list-keys

--- a/tmux.1
+++ b/tmux.1
@@ -3730,7 +3730,8 @@ options.
 .Fl N
 attaches a note to the key (shown with
 .Ic list-keys
-.Fl N ) .
+.Fl N ) ,
+which can be cleared by passing an empty string.
 .Pp
 To view the default bindings and possible commands, see the
 .Ic list-keys


### PR DESCRIPTION
This makes it possible to make the default bindings repeatable without knowing their command.