### PR TITLE
Fix border/scrollbar gllitch with swapping panes when scrollbars enabled

### DIFF
--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -132,11 +132,12 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 		window_pane_stack_remove(&dst_w->last_panes, dst_wp);
 		colour_palette_from_option(&src_wp->palette, src_wp->options);
 		colour_palette_from_option(&dst_wp->palette, dst_wp->options);
+		layout_fix_panes(src_w, NULL);
+		server_redraw_window(src_w);
 	}
-	layout_fix_panes(src_w, NULL);
 	layout_fix_panes(dst_w, NULL);
-	server_redraw_window(src_w);
 	server_redraw_window(dst_w);
+
 	notify_window("window-layout-changed", src_w);
 	if (src_w != dst_w)
 		notify_window("window-layout-changed", dst_w);

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -133,6 +133,8 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 		colour_palette_from_option(&src_wp->palette, src_wp->options);
 		colour_palette_from_option(&dst_wp->palette, dst_wp->options);
 	}
+	layout_fix_panes(src_w, NULL);
+	layout_fix_panes(dst_w, NULL);
 	server_redraw_window(src_w);
 	server_redraw_window(dst_w);
 	notify_window("window-layout-changed", src_w);


### PR DESCRIPTION
Add calls to `layout_fix_panes` after a pane swap to fix case if one of the panes is in alternate screen mode and had a scrollbar.