### PR TITLE
Use MAC_OS_X_VERSION_MIN_REQUIRED macro for OS version guards

### DIFF
--- a/compat/daemon-darwin.c
+++ b/compat/daemon-darwin.c
@@ -49,12 +49,12 @@
 
 #include <mach/mach.h>
 
-#include <Availability.h>
+#include <AvailabilityMacros.h>
 #include <unistd.h>
 
 void daemon_darwin(void);
 
-#ifdef __MAC_10_10
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 101000
 
 extern kern_return_t	bootstrap_look_up_per_user(mach_port_t, const char *,
 			    uid_t, mach_port_t *);

--- a/osdep-darwin.c
+++ b/osdep-darwin.c
@@ -19,11 +19,14 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
-#include <Availability.h>
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 #include <libproc.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/cdefs.h>
 
 #include "compat.h"
 
@@ -31,14 +34,10 @@ char			*osdep_get_name(int, char *);
 char			*osdep_get_cwd(int);
 struct event_base	*osdep_event_init(void);
 
-#ifndef __unused
-#define __unused __attribute__ ((__unused__))
-#endif
-
 char *
 osdep_get_name(int fd, __unused char *tty)
 {
-#ifdef __MAC_10_7
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
 	struct proc_bsdshortinfo	bsdinfo;
 	pid_t				pgrp;
 	int				ret;
@@ -72,6 +71,7 @@ osdep_get_name(int fd, __unused char *tty)
 char *
 osdep_get_cwd(int fd)
 {
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1050
 	static char			wd[PATH_MAX];
 	struct proc_vnodepathinfo	pathinfo;
 	pid_t				pgrp;
@@ -86,6 +86,7 @@ osdep_get_cwd(int fd)
 		strlcpy(wd, pathinfo.pvi_cdir.vip_path, sizeof wd);
 		return (wd);
 	}
+#endif
 	return (NULL);
 }
 


### PR DESCRIPTION
tmux now builds on OS X 10.4 & up. Tested every release up to 10.11.
Terminal.app on OS versions prior to 10.11 print `1;2c` when tmux is first invoked (fresh install, default config).
`__unused` is defined in `sys/cdefs.h`.