### PR TITLE
feat(list-x): Adding -O flag to list-x and switch-client commands

### DIFF
--- a/sort.c
+++ b/sort.c
@@ -197,10 +197,11 @@ sort_pane_cmp(const void *a0, const void *b0)
 	case SORT_CREATION:
 		result = a->id - b->id;
 		break;
+	case SORT_SIZE:
+		result = a->sx * a->sy - b->sx * b->sy;
 	case SORT_INDEX:
 	case SORT_NAME:
 	case SORT_ORDER:
-	case SORT_SIZE:
 	case SORT_END:
 		break;
 	}
@@ -258,8 +259,10 @@ sort_winlink_cmp(const void *a0, const void *b0)
 	case SORT_NAME:
 		result = strcmp(wa->name, wb->name);
 		break;
-	case SORT_ORDER:
 	case SORT_SIZE:
+		result = wa->xpixel * wa->ypixel - wb->xpixel * wb->ypixel;
+		break;
+	case SORT_ORDER:
 	case SORT_END:
 		break;
 	}

--- a/sort.c
+++ b/sort.c
@@ -235,6 +235,16 @@ sort_winlink_cmp(const void *a0, const void *b0)
 	case SORT_INDEX:
 		result = wla->idx - wlb->idx;
 		break;
+	case SORT_CREATION:
+		if (timercmp(&wa->creation_time, &wb->creation_time, >)) {
+			result = -1;
+			break;
+		}
+		if (timercmp(&wa->creation_time, &wb->creation_time, <)) {
+			result = 1;
+			break;
+		}
+		break;
 	case SORT_ACTIVITY:
 		if (timercmp(&wa->activity_time, &wb->activity_time, >)) {
 			result = -1;
@@ -248,7 +258,6 @@ sort_winlink_cmp(const void *a0, const void *b0)
 	case SORT_NAME:
 		result = strcmp(wa->name, wb->name);
 		break;
-	case SORT_CREATION:
 	case SORT_ORDER:
 	case SORT_SIZE:
 	case SORT_END:

--- a/sort.c
+++ b/sort.c
@@ -200,19 +200,18 @@ sort_pane_cmp(const void *a0, const void *b0)
 	case SORT_SIZE:
 		result = a->sx * a->sy - b->sx * b->sy;
 	case SORT_INDEX:
+		window_pane_index(a, &ai);
+		window_pane_index(b, &bi);
+		result = ai - bi;
 	case SORT_NAME:
+		result = strcmp(a->screen->title, b->screen->title);
 	case SORT_ORDER:
 	case SORT_END:
 		break;
 	}
+
 	if (result == 0) {
-		/*
-		 * Panes don't have names, so use number order for any other
-		 * sort field.
-		 */
-		window_pane_index(a, &ai);
-		window_pane_index(b, &bi);
-		result = ai - bi;
+		result = strcmp(a->screen->title, b->screen->title);
 	}
 
 	if (sort_crit->reversed)
@@ -307,7 +306,8 @@ sort_order_from_string(const char* order)
 			return (SORT_CREATION);
 		if (strcasecmp(order, "index") == 0)
 			return (SORT_INDEX);
-		if (strcasecmp(order, "name") == 0)
+		if (strcasecmp(order, "name") == 0 ||
+		    strcasecmp(order, "title") == 0)
 			return (SORT_NAME);
 		if (strcasecmp(order, "order") == 0)
 			return (SORT_ORDER);

--- a/tmux.1
+++ b/tmux.1
@@ -3092,7 +3092,9 @@ See the
 section.
 .Fl O
 specifies the sort order: one of
-.Ql name ,
+.Ql title
+(screen title),
+.Ql index ,
 .Ql size
 (area),
 .Ql creation

--- a/tmux.1
+++ b/tmux.1
@@ -3093,6 +3093,8 @@ section.
 .Fl O
 specifies the sort order: one of
 .Ql name ,
+.Ql size
+(area),
 .Ql creation
 (time), or
 .Ql activity
@@ -3125,6 +3127,8 @@ section.
 specifies the sort order: one of
 .Ql index ,
 .Ql name ,
+.Ql size
+(area),
 .Ql creation
 (time),
 or

--- a/tmux.1
+++ b/tmux.1
@@ -3125,6 +3125,8 @@ section.
 specifies the sort order: one of
 .Ql index ,
 .Ql name ,
+.Ql creation
+(time),
 or
 .Ql activity
 (time).

--- a/tmux.h
+++ b/tmux.h
@@ -1285,6 +1285,7 @@ struct window {
 	struct event		 offset_timer;
 
 	struct timeval		 activity_time;
+	struct timeval		 creation_time;
 
 	struct window_pane	*active;
 	struct window_panes 	 last_panes;

--- a/window.c
+++ b/window.c
@@ -328,6 +328,9 @@ window_create(u_int sx, u_int sy, u_int xpixel, u_int ypixel)
 	RB_INSERT(windows, &windows, w);
 
 	window_set_fill_character(w);
+
+	if (gettimeofday(&w->creation_time, NULL) != 0)
+		fatal("gettimeofday failed");
 	window_update_activity(w);
 
 	log_debug("%s: @%u create %ux%u (%ux%u)", __func__, w->id, sx, sy,


### PR DESCRIPTION
This is an implementation of issue [#4811](https://github.com/orgs/tmux/discussions/4811) to add the -O sorting flag to the commands `switch-client`, `list-windows`, `list-sessions`, and `list-panes`.

**This pr is currently a draft and not ready to merge.**
 I wanted to show the approach I'm taking to make sure it is acceptable before committing to it. I also have some questions about how a change to the `switch-client` internals could/should affect the `detach-on-destroy` option.

I have ported over the sorting machinery from `choose-session` into `list-sessions`. Is this an acceptable solution? If so, would an abstraction around sorting be desired as this would spray similar logic over 4+ files.

As for `switch-client`, my thought was to alter the api of `session_next_session` and `session_previous_session` to take a sort_criterion parameter (or other relevant context) and do something similar to what i plan on doing in the `list-x` commands. A side effect would be that `detach-on-destroy` would basically inherit the -O flag. If it is not desirable to change the `session-x` api then im guessing i would have to abandon those calls in `switch-client` to do sorting in cmd_switch_client_exec.

I look forward to feedback. Thanks!