### PR TITLE
Do not squeeze sixel image height to multiples of 6

### DIFF
--- a/image-sixel.c
+++ b/image-sixel.c
@@ -420,8 +420,7 @@ sixel_scale(struct sixel_image *si, u_int xpixel, u_int ypixel, u_int ox,
 
 	/*
 	 * We want to get the section of the image at ox,oy in image cells and
-	 * map it onto the same size in terminal cells, remembering that we
-	 * can only draw vertical sections of six pixels.
+	 * map it onto the same size in terminal cells.
 	 */
 
 	sixel_size_in_cells(si, &cx, &cy);
@@ -445,7 +444,7 @@ sixel_scale(struct sixel_image *si, u_int xpixel, u_int ypixel, u_int ox,
 	psy = sy * si->ypixel;
 
 	tsx = sx * xpixel;
-	tsy = ((sy * ypixel) / 6) * 6;
+	tsy = sy * ypixel;
 
 	new = xcalloc (1, sizeof *si);
 	new->xpixel = xpixel;


### PR DESCRIPTION
This removes the problematic truncation discussed in #4529.  Besides the linked ticket, this also fixes things like

```
printf '\033Pq"1;1;100;28#0;2;99;0;0#1;2;0;99;0#1!100~-!100~-!100~-!100~-!100N\033\\\n'
```

which on current tmux bleeds some arbitrary color into the last line - depending on the terminal, you get register 0/red (XTerm, foot), register 255 (Windows terminal - I *think*), or the terminal background.

---

The comment at the top of the function provides some rationale:

> We want to get the section of the image at ox,oy in image cells and
> map it onto the same size in terminal cells, remembering that we
> can only draw vertical sections of six pixels.

...but this is a misconception.  Sixel draws sections of six pixels at once, but you can simply omit painting the bottom rows to draw images of arbitrary heights, provided you send image dimensions ("set raster attributes").

I suspect the actual reason for the truncation was that previously, tmux did not handle raster attributes at all.  So an image with an uneven number of lines (before or after scaling) would have resulted in filling the last lines with some terminal-dependent color, and scaling to multiples of six is a simple workaround for that.

But since we now support both raster attributes and P2=1 (transparency), this workaround is just causing problems without any real benefit.