### PR TITLE
Add command rename-client.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,7 @@ dist_tmux_SOURCES = \
 	cmd-pipe-pane.c \
 	cmd-queue.c \
 	cmd-refresh-client.c \
+	cmd-rename-client.c \
 	cmd-rename-session.c \
 	cmd-rename-window.c \
 	cmd-resize-pane.c \

--- a/cmd-rename-client.c
+++ b/cmd-rename-client.c
@@ -1,0 +1,79 @@
+/* $OpenBSD$ */
+
+/*
+ * Copyright (c) 2007 Nicholas Marriott <nicholas.marriott@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tmux.h"
+
+/*
+ * Change client name.
+ */
+
+static enum cmd_retval	cmd_rename_client_exec(struct cmd *,
+			    struct cmdq_item *);
+
+const struct cmd_entry cmd_rename_client_entry = {
+	.name = "rename-client",
+	.alias = "renamec",
+
+	.args = { "c:", 1, 1, NULL },
+	.usage = CMD_TARGET_CLIENT_USAGE " new-name",
+
+	.flags = CMD_CLIENT_CFLAG,
+	.exec = cmd_rename_client_exec
+};
+
+static enum cmd_retval
+cmd_rename_client_exec(struct cmd *self, struct cmdq_item *item)
+{
+	struct args	*args = cmd_get_args(self);
+	struct client	*tc = cmdq_get_target_client(item), *c;
+	char		*newname, *tmp;
+
+	tmp = format_single_from_target(item, args_string(args, 0));
+	newname = session_check_name(tmp);
+	if (newname == NULL) {
+		cmdq_error(item, "invalid client name: %s", tmp);
+		free(tmp);
+		return (CMD_RETURN_ERROR);
+	}
+	free(tmp);
+	if (strcmp(newname, tc->name) == 0) {
+		free(newname);
+		return (CMD_RETURN_NORMAL);
+	}
+	TAILQ_FOREACH(c, &clients, entry) {
+		if (strcmp(c->name, newname) == 0) {
+			cmdq_error(item, "duplicate client name: %s", newname);
+			free(newname);
+			return (CMD_RETURN_ERROR);
+		}
+	}
+
+	TAILQ_REMOVE(&clients, tc, entry);
+	free(tc->name);
+	tc->name = newname;
+	TAILQ_INSERT_TAIL(&clients, tc, entry);
+
+	notify_client("client-renamed", c);
+
+	return (CMD_RETURN_NORMAL);
+}

--- a/cmd.c
+++ b/cmd.c
@@ -80,6 +80,7 @@ extern const struct cmd_entry cmd_pipe_pane_entry;
 extern const struct cmd_entry cmd_previous_layout_entry;
 extern const struct cmd_entry cmd_previous_window_entry;
 extern const struct cmd_entry cmd_refresh_client_entry;
+extern const struct cmd_entry cmd_rename_client_entry;
 extern const struct cmd_entry cmd_rename_session_entry;
 extern const struct cmd_entry cmd_rename_window_entry;
 extern const struct cmd_entry cmd_resize_pane_entry;
@@ -172,6 +173,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_previous_layout_entry,
 	&cmd_previous_window_entry,
 	&cmd_refresh_client_entry,
+	&cmd_rename_client_entry,
 	&cmd_rename_session_entry,
 	&cmd_rename_window_entry,
 	&cmd_resize_pane_entry,

--- a/tmux.1
+++ b/tmux.1
@@ -1510,6 +1510,14 @@ See the
 .Ic window-size
 option.
 .Tg rename
+.It Xo Ic rename-client
+.Op Fl c Ar target-client
+.Ar new-name
+.Xc
+.D1 Pq alias: Ic renamec
+Rename the client to
+.Ar new-name .
+.Tg rename
 .It Xo Ic rename-session
 .Op Fl t Ar target-session
 .Ar new-name
@@ -6377,10 +6385,10 @@ bg=black,fg=default,noreverse
 .Sh NAMES AND TITLES
 .Nm
 distinguishes between names and titles.
-Windows and sessions have names, which may be used to specify them in targets
+Windows, sessions, and clients have names, which may be used to specify them in targets
 and are displayed in the status line and various lists: the name is the
 .Nm
-identifier for a window or session.
+identifier for a window, session, or client.
 Only panes have titles.
 A pane's title is typically set by the program running inside the pane using
 an escape sequence (like it would set the
@@ -6400,6 +6408,9 @@ A session's name is set with the
 and
 .Ic rename-session
 commands.
+A client's name is set automatically at launch and with the
+.Ic rename-client
+command.
 A window's name is set with one of:
 .Bl -enum -width Ds
 .It


### PR DESCRIPTION
I've recently found myself wanting to name clients some human-friendly name so that I can easily target them with other commands.   I was a bit surprised to find that this command didn't already exist.   So, I'm hoping that it will be found worthy of being upstreamed..   Contribution guidelines focused on issue reporting, not so much on PRs, so I do apologize for any anti-pattern.   Anyway, I would appreciate consideration for inclusion.