### PR TITLE
Also check PANE_STATUSREADY for pane_dead format to match pane_dead_status.

### DIFF
--- a/format.c
+++ b/format.c
@@ -2012,8 +2012,10 @@ format_cb_pane_bottom(struct format_tree *ft)
 static void *
 format_cb_pane_dead(struct format_tree *ft)
 {
-	if (ft->wp != NULL) {
-		if (ft->wp->fd == -1)
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL) {
+		if (wp->fd == -1 && (wp->flags & PANE_STATUSREADY))
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}


### PR DESCRIPTION
A pane is dead when its fd is closed (fd == -1) and its exit status is available
(PANE_STATUSREADY). This avoids a race where the fd closes before the SIGCHLD
handler has retrieved the exit status via waitpid(), which would cause pane_dead
to be 1 while pane_dead_status is still empty.