### PR TITLE
Avoid losing spaces in `pane-border-format`

### DIFF
--- a/format-draw.c
+++ b/format-draw.c
@@ -745,6 +745,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 		screen_init(&s[i], size, 1, 0);
 		screen_write_start(&ctx[i], &s[i]);
 		screen_write_clearendofline(&ctx[i], current_default.bg);
+		ctx[i].flags |= SCREEN_WRITE_DEFAULT_CELL;
 		width[i] = 0;
 	}
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -2023,9 +2023,7 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 
 	/* If no change, do not draw. */
 	if (skip) {
-		if (s->cx >= gl->cellsize)
-			skip = grid_cells_equal(gc, &grid_default_cell);
-		else {
+		if (s->cx < gl->cellsize) {
 			gce = &gl->celldata[s->cx];
 			if (gce->flags & GRID_FLAG_EXTENDED)
 				skip = 0;
@@ -2043,7 +2041,10 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 				skip = 0;
 			else if (gce->data.data != gc->data.data[0])
 				skip = 0;
-		}
+		} else if (ctx->flags & SCREEN_WRITE_DEFAULT_CELL)
+			skip = 0;
+		else
+			skip = grid_cells_equal(gc, &grid_default_cell);
 	}
 
 	/* Update the selected flag and set the cell. */

--- a/tmux.h
+++ b/tmux.h
@@ -1001,6 +1001,7 @@ struct screen_write_ctx {
 
 	int				 flags;
 #define SCREEN_WRITE_SYNC 0x1
+#define SCREEN_WRITE_DEFAULT_CELL 0x2
 
 	screen_write_init_ctx_cb	 init_ctx_cb;
 	void				*arg;


### PR DESCRIPTION
Currently trailing spaces in `pane-border-format` are rendered in a strange way.

Current behavior (`pane-border-status` is set to `top`):
1. When `pane-border-format` is `"#[default] 12345678 "` all spaces rendered for both active and inactive panes:
   <img width="400" height="140" alt="size8" src="https://github.com/user-attachments/assets/897a3de5-9e8d-485c-804c-184e10a79c7e" />
1. When `pane-border-format` is `"#[default] 123456789 "` trailing space does not show up for inactive pane:
   <img width="400" height="140" alt="size9" src="https://github.com/user-attachments/assets/3cbfd7ba-1aba-4e54-8fc8-032dc05a4671" />
1. When `pane-border-format` is `"#[default] 12345678901 "` all spaces show up again:
   <img width="400" height="140" alt="size11" src="https://github.com/user-attachments/assets/9a6db1d5-1862-4949-9b98-20c8d138592d" />
1. When there are multiple trailing spaces only some of them are rendered: for example with `"#[default] 123456789      "` (6 spaces) only 3 are visible:
   <img width="400" height="140" alt="size9-6spaces" src="https://github.com/user-attachments/assets/3bb4103b-0a47-48dd-a4ba-0c7446a42dab" />
1. Adding extra dummy `#[default]` (e.g. `"#[default]#[default] 123456789 "`) makes spaces visible for sizes 9 and 10, but instead they are missing for sizes 5, 6.
1. This issue only happens with the default style - changing either `pane-border-style` or `#[default]` to some other value makes it go away.
1. It can be reproduced regardless of size by setting `pane-border-format` to only spaces:
   <img width="400" height="140" alt="spaces" src="https://github.com/user-attachments/assets/0ebb0642-13cf-4cb4-b6a4-07e9ad00af91" />

After some debugging I think I found why this happens:
1. `format_draw()` firstly formats pane border text into temporary empty screens (with sizes set to a length of a string before processing style directives).
1. `screen_write_cell()` does not insert a cell if:
   1. storage for it is allocated and the new cell is equal to the old cell (not applicable here because temporary screens are empty);
   1. storage for it is not allocated yet and it is equal to the default cell (space, `fg=8`, `bg=8`).

   This is why this problem does not reproduce for non-default style.
1. Allocated storage for cells is proportional to sizes of screens (via `grid_expand_line()`) - this is why adding dummy `#[default]`-s changes behavior.
1. `screen_write_fast_copy()` does not copy cells that are not allocated.

Here I fixed it by adding flag to `screen_write_ctx` that makes `screen_write_cell()` append cell even if it is equal to the default cell (flag is only set for temporary screens in `format_draw()`). Not sure if it the right place to fix it, but seems to be working.