### PR TITLE
Add `buffer_full` variable

### DIFF
--- a/format.c
+++ b/format.c
@@ -1365,7 +1365,16 @@ static void *
 format_cb_buffer_sample(struct format_tree *ft)
 {
 	if (ft->pb != NULL)
-		return (paste_make_sample(ft->pb));
+		return (paste_make_sample(ft->pb, 200));
+	return (NULL);
+}
+
+/* Callback for buffer_full. */
+static void *
+format_cb_buffer_full(struct format_tree *ft)
+{
+	if (ft->pb != NULL)
+		return (paste_make_sample(ft->pb, 0));
 	return (NULL);
 }
 
@@ -3007,6 +3016,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "buffer_created", FORMAT_TABLE_TIME,
 	  format_cb_buffer_created
+	},
+	{ "buffer_full", FORMAT_TABLE_STRING,
+	  format_cb_buffer_full
 	},
 	{ "buffer_mode_format", FORMAT_TABLE_STRING,
 	  format_cb_buffer_mode_format

--- a/paste.c
+++ b/paste.c
@@ -325,12 +325,13 @@ paste_replace(struct paste_buffer *pb, char *data, size_t size)
 
 /* Convert start of buffer into a nice string. */
 char *
-paste_make_sample(struct paste_buffer *pb)
+paste_make_sample(struct paste_buffer *pb, size_t width)
 {
 	char		*buf;
 	size_t		 len, used;
 	const int	 flags = VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL;
-	const size_t	 width = 200;
+
+	width = width ? width : pb->size;
 
 	len = pb->size;
 	if (len > width)

--- a/tmux.1
+++ b/tmux.1
@@ -6052,6 +6052,7 @@ The following variables are available, where appropriate:
 .It Li "buffer_created" Ta "" Ta "Time buffer created"
 .It Li "buffer_name" Ta "" Ta "Name of buffer"
 .It Li "buffer_sample" Ta "" Ta "Sample of start of buffer"
+.It Li "buffer_full" Ta "" Ta "Full buffer"
 .It Li "buffer_size" Ta "" Ta "Size of the specified buffer in bytes"
 .It Li "client_activity" Ta "" Ta "Time client last had activity"
 .It Li "client_cell_height" Ta "" Ta "Height of each client cell in pixels"

--- a/tmux.h
+++ b/tmux.h
@@ -2294,7 +2294,7 @@ void		 paste_add(const char *, char *, size_t);
 int		 paste_rename(const char *, const char *, char **);
 int		 paste_set(char *, size_t, const char *, char **);
 void		 paste_replace(struct paste_buffer *, char *, size_t);
-char		*paste_make_sample(struct paste_buffer *);
+char		*paste_make_sample(struct paste_buffer *, size_t);
 
 /* format.c */
 #define FORMAT_STATUS 0x1


### PR DESCRIPTION
 Sometimes you have a bunch of one-line buffers, and you just want to
 do:

     tmux list-buffers -F '#{buffer_full}' | head -10

 ..and use/store that output without any gotchas.

 And it's simpler than:

     tmux list-buffers -F '#{buffer_name}' | head -10 | while read l; do
       tmux show-buffer -b $l
       echo
     done

 This also allows more flexibility than the hard-coded 200 width for
 `buffer_sample`.

 For example, one can do this instead of the default format:

     tmux list-buffers -F '#{buffer_name}: #{buffer_size} bytes: "#{=250:buffer_full}"'

 Yes, there are performance/memory usage concerns in the presence of
 huge buffers. But the usability improvement is worth it IMHO.