### PR TITLE
Fix y offset of mouse if status at top.

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1028,6 +1028,11 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	int			 sx = ctx->sx, sy = ctx->sy, xoff = wp->xoff;
 	int			 yoff = wp->yoff;
 
+	if (ctx->statustop) {
+		sb_y += ctx->statuslines;
+		sy += ctx->statuslines;
+	}
+
 	/* Set up style for slider. */
 	gc = sb_style->gc;
 	memcpy(&slgc, &gc, sizeof slgc);

--- a/server-client.c
+++ b/server-client.c
@@ -1271,7 +1271,11 @@ have_event:
 		if (c->tty.mouse_scrolling_flag == 0 &&
 		    where == SCROLLBAR_SLIDER) {
 			c->tty.mouse_scrolling_flag = 1;
-			c->tty.mouse_slider_mpos = sl_mpos;
+			if (m->statusat == 0)
+				c->tty.mouse_slider_mpos = sl_mpos +
+				    m->statuslines;
+			else
+				c->tty.mouse_slider_mpos = sl_mpos;
 		}
 		break;
 	case WHEEL:

--- a/window-copy.c
+++ b/window-copy.c
@@ -627,7 +627,7 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 		new_slider_y = sb_top - wp->yoff + (sb_height - slider_height);
 	} else {
 		/* Slider is somewhere in the middle. */
-		new_slider_y = my - wp->yoff - sl_mpos + 1;
+		new_slider_y = my - wp->yoff - sl_mpos;
 	}
 
 	if (TAILQ_FIRST(&wp->modes) == NULL ||


### PR DESCRIPTION
Take into account if the status line is at the top of the screen when calculating the position of the scrollbar.