### PR TITLE
Updated README file to show libncurses-dev as a required package

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -43,7 +43,7 @@ For more detailed instructions on building and installing tmux, see
 ### From version control
 
 To get and build the latest from version control - note that this requires
-`autoconf`, `automake` and `pkg-config`:
+`autoconf`, `automake`, `libncurses-dev` and `pkg-config`:
 
 ~~~bash
 git clone https://github.com/tmux/tmux.git


### PR DESCRIPTION
Somehow Debian 13 doesn't ship with libncurses-dev, I added that to README to make notice of it being required
