### PR TITLE
Add focus-follows-mouse session option

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -664,6 +664,13 @@ const struct options_table_entry options_table[] = {
 	  .text = "Time for which status line messages should appear."
 	},
 
+	{ .name = "focus-follows-mouse",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 0,
+	  .text = "Whether moving the mouse into a pane selects it."
+	},
+
 	{ .name = "history-limit",
 	  .type = OPTIONS_TABLE_NUMBER,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/tmux.1
+++ b/tmux.1
@@ -4242,6 +4242,12 @@ passed through to applications running in
 .Nm .
 Attached clients should be detached and attached again after changing this
 option.
+.It Xo Ic focus-follows-mouse
+.Op Ic on | off
+.Xc
+When enabled and
+.Ic mouse
+is on, moving the mouse into a pane selects it.
 .It Xo Ic get-clipboard
 .Op Ic both | request | buffer | off
 .Xc


### PR DESCRIPTION
Implements the feature requested in #782. Adds a new session option `focus-follows-mouse` that automatically selects a pane when the mouse moves over it.

Requires the mouse option to be enabled. Uses all-motion mouse mode (1003h) to receive movement events without requiring a button press.