### PR TITLE
Add F1 help key binding to choose modes

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -133,6 +133,32 @@ static const struct menu_item mode_tree_menu_items[] = {
 	{ NULL, KEYC_NONE, NULL }
 };
 
+static const char mode_tree_help_text[] =
+	"Up, k              Move cursor up\n"
+	"Down, j            Move cursor down\n"
+	"g                  Go to top\n"
+	"G                  Go to bottom\n"
+	"PgUp, C-b          Page up\n"
+	"PgDn, C-f          Page down\n"
+	"Left, h            Collapse item\n"
+	"Right, l           Expand item\n"
+	"M--                Collapse all items\n"
+	"M-+                Expand all items\n"
+	"t                  Toggle item tag\n"
+	"T                  Untag all items\n"
+	"C-t                Tag all items\n"
+	"/                  Search forward\n"
+	"?                  Search backward\n"
+	"n                  Repeat search forward\n"
+	"N                  Repeat search backward\n"
+	"f                  Filter items\n"
+	"O                  Change sort order\n"
+	"r                  Reverse sort order\n"
+	"v                  Toggle preview\n"
+	"q, Escape          Exit mode\n"
+	"\n"
+	"Press any key to close";
+
 static int
 mode_tree_is_lowercase(const char *ptr)
 {
@@ -1132,6 +1158,27 @@ mode_tree_display_menu(struct mode_tree_data *mtd, struct client *c, u_int x,
 	}
 }
 
+static void
+mode_tree_display_help(__unused struct mode_tree_data *mtd, struct client *c)
+{
+	struct session	*s = c->session;
+	char		*cmd;
+	u_int		 px, py, w, h;
+
+	w = 37;
+	h = 26;
+	if (c->tty.sx < w || c->tty.sy < h)
+		return;
+	px = (c->tty.sx - w) / 2;
+	py = (c->tty.sy - h) / 2;
+
+	xasprintf(&cmd, "cat <<'EOF'\n%s\nEOF", mode_tree_help_text);
+	if (popup_display(POPUP_CLOSEANYKEY, BOX_LINES_DEFAULT, NULL, px, py,
+	    w, h, NULL, cmd, 0, NULL, NULL, "Key Bindings", c, s, NULL, NULL,
+	    NULL, NULL) != 0)
+		free(cmd);
+}
+
 int
 mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
     struct mouse_event *m, u_int *xp, u_int *yp)
@@ -1202,6 +1249,10 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 	case '\033': /* Escape */
 	case 'g'|KEYC_CTRL:
 		return (1);
+	case KEYC_F1:
+	case 'h'|KEYC_CTRL:
+		mode_tree_display_help(mtd, c);
+		break;
 	case KEYC_UP:
 	case 'k':
 	case KEYC_WHEELUP_PANE:

--- a/tmux.1
+++ b/tmux.1
@@ -2664,6 +2664,8 @@ The following keys may be used in client mode:
 .It Li "O" Ta "Change sort field"
 .It Li "r" Ta "Reverse sort order"
 .It Li "v" Ta "Toggle preview"
+.It Li "F1" Ta "Display help"
+.It Li "C-h" Ta "Display help"
 .It Li "q" Ta "Exit mode"
 .El
 .Pp
@@ -2752,6 +2754,8 @@ The following keys may be used in tree mode:
 .It Li "O" Ta "Change sort field"
 .It Li "r" Ta "Reverse sort order"
 .It Li "v" Ta "Toggle preview"
+.It Li "F1" Ta "Display help"
+.It Li "C-h" Ta "Display help"
 .It Li "q" Ta "Exit mode"
 .El
 .Pp
@@ -2827,6 +2831,8 @@ The following keys may be used in customize mode:
 .It Li "C-t" Ta "Tag all items"
 .It Li "f" Ta "Enter a format to filter items"
 .It Li "v" Ta "Toggle option information"
+.It Li "F1" Ta "Display help"
+.It Li "C-h" Ta "Display help"
 .It Li "q" Ta "Exit mode"
 .El
 .Pp
@@ -7226,6 +7232,8 @@ The following keys may be used in buffer mode:
 .It Li "O" Ta "Change sort field"
 .It Li "r" Ta "Reverse sort order"
 .It Li "v" Ta "Toggle preview"
+.It Li "F1" Ta "Display help"
+.It Li "C-h" Ta "Display help"
 .It Li "q" Ta "Exit mode"
 .El
 .Pp


### PR DESCRIPTION
### Problem

Users find it difficult to discover key bindings for choose modes (choose-tree, choose-buffer, choose-client, customize-mode) without consulting the manual.

Fixes #4357

### Solution

Add an F1 key binding that displays a help menu showing all available key bindings in choose modes. The menu lists navigation, selection, tagging, searching, and sorting keys.

### Key Choice

F1 was chosen because the more intuitive alternatives are already in use:

- `h` - Used for collapse/left navigation (same as Left arrow)
- `?` - Used for forward search (same as `/`)
- `H` - Used in window-tree.c to jump to the current pane ("Home")

F1 is a conventional help key that doesn't conflict with existing bindings.

### Testing

1. Start tmux: `tmux new-session`
2. Enter choose-tree mode: `Ctrl+b w`
3. Press `F1` to see the help menu
4. Press `q` or `Escape` to close the help menu