### PR TITLE
menu: preserve menu on resize and reposition if needed

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -439,6 +439,37 @@ chosen:
 }
 
 static void
+menu_resize_cb(struct client *c, void *data)
+{
+	int			nx, ny;
+	int			w, h;
+	struct menu_data	*md = data;
+
+	if (md == NULL)
+		return;
+
+	nx = md->px;
+	ny = md->py;
+
+	w = md->menu->width + 4;
+	h = md->menu->count + 2;
+	
+	if (nx + w > (int)c->tty.sx) {
+		nx = c->tty.sx - w;
+		if (nx < 0)
+			nx = 0;
+	}
+
+	if (ny + h > (int)c->tty.sy - 1) {
+		ny = c->tty.sy - h - 1;
+		if (ny < 0)
+			ny = 0;
+	}
+	md->px = nx;
+	md->py = ny;
+}
+
+static void
 menu_set_style(struct client *c, struct grid_cell *gc, const char *style,
     const char *option)
 {
@@ -551,6 +582,6 @@ menu_display(struct menu *menu, int flags, int starting_choice,
 	if (md == NULL)
 		return (-1);
 	server_client_set_overlay(c, 0, NULL, menu_mode_cb, menu_draw_cb,
-	    menu_key_cb, menu_free_cb, NULL, md);
+	    menu_key_cb, menu_free_cb, menu_resize_cb, md);
 	return (0);
 }


### PR DESCRIPTION
This changes menu behaviour on resize events. Previously, any SIGWINCH
caused the menu overlay to be cleared. This made menus disappear when
the terminal font size changed.

A new resize callback (menu_resize_cb) is added which keeps the menu
open and repositions it if needed so it remains fully visible.

Tested with tmux next-3.6 on xterm-256color.