### PR TITLE
Fix compile error of server-fs.c

### DIFF
--- a/server-fn.c
+++ b/server-fn.c
@@ -24,6 +24,9 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#ifdef HAVE_UTEMPTER
+#include <signal.h>
+#endif
 
 #include "tmux.h"
 


### PR DESCRIPTION
If configure script is invoked with --enable-utempter option, compile of server-fs.c fails as below.

```
depbase=`echo server-fn.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`; cc -DPACKAGE_NAME=\"tmux\" -DPACKAGE_TARNAME=\"tmux\" -DPACKAGE_VERSION=\"3.6\" -DPACKAGE_STRING=\"tmux\ 3.6\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"tmux\" -DVERSION=\"3.6\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -D__EXTENSIONS__=1 -D_ALL_SOURCE=1 -D_GNU_SOURCE=1 -D_POSIX_PTHREAD_SEMANTICS=1 -D_TANDEM_SOURCE=1 -DHAVE_BITSTRING_H=1 -DHAVE_DIRENT_H=1 -DHAVE_FCNTL_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_LIBPROC_H=1 -DHAVE_LIBUTIL_H=1 -DHAVE_PATHS_H=1 -DHAVE_STDINT_H=1 -DHAVE_SYS_TREE_H=1 -DHAVE_SYS_SIGNAME=1 -DHAVE_LIBM=1 -DHAVE_DIRFD=1 -DHAVE_FLOCK=1 -DHAVE_SYSCONF=1 -DHAVE_ASPRINTF=1 -DHAVE_CFMAKERAW=1 -DHAVE_CLOCK_GETTIME=1 -DHAVE_CLOSEFROM=1 -DHAVE_EXPLICIT_BZERO=1 -DHAVE_FGETLN=1 -DHAVE_GETDTABLESIZE=1 -DHAVE_GETPEEREID=1 -DHAVE_GETLINE=1 -DHAVE_GETPROGNAME=1 -DHAVE_MEMMEM=1 -DHAVE_SETENV=1 -DHAVE_SETPROCTITLE=1 -DHAVE_STRCASESTR=1 -DHAVE_STRLCAT=1 -DHAVE_STRLCPY=1 -DHAVE_STRNDUP=1 -DHAVE_STRSEP=1 -DHAVE_STRTONUM=1 -DHAVE_EVENT2_EVENT_H=1 -DHAVE_NCURSES_H=1 -DHAVE_TIPARM=1 -DHAVE_TIPARM_S=1 -DHAVE_UTEMPTER=1 -DHAVE_B64_NTOP=1 -DHAVE_LIBXNET=1 -DHAVE_DAEMON=1 -DHAVE_FORKPTY=1 -DHAVE_QUEUE_H=1 -DHAVE___PROGNAME=1 -I.  -I/usr/local/include    -DTMUX_VERSION='"3.6"'  -DTMUX_CONF='"/etc/tmux.conf:~/.tmux.conf:$XDG_CONFIG_HOME/tmux/tmux.conf:~/.config/tmux/tmux.conf"'  -DTMUX_LOCK_CMD='"lock -np"'  -DTMUX_TERM='"tmux-256color"'  -iquote.           -std=gnu99 -O2      -MT server-fn.o -MD -MP -MF $depbase.Tpo -c -o server-fn.o server-fn.c && mv -f $depbase.Tpo $depbase.Po
server-fn.c:323:3: warning: call to undeclared function 'kill'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  323 |                 kill(getpid(), SIGCHLD);
      |                 ^
server-fn.c:323:18: error: use of undeclared identifier 'SIGCHLD'
  323 |                 kill(getpid(), SIGCHLD);
      |                                ^
1 warning and 1 error generated.
*** Error code 1

Stop.
```

Fixes #4700.