### PR TITLE
Added clock-mode-seconds option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -36,7 +36,7 @@ static const char *options_table_mode_keys_list[] = {
 	"emacs", "vi", NULL
 };
 static const char *options_table_clock_mode_style_list[] = {
-	"12", "24", NULL
+	"12", "24", "12-with-seconds", "24-with-seconds", NULL
 };
 static const char *options_table_status_list[] = {
 	"off", "on", "2", "3", "4", "5", NULL

--- a/tmux.1
+++ b/tmux.1
@@ -4927,7 +4927,7 @@ option is enabled.
 Set clock colour.
 .Pp
 .It Xo Ic clock-mode-style
-.Op Ic 12 | 24
+.Op Ic 12 | 24 | 12-with-seconds | 24-with-seconds
 .Xc
 Set clock hour format.
 .Pp

--- a/window-clock.c
+++ b/window-clock.c
@@ -142,7 +142,7 @@ window_clock_timer_callback(__unused int fd, __unused short events, void *arg)
 	t = time(NULL);
 	gmtime_r(&t, &now);
 	gmtime_r(&data->tim, &then);
-	if (now.tm_min == then.tm_min)
+	if (now.tm_sec == then.tm_sec)
 		return;
 	data->tim = t;
 
@@ -212,6 +212,7 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 	struct screen			*s = &data->screen;
 	struct grid_cell		 gc;
 	char				 tim[64], *ptr;
+	const char			 *timeformat;
 	time_t				 t;
 	struct tm			*tm;
 	u_int				 i, j, x, y, idx;
@@ -223,14 +224,23 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 
 	t = time(NULL);
 	tm = localtime(&t);
-	if (style == 0) {
-		strftime(tim, sizeof tim, "%l:%M ", localtime(&t));
+	if (style == 0 || style == 2) {
+		if (style == 2)
+			timeformat = "%l:%M:%S ";
+		else
+			timeformat = "%l:%M ";
+		strftime(tim, sizeof tim, timeformat, localtime(&t));
 		if (tm->tm_hour >= 12)
 			strlcat(tim, "PM", sizeof tim);
 		else
 			strlcat(tim, "AM", sizeof tim);
-	} else
-		strftime(tim, sizeof tim, "%H:%M", tm);
+	} else {
+		if (style == 3)
+			timeformat = "%H:%M:%S";
+		else
+			timeformat = "%H:%M";
+		strftime(tim, sizeof tim, timeformat, tm);
+	}
 
 	screen_write_clearscreen(&ctx, 8);
 


### PR DESCRIPTION
Added a `clock-mode-seconds` option to enable or disable seconds in clock-mode. Works with both 12 and 24 hour clock.

Is toggled by 
```
set-window-option -g clock-mode-seconds on
set-window-option -g clock-mode-seconds off
```

With 12 hour clock
<img width="610" height="120" alt="image" src="https://github.com/user-attachments/assets/646e2e81-36c0-4fee-a24c-d6a3d2985e54" />

With 24 hour clock
<img width="470" height="120" alt="image" src="https://github.com/user-attachments/assets/6c59fe29-3322-4ccc-90f6-9fe5b3c407d8" />
