### PR TITLE
Feature: session loop sorting and session activity format variable

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -5901,8 +5901,18 @@ or
 .Ql L:\&
 will loop over each session, window, pane or client and insert the format once
 for each.
-For windows and panes, two comma-separated formats may be given:
-the second is used for the current window or active pane.
+.Ql S:\& ,
+can take an optional sort argument
+.Ql /i\& ,
+.Ql /n\& ,
+.Ql /t\&
+to sort by index, name, or time, and optionally you can add
+.Ql /r\&
+to sort in reverse order, for example
+.Ql S/nr:\&
+to sort sessions by name in reverse order.
+For each, two comma-separated formats may be given:
+the second is used for the current window, active pane, or active session.
 For example, to get a list of windows formatted like the status line:
 .Bd -literal -offset indent
 #{W:#{E:window-status-format} ,#{E:window-status-current-format} }


### PR DESCRIPTION
Adds sorting flags to the S: format.  

Adds `session_alert` format which returns `#` for activity, `!` for bell, and `~` for silence if one of the windows in has those alerts.

Adds `session_bell_flag` format which is true if one of the windows had rung the bell in one of the windows in a session.

