### PR TITLE
Add border case for middle window.

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -155,9 +155,9 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 				if (!hsplit || (hsplit && py <= wp->sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			if (wp->xoff - sb_w != 0) {
-				if (px == wp->xoff - sb_w - 1)
-					if (!hsplit || (hsplit && py > wp->sy / 2))
-						return (SCREEN_REDRAW_BORDER_LEFT);
+				if (px == wp->xoff - sb_w - 1 &&
+				    (!hsplit || (hsplit && py > wp->sy / 2)))
+					return (SCREEN_REDRAW_BORDER_LEFT);
 				if (px == wp->xoff + wp->sx + sb_w - 1)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
@@ -166,9 +166,9 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 				if (!hsplit || (hsplit && py <= wp->sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			if (wp->xoff != 0) {
-				if (px == wp->xoff - 1)
-					if (!hsplit || (hsplit && py > wp->sy / 2))
-						return (SCREEN_REDRAW_BORDER_LEFT);
+				if (px == wp->xoff - 1 &&
+				    (!hsplit || (hsplit && py > wp->sy / 2)))
+					return (SCREEN_REDRAW_BORDER_LEFT);
 				if (px == wp->xoff + wp->sx + sb_w)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -121,7 +121,12 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	u_int		 ex = wp->xoff + wp->sx, ey = wp->yoff + wp->sy;
 	int		 hsplit = 0, vsplit = 0, pane_status = ctx->pane_status;
 	int		 pane_scrollbars = ctx->pane_scrollbars, sb_w = 0;
-	int		 sb_pos = ctx->pane_scrollbars_pos;
+	int		 sb_pos;
+
+	if (pane_scrollbars != 0)
+		sb_pos = ctx->pane_scrollbars_pos;
+	else
+		sb_pos = 0;
 
 	/* Inside pane. */
 	if (px >= wp->xoff && px < ex && py >= wp->yoff && py < ey)
@@ -149,16 +154,24 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 			if (wp->xoff - sb_w == 0 && px == wp->sx + sb_w)
 				if (!hsplit || (hsplit && py <= wp->sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
-			if (wp->xoff - sb_w != 0 && px == wp->xoff - sb_w - 1)
-				if (!hsplit || (hsplit && py > wp->sy / 2))
-					return (SCREEN_REDRAW_BORDER_LEFT);
-		} else { /* sb_pos == PANE_SCROLLBARS_RIGHT */
+			if (wp->xoff - sb_w != 0) {
+				if (px == wp->xoff - sb_w - 1)
+					if (!hsplit || (hsplit && py > wp->sy / 2))
+						return (SCREEN_REDRAW_BORDER_LEFT);
+				if (px == wp->xoff + wp->sx + sb_w - 1)
+					return (SCREEN_REDRAW_BORDER_RIGHT);
+			}
+		} else { /* sb_pos == PANE_SCROLLBARS_RIGHT or disabled*/
 			if (wp->xoff == 0 && px == wp->sx + sb_w)
 				if (!hsplit || (hsplit && py <= wp->sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
-			if (wp->xoff != 0 && px == wp->xoff - 1)
-				if (!hsplit || (hsplit && py > wp->sy / 2))
-					return (SCREEN_REDRAW_BORDER_LEFT);
+			if (wp->xoff != 0) {
+				if (px == wp->xoff - 1)
+					if (!hsplit || (hsplit && py > wp->sy / 2))
+						return (SCREEN_REDRAW_BORDER_LEFT);
+				if (px == wp->xoff + wp->sx + sb_w)
+					return (SCREEN_REDRAW_BORDER_RIGHT);
+			}
 		}
 	}
 


### PR DESCRIPTION
When there are more than two horizontal windows and the active window is in not on an edge this fix correctly highlights both its left and right borders.