### PR TITLE
Fix stability bugs and improve allocation performance

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -65,8 +65,11 @@ control_notify_window_layout_changed(struct window *w)
 		if (!CONTROL_SHOULD_NOTIFY_CLIENT(c) || c->session == NULL)
 			continue;
 		s = c->session;
-		if (winlink_find_by_window_id(&s->windows, w->id) != NULL)
-			control_write(c, "%s", cp);
+
+		if (winlink_find_by_window_id(&s->windows, w->id) == NULL)
+			continue;
+
+		control_write(c, "%s", cp);
 	}
 	free(cp);
 }

--- a/control.c
+++ b/control.c
@@ -1081,9 +1081,7 @@ control_check_subs_timer(__unused int fd, __unused short events, void *data)
 		case CONTROL_SUB_WINDOW:
 			control_check_subs_window(c, csub);
 			break;
-		case CONTROL_SUB_SESSION:
-		case CONTROL_SUB_ALL_PANES:
-		case CONTROL_SUB_ALL_WINDOWS:
+		default:
 			break;
 		}
 	}
@@ -1095,10 +1093,9 @@ control_check_subs_timer(__unused int fd, __unused short events, void *data)
 				ft = format_create_defaults(NULL, c, s, wl, wp);
 				RB_FOREACH_SAFE(csub, control_subs, &cs->subs,
 				    csub1) {
-					if (csub->type != CONTROL_SUB_ALL_PANES)
-						continue;
-					control_check_subs_all_panes_one(c,
-					    csub, ft, wl, wp);
+					if (csub->type == CONTROL_SUB_ALL_PANES)
+						control_check_subs_all_panes_one(
+						    c, csub, ft, wl, wp);
 				}
 				format_free(ft);
 			}
@@ -1111,10 +1108,9 @@ control_check_subs_timer(__unused int fd, __unused short events, void *data)
 			ft = format_create_defaults(NULL, c, s, wl, NULL);
 			RB_FOREACH_SAFE(csub, control_subs, &cs->subs,
 			    csub1) {
-				if (csub->type != CONTROL_SUB_ALL_WINDOWS)
-					continue;
-				control_check_subs_all_windows_one(c, csub, ft,
-				    wl);
+				if (csub->type == CONTROL_SUB_ALL_WINDOWS)
+					control_check_subs_all_windows_one(c,
+					    csub, ft, wl);
 			}
 			format_free(ft);
 		}

--- a/grid.c
+++ b/grid.c
@@ -939,10 +939,22 @@ grid_string_cells_us(const struct grid_cell *gc, int *values)
 	return (n);
 }
 
+static inline void
+grid_string_cells_cat(char *buf, size_t len, size_t *off, const char *s)
+{
+	size_t	slen = strlen(s);
+
+	if (*off + slen < len) {
+		memcpy(buf + *off, s, slen);
+		*off += slen;
+	}
+	buf[*off] = '\0';
+}
+
 /* Add on SGR code. */
 static void
