### PR TITLE
Prevent DECRQSS being misinterpreted as Sixel

### DIFF
--- a/input.c
+++ b/input.c
@@ -2384,7 +2384,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 
 #ifdef ENABLE_SIXEL
 	w = wp->window;
-	if (buf[0] == 'q') {
+	if (buf[0] == 'q' && ictx->interm_len == 0) {
 		if (input_split(ictx) != 0)
 			return (0);
 		p2 = input_get(ictx, 1, 0, 0);


### PR DESCRIPTION
As currently implemented, the DCS dispatcher detects Sixel sequences based entirely on the _final_ character of the sequence, ignoring any intermediates. This means that other DCS sequences with a `q` final (like DECRQSS), can be mistakenly interpreted as Sixel.

On terminals that don't support Sixel, this can result in a undesirable block of text being output (of the form `SIXEL IMAGE (1x1)`) whenever an application makes a DECRQSS query.

This PR fixes the issue by adding a check to make sure there are no intermediates before dispatching potential Sixel sequences.