### PR TITLE
feat: Use posix_spawn for JOB_NOWAIT jobs

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -2453,6 +2453,8 @@ void printflike(4, 5) environ_set(struct environ *, const char *, int,
 	    const char *, ...);
 void	environ_clear(struct environ *, const char *);
 void	environ_put(struct environ *, const char *, int);
+char   **environ_get_envp(struct environ *);
+void	environ_free_envp(char **);
 void	environ_unset(struct environ *, const char *);
 void	environ_update(struct options *, struct environ *, struct environ *);
 void	environ_push(struct environ *);


### PR DESCRIPTION
Ah wow, have been testing this for two weeks and making the status calls (JOB_NOWAIT) go via posix_spawn() seems to fix #3352, no accumulating sluggishness like before. Awesome : D
If AI co-created code is not acceptable, at least this provides a proof of concept..
Oh and the environment handling, probably only useful for a very small subset of status line commands, I didn't ask for it but neither did I try ripping it out yet..

--------------------------

Implement posix_spawn() in job_run() for jobs flagged with JOB_NOWAIT and not requiring a PTY. This avoids a full fork() for simple background tasks.

Includes:
- Added posix_spawn path in job_run().
- Added environ_get_envp() and environ_free_envp() helpers.
- Set up pipe and bufferevent to capture stdout for spawned jobs.
- Addressed various compilation and runtime issues during implementation.

Note: The cwd parameter is currently ignored for posix_spawn jobs.

[**AI crafted using roo code and gemini 2.5 pro**]