### PR TITLE
man page: fix reverse documentation of display-popup -s and -S

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6941,8 +6941,8 @@ forwards any input read from stdin to the empty pane given by
 .Op Fl d Ar start-directory
 .Op Fl e Ar environment
 .Op Fl h Ar height
-.Op Fl s Ar border-style
-.Op Fl S Ar style
+.Op Fl s Ar style
+.Op Fl S Ar border-style
 .Op Fl t Ar target-pane
 .Op Fl T Ar title
 .Op Fl w Ar width


### PR DESCRIPTION
The summary of options has things backward.  The rest of the text had it correct.  This makes the short form correct.  That's all!