### PR TITLE
Add format for selection mode.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+CHANGES FROM 3.6a TO 3.7
+
+* Add format for selection mode (from Mike Jonkmans).
+
 CHANGES FROM 3.6 TO 3.6a
 
 * Fix a buffer overread and an infinite loop in format processing (reported by

--- a/tmux.1
+++ b/tmux.1
@@ -6226,6 +6226,7 @@ The following variables are available, where appropriate:
 .It Li "selection_active" Ta "" Ta "1 if selection started and changes with the cursor in copy mode"
 .It Li "selection_end_x" Ta "" Ta "X position of the end of the selection"
 .It Li "selection_end_y" Ta "" Ta "Y position of the end of the selection"
+.It Li "selection_mode" Ta "" Ta "Selection mode"
 .It Li "selection_present" Ta "" Ta "1 if selection started in copy mode"
 .It Li "selection_start_x" Ta "" Ta "X position of the start of the selection"
 .It Li "selection_start_y" Ta "" Ta "Y position of the start of the selection"

--- a/window-copy.c
+++ b/window-copy.c
@@ -956,6 +956,18 @@ window_copy_formats(struct window_mode_entry *wme, struct format_tree *ft)
 		format_add(ft, "selection_present", "0");
 	}
 
+	switch (data->selflag) {
+	case SEL_CHAR:
+		format_add(ft, "selection_mode", "char");
+		break;
+	case SEL_WORD:
+		format_add(ft, "selection_mode", "word");
+		break;
+	case SEL_LINE:
+		format_add(ft, "selection_mode", "line");
+		break;
+	}
+
 	format_add(ft, "search_present", "%d", data->searchmark != NULL);
 	format_add(ft, "search_timed_out", "%d", data->timeout);
 	if (data->searchcount != -1) {


### PR DESCRIPTION
Add format for selection mode.
Could be used as:
set -g pane-border-format ' #T pane#P=#D #{s|/dev/||:pane_tty} '
set -ag pane-border-format '#{pane_width}x#{pane_height} '
set -ag pane-border-format '#{?alternate_on,ALT }'
set -ag pane-border-format '#{?mouse_any_flag,MAF }'
set -ag pane-border-format '#{?pane_active,FOC }'
set -ag pane-border-format '#{?pane_in_mode,#{s|-mode$||:pane_mode} '
set -ag pane-border-format '#{?selection_active,#{?rectangle_toggle,R,#{selection_mode}}-SEL}#{?selection_present,+} }'