### PR TITLE
Add more features for boolean expressions in formats

### DIFF
--- a/regress/format-strings.sh
+++ b/regress/format-strings.sh
@@ -175,6 +175,47 @@ test_conditional_with_pane_in_mode "#{?#{==:#{?pane_in_mode,#{session_name},#(ec
 
 
 
+# Tests for boolean expressions
+
+# "0" and the empty string are false, everything else is true.
+test_format "#{!!:0}" "0"
+test_format "#{!!:}" "0"
+test_format "#{!!:1}" "1"
+test_format "#{!!:2}" "1"
+test_format "#{!!:non-empty string}" "1"
+test_format "#{!!:-0}" "1"
+test_format "#{!!:0.0}" "1"
+
+# Logical operators
+test_format "#{!:0}" "1"
+test_format "#{!:1}" "0"
+
+test_format "#{&&:0}" "0"
+test_format "#{&&:1}" "1"
+test_format "#{&&:0,0}" "0"
+test_format "#{&&:0,1}" "0"
+test_format "#{&&:1,0}" "0"
+test_format "#{&&:1,1}" "1"
+test_format "#{&&:0,0,0}" "0"
+test_format "#{&&:0,1,1}" "0"
+test_format "#{&&:1,0,1}" "0"
+test_format "#{&&:1,1,0}" "0"
+test_format "#{&&:1,1,1}" "1"
+
+test_format "#{||:0}" "0"
+test_format "#{||:1}" "1"
+test_format "#{||:0,0}" "0"
+test_format "#{||:0,1}" "1"
+test_format "#{||:1,0}" "1"
+test_format "#{||:1,1}" "1"
+test_format "#{||:0,0,0}" "0"
+test_format "#{||:1,0,0}" "1"
+test_format "#{||:0,1,0}" "1"
+test_format "#{||:0,0,1}" "1"
+test_format "#{||:1,1,1}" "1"
+
+
+
 # Format test for the literal option
 # Note: The behavior for #{l:...} with escapes is sometimes weird as #{l:...}
 # respects the escapes.

--- a/tmux.1
+++ b/tmux.1
@@ -5706,9 +5706,17 @@ otherwise by
 .Ql ||
 and
 .Ql &&
-evaluate to true if either or both of two comma-separated alternatives are
+evaluate to true if any or all of the comma-separated alternatives are
 true, for example
 .Ql #{||:#{pane_in_mode},#{alternate_on}} .
+.Ql !
+evaluates to true if the value is false and vice versa, for example
+.Ql #{!:#{pane_in_mode}} .
+.Ql !!
+converts a value to a canonical boolean form, 1 for true and 0 for false, for
+example
+.Ql #{!!:non-empty string}
+evaluates to 1.
 .Pp
 An
 .Ql m


### PR DESCRIPTION
1. Extend `&&` and `||` to support arbitrarily many arguments.
2. Add `!` and `!!`.

Fixes #4466