### PR TITLE
Fix clients_calculate_size for manual type when window is NULL.

### DIFF
--- a/resize.c
+++ b/resize.c
@@ -250,7 +250,7 @@ skip:
 	/* Return whether a suitable size was found. */
 	if (type == WINDOW_SIZE_MANUAL) {
 		log_debug("%s: type is manual", __func__);
-		return (1);
+		return (w != NULL);
 	}
 	if (type == WINDOW_SIZE_LARGEST) {
 		log_debug("%s: type is largest", __func__);


### PR DESCRIPTION
When `window-size` is set to `manual` and a second session is created with
`new-session -d -x/-y`, `clients_calculate_size()` is called with `w` set to
NULL since the window does not exist yet.

Before 6234d798 this was a NULL pointer dereference crash (`w->manual_sx`) that
kills the server and all sessions on it. After 6234d798 the NULL guard prevents
the crash but the function still unconditionally returns 1 (success) for manual
type, preventing `default_window_size()` from falling back to the session's
`default-size` option. The sx/sy values remain at UINT_MAX and are clamped to
WINDOW_MAXIMUM (10000), producing a 10000x10000 window instead of the requested
size.

The 10000x10000 window has a serious performance impact. The terminal becomes
very slow, with screen refreshes taking several seconds, effectively making
the session unusable.

Fix by returning `w != NULL` instead of `1` for manual type so the caller uses
`default-size` when the window does not exist yet.

Reproducer:

    tmux new-session -d -s existing -x 80 -y 24
    tmux set-option -g window-size manual
    tmux new-session -d -s new -x 100 -y 30    # crashes 3.6a, 10000x10000 on master
    tmux display-message -p -t new '#{pane_width}x#{pane_height}'

[repro-tmux-manual-size.sh](https://github.com/user-attachments/files/25157619/repro-tmux-manual-size.sh)
