### PR TITLE
Fix PageDown in pop-up menu, it should go 5 positions down

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -363,7 +363,7 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 				name = menu->items[md->choice].name;
 				if (md->choice != count - 1 &&
 				    (name != NULL && *name != '-'))
-					i++;
+					i--;
 				else if (md->choice == count - 1)
 					break;
 			}


### PR DESCRIPTION
The current behavior is to get the cursor to the last position. That's not what PageUp down, and it's not what the code was meant to do. `i` starts at 5 but never reaches zero because it's incremented rather than decremented.