### PR TITLE
Optionally limit number of columns in tiled layout

### DIFF
--- a/layout-set.c
+++ b/layout-set.c
@@ -587,7 +587,7 @@ layout_set_tiled(struct window *w)
 	struct window_pane	*wp;
 	struct layout_cell	*lc, *lcrow, *lcchild;
 	u_int			 n, width, height, used, sx, sy;
-	u_int			 i, j, columns, rows;
+	u_int			 i, j, columns, rows, max_columns;
 
 	layout_print_cell(w->layout_root, __func__, 1);
 
@@ -596,11 +596,14 @@ layout_set_tiled(struct window *w)
 	if (n <= 1)
 		return;
 
+	/* Get maximum columns from window option. */
+	max_columns = options_get_number(w->options, "tiled-layout-max-columns");
+
 	/* How many rows and columns are wanted? */
 	rows = columns = 1;
 	while (rows * columns < n) {
 		rows++;
-		if (rows * columns < n)
+		if (rows * columns < n && (max_columns == 0 || columns < max_columns))
 			columns++;
 	}
 

--- a/options-table.c
+++ b/options-table.c
@@ -1394,6 +1394,16 @@ const struct options_table_entry options_table[] = {
 	  .text = "Whether typing should be sent to all panes simultaneously."
 	},
 
+	{ .name = "tiled-layout-max-columns",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .minimum = 0,
+	  .maximum = USHRT_MAX,
+	  .default_num = 0,
+	  .text = "Maximum number of columns in the 'tiled' layout. "
+		  "A value of 0 means no limit."
+	},
+
 	{ .name = "window-active-style",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,

--- a/tmux.1
+++ b/tmux.1
@@ -5222,6 +5222,14 @@ see the
 .Sx STYLES
 section.
 .Pp
+.It Ic tiled-layout-max-columns Ar number
+Set the maximum number of columns in the
+.Ic tiled
+layout.
+A value of 0 (the default) means no limit.
+When a limit is set, panes are arranged to not exceed this number of columns,
+with additional panes stacked in extra rows.
+.Pp
 .It Ic window-status-activity-style Ar style
 Set status line style for windows with an activity alert.
 For how to specify


### PR DESCRIPTION
Introduce a new window option: tiled-layout-max-columns. It configures the maximum number of columns in the tiled layout. The default value is 0 which means no limit and makes the change backward-compatible.

Implements RFE #4624