### PR TITLE
Move the escape logic outside the loop in cmd_list_print

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -681,6 +681,9 @@ cmd_list_print(const struct cmd_list *cmdlist, int escaped)
 	struct cmd	*cmd, *next;
 	char		*buf, *this;
 	size_t		 len;
+	const char	*separator;     
+	const char	*single_separator = escaped ? " \\; " : " ; ";
+	const char	*double_separator = escaped ? " \\;\\; " : " ;; ";
 
 	len = 1;
 	buf = xcalloc(1, len);
@@ -696,16 +699,11 @@ cmd_list_print(const struct cmd_list *cmdlist, int escaped)
 		next = TAILQ_NEXT(cmd, qentry);
 		if (next != NULL) {
 			if (cmd->group != next->group) {
-				if (escaped)
-					strlcat(buf, " \\;\\; ", len);
-				else
-					strlcat(buf, " ;; ", len);
+				separator = double_separator;
 			} else {
-				if (escaped)
-					strlcat(buf, " \\; ", len);
-				else
-					strlcat(buf, " ; ", len);
+				separator = single_separator;
 			}
+			strlcat(buf, separator, len);
 		}
 
 		free(this);


### PR DESCRIPTION
Readability improvement and marginal speedup. No visible changes in the behavior.

* Avoid nested `if`
* Give names to string constants for more readability
* Use one `strlcat` instead of four
* Check `escaped` only outside the loop