### PR TITLE
detach-on-destroy: no-detach broken after previous and next were introduced

### DIFF
--- a/server-fn.c
+++ b/server-fn.c
@@ -403,7 +403,7 @@ server_find_session(struct session *s,
 	struct session *s_loop, *s_out = NULL;
 
 	RB_FOREACH(s_loop, sessions, &sessions) {
-		if (s_loop != s && (s_out == NULL || f(s_loop, s_out)))
+		if (s_loop != s && f(s_loop, s_out))
 			s_out = s_loop;
 	}
 	return (s_out);
@@ -412,6 +412,8 @@ server_find_session(struct session *s,
 static int
 server_newer_session(struct session *s_loop, struct session *s_out)
 {
+	if (s_out == NULL)
+		return (1);
 	return (timercmp(&s_loop->activity_time, &s_out->activity_time, >));
 }
 


### PR DESCRIPTION
Hi,

The refactor that came with the addition of the new "next" and "previous" values for the "detach-on-destroy" option broke the logic of the "no-detached" case.
This made it so that even in the "no-detached" case, tmux would always re-attach to a session, even if there weren't any detached ones.

This commit fixes the logic issue by checking for the NULL case within `server_newer_session`. I've done some quick sanity check with all of the possible values of "detach-on-destroy", and haven't found any issues.

The only downside I see with this change is that previously `(s_out == NULL || f(s_loop, s_out))` acted as an implicit safety check. So technically someone in the future could do something stupid with `s_out` within `server_newer_detached_session` with the expectation that the NULL case was already handled somewhere else or something like that.
I don't see any elegant solution to this other than adding a redundant check in `server_newer_detached_session`.

Let me know what you think.
Have a good day.