### PR TITLE
add note for window and pane menus

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -433,8 +433,9 @@ key_bindings_init(void)
 		"bind -N 'Resize the pane right' -r C-Right { resize-pane -R }",
 
 		/* Menu keys */
-		"bind < { display-menu -xW -yW -T '#[align=centre]#{window_index}:#{window_name}' " DEFAULT_WINDOW_MENU " }",
-		"bind > { display-menu -xP -yP -T '#[align=centre]#{pane_index} (#{pane_id})' " DEFAULT_PANE_MENU " }",
+		"bind -N 'Display window menu' < { display-menu -xW -yW -T '#[align=centre]#{window_index}:#{window_name}' " DEFAULT_WINDOW_MENU " }",
+		"bind -N 'Display pane menu' > { display-menu -xP -yP -T '#[align=centre]#{pane_index} (#{pane_id})' " DEFAULT_PANE_MENU " }",
+
 
 		/* Mouse button 1 down on pane. */
 		"bind -n MouseDown1Pane { select-pane -t=; send -M }",


### PR DESCRIPTION
I noticed that the default key bindings for tmux include an option to show a window and pane menu with `prefix >` and `prefix <`. I could not find them though in the key mapping list in `prefix ?`. I added a note to the key bindings so that now they show up as expected in `prefix ?` with a default config. Let me know if you would like any changes or other documentation elsewhere! Thanks