### PR TITLE
Re-evaluate copy-mode styles when user options change

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -2684,13 +2684,25 @@ server_client_handle_key(struct client *c, struct key_event *event)
 void
 server_client_loop(void)
 {
-	struct client		*c;
-	struct window		*w;
-	struct window_pane	*wp;
+	struct client			*c;
+	struct window			*w;
+	struct window_pane		*wp;
+	struct window_mode_entry	*wme;
 
 	/* Check for window resize. This is done before redrawing. */
 	RB_FOREACH(w, windows, &windows)
 		server_client_check_window_resize(w);
+
+	/* Notify modes that pane styles may have changed. */
+	RB_FOREACH(w, windows, &windows) {
+		TAILQ_FOREACH(wp, &w->panes, entry) {
+			if (wp->flags & PANE_STYLECHANGED) {
+				wme = TAILQ_FIRST(&wp->modes);
+				if (wme != NULL && wme->mode->style_changed != NULL)
+					wme->mode->style_changed(wme);
+			}
+		}
+	}
 
 	/* Check clients. */
 	TAILQ_FOREACH(c, &clients, entry) {

--- a/tmux.h
+++ b/tmux.h
@@ -1101,6 +1101,7 @@ struct window_mode {
 	void		 (*free)(struct window_mode_entry *);
 	void		 (*resize)(struct window_mode_entry *, u_int, u_int);
 	void		 (*update)(struct window_mode_entry *);
+	void		 (*style_changed)(struct window_mode_entry *);
 	void		 (*key)(struct window_mode_entry *, struct client *,
 			     struct session *, struct winlink *, key_code,
 			     struct mouse_event *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -51,6 +51,7 @@ static void	window_copy_redraw_selection(struct window_mode_entry *, u_int);
 static void	window_copy_redraw_lines(struct window_mode_entry *, u_int,
 		    u_int);
 static void	window_copy_redraw_screen(struct window_mode_entry *);
+static void	window_copy_style_changed(struct window_mode_entry *);
 static void	window_copy_write_line(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int);
 static void	window_copy_write_lines(struct window_mode_entry *,
@@ -158,6 +159,7 @@ const struct window_mode window_copy_mode = {
 	.init = window_copy_init,
 	.free = window_copy_free,
 	.resize = window_copy_resize,
+	.style_changed = window_copy_style_changed,
 	.key_table = window_copy_key_table,
 	.command = window_copy_command,
 	.formats = window_copy_formats,
@@ -170,6 +172,7 @@ const struct window_mode window_view_mode = {
 	.init = window_copy_view_init,
 	.free = window_copy_free,
 	.resize = window_copy_resize,
+	.style_changed = window_copy_style_changed,
 	.key_table = window_copy_key_table,
 	.command = window_copy_command,
 	.formats = window_copy_formats,
@@ -4593,6 +4596,18 @@ window_copy_redraw_screen(struct window_mode_entry *wme)
 	struct window_copy_mode_data	*data = wme->data;
 
 	window_copy_redraw_lines(wme, 0, screen_size_y(&data->screen));
+}
+
+static void
+window_copy_style_changed(struct window_mode_entry *wme)
+{
+	struct window_copy_mode_data	*data = wme->data;
+
+	/* Refresh selection with new style if active. */
+	if (data->screen.sel != NULL)
+		window_copy_set_selection(wme, 0, 1);
+
+	window_copy_redraw_screen(wme);
 }
 
 static void


### PR DESCRIPTION
Copy mode styles (copy-mode-selection-style, etc.) were not updating when a user variable they referenced changed because the mode screen content was pre-rendered and not refreshed on style changes.