### PR TITLE
Fix format_cmp_window: windows should be sorted based on index, not id

### DIFF
--- a/format.c
+++ b/format.c
@@ -4490,7 +4490,6 @@ format_cmp_window(const void *a0, const void *b0)
 
 	switch (sc->field) {
 	case FORMAT_LOOP_BY_INDEX:
-		result = wa->id - wb->id;
 		break;
 	case FORMAT_LOOP_BY_TIME:
 		if (timercmp(&wa->activity_time, &wb->activity_time, >)) {


### PR DESCRIPTION
I am using the current master branch (7e439539377e272f37d18bb10dbff374b87acee6) and realized that the ordering of the windows in status bar is broken.

It turned out that `format_cmp_window` is sorting windows based on id, not by index by default now due to [a recent change](https://github.com/tmux/tmux/pull/4516/files#r2202331906).

`format_cmp_client` has the exact same logic [here](https://github.com/tmux/tmux/blob/7e439539377e272f37d18bb10dbff374b87acee6/format.c#L4685-L4686) so I think this was just a mistake.

## ✅ Verification

I created a session with 3 windows on macOS 15.5 and checked the status bar. I did not use any custom tmux config so the status bar format is the default one.
After creating windows, I used swap-window to "move" windows around.
Note that I also confirmed that before [this recent change](https://github.com/tmux/tmux/pull/4516/files#r2202331906), the issue did not exist so this issue is a regression introduced on `master` and not yet released.

### ❌  Before this PR (7e439539377e272f37d18bb10dbff374b87acee6)

We see that the windows are NOT ordered by index

<img width="292" height="31" alt="ok" src="https://github.com/user-attachments/assets/9c8077eb-ddb6-4e56-b8ab-bcbc4c88393e" />


### ✅ After this PR (9ac982a73812fea80c6d5b6195ad13ca461b6be5)

We see that the windows are ordered by index even after `swap-window`

<img width="275" height="32" alt="ng" src="https://github.com/user-attachments/assets/f0d1ae8d-b7be-4817-a352-9ae6a42883fa" />
