### PR TITLE
fix slow escapetime on startup

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -959,8 +959,8 @@ partial_key:
 	    (tty->flags & TTY_ALL_REQUEST_FLAGS) != TTY_ALL_REQUEST_FLAGS) ||
 	    !TAILQ_EMPTY(&c->input_requests)) {
 		log_debug("%s: increasing delay for active query", c->name);
-		if (delay < 500)
-			delay = 500;
+		int min_delay = len == 1 && *buf == '\033' ? 100 : 500;
+		delay = MAX(min_delay, delay);
 	}
 	tv.tv_sec = delay / 1000;
 	tv.tv_usec = (delay % 1000) * 1000L;


### PR DESCRIPTION
tmux queries some stuff from the terminal and meanwhile `escape-time` is essentially replaced with 500ms. I find this annoying when opening a tmux popup running tmux for persistence and I hit escape in my prompt to edit vi normal mode.

```
# tmux.conf:
set -g escape-time 1

# start tmux
tmux -f tmux.conf new

# start nested tmux
tmux display-popup -E tmux -f tmux.conf new cat

# hit escape: noticeable delay
```

My proposed solution is to avoid applying the 500ms wait when escape is the only key pressed and instead apply a much lower 100ms (or escape-time if it is higher).

I am making a guess that the slow part of the response is silence and then once escape is sent it should not take very long for the rest of the terminal response to come through.