### PR TITLE
input.c: add replies for DECRQSS cursor, DECRQM ?12, and others

### DIFF
--- a/input.c
+++ b/input.c
@@ -2489,15 +2489,14 @@ input_dcs_dispatch(struct input_ctx *ictx)
 				return (0);
 			}
 			/* 
-			 * Unrecognized DECRQSS ($ q Pt): DCS 0 $ r Pt ST
-			 * kitty, wezterm, and possibly other terminals omit Pt and
-			 * simply reply DCS 0 $ r ST. We closely follow ctlseqs,
-			 * thus returning Pt as well.
-			 */
-			if (len > 1)
-				input_reply(ictx, "\033P0$r%.*s\033\\", (int)(len - 1), buf + 1);
-			else
-				input_reply(ictx, "\033P0$r\033\\");
+			 * Unrecognized DECRQSS ($ q Pt): DCS 0 $ r ST
+			 * Note that the VT510 manual states that the terminal should echo
+			 *`Pt` in the failure reply (`DCS 0 $ r Pt ST`). In practice, xterm
+			 * (and kitty, wezterm, etc) *do not* echo `Pt`; they reply just
+			 * `DCS 0 $ r ST`. We decided to omit `Pt` in order to match xterm
+			 * (and what most apps expect).
+			 */	
+			input_reply(ictx, "\033P0$r\033\\");
 			return (0);
 		}
 

--- a/input.c
+++ b/input.c
@@ -2488,14 +2488,7 @@ input_dcs_dispatch(struct input_ctx *ictx)
 				input_reply(ictx, "\033P1$r q%d q\033\\", ps);
 				return (0);
 			}
-			/* 
-			 * Unrecognized DECRQSS ($ q Pt): DCS 0 $ r ST
-			 * Note that the VT510 manual states that the terminal should echo
-			 *`Pt` in the failure reply (`DCS 0 $ r Pt ST`). In practice, xterm
-			 * (and kitty, wezterm, etc) *do not* echo `Pt`; they reply just
-			 * `DCS 0 $ r ST`. We decided to omit `Pt` in order to match xterm
-			 * (and what most apps expect).
-			 */	
+			/* Unrecognized DECRQSS ($ q Pt): DCS 0 $ r ST */	
 			input_reply(ictx, "\033P0$r\033\\");
 			return (0);
 		}

--- a/screen.c
+++ b/screen.c
@@ -208,26 +208,32 @@ screen_set_cursor_style(u_int style, enum screen_cursor_style *cstyle,
 	case 1:
 		*cstyle = SCREEN_CURSOR_BLOCK;
 		*mode |= MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	case 2:
 		*cstyle = SCREEN_CURSOR_BLOCK;
 		*mode &= ~MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	case 3:
 		*cstyle = SCREEN_CURSOR_UNDERLINE;
 		*mode |= MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	case 4:
 		*cstyle = SCREEN_CURSOR_UNDERLINE;
 		*mode &= ~MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	case 5:
 		*cstyle = SCREEN_CURSOR_BAR;
 		*mode |= MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	case 6:
 		*cstyle = SCREEN_CURSOR_BAR;
 		*mode &= ~MODE_CURSOR_BLINKING;
+		*mode |= MODE_CURSOR_BLINKING_SET;
 		break;
 	}
 }


### PR DESCRIPTION
# Summary

Note: this is a new PR that reopens previous PR #4614 where the conversation initially started; PR #4614 was inadvertently closed; this is why it is reopened here.

This patch extends `input.c` to support proper replies to terminal state/status queries so that applications running *inside tmux* can query cursor style and cursor blink status just as they would against a real terminal emulator.

Specifically:

* **DECRQSS “ q”** (`DCS $ q q ST`)  
    → Reply with the current cursor shape (`Ps=0–6`), falling back to the cursor-style option if no explicit DECSCUSR; handle invalid requests.
    If the application has explicitly set a style via DECSCUSR, that is reported; otherwise tmux falls back to the configured `cursor-style` option (so queries now reflect the effective cursor users actually see on screen).
* **DECRQM ?12$p**  
    → Reply with the current blink state.  
    If blink has been explicitly controlled by the application (`MODE_CURSOR_BLINKING_SET`), we report that; otherwise, we infer from the configured `cursor-style` option (`blink-*` vs steady).
* **DECRQM ?2004, ?1004, ?1006**  
    → Reply with bracketed paste, focus event, and SGR mouse reporting status, based on the screen mode bits.

These replies are emitted from `input_csi_dispatch` and `input_dcs_dispatch` alongside the existing query handlers.

---

# Rationale

* Many TUIs (e.g. [Yazi](https://github.com/sxyazi/yazi?utm_source=chatgpt.com), editors, Ratatui apps) **probe terminal capabilities and status** on startup.
* Before this patch, tmux would not reply to queries like `\eP$q q\e\` (cursor shape) or `\e[?u` (CSI u), leading applications to assume features were unsupported.
* This forced developers to resort to passthrough hacks or disabled features inside tmux.
* With this patch, tmux responds consistently with the **effective state the user sees**:
    * If an app sets DECSCUSR, that takes precedence.
    * Otherwise, tmux reports the configured defaults (`cursor-style`).
    * Status queries for modes (bracketed paste, focus, mouse) reflect `s->mode`.
* Applications can now initialize correctly inside tmux without passthrough because queries and replies match the semantics of real terminals like xterm or alacritty.

---

# Notes

* Replies use standard DECSCUSR / DECRQM semantics (`Ps=0–6` for shape; `;1`/`;2` for on/off status).
* We intentionally **keep application state and option defaults separate**: tmux still allows apps to override cursor style at runtime, but query replies fall back to the configured option if no app override exists.
* This matches user expectations (“queries should show what’s on screen”) without taking control away from applications.

---

# Testing

Verified using a shell script [term_query.sh](https://github.com/alberti42/term_query) that queries:

* `\eP$q q\e\` → cursor shape
* `\e[?12$p` → blink status
* `\e[?2004$p`, `\e[?1004$p`, `\e[?1006$p`

All return the correct values in tmux, consistent with the cursor appearance and active modes. Yazi and Crossterm apps now initialize correctly inside tmux.