### PR TITLE
Document DEC mode 2031 hooks in manpage

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -5471,6 +5471,10 @@ Run when focus exits a client
 Run when a client is resized.
 .It client-session-changed
 Run when a client's attached session is changed.
+.It client-light-theme
+Run when a client switches to a light theme.
+.It client-dark-theme
+Run when a client switches to a dark theme.
 .It command-error
 Run when a command fails.
 .It pane-died


### PR DESCRIPTION
See Git commit eaf70c95, GitHub issue #4353

--

Hello,

Here's an immensely simple commit, but I suppose it's a good way to get
one's feet wet: I would like to contribute as well as possible.

It's my first time using CVS and I figured I'd be more comfortable
asking here :)

Can I simply post to the `tech` mailing list with a Git patch?  It
seems odd, but the few patches I can find on that mailing list are
Git-formatted.  I can't seem to find a patch there that corresponds to a
commit on GitHub either... I must be missing something.

By the way, the last line of the `man` page displays a literal
`$Mdocdate$` for me. Is that an issue or my end, or could I attempt
addressing that nitpick myself, as a bit of an exercise?

Thanks for the excellent tool!
Cheers,