### PR TITLE
Add "box" option to pane-border-indicators

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -73,7 +73,7 @@ static const char *options_table_pane_status_list[] = {
 	"off", "top", "bottom", NULL
 };
 static const char *options_table_pane_border_indicators_list[] = {
-	"off", "colour", "arrows", "both", NULL
+	"off", "colour", "arrows", "both", "box", NULL
 };
 static const char *options_table_pane_border_lines_list[] = {
 	"single", "double", "heavy", "simple", "number", "spaces", NULL
@@ -1282,8 +1282,9 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_WINDOW,
 	  .choices = options_table_pane_border_indicators_list,
 	  .default_num = PANE_BORDER_COLOUR,
-	  .text = "Whether to indicate the active pane by colouring border or "
-		  "displaying arrow markers."
+	  .text = "Whether to indicate the active pane by colouring border, "
+		  "displaying arrow markers, or drawing a box around the "
+		  "active pane."
 	},
 
 	{ .name = "pane-border-lines",

--- a/options.c
+++ b/options.c
@@ -1244,6 +1244,29 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows)
 			layout_fix_panes(w, NULL);
 	}
+	if (strcmp(name, "pane-border-indicators") == 0) {
+		RB_FOREACH(w, windows, &windows) {
+			TAILQ_FOREACH(wp, &w->panes, entry) {
+				u_int	screen_sx, screen_sy;
+
+				/*
+				 * Resize screen buffer for box mode. The PTY
+				 * size is handled by window_pane_send_resize.
+				 */
+				if (window_pane_box_mode(wp) &&
+				    wp->sx >= 3 && wp->sy >= 3) {
+					screen_sx = wp->sx - 2;
+					screen_sy = wp->sy - 2;
+				} else {
+					screen_sx = wp->sx;
+					screen_sy = wp->sy;
+				}
+				screen_resize(&wp->base, screen_sx, screen_sy,
+				    wp->base.saved_grid == NULL);
+				window_pane_send_resize(wp, wp->sx, wp->sy);
+			}
+		}
+	}
 	if (strcmp(name, "codepoint-widths") == 0)
 		utf8_update_width_cache();
 	if (strcmp(name, "input-buffer-size") == 0)

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -35,6 +35,7 @@ static void	screen_redraw_draw_scrollbar(struct screen_redraw_ctx *,
 		    struct window_pane *, int, int, int, u_int, u_int, u_int);
 static void	screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *,
 		    struct window_pane *);
+static void	screen_redraw_draw_active_box(struct screen_redraw_ctx *);
 
 #define START_ISOLATE "\342\201\246"
 #define END_ISOLATE   "\342\201\251"
@@ -662,11 +663,13 @@ screen_redraw_screen(struct client *c)
 		screen_redraw_draw_borders(&ctx);
 		if (ctx.pane_status != PANE_STATUS_OFF)
 			screen_redraw_draw_pane_status(&ctx);
