### PR TITLE
Add `buffer_raw` variable

### DIFF
--- a/format.c
+++ b/format.c
@@ -1369,6 +1369,19 @@ format_cb_buffer_sample(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for buffer_raw. */
+static void *
+format_cb_buffer_raw(struct format_tree *ft)
+{
+	if (ft->pb != NULL) {
+    size_t sz;
+    const char *s = paste_buffer_data(ft->pb, &sz);
+    if (s)
+      return strndup(s, sz);
+  }
+	return (NULL);
+}
+
 /* Callback for buffer_size. */
 static void *
 format_cb_buffer_size(struct format_tree *ft)
@@ -3013,6 +3026,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "buffer_name", FORMAT_TABLE_STRING,
 	  format_cb_buffer_name
+	},
+	{ "buffer_raw", FORMAT_TABLE_STRING,
+	  format_cb_buffer_raw
 	},
 	{ "buffer_sample", FORMAT_TABLE_STRING,
 	  format_cb_buffer_sample

--- a/tmux.1
+++ b/tmux.1
@@ -6052,6 +6052,7 @@ The following variables are available, where appropriate:
 .It Li "buffer_created" Ta "" Ta "Time buffer created"
 .It Li "buffer_name" Ta "" Ta "Name of buffer"
 .It Li "buffer_sample" Ta "" Ta "Sample of start of buffer"
+.It Li "buffer_raw" Ta "" Ta "Full raw buffer, not limited in length, no escapes"
 .It Li "buffer_size" Ta "" Ta "Size of the specified buffer in bytes"
 .It Li "client_activity" Ta "" Ta "Time client last had activity"
 .It Li "client_cell_height" Ta "" Ta "Height of each client cell in pixels"


### PR DESCRIPTION
This is an alternative to #4627 which copies the raw buffer as is, which avoids escapes (and appended `...` in presence of escapes). This is the desired behavior in cases like piping, and provides the correct symmetry with multiple `show-buffer` calls.

-----

 Sometimes you have a bunch of one-line buffers, and you just want to
 do:

     tmux list-buffers -F '#{buffer_raw}' | head -10

 ..and use/store that output without any gotchas.

 And it's simpler than:

     tmux list-buffers -F '#{buffer_name}' | head -10 | while read l; do
       tmux show-buffer -b $l
       echo
     done

 This also allows more flexibility than the hard-coded 200 width for
 `buffer_sample`. And avoids possibly undesired escapes like:
 `\t` -> `\\t`.

 Yes, there are performance/memory usage concerns in the presence of
 huge buffers. But the usability improvement is worth it IMHO.