### PR TITLE
Detect support for OSC 52 using the device attributes report

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1459,6 +1459,8 @@ tty_keys_device_attributes(struct tty *tty, const char *buf, size_t len,
 				tty_add_features(features, "margins", ",");
 			if (p[i] == 28)
 				tty_add_features(features, "rectfill", ",");
+			if (p[i] == 52)
+				tty_add_features(features, "clipboard", ",");
 		}
 		break;
 	}


### PR DESCRIPTION
Detect support for OSC 52 using the device attributes report

This is an extension agreed upon by modern terminals to indicate that
they support copying to the clipboard with XTerm's OSC 52 sequence.
On terminals that can disable clipboard access, this extension is only
reported when writing to the clipboard is actually allowed, so this is
a more reliable indicator than the Ms terminfo capability.

Fixes #4532
