### PR TITLE
Improve code readability in colour_palette_get and colour_palette_set

### DIFF
--- a/colour.c
+++ b/colour.c
@@ -1082,22 +1082,22 @@ colour_palette_free(struct colour_palette *p)
 
 /* Get a colour from a palette. */
 int
-colour_palette_get(struct colour_palette *p, int c)
+colour_palette_get(struct colour_palette *p, int n)
 {
 	if (p == NULL)
 		return (-1);
 
-	if (c >= 90 && c <= 97)
-		c = 8 + c - 90;
-	else if (c & COLOUR_FLAG_256)
-		c &= ~COLOUR_FLAG_256;
-	else if (c >= 8)
+	if (n >= 90 && n <= 97)
+		n = 8 + n - 90;
+	else if (n & COLOUR_FLAG_256)
+		n &= ~COLOUR_FLAG_256;
+	else if (n >= 8)
 		return (-1);
 
-	if (p->palette != NULL && p->palette[c] != -1)
-		return (p->palette[c]);
-	if (p->default_palette != NULL && p->default_palette[c] != -1)
-		return (p->default_palette[c]);
+	if (p->palette != NULL && p->palette[n] != -1)
+		return (p->palette[n]);
+	if (p->default_palette != NULL && p->default_palette[n] != -1)
+		return (p->default_palette[n]);
 	return (-1);
 }
 
@@ -1107,15 +1107,14 @@ colour_palette_set(struct colour_palette *p, int n, int c)
 {
 	u_int	i;
 
-	if (p == NULL || n > 255)
+	if (p == NULL || n < 0 || n > 255)
 		return (0);
 
 	if (c == -1 && p->palette == NULL)
 		return (0);
 
-	if (c != -1 && p->palette == NULL) {
-		if (p->palette == NULL)
-			p->palette = xcalloc(256, sizeof *p->palette);
+	if (p->palette == NULL) {
+		p->palette = xcalloc(256, sizeof *p->palette);
 		for (i = 0; i < 256; i++)
 			p->palette[i] = -1;
 	}


### PR DESCRIPTION
In `colour_palette_get`, rename `c` to `n` for consistency with other code where `n` is the index in the palette and `c` is the color.

In `colour_palette_set`, check both limits of `n`. Checking just the upper limit sets a bad example, it pretends to be a complete check, but it's actually incomplete. The callers do their own checks, so I'm OK with not checking any limits at all as an alternative.

Also simplify the logic without changing the behavior. The goal of the code is to allocate the palette if it's not allocated yet; the value of `c` doesn't matter (the special case of `c = -1` without a palette has already been handled).