### PR TITLE
Fix for scrolling pane-scrollbar whilst in show-messages causes copy-mode to be invoked

### DIFF
--- a/cmd-copy-mode.c
+++ b/cmd-copy-mode.c
@@ -64,14 +64,6 @@ cmd_copy_mode_exec(struct cmd *self, struct cmdq_item *item)
 	struct session		*s;
 	struct window_pane	*wp = target->wp, *swp;
 
-	if (args_has(args, 'S')) {
-		if (TAILQ_EMPTY(&wp->modes))
-			window_pane_set_mode(wp, wp, &window_copy_mode, NULL,
-			args);
-		window_copy_scroll(wp, c->tty.mouse_slider_mpos, event->m.y,
-		    args_has(args, 'e'));
-		return (CMD_RETURN_NORMAL);
-	}
 	if (args_has(args, 'q')) {
 		window_pane_reset_mode_all(wp);
 		return (CMD_RETURN_NORMAL);
@@ -93,7 +85,6 @@ cmd_copy_mode_exec(struct cmd *self, struct cmdq_item *item)
 		swp = source->wp;
 	else
 		swp = wp;
-
 	if (!window_pane_set_mode(wp, swp, &window_copy_mode, NULL, args)) {
 		if (args_has(args, 'M'))
 			window_copy_start_drag(c, &event->m);
@@ -102,6 +93,11 @@ cmd_copy_mode_exec(struct cmd *self, struct cmdq_item *item)
 		window_copy_pageup(wp, 0);
 	if (args_has(args, 'd'))
 		window_copy_pagedown(wp, 0, args_has(args, 'e'));
+	if (args_has(args, 'S')) {
+		window_copy_scroll(wp, c->tty.mouse_slider_mpos, event->m.y,
+		    args_has(args, 'e'));
+		return (CMD_RETURN_NORMAL);
+	}
 
 	return (CMD_RETURN_NORMAL);
 }

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -480,9 +480,9 @@ key_bindings_init(void)
 		"bind -n M-MouseDown3Pane { display-menu -t= -xM -yM -T '#[align=centre]#{pane_index} (#{pane_id})' " DEFAULT_PANE_MENU " }",
 
 		/* Mouse on scrollbar. */
-		"bind -n MouseDown1ScrollbarUp { copy-mode -u }",
-		"bind -n MouseDown1ScrollbarDown { copy-mode -d }",
-		"bind -n MouseDrag1ScrollbarSlider { copy-mode -S }",
+		"bind -n MouseDown1ScrollbarUp { if -Ft= '#{pane_in_mode}' { send -X page-up } {copy-mode -u } }",
+		"bind -n MouseDown1ScrollbarDown { if -Ft= '#{pane_in_mode}' { send -X page-down } {copy-mode -d } }",
+		"bind -n MouseDrag1ScrollbarSlider { if -Ft= '#{pane_in_mode}' { send -X scroll-to-mouse } { copy-mode -S } }",
 
 		/* Copy mode (emacs) keys. */
 		"bind -Tcopy-mode C-Space { send -X begin-selection }",

--- a/tmux.1
+++ b/tmux.1
@@ -2213,6 +2213,33 @@ but also exit copy mode if the cursor reaches the bottom.
 Scroll so that the current line becomes the middle one while keeping the
 cursor on that line.
 .It Xo
+.Ic scroll-to-mouse
+.Xc
+Scroll pane in copy-mode when bound to a mouse drag event.
+.Fl e
+causes copy-mode to exit when at the bottom.  By default
+.Ar MouseDrag1ScrollbarSlider
+is bound to:
+.Pp
+.Bd -literal -offset indent
+.Ic if -Ft= '#{pane_in_mode}' { send -X scroll-to-mouse }
+{ copy-mode -S }
+.Ed
+.Pp
+To exit copy-mode at the bottom, supply
+.Fl e
+to both
+.Ic scroll-to-mouse
+and
+.Ic copy-mode -S
+like this:
+.Pp
+.Bd -literal -offset indent
+.Ic if -Ft= '#{pane_in_mode}' { send -X scroll-to-mouse -e }
+{ copy-mode -Se }
+.Ed
+.Pp
+.It Xo
 .Ic scroll-top
 .Xc
 Scroll down until the current line is at the top while keeping the cursor on
@@ -2449,12 +2476,10 @@ cancels copy mode and any other modes.
 .Fl M
 begins a mouse drag (only valid if bound to a mouse key binding, see
 .Sx MOUSE SUPPORT ) .
+.Pp
 .Fl S
-scrolls when bound to a mouse drag event; for example,
-.Ic copy-mode -Se
-is bound to
-.Ar MouseDrag1ScrollbarSlider
-by default.
+enters copy-mode and scrolls when bound to a mouse drag event; See
+.Ic scroll-to-mouse .
 .Pp
 .Fl s
 copies from

--- a/window-copy.c
+++ b/window-copy.c
@@ -1479,6 +1479,20 @@ window_copy_cmd_scroll_middle(struct window_copy_cmd_state *cs)
 	return (window_copy_cmd_scroll_to(cs, mid_value));
 }
 
+/* Scroll the pane to the mouse in the scrollbar. xyz*/
+static enum window_copy_cmd_action
+window_copy_cmd_scroll(struct window_copy_cmd_state *cs)
+{
+	struct window_mode_entry	*wme = cs->wme;
+	struct window_pane		*wp = wme->wp;
+	struct client			*c = cs->c;
+	struct mouse_event		*m = cs->m;
+	int				 scroll_exit = args_has(cs->wargs, 'e');
+
+	window_copy_scroll(wp, c->tty.mouse_slider_mpos, m->y, scroll_exit);
+	return (WINDOW_COPY_CMD_NOTHING);
+}
+
 /* Scroll line containing the cursor to the top. */
 static enum window_copy_cmd_action
 window_copy_cmd_scroll_top(struct window_copy_cmd_state *cs)
@@ -3043,6 +3057,11 @@ static const struct {
 	  .args = { "", 0, 0, NULL },
 	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
 	  .f = window_copy_cmd_scroll_middle
+	},
+	{ .command = "scroll-to-mouse",
+	  .args = { "e", 0, 0, NULL },
+	  .clear = WINDOW_COPY_CMD_CLEAR_EMACS_ONLY,
+	  .f = window_copy_cmd_scroll
 	},
 	{ .command = "scroll-top",
 	  .args = { "", 0, 0, NULL },


### PR DESCRIPTION
Add logic to window_pane_set_mode to not go into copy-mode from a different mode.