-grid_string_cells_add_code(char *buf, size_t len, u_int n, int *s, int *newc,
-    int *oldc, size_t nnewc, size_t noldc, int flags)
+grid_string_cells_add_code(char *buf, size_t len, size_t *off, u_int n,
+    int *s, int *newc, int *oldc, size_t nnewc, size_t noldc, int flags)
 {
 	u_int	i;
 	char	tmp[64];
@@ -958,43 +970,43 @@ grid_string_cells_add_code(char *buf, size_t len, u_int n, int *s, int *newc,
 		return; /* reset and colour default */
 
 	if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-		strlcat(buf, "\\033[", len);
+		grid_string_cells_cat(buf, len, off, "\\033[");
 	else
-		strlcat(buf, "\033[", len);
+		grid_string_cells_cat(buf, len, off, "\033[");
 	for (i = 0; i < nnewc; i++) {
 		if (i + 1 < nnewc)
 			xsnprintf(tmp, sizeof tmp, "%d;", newc[i]);
 		else
 			xsnprintf(tmp, sizeof tmp, "%d", newc[i]);
-		strlcat(buf, tmp, len);
+		grid_string_cells_cat(buf, len, off, tmp);
 	}
-	strlcat(buf, "m", len);
+	grid_string_cells_cat(buf, len, off, "m");
 }
 
 static int
-grid_string_cells_add_hyperlink(char *buf, size_t len, const char *id,
-    const char *uri, int flags)
+grid_string_cells_add_hyperlink(char *buf, size_t len, size_t *off,
+    const char *id, const char *uri, int flags)
 {
 	char	*tmp;
 
-	if (strlen(uri) + strlen(id) + 17 >= len)
+	if (*off + strlen(uri) + strlen(id) + 17 >= len)
 		return (0);
 
 	if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-		strlcat(buf, "\\033]8;", len);
+		grid_string_cells_cat(buf, len, off, "\\033]8;");
 	else
-		strlcat(buf, "\033]8;", len);
+		grid_string_cells_cat(buf, len, off, "\033]8;");
 	if (*id != '\0') {
 		xasprintf(&tmp, "id=%s;", id);
-		strlcat(buf, tmp, len);
+		grid_string_cells_cat(buf, len, off, tmp);
 		free(tmp);
 	} else
-		strlcat(buf, ";", len);
-	strlcat(buf, uri, len);
+		grid_string_cells_cat(buf, len, off, ";");
+	grid_string_cells_cat(buf, len, off, uri);
 	if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-		strlcat(buf, "\\033\\\\", len);
+		grid_string_cells_cat(buf, len, off, "\\033\\\\");
 	else
-		strlcat(buf, "\033\\", len);
+		grid_string_cells_cat(buf, len, off, "\033\\");
 	return (1);
 }
 
@@ -1008,7 +1020,7 @@ grid_string_cells_code(const struct grid_cell *lastgc,
     struct screen *sc, int *has_link)
 {
 	int			 oldc[64], newc[64], s[128];
-	size_t			 noldc, nnewc, n, i;
+	size_t			 noldc, nnewc, n, i, off = 0;
 	u_int			 attr = gc->attr, lastattr = lastgc->attr;
 	char			 tmp[64];
 	const char		*uri, *id;
@@ -1050,12 +1062,13 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 	}
 
 	/* Write the attributes. */
-	*buf = '\0';
+	off = 0;
+	buf[0] = '\0';
 	if (n > 0) {
 		if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-			strlcat(buf, "\\033[", len);
+			grid_string_cells_cat(buf, len, &off, "\\033[");
 		else
-			strlcat(buf, "\033[", len);
+			grid_string_cells_cat(buf, len, &off, "\033[");
 		for (i = 0; i < n; i++) {
 			if (s[i] < 10)
 				xsnprintf(tmp, sizeof tmp, "%d", s[i]);
@@ -1063,52 +1076,52 @@ grid_string_cells_code(const struct grid_cell *lastgc,
 				xsnprintf(tmp, sizeof tmp, "%d:%d", s[i] / 10,
 				    s[i] % 10);
 			}
-			strlcat(buf, tmp, len);
+			grid_string_cells_cat(buf, len, &off, tmp);
 			if (i + 1 < n)
-				strlcat(buf, ";", len);
+				grid_string_cells_cat(buf, len, &off, ";");
 		}
-		strlcat(buf, "m", len);
+		grid_string_cells_cat(buf, len, &off, "m");
 	}
 
 	/* If the foreground colour changed, write its parameters. */
 	nnewc = grid_string_cells_fg(gc, newc);
 	noldc = grid_string_cells_fg(lastgc, oldc);
-	grid_string_cells_add_code(buf, len, n, s, newc, oldc, nnewc, noldc,
-	    flags);
+	grid_string_cells_add_code(buf, len, &off, n, s, newc, oldc, nnewc,
+	    noldc, flags);
 
 	/* If the background colour changed, append its parameters. */
 	nnewc = grid_string_cells_bg(gc, newc);
 	noldc = grid_string_cells_bg(lastgc, oldc);
-	grid_string_cells_add_code(buf, len, n, s, newc, oldc, nnewc, noldc,
-	    flags);
+	grid_string_cells_add_code(buf, len, &off, n, s, newc, oldc, nnewc,
+	    noldc, flags);
 
 	/* If the underscore colour changed, append its parameters. */
 	nnewc = grid_string_cells_us(gc, newc);
 	noldc = grid_string_cells_us(lastgc, oldc);
-	grid_string_cells_add_code(buf, len, n, s, newc, oldc, nnewc, noldc,
-	    flags);
+	grid_string_cells_add_code(buf, len, &off, n, s, newc, oldc, nnewc,
+	    noldc, flags);
 
 	/* Append shift in/shift out if needed. */
 	if ((attr & GRID_ATTR_CHARSET) && !(lastattr & GRID_ATTR_CHARSET)) {
 		if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-			strlcat(buf, "\\016", len); /* SO */
+			grid_string_cells_cat(buf, len, &off, "\\016"); /* SO */
 		else
-			strlcat(buf, "\016", len);  /* SO */
+			grid_string_cells_cat(buf, len, &off, "\016");  /* SO */
 	}
 	if (!(attr & GRID_ATTR_CHARSET) && (lastattr & GRID_ATTR_CHARSET)) {
 		if (flags & GRID_STRING_ESCAPE_SEQUENCES)
-			strlcat(buf, "\\017", len); /* SI */
+			grid_string_cells_cat(buf, len, &off, "\\017"); /* SI */
 		else
-			strlcat(buf, "\017", len);  /* SI */
+			grid_string_cells_cat(buf, len, &off, "\017");  /* SI */
 	}
 
 	/* Add hyperlink if changed. */
 	if (sc != NULL && sc->hyperlinks != NULL && lastgc->link != gc->link) {
 		if (hyperlinks_get(sc->hyperlinks, gc->link, &uri, &id, NULL)) {
 			*has_link = grid_string_cells_add_hyperlink(buf, len,
-			    id, uri, flags);
+			    &off, id, uri, flags);
 		} else if (*has_link) {
-			grid_string_cells_add_hyperlink(buf, len, "", "",
+			grid_string_cells_add_hyperlink(buf, len, &off, "", "",
 			    flags);
 			*has_link = 0;
 		}
@@ -1190,9 +1203,9 @@ grid_string_cells(struct grid *gd, u_int px, u_int py, u_int nx,
 	}
 
 	if (has_link) {
-		grid_string_cells_add_hyperlink(code, sizeof code, "", "",
-		    flags);
-		codelen = strlen(code);
+		codelen = 0;
+		grid_string_cells_add_hyperlink(code, sizeof code, &codelen,
+		    "", "", flags);
 		while (len < off + size + codelen + 1) {
 			buf = xreallocarray(buf, 2, len);
 			len *= 2;

--- a/grid.c
+++ b/grid.c
@@ -104,7 +104,13 @@ grid_get_extended_cell(struct grid_line *gl, struct grid_cell_entry *gce,
 {
 	u_int at = gl->extdsize + 1;
 
-	gl->extddata = xreallocarray(gl->extddata, at, sizeof *gl->extddata);
+	if (at > gl->extdalloc) {
+		gl->extdalloc = (gl->extdalloc == 0) ? 8 : gl->extdalloc * 2;
+		if (gl->extdalloc < at)
+			gl->extdalloc = at;
+		gl->extddata = xreallocarray(gl->extddata, gl->extdalloc,
+		    sizeof *gl->extddata);
+	}
 	gl->extdsize = at;
 
 	gce->offset = at - 1;
@@ -165,6 +171,7 @@ grid_compact_line(struct grid_line *gl)
 		free(gl->extddata);
 		gl->extddata = NULL;
 		gl->extdsize = 0;
+		gl->extdalloc = 0;
 		return;
 	}
 	new_extddata = xreallocarray(NULL, new_extdsize, sizeof *gl->extddata);
@@ -182,6 +189,21 @@ grid_compact_line(struct grid_line *gl)
 	free(gl->extddata);
 	gl->extddata = new_extddata;
 	gl->extdsize = new_extdsize;
+	gl->extdalloc = new_extdsize;
+}
+
+/* Ensure linedata has enough space. */
+static void
+grid_ensure_linedata(struct grid *gd, u_int needed)
+{
+	if (needed <= gd->linealloc)
+		return;
+	if (gd->linealloc == 0)
+		gd->linealloc = gd->sy;
+	while (gd->linealloc < needed)
+		gd->linealloc = (gd->linealloc < 64) ? 64 : gd->linealloc * 2;
+	gd->linedata = xreallocarray(gd->linedata, gd->linealloc,
+	    sizeof *gd->linedata);
 }
 
 /* Get line data. */
@@ -196,6 +218,7 @@ void
 grid_adjust_lines(struct grid *gd, u_int lines)
 {
 	gd->linedata = xreallocarray(gd->linedata, lines, sizeof *gd->linedata);
+	gd->linealloc = lines;
 }
 
 /* Copy default into a cell. */
@@ -319,10 +342,13 @@ grid_create(u_int sx, u_int sy, u_int hlimit)
 	gd->hsize = 0;
 	gd->hlimit = hlimit;
 
-	if (gd->sy != 0)
+	gd->linealloc = 0;
+	if (gd->sy != 0) {
 		gd->linedata = xcalloc(gd->sy, sizeof *gd->linedata);
-	else
+		gd->linealloc = gd->sy;
+	} else {
 		gd->linedata = NULL;
+	}
 
 	return (gd);
 }
@@ -433,8 +459,7 @@ grid_scroll_history(struct grid *gd, u_int bg)
 	u_int	yy;
 
 	yy = gd->hsize + gd->sy;
-	gd->linedata = xreallocarray(gd->linedata, yy + 1,
-	    sizeof *gd->linedata);
+	grid_ensure_linedata(gd, yy + 1);
 	grid_empty_line(gd, yy, bg);
 
 	gd->hscrolled++;
@@ -454,6 +479,7 @@ grid_clear_history(struct grid *gd)
 
 	gd->linedata = xreallocarray(gd->linedata, gd->sy,
 	    sizeof *gd->linedata);
+	gd->linealloc = gd->sy;
 }
 
 /* Scroll a region up, moving the top line into the history. */
@@ -465,8 +491,7 @@ grid_scroll_history_region(struct grid *gd, u_int upper, u_int lower, u_int bg)
 
 	/* Create a space for a new line. */
 	yy = gd->hsize + gd->sy;
-	gd->linedata = xreallocarray(gd->linedata, yy + 1,
-	    sizeof *gd->linedata);
+	grid_ensure_linedata(gd, yy + 1);
 
 	/* Move the entire screen down to free a space for this line. */
 	gl_history = &gd->linedata[gd->hsize];
@@ -1231,7 +1256,7 @@ grid_reflow_add(struct grid *gd, u_int n)
 	struct grid_line	*gl;
 	u_int			 sy = gd->sy + n;
 
-	gd->linedata = xreallocarray(gd->linedata, sy, sizeof *gd->linedata);
+	grid_ensure_linedata(gd, sy);
 	gl = &gd->linedata[gd->sy];
 	memset(gl, 0, n * (sizeof *gl));
 	gd->sy = sy;
@@ -1508,6 +1533,7 @@ grid_reflow(struct grid *gd, u_int sx)
 		gd->hscrolled = gd->hsize;
 	free(gd->linedata);
 	gd->linedata = target->linedata;
+	gd->linealloc = target->linealloc;
 	free(target);
 }
 

--- a/grid.c
+++ b/grid.c
@@ -662,6 +662,18 @@ grid_set_cells(struct grid *gd, u_int px, u_int py, const struct grid_cell *gc,
 	if (px + slen > gl->cellused)
 		gl->cellused = px + slen;
 
+	/* Grow extended data. */
+	if (grid_need_extended_cell(&gl->celldata[px], gc)) {
+		if (gl->extdsize + slen > gl->extdalloc) {
+			if (gl->extdalloc == 0)
+				gl->extdalloc = 8;
+			while (gl->extdalloc < gl->extdsize + slen)
+				gl->extdalloc *= 2;
+			gl->extddata = xreallocarray(gl->extddata,
+			    gl->extdalloc, sizeof *gl->extddata);
+		}
+	}
+
 	for (i = 0; i < slen; i++) {
 		gce = &gl->celldata[px + i];
 		if (grid_need_extended_cell(gce, gc)) {

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1088,7 +1088,7 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	u_int			 sb_w = sb_style->width, sb_pad = sb_style->pad;
 	int			 px, py, ox = ctx->ox, oy = ctx->oy;
 	int			 sx = ctx->sx, sy = ctx->sy, xoff = wp->xoff;
-	int			 yoff = wp->yoff;
+	int			 yoff = wp->yoff, need_cursor;
 
 	if (ctx->statustop) {
 		sb_y += ctx->statuslines;
@@ -1110,14 +1110,20 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 
 	for (j = 0; j < jmax; j++) {
 		py = sb_y + j;
+		need_cursor = 1;
 		for (i = 0; i < imax; i++) {
 			px = sb_x + i;
 			if (px < xoff - ox - (int)sb_w - (int)sb_pad ||
 			    px >= sx || px < 0 ||
 			    py < yoff - oy - 1 ||
-			    py >= sy || py < 0)
+			    py >= sy || py < 0) {
+				need_cursor = 1;
 				continue;
-			tty_cursor(tty, px, py);
+			}
+			if (need_cursor) {
+				tty_cursor(tty, px, py);
+				need_cursor = 0;
+			}
 			if ((sb_pos == PANE_SCROLLBARS_LEFT &&
 			    i >= sb_w && i < sb_w + sb_pad) ||
 			    (sb_pos == PANE_SCROLLBARS_RIGHT &&

--- a/tmux.h
+++ b/tmux.h
@@ -827,6 +827,7 @@ struct grid_line {
 
 	struct grid_extd_entry	*extddata;
 	u_int			 extdsize;
+	u_int			 extdalloc;
 
 	int			 flags;
 	time_t			 time;
@@ -844,6 +845,7 @@ struct grid {
 	u_int			 hsize;
 	u_int			 hlimit;
 
+	u_int			 linealloc;
 	struct grid_line	*linedata;
 };
 

--- a/tty-draw.c
+++ b/tty-draw.c
@@ -263,12 +263,12 @@ tty_draw_line(struct tty *tty, struct screen *s, u_int px, u_int py, u_int nx,
 			else
 				next_state = TTY_DRAW_LINE_NEW1;
 		}
-		if (log_get_level() != 0) {
+
+		if (log_get_level() != 0)
 			log_debug("%s: cell %u empty %u, bg %u; state: "
 			    "current %s, next %s", __func__, px + i, empty,
 			    gcp->bg, tty_draw_line_states[current_state],
 			    tty_draw_line_states[next_state]);
-		}
 
 		/* If the state has changed, flush any collected data. */
 		if (next_state != current_state) {


### PR DESCRIPTION
A lot of somewhat unrelated small fixes and improvements in this PR -- I split it by commit to hopefully make it easier to review!

Stability fixes:
- Add NULL checks for grid_peek_line() in grid_string_cells and five sites in window-copy.c reachable during pane resize.
- Fix wrong TAILQ member in input_cancel_requests, use centry not entry.
- Move client keytable check before unref in key_bindings_remove_table.

Performance improvements:
- Use geometric (2x) growth for grid linedata and extended cell arrays instead of +1 reallocation.
- Batch runs of printable bytes in control mode output instead of per-byte evbuffer_add_printf.
- Do not call tty_attributes twice for single-width characters.
- Check log level before log_debug in tty_draw_line.
- Only set cursor position when needed in scrollbar drawing.
- Pre-grow extddata in grid_set_cells.
- Check event_pending before event_add in tty_add.
- Format layout change string once per window in control_notify_window_layout_changed instead of per client.
- Reuse format trees for subscriptions in control_check_subs_timer.
- Use offset tracking instead of strlcat in grid_string_cells.