### PR TITLE
Strip trailing slash from «new -c ""» $PWD

### DIFF
--- a/spawn.c
+++ b/spawn.c
@@ -229,8 +229,9 @@ spawn_pane(struct spawn_context *sc, char **cause)
 	if (sc->cwd != NULL) {
 		cwd = format_single(item, sc->cwd, c, target->s, NULL, NULL);
 		if (*cwd != '/') {
-			xasprintf(&new_cwd, "%s/%s", server_client_get_cwd(c,
-			    target->s), cwd);
+			xasprintf(&new_cwd, "%s%s%s",
+			    server_client_get_cwd(c, target->s),
+			    *cwd != '\0' ? "/" : "", cwd);
 			free(cwd);
 			cwd = new_cwd;
 		}


### PR DESCRIPTION
Setting an empty (relative) working directory will
export $PWD with a trailing slash:

	tmux new-session -c "" bash -c 'echo $PWD; read'

Fix this.

Do not touch slashes added by the user.
For example this command still outputs three slashes:

	tmux new-session -c "///" bash -c 'echo $PWD; read'

I checked other occurrences of %s/%s and server_client_get_cwd
and didn't find other affected cases.

There may be one if client_file.path can have a trailing slash.
I'm guessing that even if it did, it probably doesn't leak into the UI.

Fixes #4471
