### PR TITLE
Avoid starting cmdq_error() with a filename

### DIFF
--- a/cmd-load-buffer.c
+++ b/cmd-load-buffer.c
@@ -66,7 +66,7 @@ cmd_load_buffer_done(__unused struct client *c, const char *path, int error,
 		return;
 
 	if (error != 0)
-		cmdq_error(item, "%s: %s", path, strerror(error));
+		cmdq_error(item, "%s: %s", strerror(error), path);
 	else if (bsize != 0) {
 		copy = xmalloc(bsize);
 		memcpy(copy, bdata, bsize);

--- a/cmd-save-buffer.c
+++ b/cmd-save-buffer.c
@@ -65,7 +65,7 @@ cmd_save_buffer_done(__unused struct client *c, const char *path, int error,
 		return;
 
 	if (error != 0)
-		cmdq_error(item, "%s: %s", path, strerror(error));
+		cmdq_error(item, "%s: %s", strerror(error), path);
 	cmdq_continue(item);
 }
 

--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -114,7 +114,7 @@ cmd_source_file_done(struct client *c, const char *path, int error,
 		return;
 
 	if (error != 0)
-		cmdq_error(item, "%s: %s", path, strerror(error));
+		cmdq_error(item, "%s: %s", strerror(error), path);
 	else if (bsize != 0) {
 		if (load_cfg_from_buffer(bdata, bsize, path, c, cdata->after,
 		    target, cdata->flags, &new_item) < 0)
@@ -233,7 +233,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 					error = strerror(ENOMEM);
 				else
 					error = strerror(EINVAL);
-				cmdq_error(item, "%s: %s", path, error);
+				cmdq_error(item, "%s: %s", error, path);
 				retval = CMD_RETURN_ERROR;
 			}
 			globfree(&g);


### PR DESCRIPTION
This is an alternative to #4635 (although both can be applied if desired). This change ensures that an error message produced by `cmdq_error()` won't start with a filename. Since `cmdq_error()` turns the first letter of the error message to uppercase, the filename in the initial position can be changed, making the message inaccurate.