### PR TITLE
cmdq_error: don't uppercase first letter, it can be a filename

### DIFF
--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -891,7 +891,6 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 			file_error(c, "%s\n", msg);
 		c->retval = 1;
 	} else {
-		*msg = toupper((u_char) *msg);
 		status_message_set(c, -1, 1, 0, 0, "%s", msg);
 	}
 


### PR DESCRIPTION
For instance, run `source-file abc.conf`. The error message would be `Abc.conf: No such file or directory`, which is confusing.