### PR TITLE
Fix integer overflow in `grid_clear` arguments

### DIFF
--- a/grid-view.c
+++ b/grid-view.c
@@ -173,7 +173,7 @@ grid_view_delete_lines(struct grid *gd, u_int py, u_int ny, u_int bg)
 	sy = grid_view_y(gd, gd->sy);
 
 	grid_move_lines(gd, py, py + ny, sy - py - ny, bg);
-	grid_clear(gd, 0, sy - ny, gd->sx, py + ny - (sy - ny), bg);
+	grid_clear(gd, 0, sy - ny, gd->sx, ny, bg);
 }
 
 /* Delete lines inside scroll region. */
@@ -221,7 +221,7 @@ grid_view_delete_cells(struct grid *gd, u_int px, u_int py, u_int nx, u_int bg)
 	sx = grid_view_x(gd, gd->sx);
 
 	grid_move_cells(gd, px, px + nx, py, sx - px - nx, bg);
-	grid_clear(gd, sx - nx, py, px + nx - (sx - nx), 1, bg);
+	grid_clear(gd, sx - nx, py, nx, 1, bg);
 }
 
 /* Convert cells into a string. */


### PR DESCRIPTION
`grid_view_delete_lines` and `grid_view_delete_cells` use wrong logic to calculate the number of lines or cells to be cleared.

For `grid_view_delete_lines`, lines after the deleted area are moved by `ny` lines (the number of lines to be deleted), so the remaining number of lines to be cleared is `ny`.

Likewise, `grid_view_delete_cells` moves cells by `nx`, so final `nx` cells need to be cleared.

Closes #4598.