### PR TITLE
Support synchronized output mode (DECSET 2026) from applications

### DIFF
--- a/format.c
+++ b/format.c
@@ -1947,6 +1947,18 @@ format_cb_origin_flag(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for synchronized_output_flag. */
+static void *
+format_cb_synchronized_output_flag(struct format_tree *ft)
+{
+	if (ft->wp != NULL) {
+		if (ft->wp->base.mode & MODE_SYNC)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
 /* Callback for pane_active. */
 static void *
 format_cb_pane_active(struct format_tree *ft)
@@ -3442,6 +3454,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "start_time", FORMAT_TABLE_TIME,
 	  format_cb_start_time
+	},
+	{ "synchronized_output_flag", FORMAT_TABLE_STRING,
+	  format_cb_synchronized_output_flag
 	},
 	{ "tree_mode_format", FORMAT_TABLE_STRING,
 	  format_cb_tree_mode_format

--- a/input.c
+++ b/input.c
@@ -898,6 +898,8 @@ input_free(struct input_ctx *ictx)
 	evbuffer_free(ictx->since_ground);
 	event_del(&ictx->ground_timer);
 
+	screen_write_stop_sync(ictx->wp);
+
 	free(ictx);
 }
 
@@ -1901,6 +1903,11 @@ input_csi_dispatch_rm_private(struct input_ctx *ictx)
 		case 2031:
 			screen_write_mode_clear(sctx, MODE_THEME_UPDATES);
 			break;
+		case 2026:	/* synchronized output */
+			screen_write_stop_sync(ictx->wp);
+			if (ictx->wp != NULL)
+				ictx->wp->flags |= PANE_REDRAW;
+			break;
 		default:
 			log_debug("%s: unknown '%c'", __func__, ictx->ch);
 			break;
@@ -1998,6 +2005,9 @@ input_csi_dispatch_sm_private(struct input_ctx *ictx)
 			break;
 		case 2031:
 			screen_write_mode_set(sctx, MODE_THEME_UPDATES);
+			break;
+		case 2026:	/* synchronized output */
+			screen_write_start_sync(ictx->wp);
 			break;
 		default:
 			log_debug("%s: unknown '%c'", __func__, ictx->ch);

--- a/regress/synchronized-output.sh
+++ b/regress/synchronized-output.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+
+# Test synchronized output mode (mode 2026)
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+sleep 1
+
+# Start tmux with a shell
+$TMUX -f/dev/null new -d -x40 -y10 || exit 1
+# Wait for shell to be ready
+sleep 2
+
+exit_status=0
+
+# Test 1: synchronized_output_flag should initially be 0
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "0" ]; then
+	echo "[FAIL] Test 1: synchronized_output_flag should initially be 0, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 1: synchronized_output_flag initially 0"
+fi
+
+# Test 2: ESC[?2026h should set synchronized_output_flag to 1
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "1" ]; then
+	echo "[FAIL] Test 2: synchronized_output_flag should be 1 after ESC[?2026h, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 2: synchronized_output_flag set to 1"
+fi
+
+# Test 3: ESC[?2026l should clear synchronized_output_flag to 0
+# First set it again
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.3
+# Then clear it
+$TMUX send-keys "printf '\\033[?2026l'" Enter
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "0" ]; then
+	echo "[FAIL] Test 3: synchronized_output_flag should be 0 after ESC[?2026l, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 3: synchronized_output_flag cleared to 0"
+fi
+
+# Test 4: synchronized_output_flag should auto-clear after timeout (1 second)
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "1" ]; then
+	echo "[FAIL] Test 4a: synchronized_output_flag should be 1, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 4a: synchronized_output_flag set to 1"
+fi
+# Wait for timeout (1 second + buffer)
+sleep 1.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "0" ]; then
+	echo "[FAIL] Test 4b: synchronized_output_flag should auto-clear after timeout, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 4b: synchronized_output_flag auto-cleared after timeout"
+fi
+
+# Test 5: synchronized_output_flag should clear on resize
+# Use resize-window since resize-pane doesn't work with a single pane
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "1" ]; then
+	echo "[FAIL] Test 5a: synchronized_output_flag should be 1, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 5a: synchronized_output_flag set to 1"
+fi
+$TMUX resize-window -x 30 -y 8
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "0" ]; then
+	echo "[FAIL] Test 5b: synchronized_output_flag should clear on resize, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 5b: synchronized_output_flag cleared on resize"
+fi
+
+$TMUX kill-server 2>/dev/null
+sleep 1
+
+# Test 6: Nested BSU is idempotent - multiple BSU calls don't break things
+$TMUX -f/dev/null new -d -x40 -y10 || exit 1
+sleep 2
+
+# Send first BSU
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.3
+# Send second BSU (nested) - timer should reset
+$TMUX send-keys "printf '\\033[?2026h'" Enter
+sleep 0.3
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "1" ]; then
+	echo "[FAIL] Test 6a: synchronized_output_flag should be 1 after nested BSU, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 6a: synchronized_output_flag set after nested BSU"
+fi
+
+# Single ESU should clear the flag
+$TMUX send-keys "printf '\\033[?2026l'" Enter
+sleep 0.5
+flag=$($TMUX display -pF '#{synchronized_output_flag}')
+if [ "$flag" != "0" ]; then
+	echo "[FAIL] Test 6b: synchronized_output_flag should be 0 after single ESU, got: $flag"
+	exit_status=1
+else
+	echo "[PASS] Test 6b: Single ESU clears nested BSU"
+fi
+
+$TMUX kill-server 2>/dev/null
+sleep 1
+
+# Test 7: Content should not appear on screen until sync ends
+$TMUX -f/dev/null new -d -x40 -y10 || exit 1
+sleep 1
+
+# Create a script that outputs content during sync mode
+TMP=$(mktemp)
+trap "rm -f $TMP" 0 1 15
+
+# Send sync start, output test pattern, capture (should be empty), then end sync
+$TMUX send-keys "printf '\\033[?2026h'; printf 'SYNCTEST'; $TMUX capturep -p > $TMP; printf '\\033[?2026l'" Enter
+sleep 1
+
+# Check that SYNCTEST was NOT captured (it was buffered)
+if grep -q "SYNCTEST" "$TMP"; then
+	echo "[FAIL] Test 7: Content appeared before sync ended"
+	exit_status=1
+else
+	echo "[PASS] Test 7: Content buffered during sync mode"
+fi
+
+# Now capture again - content should be visible
+$TMUX capturep -p > $TMP
+if grep -q "SYNCTEST" "$TMP"; then
+	echo "[PASS] Test 8: Content visible after sync ended"
+else
+	echo "[FAIL] Test 8: Content not visible after sync ended"
+	exit_status=1
+fi
+
+$TMUX kill-server 2>/dev/null
+sleep 1
+
+# Test 9: Content should appear after timeout (timer fires)
+$TMUX -f/dev/null new -d -x40 -y10 || exit 1
+sleep 1
+
+TMP2=$(mktemp)
+trap "rm -f $TMP $TMP2" 0 1 15
+
+# Send sync start, output test pattern, capture immediately (should be empty)
+$TMUX send-keys "printf '\\033[?2026h'; printf 'TIMERTEST'; $TMUX capturep -p > $TMP2" Enter
+sleep 0.5
+
+# Check that TIMERTEST was NOT captured (it was buffered)
+if grep -q "TIMERTEST" "$TMP2"; then
+	echo "[FAIL] Test 9a: Content appeared before timeout"
+	exit_status=1
+else
+	echo "[PASS] Test 9a: Content buffered during sync mode"
+fi
+
+# Wait for timeout (1 second + buffer) - don't send ESC[?2026l
+sleep 1.5
+
+# Now capture again - content should be visible after timer fired
+$TMUX capturep -p > $TMP2
+if grep -q "TIMERTEST" "$TMP2"; then
+	echo "[PASS] Test 9b: Content visible after timeout"
+else
+	echo "[FAIL] Test 9b: Content not visible after timeout"
+	exit_status=1
+fi
+
+$TMUX kill-server 2>/dev/null
+
+if [ $exit_status -eq 0 ]; then
+	echo "All tests passed"
+fi
+
+exit $exit_status

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -897,6 +897,9 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	struct grid_cell	 defaults;
 	u_int			 i, j, top, x, y, width;
 
