### PR TITLE
Set PANE_STYLECHANGED when user options change

### DIFF
--- a/options.c
+++ b/options.c
@@ -1226,6 +1226,10 @@ options_push_changes(const char *name)
 		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
 			wp->flags |= (PANE_STYLECHANGED|PANE_THEMECHANGED);
 	}
+	if (*name == '@') {
+		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
+			wp->flags |= PANE_STYLECHANGED;
+	}
 	if (strcmp(name, "pane-colours") == 0) {
 		RB_FOREACH(wp, window_pane_tree, &all_window_panes)
 			colour_palette_from_option(&wp->palette, wp->options);


### PR DESCRIPTION
When a user variable is modified, set PANE_STYLECHANGED on all panes so
that window-style and window-active-style are re-evaluated. This fixes
hot-reloading of window styles that reference user variables via format
strings.