### PR TITLE
Fix unsafe event_once(-1) timeout call

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -173,7 +173,9 @@ alerts_queue(struct window *w, int flags)
 
 		if (!alerts_fired) {
 			log_debug("alerts check queued (by @%u)", w->id);
-			event_once(-1, EV_TIMEOUT, alerts_callback, NULL, NULL);
+			struct timeval tv = {0, 0};
+			evtimer_once(alerts_callback, NULL, &tv);
+
 			alerts_fired = 1;
 		}
 	}


### PR DESCRIPTION
Using event_once with fd = -1 is not portable across all libevent versions and can cause the timeout callback to fail to fire. I replaced it with a proper evtimer based timeout to ensure a a consistent behavior

Was originally:
`event_once(-1, EV_TIMEOUT, alerts_callback, NULL, NULL);`
Now:
`struct timeval tv = {0, 0};`
`evtimer_once(alerts_callback, NULL, &tv);`

