### PR TITLE
Add check that the pane is not in alternate screen mode when in copy-mode.

### DIFF
--- a/window.c
+++ b/window.c
@@ -1780,7 +1780,7 @@ window_pane_mode(struct window_pane *wp)
 int
 window_pane_show_scrollbar(struct window_pane *wp, int sb_option)
 {
-	if (SCREEN_IS_ALTERNATE(wp->screen) || SCREEN_IS_ALTERNATE(&wp->base))
+	if (SCREEN_IS_ALTERNATE(&wp->base))
 		return (0);
 	if (sb_option == PANE_SCROLLBARS_ALWAYS ||
 	    (sb_option == PANE_SCROLLBARS_MODAL &&


### PR DESCRIPTION
Add check to window_pane_show_scrollbar to chek bwp->base to see if pane is in alt screen and do return 0 to not enable scrollbars in this case.