### PR TITLE
Point to new bash completion file

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -79,7 +79,7 @@ A small example configuration is in `example_tmux.conf`.
 
 And a bash(1) completion file at:
 
-https://github.com/imomaliev/tmux-bash-completion
+https://github.com/scop/bash-completion/blob/main/completions/tmux
 
 For debugging, run tmux with `-v` or `-vv` to generate server and client log
 files in the current directory.

--- a/README
+++ b/README
@@ -66,7 +66,7 @@ Also see the tmux FAQ at:
 
 A bash(1) completion file is at:
 
-	https://github.com/imomaliev/tmux-bash-completion
+	https://github.com/scop/bash-completion/blob/main/completions/tmux
 
 For debugging, run tmux with -v and -vv to generate server and client log files
 in the current directory.

--- a/README.ja
+++ b/README.ja
@@ -38,7 +38,7 @@ tmuxのドキュメントについてはtmux.1マニュアルをご覧くださ�
 サンプル設定は本リポジトリのexample_tmux.confに
 また、bash-completionファイルは下記にあります。
 
-	https://github.com/imomaliev/tmux-bash-completion
+	https://github.com/scop/bash-completion/blob/main/completions/tmux
 
 「-v」や「-vv」を指定することでデバッグモードでの起動が可能です。カレントディレクトリにサーバーやクライアントのログファイルが生成されます。
 


### PR DESCRIPTION
I can't read Japanese, so I just guessed about the change to README.ja.

From https://github.com/imomaliev/tmux-bash-completion:
> **Archived**: Bash completion for tmux is now part of the [bash-completion](https://github.com/scop/bash-completion/), please read more [here](https://github.com/imomaliev/tmux-bash-completion/issues/13#issuecomment-2873735797)