+		screen_redraw_draw_active_box(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
 	if (flags & CLIENT_REDRAWWINDOW) {
 		log_debug("%s: redrawing panes", c->name);
 		screen_redraw_draw_panes(&ctx);
+		screen_redraw_draw_active_box(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
 	if (ctx.statuslines != 0 &&
@@ -696,8 +699,10 @@ screen_redraw_pane(struct client *c, struct window_pane *wp,
 	tty_sync_start(&c->tty);
 	tty_update_mode(&c->tty, c->tty.mode, NULL);
 
-	if (!redraw_scrollbar_only)
+	if (!redraw_scrollbar_only) {
 		screen_redraw_draw_pane(&ctx, wp);
+		screen_redraw_draw_active_box(&ctx);
+	}
 
 	if (window_pane_show_scrollbar(wp, ctx.pane_scrollbars))
 		screen_redraw_draw_pane_scrollbar(&ctx, wp);
@@ -833,10 +838,19 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	struct client		*c = ctx->c;
 	struct session		*s = c->session;
 	struct window		*w = s->curw->window;
+	struct options		*oo = w->options;
 	struct window_pane	*wp;
 	u_int			 i, j;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
+
+	/*
+	 * Skip drawing pane separator borders when box mode is active,
+	 * since each pane has its own complete box border.
+	 */
+	if (options_get_number(oo, "pane-border-indicators") == PANE_BORDER_BOX &&
+	    TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) != NULL)
+		return;
 
 	TAILQ_FOREACH(wp, &w->panes, entry)
 		wp->border_gc_set = 0;
@@ -844,6 +858,134 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	for (j = 0; j < c->tty.sy - ctx->statuslines; j++) {
 		for (i = 0; i < c->tty.sx; i++)
 			screen_redraw_draw_borders_cell(ctx, i, j);
+	}
+}
+
+/* Draw box border around the active pane. */
+static void
+screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
+{
+	struct client		*c = ctx->c;
+	struct session		*s = c->session;
+	struct window		*w = s->curw->window;
+	struct options		*oo = w->options;
+	struct tty		*tty = &c->tty;
+	struct window_pane	*wp, *active_wp;
+	struct grid_cell	 gc, blank_gc;
+	struct format_tree	*ft;
+	u_int			 i, top, left, right, bottom, tty_top;
+	int			 is_active;
+
+	/* Check if box mode is enabled. */
+	if (options_get_number(oo, "pane-border-indicators") != PANE_BORDER_BOX)
+		return;
+	if (TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) == NULL)
+		return;
+
+	/* Get active pane. */
+	active_wp = server_client_get_pane(c);
+
+	/* Account for status line at top. */
+	if (ctx->statustop)
+		tty_top = ctx->statuslines;
+	else
+		tty_top = 0;
+
+	/* Set up blank cell for inactive pane borders. */
+	memcpy(&blank_gc, &grid_default_cell, sizeof blank_gc);
+	utf8_set(&blank_gc.data, ' ');
+
+	/* Draw border area for all panes. */
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (!window_pane_visible(wp))
+			continue;
+		if (wp->sx < 3 || wp->sy < 3)
+			continue;
+
+		is_active = (wp == active_wp);
+
+		log_debug("%s: %s @%u %%%u active=%d", __func__, c->name,
+		    w->id, wp->id, is_active);
+
+		/* Calculate box position. */
+		left = wp->xoff;
+		right = wp->xoff + wp->sx - 1;
+		top = wp->yoff;
+		bottom = wp->yoff + wp->sy - 1;
+
+		if (is_active) {
+			/* Set up grid cell with active border style. */
+			memcpy(&gc, &grid_default_cell, sizeof gc);
+			ft = format_create_defaults(NULL, c, s, s->curw, wp);
+			style_apply(&gc, oo, "pane-active-border-style", ft);
+			format_free(ft);
+		}
+
+		/* Draw top border. */
+		for (i = left; i <= right; i++) {
+			if (is_active) {
+				if (i == left)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPLEFT, &gc);
+				else if (i == right)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPRIGHT, &gc);
+				else
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
+				tty_cursor(tty, i, tty_top + top);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, i, tty_top + top);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw bottom border. */
+		for (i = left; i <= right; i++) {
+			if (is_active) {
+				if (i == left)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_BOTTOMLEFT, &gc);
+				else if (i == right)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_BOTTOMRIGHT, &gc);
+				else
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
+				tty_cursor(tty, i, tty_top + bottom);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, i, tty_top + bottom);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw left border (excluding corners). */
+		for (i = top + 1; i < bottom; i++) {
+			if (is_active) {
+				screen_redraw_border_set(w, wp, ctx->pane_lines,
+				    CELL_TOPBOTTOM, &gc);
+				tty_cursor(tty, left, tty_top + i);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, left, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw right border (excluding corners). */
+		for (i = top + 1; i < bottom; i++) {
+			if (is_active) {
+				screen_redraw_border_set(w, wp, ctx->pane_lines,
+				    CELL_TOPBOTTOM, &gc);
+				tty_cursor(tty, right, tty_top + i);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, right, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
 	}
 }
 
@@ -896,8 +1038,11 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	struct colour_palette	*palette = &wp->palette;
 	struct grid_cell	 defaults;
 	u_int			 i, j, top, x, y, width;
+	int			 box_mode;
 
-	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
+	box_mode = window_pane_box_mode(wp);
+	log_debug("%s: %s @%u %%%u box=%d", __func__, c->name, w->id, wp->id,
+	    box_mode);
 
 	if (wp->xoff + wp->sx <= ctx->ox || wp->xoff >= ctx->ox + ctx->sx)
 		return;
@@ -905,34 +1050,44 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		top = ctx->statuslines;
 	else
 		top = 0;
-	for (j = 0; j < wp->sy; j++) {
+	for (j = 0; j < (box_mode ? wp->sy - 2 : wp->sy); j++) {
 		if (wp->yoff + j < ctx->oy || wp->yoff + j >= ctx->oy + ctx->sy)
 			continue;
-		y = top + wp->yoff + j - ctx->oy;
 
-		if (wp->xoff >= ctx->ox &&
+		if (box_mode) {
+			/* Box mode: draw at offset position. */
+			y = top + wp->yoff + 1 + j - ctx->oy;
+			i = 0;
+			x = wp->xoff + 1 - ctx->ox;
+			width = wp->sx - 2;
+		} else if (wp->xoff >= ctx->ox &&
 		    wp->xoff + wp->sx <= ctx->ox + ctx->sx) {
 			/* All visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = 0;
 			x = wp->xoff - ctx->ox;
 			width = wp->sx;
 		} else if (wp->xoff < ctx->ox &&
 		    wp->xoff + wp->sx > ctx->ox + ctx->sx) {
 			/* Both left and right not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = ctx->ox;
 			x = 0;
 			width = ctx->sx;
 		} else if (wp->xoff < ctx->ox) {
 			/* Left not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = ctx->ox - wp->xoff;
 			x = 0;
 			width = wp->sx - i;
 		} else {
 			/* Right not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = 0;
 			x = wp->xoff - ctx->ox;
 			width = ctx->sx - x;
 		}
+
 		log_debug("%s: %s %%%u line %u,%u at %u,%u, width %u",
 		    __func__, c->name, wp->id, i, j, x, y, width);
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -986,6 +986,37 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
 			}
 		}
+
+		/*
+		 * Clear separator column to the right of this pane. This is
+		 * the column that normally holds the pane separator border.
+		 */
+		if (wp->xoff + wp->sx < w->sx) {
+			for (i = top; i <= bottom; i++) {
+				tty_cursor(tty, wp->xoff + wp->sx, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+		}
+
+		/*
+		 * Clear separator row below this pane. This is the row that
+		 * normally holds the pane separator border.
+		 */
+		if (wp->yoff + wp->sy < w->sy) {
+			for (i = left; i <= right; i++) {
+				tty_cursor(tty, i, tty_top + wp->yoff + wp->sy);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+			/* Also clear the corner where separators meet. */
+			if (wp->xoff + wp->sx < w->sx) {
+				tty_cursor(tty, wp->xoff + wp->sx,
+				    tty_top + wp->yoff + wp->sy);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+		}
 	}
 }
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -161,6 +161,12 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	ttyctx->xoff = ttyctx->rxoff = wp->xoff;
 	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
 
+	/* Apply box mode offset for content positioning. */
+	if (window_pane_box_mode(wp)) {
+		ttyctx->xoff += 1;
+		ttyctx->yoff += 1;
+	}
+
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
 

--- a/server-client.c
+++ b/server-client.c
@@ -2949,14 +2949,25 @@ server_client_reset_state(struct client *c)
 		}
 		cx = c->prompt_cursor;
 	} else if (c->overlay_draw == NULL) {
+		u_int	pxoff, pyoff;
+
 		cursor = 0;
 		tty_window_offset(tty, &ox, &oy, &sx, &sy);
-		if (wp->xoff + s->cx >= ox && wp->xoff + s->cx <= ox + sx &&
-		    wp->yoff + s->cy >= oy && wp->yoff + s->cy <= oy + sy) {
+
+		/* Account for box mode offset. */
+		pxoff = wp->xoff;
+		pyoff = wp->yoff;
+		if (window_pane_box_mode(wp)) {
+			pxoff += 1;
+			pyoff += 1;
+		}
+
+		if (pxoff + s->cx >= ox && pxoff + s->cx <= ox + sx &&
+		    pyoff + s->cy >= oy && pyoff + s->cy <= oy + sy) {
 			cursor = 1;
 
-			cx = wp->xoff + s->cx - ox;
-			cy = wp->yoff + s->cy - oy;
+			cx = pxoff + s->cx - ox;
+			cy = pyoff + s->cy - oy;
 
 			if (status_at_line(c) == 0)
 				cy += status_line_size(c);

--- a/tmux.1
+++ b/tmux.1
@@ -5096,10 +5096,17 @@ but set the starting index for pane numbers.
 Set the text shown in pane border status lines.
 .Pp
 .It Xo Ic pane-border-indicators
-.Op Ic off | colour | arrows | both
+.Op Ic off | colour | arrows | both | box
 .Xc
 Indicate active pane by colouring only half of the border in windows with
-exactly two panes, by displaying arrow markers, by drawing both or neither.
+exactly two panes, by displaying arrow markers, by drawing both, by drawing
+a complete box around the active pane, or neither.
+When
+.Ic box
+is used, all panes display content inset by one character from each edge
+to prevent content reflow when switching between panes.
+The box border is only drawn around the active pane.
+Panes smaller than 3x3 do not show a box border.
 .Pp
 .It Ic pane-border-lines Ar type
 Set the type of characters used for drawing pane borders.

--- a/tmux.h
+++ b/tmux.h
@@ -1038,6 +1038,7 @@ enum pane_lines {
 #define PANE_BORDER_COLOUR 1
 #define PANE_BORDER_ARROWS 2
 #define PANE_BORDER_BOTH 3
+#define PANE_BORDER_BOX 4
 
 /* Mode returned by window_pane_mode function. */
 #define WINDOW_PANE_NO_MODE 0
@@ -3258,6 +3259,7 @@ struct window_pane *window_add_pane(struct window *, struct window_pane *,
 		     u_int, int);
 void		 window_resize(struct window *, u_int, u_int, int, int);
 void		 window_pane_send_resize(struct window_pane *, u_int, u_int);
+int		 window_pane_box_mode(struct window_pane *);
 int		 window_zoom(struct window_pane *);
 int		 window_unzoom(struct window *, int);
 int		 window_push_zoom(struct window *, int, int);

--- a/tty.c
+++ b/tty.c
@@ -995,6 +995,12 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 		cx = wp->xoff + wp->screen->cx;
 		cy = wp->yoff + wp->screen->cy;
 
+		/* Account for box mode offset. */
+		if (window_pane_box_mode(wp)) {
+			cx += 1;
+			cy += 1;
+		}
+
 		if (cx < *sx)
 			*ox = 0;
 		else if (cx > w->sx - *sx)


### PR DESCRIPTION
Add a new "box" option for `pane-border-indicators` that draws a complete box border around the active pane instead of using shared separator borders between panes.

- Add `PANE_BORDER_BOX` constant and `window_pane_box_mode()` helper function
- Reduce internal screen buffer and PTY by 2 in each dimension to reserve space for box borders
- Offset pane content drawing by 1 to account for box border
- Adjust cursor positioning for box mode offset
- Draw styled box border for active pane, blank borders for inactive panes
- Skip normal pane separator borders when box mode is active
- Clear separator cells between panes that would otherwise show old borders

---

Hey @nicm - There's still a bit of polish I want to add before submitting it for a full review, but I wanted to share this draft with you on the off chance that you may be interested in a fully implemented version of this being added to `tmux/tmux`. 

I have a heck of a time determining which pane is in focus when there are multiple panes in a window. The default boarder behavior trips me up. Updating my config to make the unfocused panes to be dimmed helped, but whenever panes have neovim open in them those panes aren't dimmed which leads to me still being unsure which pane is focused. So I decided to take a crack at adding support for adding a frame around all sides of the focused panel. 

Here's a screencast showing the current behavior of this PR.

https://github.com/user-attachments/assets/45e0a432-a0ad-4c5e-80fc-9fb643a4a724

