### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ fuzz/*-fuzzer
 tags
 tmux
 tmux.1.*
+.idea


### PR DESCRIPTION
This update adds the JetBrains .idea directory to .gitignore to prevent IDE-specific configuration files from being committed. These files are machine-dependent, add unnecessary noise to the repo, and can cause merge conflicts. Ignoring them ensures the repository remains clean, portable, and focused only on source code and project-relevant files.