### PR TITLE
feat(popup): add -k flag

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -54,8 +54,8 @@ const struct cmd_entry cmd_display_popup_entry = {
 	.name = "display-popup",
 	.alias = "popup",
 
-	.args = { "Bb:Cc:d:e:Eh:s:S:t:T:w:x:y:", 0, -1, NULL },
-	.usage = "[-BCE] [-b border-lines] [-c target-client] "
+	.args = { "Bb:Cc:d:e:Eh:ks:S:t:T:w:x:y:", 0, -1, NULL },
+	.usage = "[-BCEk] [-b border-lines] [-c target-client] "
 		 "[-d start-directory] [-e environment] [-h height] "
 		 "[-s style] [-S border-style] " CMD_TARGET_PANE_USAGE
 		 " [-T title] [-w width] [-x position] [-y position] "
@@ -484,6 +484,8 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 		flags |= POPUP_CLOSEEXITZERO;
 	else if (args_has(args, 'E'))
 		flags |= POPUP_CLOSEEXIT;
+	if (args_has(args, 'k'))
+		flags |= POPUP_CLOSEANYKEY;
 	if (popup_display(flags, lines, item, px, py, w, h, env, shellcmd, argc,
 	    argv, cwd, title, tc, s, style, border_style, NULL, NULL) != 0) {
 		cmd_free_argv(argc, argv);

--- a/popup.c
+++ b/popup.c
@@ -548,6 +548,9 @@ popup_key_cb(struct client *c, void *data, struct key_event *event)
 	    pd->job == NULL) &&
 	    (event->key == '\033' || event->key == ('c'|KEYC_CTRL)))
 		return (1);
+	if (pd->job == NULL && (pd->flags & POPUP_CLOSEANYKEY) &&
+            !KEYC_IS_MOUSE(event->key) && !KEYC_IS_PASTE(event->key))
+		return (1);
 	if (pd->job != NULL) {
 		if (KEYC_IS_MOUSE(event->key)) {
 			/* Must be inside, checked already. */

--- a/tmux.1
+++ b/tmux.1
@@ -6969,7 +6969,7 @@ forwards any input read from stdin to the empty pane given by
 .Ar target-pane .
 .Tg popup
 .It Xo Ic display-popup
-.Op Fl BCE
+.Op Fl BCEk
 .Op Fl b Ar border-lines
 .Op Fl c Ar target-client
 .Op Fl d Ar start-directory
@@ -7003,6 +7003,8 @@ Two
 closes the popup only if
 .Ar shell-command
 exited with success.
+.Fl k
+allows any key to dismiss the popup instead of only Escape or Ctrl-c.
 .Pp
 .Fl x
 and

--- a/tmux.h
+++ b/tmux.h
@@ -3572,6 +3572,7 @@ int		 menu_key_cb(struct client *, void *, struct key_event *);
 #define POPUP_CLOSEEXIT 0x1
 #define POPUP_CLOSEEXITZERO 0x2
 #define POPUP_INTERNAL 0x4
+#define POPUP_CLOSEANYKEY 0x8
 typedef void (*popup_close_cb)(int, void *);
 typedef void (*popup_finish_edit_cb)(char *, size_t, void *);
 int		 popup_display(int, enum box_lines, struct cmdq_item *, u_int,


### PR DESCRIPTION
Allows any key to dismiss the popup once the command has exited. Closes #4611

That aside, I'm marking this as a draft because I couldn't quite figure out how to check that a key event is a keyboard key and not a mouse or a paste, which probably shouldn't dismiss the popup.