### PR TITLE
Add prompt-command-cursor-style option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -970,6 +970,15 @@ const struct options_table_entry options_table[] = {
 	  .text = "Style of the cursor when in the command prompt."
 	},
 
+	{ .name = "prompt-command-cursor-style",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_cursor_style_list,
+	  .default_num = 0,
+	  .text = "Style of the cursor in the command prompt when in command "
+		  "mode, if 'status-keys' is set to 'vi'."
+	},
+
 	{ .name = "session-status-current-style",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_WINDOW,

--- a/status.c
+++ b/status.c
@@ -804,7 +804,10 @@ status_prompt_redraw(struct client *c)
 
 	n = options_get_number(s->options, "prompt-cursor-colour");
 	sl->active->default_ccolour = n;
-	n = options_get_number(s->options, "prompt-cursor-style");
+	if (c->prompt_mode == PROMPT_COMMAND)
+		n = options_get_number(s->options, "prompt-command-cursor-style");
+	else
+		n = options_get_number(s->options, "prompt-cursor-style");
 	screen_set_cursor_style(n, &sl->active->default_cstyle,
 	    &sl->active->default_mode);
 

--- a/tmux.1
+++ b/tmux.1
@@ -4696,6 +4696,12 @@ Set the style of the cursor in the command prompt.
 See the
 .Ic cursor-style
 options for available styles.
+.It Ic prompt-command-cursor-style Ar style
+Set the style of the cursor in the command prompt when vi keys are enabled and
+the prompt is in command mode.
+See the
+.Ic cursor-style
+options for available styles.
 .It Xo Ic renumber-windows
 .Op Ic on | off
 .Xc


### PR DESCRIPTION
This PR adds prompt-command-cursor-style to let you set the cursor style separately in insert/normal mode in the command prompt when status-keys is vi.

This lets the cursor shape act as a lightweight mode indicator without needing different colours or prompt styles. This is done in neovim by default too.