### PR TITLE
Fix Hangul Jamo width problem (#4543)

### DIFF
--- a/input.c
+++ b/input.c
@@ -2583,14 +2583,8 @@ input_exit_rename(struct input_ctx *ictx)
 	server_status_window(w);
 }
 
-#define HANGULJAMO_TO_CODEPOINT(p) \
-    (((((u_char*)(p))[0] & 0x0F) << 12) | \
-     ((((u_char*)(p))[1] & 0x3F) << 6)  | \
-     (((u_char*)(p))[2] & 0x3F))
-
 static void
 set_width_chosung(struct input_ctx *ictx, struct utf8_data *ud) {
-	log_debug("HangulJamo: U+%04X[%.3s] width:%d: Chosung set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
 	ud->width = 2;
 	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
 	ictx->flags |= INPUT_UTF8_HANGULJAMO_CHOSEONG;
@@ -2599,10 +2593,8 @@ set_width_chosung(struct input_ctx *ictx, struct utf8_data *ud) {
 static void
 set_width_jungseong(struct input_ctx *ictx, struct utf8_data *ud) {
 	if (ictx->flags & INPUT_UTF8_HANGULJAMO_CHOSEONG) {
-		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jungseong set width 0", HANGULJAMO_TO_CODEPOINT(ud->data),ud->data, ud->width);
 		ud->width = 0;
-	} else {
-		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jungseong without Choseong set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+	} else { // Jungseong without Choseong
 		ud->width = 2;
 	}
 	ictx->flags |= INPUT_UTF8_HANGULJAMO_JUNGSEONG;
@@ -2611,10 +2603,8 @@ set_width_jungseong(struct input_ctx *ictx, struct utf8_data *ud) {
 static void
 set_width_jongseong(struct input_ctx *ictx, struct utf8_data *ud) {
 	if (ictx->flags & INPUT_UTF8_HANGULJAMO_CHOSEONG && ictx->flags & INPUT_UTF8_HANGULJAMO_JUNGSEONG) {
-		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jongseong set width 0", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
 		ud->width = 0;
-	} else {
-		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jongseong without Choseong and Jungseong set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+	} else { // Jongseong without Choseong and Jungseong
 		ud->width = 2;
 	}
 	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
@@ -2623,7 +2613,6 @@ set_width_jongseong(struct input_ctx *ictx, struct utf8_data *ud) {
 static void
 handle_hanguljamo(struct input_ctx *ictx, struct utf8_data *ud) {
     if (ud->size != 3 || ud->data[0] != 0xE1) { // not Hangul Jamo
-		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Not HangulJamo", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
 		ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
 		return ;
 	}

--- a/input.c
+++ b/input.c
@@ -113,6 +113,9 @@ struct input_ctx {
 	int			flags;
 #define INPUT_DISCARD 0x1
 #define INPUT_LAST 0x2
+#define INPUT_UTF8_HANGULJAMO_CHOSEONG 0x4
+#define INPUT_UTF8_HANGULJAMO_JUNGSEONG 0x8
+#define INPUT_UTF8_HANGULJAMO (INPUT_UTF8_HANGULJAMO_CHOSEONG | INPUT_UTF8_HANGULJAMO_JUNGSEONG)
 
 	const struct input_state *state;
 
@@ -1145,6 +1148,7 @@ input_print(struct input_ctx *ictx)
 	int			 set;
 
 	ictx->utf8started = 0; /* can't be valid UTF-8 */
+	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
 
 	set = ictx->cell.set == 0 ? ictx->cell.g0set : ictx->cell.g1set;
 	if (set == 1)
@@ -1225,6 +1229,7 @@ input_c0_dispatch(struct input_ctx *ictx)
 	int			 has_content = 0;
 
 	ictx->utf8started = 0; /* can't be valid UTF-8 */
+	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
 
 	log_debug("%s: '%c'", __func__, ictx->ch);
 
@@ -2578,6 +2583,74 @@ input_exit_rename(struct input_ctx *ictx)
 	server_status_window(w);
 }
 
+#define HANGULJAMO_TO_CODEPOINT(p) \
+    (((((u_char*)(p))[0] & 0x0F) << 12) | \
+     ((((u_char*)(p))[1] & 0x3F) << 6)  | \
+     (((u_char*)(p))[2] & 0x3F))
+
+static void
+set_width_chosung(struct input_ctx *ictx, struct utf8_data *ud) {
+	log_debug("HangulJamo: U+%04X[%.3s] width:%d: Chosung set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+	ud->width = 2;
+	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
+	ictx->flags |= INPUT_UTF8_HANGULJAMO_CHOSEONG;
+}
+
+static void
+set_width_jungseong(struct input_ctx *ictx, struct utf8_data *ud) {
+	if (ictx->flags & INPUT_UTF8_HANGULJAMO_CHOSEONG) {
+		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jungseong set width 0", HANGULJAMO_TO_CODEPOINT(ud->data),ud->data, ud->width);
+		ud->width = 0;
+	} else {
+		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jungseong without Choseong set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+		ud->width = 2;
+	}
+	ictx->flags |= INPUT_UTF8_HANGULJAMO_JUNGSEONG;
+}
+
+static void
+set_width_jongseong(struct input_ctx *ictx, struct utf8_data *ud) {
+	if (ictx->flags & INPUT_UTF8_HANGULJAMO_CHOSEONG && ictx->flags & INPUT_UTF8_HANGULJAMO_JUNGSEONG) {
+		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jongseong set width 0", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+		ud->width = 0;
+	} else {
+		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Jongseong without Choseong and Jungseong set width 2", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+		ud->width = 2;
+	}
+	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
+}
+
+static void
+handle_hanguljamo(struct input_ctx *ictx, struct utf8_data *ud) {
+    if (ud->size != 3 || ud->data[0] != 0xE1) { // not Hangul Jamo
+		log_debug("HangulJamo: U+%04X[%.3s] width:%d: Not HangulJamo", HANGULJAMO_TO_CODEPOINT(ud->data), ud->data, ud->width);
+		ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
+		return ;
+	}
+
+    if (ud->data[1] == 0x84 && ud->data[2] >= 0x80 && ud->data[2] <= 0x92) { // Choseong U+1100 ~ U+1112
+		set_width_chosung(ictx, ud);
+		return;
+	}
+    if (ud->data[1] == 0x85) {
+        if (ud->data[2] >= 0xA0 && ud->data[2] <= 0xB5) { // Jungseong U+1160 ~ U+1175
+			set_width_jungseong(ictx, ud);
+			return;
+		}
+		if (ud->data[2] == 0x9F) { // HCF U+115F
+			set_width_chosung(ictx, ud);
+			return;
+		}
+		return;
+    }
+    if ((ud->data[1] == 0x86 && ud->data[2] >= 0xA8) || (ud->data[1] == 0x87 && ud->data[2] <= 0x82)) { // Jeongsung U+11A8 ~ U+11C2
+		set_width_jongseong(ictx, ud);
+		return;
+	}
+	// not Hangul Jamo
+	ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
+}
+
 /* Open UTF-8 character. */
 static int
 input_top_bit_set(struct input_ctx *ictx)
@@ -2599,8 +2672,10 @@ input_top_bit_set(struct input_ctx *ictx)
 		return (0);
 	case UTF8_ERROR:
 		ictx->utf8started = 0;
+		ictx->flags &= ~INPUT_UTF8_HANGULJAMO;
 		return (0);
 	case UTF8_DONE:
+		handle_hanguljamo(ictx, ud);
 		break;
 	}
 	ictx->utf8started = 0;


### PR DESCRIPTION
This pull request fixes the incorrect width handling of individual Hangul Jamo characters (U+1100–U11FF), as described in issue #4543.

### Context

While it's uncommon for users to type standalone Hangul Jamo characters directly, they often appear in filenames on macOS. This is because macOS uses Unicode Normalization Form D (NFD), which decomposes Hangul syllables into individual Jamo characters.

For example, the syllable "한" (U+D55C) may be stored as:
- U+1112 HANGUL CHOSEONG HIEUH
- U+1161 HANGUL JUNGSEONG A
- U+11AB HANGUL JONGSEONG NIEUN

In the current behavior, tmux assigns widths of 2 to Choseong, 1 to Jungseong, and 1 to Jongseong — resulting in a total width of 4 for a single syllable. This leads to visual misalignment in terminal applications such as `ls` or Vim when filenames contain decomposed Hangul characters.

### Fix

This patch adds a workaround for decomposed Hangul sequences by adjusting character widths as follows:

- When a sequence of Hangul Jamo characters appears (i.e., **Choseong (initial) + Jungseong (medial) + Jongseong (final)**):
  - The **first character (Choseong)** is given width **2**
  - The **subsequent characters (Jungseong and Jongseong)** are given width **0**

This approximates the width of a fully composed syllable and resolves alignment issues when rendering filenames.

While this is not a complete or linguistically precise solution, it provides a practical fix for the macOS NFD normalization case and avoids rendering problems in real-world usage.

### Result

With this patch:
- Decomposed Hangul sequences in macOS filenames display correctly
- Terminal layout remains consistent when listing or editing files

### Related

Fixes #4543
