### PR TITLE
Fix lengths of panes and windows in status bar.

### DIFF
--- a/format-draw.c
+++ b/format-draw.c
@@ -1042,6 +1042,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 			    sr->start, sr->end);
 			break;
 		case STYLE_RANGE_PANE:
+			sr->end--;  /* Compensate for undisplayed '%' char */
 			log_debug("%s: range pane|%%%u at %u-%u", __func__,
 			    sr->argument, sr->start, sr->end);
 			break;
@@ -1050,6 +1051,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 			    sr->argument, sr->start, sr->end);
 			break;
 		case STYLE_RANGE_SESSION:
+			sr->end--;  /* Compensate for undisplayed '$' char */
 			log_debug("%s: range session|$%u at %u-%u", __func__,
 			    sr->argument, sr->start, sr->end);
 			break;


### PR DESCRIPTION
The issue in format-draw.c fixes is an "off-by-one" error because of the prefix character: $, %, or @ which is contained in the argument. When the mouse clicks in the status line, it ends up being off by one character because of this extra undisplayed prefix character. If you click the mouse on the first character of a session index, it was selecting the session immedietly to the left because it sees that target as one character too wide.
