### PR TITLE
Fix rpath issue on macOS 15

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ AM_CFLAGS += -Wdeclaration-after-statement -Wno-pointer-sign -Wno-attributes
 AM_CFLAGS += -Wno-unused-result -Wno-format-y2k
 if IS_DARWIN
 AM_CFLAGS += -Wno-deprecated-declarations -Wno-cast-align -Wno-macro-redefined
+AM_LDFLAGS += -Wl,-rpath,/usr/local/lib
 endif
 AM_CPPFLAGS += -DDEBUG
 endif


### PR DESCRIPTION
Running tmux fails with the error

dyld[85540]: Library not loaded: @rpath/libevent_core-2.2.1.dylib
  Referenced from: <04573DE8-0B9F-3941-AF91-5205FEE73089> tmux
  Reason: no LC_RPATH's found

This change adds /usr/local/lib to rpath.