### PR TITLE
Fix cursor position after escape with status-keys vi

### DIFF
--- a/status.c
+++ b/status.c
@@ -936,6 +936,8 @@ status_prompt_translate_key(struct client *c, key_code key, key_code *new_key)
 			return (1);
 		case '\033': /* Escape */
 			c->prompt_mode = PROMPT_COMMAND;
+			if (c->prompt_index != 0)
+				c->prompt_index--;
 			c->flags |= CLIENT_REDRAWSTATUS;
 			return (0);
 		}
@@ -961,9 +963,10 @@ status_prompt_translate_key(struct client *c, key_code key, key_code *new_key)
 		*new_key = 'u'|KEYC_CTRL;
 		return (1);
 	case 'i':
-	case '\033': /* Escape */
 		c->prompt_mode = PROMPT_ENTRY;
 		c->flags |= CLIENT_REDRAWSTATUS;
+		return (0);
+	case '\033': /* Escape */
 		return (0);
 	}
 


### PR DESCRIPTION
When using status-keys vi, pressing Escape to enter prompt command mode now moves the cursor left by one, matching vi.