### PR TITLE
Fix description of `pane_in_mode`

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6054,7 +6054,7 @@ The following variables are available, where appropriate:
 .It Li "pane_format" Ta "" Ta "1 if format is for a pane"
 .It Li "pane_height" Ta "" Ta "Height of pane"
 .It Li "pane_id" Ta "#D" Ta "Unique pane ID"
-.It Li "pane_in_mode" Ta "" Ta "1 if pane is in a mode"
+.It Li "pane_in_mode" Ta "" Ta "Number of modes pane is in"
 .It Li "pane_index" Ta "#P" Ta "Index of pane"
 .It Li "pane_input_off" Ta "" Ta "1 if input to pane is disabled"
 .It Li "pane_key_mode" Ta "" Ta "Extended key reporting mode in this pane"


### PR DESCRIPTION
Since 3f6bfbaf2bab ("Allow multiple modes to be open in a pane...") `pane_in_mode` is not just a boolean, but reflects the number of modes a pane is currently in.