### PR TITLE
Make image limit configurable

### DIFF
--- a/image.c
+++ b/image.c
@@ -97,6 +97,7 @@ struct image*
 image_store(struct screen *s, struct sixel_image *si)
 {
 	struct image	*im;
+	u_int		 limit;
 
 	im = xcalloc(1, sizeof *im);
 	im->s = s;
@@ -111,7 +112,8 @@ image_store(struct screen *s, struct sixel_image *si)
 	TAILQ_INSERT_TAIL(&s->images, im, entry);
 
 	TAILQ_INSERT_TAIL(&all_images, im, all_entry);
-	if (++all_images_count == 10/*XXX*/)
+	limit = options_get_number(global_options, "image-limit");
+	if (++all_images_count == limit)
 		image_free(TAILQ_FIRST(&all_images));
 
 	return (im);

--- a/options-table.c
+++ b/options-table.c
@@ -422,6 +422,16 @@ const struct options_table_entry options_table[] = {
 	  .text = "Number of bytes accepted in a single input before dropping."
 	},
 
+	{ .name = "image-limit",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .minimum = 1,
+	  .maximum = INT_MAX,
+	  .default_num = 10,
+	  .text = "Maximum number of sixel images to keep. "
+		  "When this is reached, the oldest image is deleted."
+	},
+
 	{ .name = "menu-style",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_WINDOW,


### PR DESCRIPTION
## Description

This PR makes the sixel image limit configurable instead of being hard-coded to 10.

## Changes

- Added a new server option `image-limit` in `options-table.c` with a default value of 10
- Modified `image.c` to use the configurable option instead of the hard-coded value
- The hard-coded limit was marked with a `/*XXX*/` comment indicating it should be made configurable

## Usage

Users can now configure the image limit using:
```
set-option -g image-limit <value>
```

## Backward Compatibility

The default value remains 10, maintaining backward compatibility with existing configurations.

## Testing

- Built successfully on macOS (darwin25.1.0)
- Code follows existing patterns for server options in tmux