### PR TITLE
Fix malformed control mode output when source-file fails

### DIFF
--- a/cfg.c
+++ b/cfg.c
@@ -221,10 +221,14 @@ cfg_add_cause(const char *fmt, ...)
 void
 cfg_print_causes(struct cmdq_item *item)
 {
-	u_int	 i;
+	struct client *c = cmdq_get_client(item);
+	u_int	       i;
 
 	for (i = 0; i < cfg_ncauses; i++) {
-		cmdq_print(item, "%s", cfg_causes[i]);
+		if (c != NULL && (c->flags & CLIENT_CONTROL))
+			control_write(c, "%%config-error %s", cfg_causes[i]);
+		else
+			cmdq_print(item, "%s", cfg_causes[i]);
 		free(cfg_causes[i]);
 	}
 

--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -185,7 +185,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 		cdata->flags |= CMD_PARSE_QUIET;
 	if (args_has(args, 'n'))
 		cdata->flags |= CMD_PARSE_PARSEONLY;
-	if (args_has(args, 'v'))
+	if (args_has(args, 'v') && (~c->flags & CLIENT_CONTROL))
 		cdata->flags |= CMD_PARSE_VERBOSE;
 
 	utf8_stravis(&cwd, server_client_get_cwd(c, NULL), VIS_GLOB);

--- a/regress/if-shell-error.sh
+++ b/regress/if-shell-error.sh
@@ -21,3 +21,10 @@ EOF
 $TMUX -f$TMP -C new <<EOF >$OUT
 EOF
 grep -q "^%config-error $TMP:1: $TMP:1: unknown command: wibble$" $OUT
+
+cat <<EOF >$TMP
+wibble wobble
+EOF
+
+echo "source $TMP" | $TMUX -C new  >$OUT
+grep -q "^%config-error $TMP:1: unknown command: wibble$" $OUT


### PR DESCRIPTION
When the `source-file` command raises an error, tmux writes the cause directly into the control mode stream outside `%begin-%error` or `%config-error` statements. This may break protocol parsers.

Example:
```
# ~/test.tmux
display-message -p header
wibble wobble
display-message -p footer
# tmux -C
source ~/test.tmux
%begin 1757263428 319 1
%end 1757263428 319 1
/home/sergio/test.tmux:2: unknown command: wibble
```

after patch:
```
source ~/test.tmux
%begin 1757263561 305 1
%end 1757263561 305 1
%config-error /home/sergio/test.tmux:2: unknown command: wibble
```

Same problem applies for "source-file -v" output so I've decided to silent it in control mode.