### PR TITLE
Quote glob characters using dedicated function

### DIFF
--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -149,6 +149,22 @@ cmd_source_file_add(struct cmd_source_file_data *cdata, const char *path)
 	cdata->files[cdata->nfiles++] = xstrdup(path);
 }
 
+static char *quote_for_glob(const char *path)
+{
+	char *const   quoted = xmalloc(2 * strlen(path) + 1);
+	const char   *p = path;
+	char         *q = quoted;
+
+	while (*p != '\0') {
+		if ((u_char)*p < 128 && !isalnum(*p) && *p != '/') {
+			*q++ = '\\';
+		}
+		*q++ = *p++;
+	}
+	*q = '\0';
+	return quoted;
+}
+
 static enum cmd_retval
 cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 {
@@ -188,7 +204,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_has(args, 'v'))
 		cdata->flags |= CMD_PARSE_VERBOSE;
 
-	utf8_stravis(&cwd, server_client_get_cwd(c, NULL), VIS_GLOB);
+	cwd = quote_for_glob(server_client_get_cwd(c, NULL));
 
 	for (i = 0; i < args_count(args); i++) {
 		path = args_string(args, i);


### PR DESCRIPTION
`utf8_stravis` is a wrong function to escape path to use with `glob`. It escapes `*` and `?` using octal encoding when `VIS_GLOB` is set, regardless of other flags. However, `glob` only accepts backslash as the escape character.

The new implementation uses backslash to escape all ASCII characters other than letters, digits and the forward slash. I tested it with directories containing various ASCII symbols and UTF-8 characters, and I was able to load files from those locations, using both full names and wildcards. The current implementation cannot load configuration files from directories containing e.g. `#` in the name.