### PR TITLE
Support more OSC 133 start of prompt commands

### DIFF
--- a/input.c
+++ b/input.c
@@ -2862,6 +2862,8 @@ input_osc_133(struct input_ctx *ictx, const char *p)
 
 	switch (*p) {
 	case 'A':
+	case 'N':
+	case 'P':
 		gl->flags |= GRID_LINE_START_PROMPT;
 		break;
 	case 'C':


### PR DESCRIPTION
Add N and P OSC 133 commands based on the [semantic prompts spec](https://gitlab.freedesktop.org/Per_Bothner/specifications/blob/master/proposals/semantic-prompts.md). For example, they're used in [wezterm's shell integration](https://github.com/wezterm/wezterm/blob/main/assets/shell-integration/wezterm.sh).
