### PR TITLE
Add `modify-popup` command to dynamically change popup styles and behavior

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -46,7 +46,6 @@ extern const struct cmd_entry cmd_detach_client_entry;
 extern const struct cmd_entry cmd_display_menu_entry;
 extern const struct cmd_entry cmd_display_message_entry;
 extern const struct cmd_entry cmd_display_popup_entry;
-extern const struct cmd_entry cmd_modify_popup_entry;
 extern const struct cmd_entry cmd_display_panes_entry;
 extern const struct cmd_entry cmd_find_window_entry;
 extern const struct cmd_entry cmd_has_session_entry;
@@ -139,7 +138,6 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_display_menu_entry,
 	&cmd_display_message_entry,
 	&cmd_display_popup_entry,
-	&cmd_modify_popup_entry,
 	&cmd_display_panes_entry,
 	&cmd_find_window_entry,
 	&cmd_has_session_entry,

--- a/popup.c
+++ b/popup.c
@@ -640,15 +640,16 @@ popup_job_complete_cb(struct job *job)
 }
 
 int
+isapopup(struct client *c) {
+	return (c->overlay_draw == popup_draw_cb);
+}
+
+int
 popup_modify(struct client *c, const char *title, const char *style,
 	const char *border_style, enum box_lines lines, int flags)
 {
 	struct popup_data		*pd = c->overlay_data;
 	struct style		sytmp;
-
-	if (c->overlay_draw != popup_draw_cb) {
-		return (-1);
-	}
 
 	if (title != NULL) {
 		if (pd->title != NULL)

--- a/tmux.1
+++ b/tmux.1
@@ -6996,7 +6996,7 @@ forwards any input read from stdin to the empty pane given by
 .Ar target-pane .
 .Tg popup
 .It Xo Ic display-popup
-.Op Fl BCEk
+.Op Fl BCEkN
 .Op Fl b Ar border-lines
 .Op Fl c Ar target-client
 .Op Fl d Ar start-directory
@@ -7019,7 +7019,21 @@ Display a popup running
 when omitted) on
 .Ar target-client .
 A popup is a rectangular box drawn over the top of any panes.
-Panes are not updated while a popup is present.
+Panes are not updated while a popup is present. If the command
+is run inside an existing popup, that popup is modified
+using the given options. Only the
+.Fl b ,
+.Fl B ,
+.Fl C ,
+.Fl E ,
+.Fl EE ,
+.Fl K ,
+.Fl N ,
+.Fl s ,
+and
+.Fl S
+options are accepted in this case;
+all others are ignored.
 .Pp
 .Fl E
 closes the popup automatically when
@@ -7083,59 +7097,9 @@ is a format for the popup title (see
 The
 .Fl C
 flag closes any popup on the client.
-.Tg modpopup
-.It Xo Ic modify-popup
-.Op Fl BEkN
-.Op Fl b Ar border-lines
-.Op Fl s Ar style
-.Op Fl S Ar border-style
-.Op Fl T Ar title
-.Xc
-.D1 Pq alias: Ic modpopup
-Changes the border and style settings when executed inside a popup.
-.Pp
-.Fl E
-closes the popup automatically when
-.Ar shell-command
-exits.
-Two
-.Fl E
-closes the popup only if
-.Ar shell-command
-exited with success.
-.Fl k
-allows any key to dismiss the popup instead of only
-.Ql Escape
-or
-.Ql C-c .
-.Pp
-.Fl B
-does not surround the popup by a border.
-.Pp
-.Fl b
-sets the type of characters used for drawing popup borders.
-When
-.Fl B
-is specified, the
-.Fl b
-option is ignored.
-See
-.Ic popup-border-lines
-for possible values for
-.Ar border-lines .
-.Pp
-.Fl s
-sets the style for the popup and
-.Fl S
-sets the style for the popup border (see
-.Sx STYLES ) .
-.Pp
-.Fl T
-is a format for the popup title (see
-.Sx FORMATS ) .
 .Pp
 .Fl N
-Disables any previously specified -E, -EE, or -k option.
+disables any previously specified -E, -EE, or -k option.
 .Tg showphist
 .It Xo Ic show-prompt-history
 .Op Fl T Ar prompt-type

--- a/tmux.h
+++ b/tmux.h
@@ -3613,6 +3613,8 @@ int		 popup_editor(struct client *, const char *, size_t,
 int		 popup_modify(struct client *, const char *, const char *, const char *,
 					enum box_lines, int);
 
+int		isapopup(struct client *);
+
 /* style.c */
 int		 style_parse(struct style *,const struct grid_cell *,
 		     const char *);


### PR DESCRIPTION
This implements a new command, `modify-popup`, following discussion in issue #3655 (https://github.com/tmux/tmux/issues/3655).

`modify-popup` allows updating the popup's color, border style, and post-exit behavior **after it has been displayed**. Parameters `-s`, `-S`, `-b`, `-B`, `-E`, `-EE`, `-k` behave analogously to `display-popup`.

A new option, `-N`, clears any previously set `-E`, `-EE`, or `-k` options, allowing full control over the popup's post-exit behavior.

**Example usage:**
Open a popup with a script
tmux display-popup 'myscript.sh'

After the script ends, modify the popup border to red if it failed or green, if the script was executed successfully.
tmux modify-popup -S fg=red