+	if (wp->base.mode & MODE_SYNC)
+		screen_write_stop_sync(wp);
+
 	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
 
 	if (wp->xoff + wp->sx <= ctx->ox || wp->xoff >= ctx->ox + ctx->sx)

--- a/tmux.1
+++ b/tmux.1
@@ -6258,6 +6258,7 @@ The following variables are available, where appropriate:
 .It Li "socket_path" Ta "" Ta "Server socket path"
 .It Li "sixel_support" Ta "" Ta "1 if server has support for SIXEL"
 .It Li "start_time" Ta "" Ta "Server start time"
+.It Li "synchronized_output_flag" Ta "" Ta "1 if pane has synchronized output enabled"
 .It Li "uid" Ta "" Ta "Server UID"
 .It Li "user" Ta "" Ta "Server user"
 .It Li "version" Ta "" Ta "Server version"

--- a/tmux.h
+++ b/tmux.h
@@ -652,6 +652,7 @@ enum tty_code_code {
 #define MODE_CURSOR_BLINKING_SET 0x20000
 #define MODE_KEYS_EXTENDED_2 0x40000
 #define MODE_THEME_UPDATES 0x80000
+#define MODE_SYNC 0x100000
 
 #define ALL_MODES 0xffffff
 #define ALL_MOUSE_MODES (MODE_MOUSE_STANDARD|MODE_MOUSE_BUTTON|MODE_MOUSE_ALL)
@@ -1222,6 +1223,7 @@ struct window_pane {
 
 	struct window_pane_resizes resize_queue;
 	struct event	 resize_timer;
+	struct event	 sync_timer;
 
 	struct input_ctx *ictx;
 
@@ -3144,6 +3146,8 @@ void	 screen_write_preview(struct screen_write_ctx *, struct screen *, u_int,
 void	 screen_write_backspace(struct screen_write_ctx *);
 void	 screen_write_mode_set(struct screen_write_ctx *, int);
 void	 screen_write_mode_clear(struct screen_write_ctx *, int);
+void	 screen_write_start_sync(struct window_pane *);
+void	 screen_write_stop_sync(struct window_pane *);
 void	 screen_write_cursorup(struct screen_write_ctx *, u_int);
 void	 screen_write_cursordown(struct screen_write_ctx *, u_int);
 void	 screen_write_cursorright(struct screen_write_ctx *, u_int);

--- a/window.c
+++ b/window.c
@@ -1001,6 +1001,8 @@ window_pane_destroy(struct window_pane *wp)
 
 	if (event_initialized(&wp->resize_timer))
 		event_del(&wp->resize_timer);
+	if (event_initialized(&wp->sync_timer))
+		event_del(&wp->sync_timer);
 	TAILQ_FOREACH_SAFE(r, &wp->resize_queue, entry, r1) {
 		TAILQ_REMOVE(&wp->resize_queue, r, entry);
 		free(r);
@@ -1079,6 +1081,8 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 
 	if (sx == wp->sx && sy == wp->sy)
 		return;
+
+	screen_write_stop_sync(wp);
 
 	r = xmalloc(sizeof *r);
 	r->sx = sx;


### PR DESCRIPTION
When an application enables synchronized output (`ESC[?2026h`), tmux now defers flushing pane output until the application disables it (`ESC[?2026l`) or a 1 second timeout expires. This reduces tearing for high-frequency updating applications running inside tmux.

The implementation follows the [synchronized output specification](https://github.com/contour-terminal/vt-extensions/blob/master/synchronized-output.md):
- Mode 2026 enables/disables synchronized output
- 1 second timeout prevents hanging if app misbehaves
- Mode is cleared on pane resize
- Redraw cancels sync mode (tmux can always redraw when needed)

This demo is performed in Apple Terminal which _doesn't support_ synchronized output. The demo draws 10 frames with a 0.01s delay between each bar in a frame. In tmux 3.5a, [the output is unbuffered and the frame tears](https://asciinema.org/a/dbZuuSTsO4QyO523Y4Jvvn1rw). With this patch applied, [the output is buffered with no tearing](https://asciinema.org/a/loDOJJicYtr9ZV84EkxrPscb8).

https://github.com/user-attachments/assets/00f4289b-9b36-4d1b-8366-b1901fa2a8cc

## Test plan

`regress/synchronized-output.sh` passes all tests:
- Initial state is 0
- `ESC[?2026h` sets flag to 1
- `ESC[?2026l` clears flag to 0  
- Auto-clear after 1 second timeout
- Clear on window resize
- Nested BSU is idempotent (multiple `ESC[?2026h` don't break things)
- Content buffered during sync mode
- Content visible after sync ends or timeout

🤖 Generated with [Claude Code](https://claude.ai/code)