### PR TITLE
feat(run-shell): add argument interpolation to shell command execution

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -7481,13 +7481,9 @@ are provided, they are interpolated into the shell command:
 is replaced by the first argument,
 .Ql %2
 by the second, and so on.
-If additional
-.Ar arguments
-are provided, they are interpolated into the shell command:
-.Ql %1
-is replaced by the first argument,
-.Ql %2
-by the second, and so on.
+Standard format syntax (such as
+.Ql #{1} )
+may also be used.
 With
 .Fl b ,
 the command is run in the background.

--- a/tmux.1
+++ b/tmux.1
@@ -7457,7 +7457,7 @@ option.
 .Op Fl c Ar start-directory
 .Op Fl d Ar delay
 .Op Fl t Ar target-pane
-.Op Ar shell-command
+.Op Ar shell-command Op Ar arguments
 .Xc
 .D1 Pq alias: Ic run
 Execute
@@ -7474,6 +7474,20 @@ Before being executed,
 is expanded using the rules specified in the
 .Sx FORMATS
 section.
+If additional
+.Ar arguments
+are provided, they are interpolated into the shell command:
+.Ql %1
+is replaced by the first argument,
+.Ql %2
+by the second, and so on.
+If additional
+.Ar arguments
+are provided, they are interpolated into the shell command:
+.Ql %1
+is replaced by the first argument,
+.Ql %2
+by the second, and so on.
 With
 .Fl b ,
 the command is run in the background.

--- a/tmux.h
+++ b/tmux.h
@@ -2333,6 +2333,7 @@ char		*paste_make_sample(struct paste_buffer *);
 #define FORMAT_NOJOBS 0x4
 #define FORMAT_VERBOSE 0x8
 #define FORMAT_LAST 0x10
+#define FORMAT_ARGS 0x20
 #define FORMAT_NONE 0
 #define FORMAT_PANE 0x80000000U
 #define FORMAT_WINDOW 0x40000000U
@@ -2381,6 +2382,7 @@ char		*format_grid_word(struct grid *, u_int, u_int);
 char		*format_grid_hyperlink(struct grid *, u_int, u_int,
 		     struct screen *);
 char		*format_grid_line(struct grid *, u_int);
+void		 format_set_flags(struct format_tree *, int);
 
 /* format-draw.c */
 void		 format_draw(struct screen_write_ctx *,


### PR DESCRIPTION
- Update usage message to reflect support for multiple command arguments

I think this is sufficient to cover everything that was requested in https://github.com/tmux/tmux/issues/4784