### PR TITLE
Add neighbor-aware window format variables

### DIFF
--- a/format.c
+++ b/format.c
@@ -4491,6 +4491,37 @@ format_window_name(struct format_expand_state *es, const char *fmt)
 	return (xstrdup("0"));
 }
 
+/* Add neighbor window variables to the format tree. */
+static void
+format_add_window_neighbor(struct format_tree *nft, struct winlink *wl,
+    struct session *s, const char *prefix)
+{
+	struct options_entry	*o;
+	const char		*oname;
+	char			*key, *prefixed, *oval;
+
+	xasprintf(&key, "%s_window_index", prefix);
+	format_add(nft, key, "%u", wl->idx);
+	free(key);
+
+	xasprintf(&key, "%s_window_active", prefix);
+	format_add(nft, key, "%d", wl == s->curw);
+	free(key);
+
+	o = options_first(wl->window->options);
+	while (o != NULL) {
+		oname = options_name(o);
+		if (*oname == '@') {
+			xasprintf(&prefixed, "%s_%s", prefix, oname + 1);
+			oval = options_to_string(o, -1, 1);
+			format_add(nft, prefixed, "%s", oval);
+			free(oval);
+			free(prefixed);
+		}
+		o = options_next(o);
+	}
+}
+
 /* Loop over windows. */
 static char *
 format_loop_windows(struct format_expand_state *es, const char *fmt)
@@ -4507,9 +4538,7 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 	size_t				  valuelen;
 	struct winlink			 *wl, **l;
 	struct window			 *w;
-	struct options_entry		 *o;
-	const char			 *oname, *sep;
-	char				 *prefixed, *oval;
+	const char			 *sep;
 	int				  i, n, last = 0;
 
 	if (ft->s == NULL) {
@@ -4545,45 +4574,10 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 		    i > 0 && l[i - 1] == ft->s->curw);
 		format_add(nft, "window_before_active", "%d",
 		    i + 1 < n && l[i + 1] == ft->s->curw);
-		if (i + 1 < n) {
-			format_add(nft, "next_window_index", "%u",
-			    l[i + 1]->idx);
-			format_add(nft, "next_window_active", "%d",
-			    l[i + 1] == ft->s->curw);
-			o = options_first(l[i + 1]->window->options);
-			while (o != NULL) {
-				oname = options_name(o);
-				if (*oname == '@') {
-					xasprintf(&prefixed, "next_%s",
-					    oname + 1);
-					oval = options_to_string(o, -1, 1);
-					format_add(nft, prefixed, "%s", oval);
-					free(oval);
-					free(prefixed);
-				}
-				o = options_next(o);
-			}
-		}
-
-		if (i > 0) {
-			format_add(nft, "prev_window_index", "%u",
-			    l[i - 1]->idx);
-			format_add(nft, "prev_window_active", "%d",
-			    l[i - 1] == ft->s->curw);
-			o = options_first(l[i - 1]->window->options);
-			while (o != NULL) {
-				oname = options_name(o);
-				if (*oname == '@') {
-					xasprintf(&prefixed, "prev_%s",
-					    oname + 1);
-					oval = options_to_string(o, -1, 1);
-					format_add(nft, prefixed, "%s", oval);
-					free(oval);
-					free(prefixed);
-				}
-				o = options_next(o);
-			}
-		}
+		if (i + 1 < n)
+			format_add_window_neighbor(nft, l[i + 1], ft->s, "next");
+		if (i > 0)
+			format_add_window_neighbor(nft, l[i - 1], ft->s, "prev");
 
 		/* Pre-expand the separator with neighbor data. */
 		sep = options_get_string(wl->window->options,

--- a/format.c
+++ b/format.c
@@ -4501,10 +4501,15 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 	struct cmdq_item		 *item = ft->item;
 	struct format_tree		 *nft;
 	struct format_expand_state	  next;
+	struct format_expand_state	  sep_es;
 	char				 *all, *active, *use, *expanded, *value;
+	char				 *sep_expanded;
 	size_t				  valuelen;
 	struct winlink			 *wl, **l;
 	struct window			 *w;
+	struct options_entry		 *o;
+	const char			 *oname, *sep;
+	char				 *prefixed, *oval;
 	int				  i, n, last = 0;
 
 	if (ft->s == NULL) {
@@ -4534,6 +4539,62 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 		nft = format_create(c, item, FORMAT_WINDOW|w->id,
 		    ft->flags|last);
 		format_defaults(nft, ft->c, ft->s, wl, NULL);
+
+		/* Add neighbor window data to the format tree. */
+		format_add(nft, "window_after_active", "%d",
+		    i > 0 && l[i - 1] == ft->s->curw);
+		format_add(nft, "window_before_active", "%d",
+		    i + 1 < n && l[i + 1] == ft->s->curw);
+		if (i + 1 < n) {
+			format_add(nft, "next_window_index", "%u",
+			    l[i + 1]->idx);
+			format_add(nft, "next_window_active", "%d",
+			    l[i + 1] == ft->s->curw);
+			o = options_first(l[i + 1]->window->options);
+			while (o != NULL) {
+				oname = options_name(o);
+				if (*oname == '@') {
+					xasprintf(&prefixed, "next_%s",
+					    oname + 1);
+					oval = options_to_string(o, -1, 1);
+					format_add(nft, prefixed, "%s", oval);
+					free(oval);
+					free(prefixed);
+				}
+				o = options_next(o);
+			}
+		}
+
+		if (i > 0) {
+			format_add(nft, "prev_window_index", "%u",
+			    l[i - 1]->idx);
+			format_add(nft, "prev_window_active", "%d",
+			    l[i - 1] == ft->s->curw);
+			o = options_first(l[i - 1]->window->options);
+			while (o != NULL) {
+				oname = options_name(o);
+				if (*oname == '@') {
+					xasprintf(&prefixed, "prev_%s",
+					    oname + 1);
+					oval = options_to_string(o, -1, 1);
+					format_add(nft, prefixed, "%s", oval);
+					free(oval);
+					free(prefixed);
+				}
+				o = options_next(o);
+			}
+		}
+
+		/* Pre-expand the separator with neighbor data. */
+		sep = options_get_string(wl->window->options,
+		    "window-status-separator");
+		format_copy_state(&sep_es, es, FORMAT_EXPAND_NOJOBS);
+		sep_es.ft = nft;
+		sep_expanded = format_expand1(&sep_es, sep);
+		format_add(nft, "window_status_separator", "%s",
+		    sep_expanded);
+		free(sep_expanded);
+
 		format_copy_state(&next, es, 0);
 		next.ft = nft;
 		expanded = format_expand1(&next, use);

--- a/format.c
+++ b/format.c
@@ -4532,13 +4532,10 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 	struct cmdq_item		 *item = ft->item;
 	struct format_tree		 *nft;
 	struct format_expand_state	  next;
-	struct format_expand_state	  sep_es;
 	char				 *all, *active, *use, *expanded, *value;
-	char				 *sep_expanded;
 	size_t				  valuelen;
 	struct winlink			 *wl, **l;
 	struct window			 *w;
-	const char			 *sep;
 	int				  i, n, last = 0;
 
 	if (ft->s == NULL) {
@@ -4578,16 +4575,6 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 			format_add_window_neighbor(nft, l[i + 1], ft->s, "next");
 		if (i > 0)
 			format_add_window_neighbor(nft, l[i - 1], ft->s, "prev");
-
-		/* Pre-expand the separator with neighbor data. */
-		sep = options_get_string(wl->window->options,
-		    "window-status-separator");
-		format_copy_state(&sep_es, es, FORMAT_EXPAND_NOJOBS);
-		sep_es.ft = nft;
-		sep_expanded = format_expand1(&sep_es, sep);
-		format_add(nft, "window_status_separator", "%s",
-		    sep_expanded);
-		free(sep_expanded);
 
 		format_copy_state(&next, es, 0);
 		next.ft = nft;

--- a/options-table.c
+++ b/options-table.c
@@ -141,7 +141,7 @@ static const char *options_table_allow_passthrough_list[] = {
 		"#{T:window-status-format}" \
 		"#[pop-default]" \
 		"#[norange default]" \
-		"#{?loop_last_flag,,#{window-status-separator}}" \
+		"#{?loop_last_flag,,#{window_status_separator}}" \
 	"," \
 		"#[range=window|#{window_index} list=focus " \
 			"#{?#{!=:#{E:window-status-current-style},default}," \
@@ -168,7 +168,7 @@ static const char *options_table_allow_passthrough_list[] = {
 		"#{T:window-status-current-format}" \
 		"#[pop-default]" \
 		"#[norange list=on default]" \
-		"#{?loop_last_flag,,#{window-status-separator}}" \
+		"#{?loop_last_flag,,#{window_status_separator}}" \
 	"}" \
 	"#[nolist align=right range=right #{E:status-right-style}]" \
 	"#[push-default]" \

--- a/options-table.c
+++ b/options-table.c
@@ -141,7 +141,7 @@ static const char *options_table_allow_passthrough_list[] = {
 		"#{T:window-status-format}" \
 		"#[pop-default]" \
 		"#[norange default]" \
-		"#{?loop_last_flag,,#{window_status_separator}}" \
+		"#{?loop_last_flag,,#{E:window-status-separator}}" \
 	"," \
 		"#[range=window|#{window_index} list=focus " \
 			"#{?#{!=:#{E:window-status-current-style},default}," \
@@ -168,7 +168,7 @@ static const char *options_table_allow_passthrough_list[] = {
 		"#{T:window-status-current-format}" \
 		"#[pop-default]" \
 		"#[norange list=on default]" \
-		"#{?loop_last_flag,,#{window_status_separator}}" \
+		"#{?loop_last_flag,,#{E:window-status-separator}}" \
 	"}" \
 	"#[nolist align=right range=right #{E:status-right-style}]" \
 	"#[push-default]" \

--- a/regress/window-neighbor.sh
+++ b/regress/window-neighbor.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# Tests for neighbor-aware window format variables in #{W:...} loops.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new-session -d || exit 1
+
+# test_wformat $format $expected_result
+# Neighbor variables only exist inside the window loop.
+test_wformat()
+{
+	fmt="$1"
+	exp="$2"
+
+	out=$($TMUX display-message -p "$fmt")
+
+	if [ "$out" != "$exp" ]; then
+		echo "Format test failed for '$fmt'."
+		echo "Expected: '$exp'"
+		echo "But got   '$out'"
+		exit 1
+	fi
+}
+
+# Single window (no neighbors)
+test_wformat "#{W:#{window_before_active}}" "0"
+test_wformat "#{W:#{window_after_active}}" "0"
+test_wformat "#{W:#{next_window_active}}" ""
+test_wformat "#{W:#{prev_window_active}}" ""
+
+# Two windows: adjacency flags
+$TMUX new-window
+
+# Window 1 is now active.
+test_wformat "#{W:#{window_index}=#{window_before_active} }" "0=1 1=0 "
+test_wformat "#{W:#{window_index}=#{window_after_active} }" "0=0 1=0 "
+
+# Switch to window 0.
+$TMUX select-window -t :0
+test_wformat "#{W:#{window_index}=#{window_before_active} }" "0=0 1=0 "
+test_wformat "#{W:#{window_index}=#{window_after_active} }" "0=0 1=1 "
+
+# Two windows: next/prev window index and active
+test_wformat "#{W:#{window_index}:next_idx=#{next_window_index} }" "0:next_idx=1 1:next_idx= "
+test_wformat "#{W:#{window_index}:prev_idx=#{prev_window_index} }" "0:prev_idx= 1:prev_idx=0 "
+test_wformat "#{W:#{window_index}:next_act=#{next_window_active} }" "0:next_act=0 1:next_act= "
+
+$TMUX select-window -t :1
+test_wformat "#{W:#{window_index}:next_act=#{next_window_active} }" "0:next_act=1 1:next_act= "
+
+# User option propagation (next_/prev_ prefixes)
+$TMUX set -wt :0 @color "red"
+$TMUX set -wt :1 @color "blue"
+test_wformat "#{W:#{window_index}:#{next_color} }" "0:blue 1: "
+test_wformat "#{W:#{window_index}:#{prev_color} }" "0: 1:red "
+
+# Non-@ options are not propagated.
+test_wformat "#{W:#{next_automatic-rename}}" ""
+
+# Pre-expanded separator (window_status_separator)
+$TMUX set -g window-status-separator " | "
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0 | 1"
+
+# Conditional separator using neighbor variables.
+$TMUX set -g window-status-separator "#{?window_before_active,>,|}"
+$TMUX select-window -t :0
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0|1"
+$TMUX select-window -t :1
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0>1"
+
+# Three windows: middle window active
+$TMUX select-window -t :0
+$TMUX new-window    # creates window 2, now active
+$TMUX set -wt :0 @bg "red"
+$TMUX set -wt :1 @bg "green"
+$TMUX set -wt :2 @bg "blue"
+$TMUX set -g window-status-separator "#{?next_window_active,>,|}"
+$TMUX select-window -t :1
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0>1|2"
+$TMUX select-window -t :0
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0|1|2"
+
+$TMUX kill-server 2>/dev/null
+exit 0

--- a/regress/window-neighbor.sh
+++ b/regress/window-neighbor.sh
@@ -62,16 +62,12 @@ test_wformat "#{W:#{window_index}:#{prev_color} }" "0: 1:red "
 # Non-@ options are not propagated.
 test_wformat "#{W:#{next_automatic-rename}}" ""
 
-# Pre-expanded separator (window_status_separator)
-$TMUX set -g window-status-separator " | "
-test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0 | 1"
-
-# Conditional separator using neighbor variables.
+# Conditional separator using neighbor variables via E: expansion.
 $TMUX set -g window-status-separator "#{?window_before_active,>,|}"
 $TMUX select-window -t :0
-test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0|1"
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{E:window-status-separator}}}" "0|1"
 $TMUX select-window -t :1
-test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0>1"
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{E:window-status-separator}}}" "0>1"
 
 # Three windows: middle window active
 $TMUX select-window -t :0
@@ -81,9 +77,9 @@ $TMUX set -wt :1 @bg "green"
 $TMUX set -wt :2 @bg "blue"
 $TMUX set -g window-status-separator "#{?next_window_active,>,|}"
 $TMUX select-window -t :1
-test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0>1|2"
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{E:window-status-separator}}}" "0>1|2"
 $TMUX select-window -t :0
-test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{window_status_separator}}}" "0|1|2"
+test_wformat "#{W:#{window_index}#{?loop_last_flag,,#{E:window-status-separator}}}" "0|1|2"
 
 $TMUX kill-server 2>/dev/null
 exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -6440,7 +6440,6 @@ The following variables are available, where appropriate:
 .It Li "window_silence_flag" Ta "" Ta "1 if window has silence alert"
 .It Li "window_stack_index" Ta "" Ta "Index in session most recent stack"
 .It Li "window_start_flag" Ta "" Ta "1 if window has the lowest index"
-.It Li "window_status_separator" Ta "" Ta "Pre-expanded window-status-separator in W: loop"
 .It Li "window_visible_layout" Ta "" Ta "Window layout description, respecting zoomed window panes"
 .It Li "window_width" Ta "" Ta "Width of window"
 .It Li "window_zoomed_flag" Ta "" Ta "1 if window is zoomed"

--- a/tmux.1
+++ b/tmux.1
@@ -6127,6 +6127,23 @@ For example, to get a list of windows formatted like the status line:
 #{W:#{E:window-status-format} ,#{E:window-status-current-format} }
 .Ed
 .Pp
+Within the
+.Ql W:\&
+loop, user options
+.Po
+.Ql @name
+.Pc
+from neighboring windows are available with a
+.Ql next_
+or
+.Ql prev_
+prefix (with the leading
+.Ql @
+removed), for example a user option
+.Ql @color
+on the next window is available as
+.Ql next_color .
+.Pp
 .Ql N:\&
 checks if a window (without any suffix or with the
 .Ql w
@@ -6295,6 +6312,8 @@ The following variables are available, where appropriate:
 .It Li "mouse_x" Ta "" Ta "Mouse X position, if any"
 .It Li "mouse_y" Ta "" Ta "Mouse Y position, if any"
 .It Li "next_session_id" Ta "" Ta "Unique session ID for next new session"
+.It Li "next_window_active" Ta "" Ta "1 if next window in W: loop is active"
+.It Li "next_window_index" Ta "" Ta "Index of next window in W: loop"
 .It Li "origin_flag" Ta "" Ta "Pane origin flag"
 .It Li "pane_active" Ta "" Ta "1 if active pane"
 .It Li "pane_at_bottom" Ta "" Ta "1 if pane is at the bottom of window"
@@ -6338,6 +6357,8 @@ The following variables are available, where appropriate:
 .It Li "pane_unseen_changes" Ta "" Ta "1 if there were changes in pane while in mode"
 .It Li "pane_width" Ta "" Ta "Width of pane"
 .It Li "pid" Ta "" Ta "Server PID"
+.It Li "prev_window_active" Ta "" Ta "1 if previous window in W: loop is active"
+.It Li "prev_window_index" Ta "" Ta "Index of previous window in W: loop"
 .It Li "rectangle_toggle" Ta "" Ta "1 if rectangle selection is activated"
 .It Li "scroll_position" Ta "" Ta "Scroll position in copy mode"
 .It Li "scroll_region_lower" Ta "" Ta "Bottom of scroll region in pane"
@@ -6391,9 +6412,11 @@ The following variables are available, where appropriate:
 .It Li "window_active_clients_list" Ta "" Ta "List of clients viewing this window"
 .It Li "window_active_sessions" Ta "" Ta "Number of sessions on which this window is active"
 .It Li "window_active_sessions_list" Ta "" Ta "List of sessions on which this window is active"
+.It Li "window_after_active" Ta "" Ta "1 if previous window in W: loop is active"
 .It Li "window_activity" Ta "" Ta "Time of window last activity"
 .It Li "window_activity_flag" Ta "" Ta "1 if window has activity"
 .It Li "window_bell_flag" Ta "" Ta "1 if window has bell"
+.It Li "window_before_active" Ta "" Ta "1 if next window in W: loop is active"
 .It Li "window_bigger" Ta "" Ta "1 if window is larger than client"
 .It Li "window_cell_height" Ta "" Ta "Height of each cell in pixels"
 .It Li "window_cell_width" Ta "" Ta "Width of each cell in pixels"
@@ -6417,6 +6440,7 @@ The following variables are available, where appropriate:
 .It Li "window_silence_flag" Ta "" Ta "1 if window has silence alert"
 .It Li "window_stack_index" Ta "" Ta "Index in session most recent stack"
 .It Li "window_start_flag" Ta "" Ta "1 if window has the lowest index"
+.It Li "window_status_separator" Ta "" Ta "Pre-expanded window-status-separator in W: loop"
 .It Li "window_visible_layout" Ta "" Ta "Window layout description, respecting zoomed window panes"
 .It Li "window_width" Ta "" Ta "Width of window"
 .It Li "window_zoomed_flag" Ta "" Ta "1 if window is zoomed"


### PR DESCRIPTION
## Overview
Expose neighboring window properties within the `#{W:...}` window loop and pre-expand `window-status-separator` in that context.

The separator between windows is inserted as a raw option value, with no format expansion -- making it impossible to use conditional expressions or reference window state within it. Styling the separator based on its neighbors (e.g. whether the adjacent window is active, or what per-window user options are set on it) is impossible.

## Changes
**1. Inject neighbor metadata into each window's format tree** (`format.c`)

During `format_loop_windows`, after `format_defaults()` binds the current window, inject:

- `window_after_active` / `window_before_active` -- adjacency flags ("1" if the active window is the immediate prev/next neighbor)
- `next_window_index`, `next_window_active` -- next window's index and active state
- `prev_window_index`, `prev_window_active` -- previous window's index and active state
- `next_<name>` / `prev_<name>` -- user `@<name>` options from the neighbor window (only per-window overrides, not globals)
- `window_status_separator` -- the `window-status-separator` option pre-expanded in this window's format context (with neighbor data available), using `FORMAT_EXPAND_NOJOBS` to prevent `#()` shell command execution

**2. Update default status template** (`options-table.c`)

Change `#{window-status-separator}` (hyphens, raw option lookup) to `#{window_status_separator}` (underscores, format entry lookup) so the default template picks up the pre-expanded value from step 1.

## Backward compatibility
- Plain-text separators (e.g., `" | "`) pass through expansion unchanged.
- Style-sequence separators (e.g., `#[fg=red]|`) are copied verbatim by the expander.
- `#(cmd)` shell commands in separators produce empty string due to `FORMAT_EXPAND_NOJOBS`
- Users with custom `status-format[0]` still referencing `#{window-status-separator}` (hyphens) get the old literal-insertion behavior.

## Usage examples
```
# Conditional separator: ">" before the active tab, "|" elsewhere
set -g window-status-separator "#{?window_before_active,>,|}"

# Per-window colors via @bg user option
set -wt :0 @bg red
set -wt :1 @bg blue
set -g window-status-separator "#[fg=#{@bg},bg=#{next_bg}]"
```

With these variables, powerline-style status bars become more straightforward: a single arrow glyph between two tabs can use `fg` from the left tab's background and `bg` from the right tab's background, with no arithmetic hacks or approximations needed.

### Before/after comparison of my own tmux.conf: powerline arrows with per-window monitor state

This is a real-world config that uses per-window `@monitor_mode` and `@silence_triggered` options to color tabs differently when silence monitoring is armed or has fired. The arrow glyphs between tabs need `fg` from the left tab's background and `bg` from the right tab's background.

**Before** -- each window must carry its own left and right arrow logic with index arithmetic to detect the active neighbor, and it can't access the active tab's `@monitor_mode`, so the arrow color is approximated:

```
# 7 macros to assemble arrows (some lines exceed 200 chars)
ACTIVE_TAB_PAIR="#[fg=#{?@monitor_mode,$BASE_BG,$HIGHLIGHT_FG},bg=#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG}]"
ACTIVE_ARROW="#{?window_start_flag,#[fg=$BASE_BG#,bg=#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG}] ,#[fg=$BASE_BG#,bg=#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG}]#[fg=$BASE_BG#,bg=#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG}] }"

# #{e|-:#{window_index},1} = "is my index minus 1 the active window?"
INACTIVE_ARROW_L="#{?#{==:#{e|-:#{window_index},1},#{active_window_index}},#[bg=$HIGHLIGHT_BG] #[fg=$HIGHLIGHT_BG#,bg=#{?@silence_triggered,$GREEN_BG,#{?@monitor_mode,$DULL_YELLOW_BG,$BASE_BG}}]#[fg=$BASE_FG] , }"
#                                                                              ^^^^^^^^^^^^^^
#                                          always HIGHLIGHT_BG -- wrong when active tab has @monitor_mode
#                                          (should be YELLOW_BG, but we can't see the neighbor's options)

INACTIVE_ARROW_R="#{?#{==:#{e|+:#{window_index},1},#{active_window_index}}, ,#{?@silence_triggered, #[fg=$GREEN_BG#,bg=$BASE_BG],#{?@monitor_mode, #[fg=$DULL_YELLOW_BG#,bg=$BASE_BG],}}}"
INACTIVE_STYLE="#{?@silence_triggered,#[fg=$BASE_BG#,bg=$GREEN_BG],#{?@monitor_mode,#[fg=$BASE_BG#,bg=$DULL_YELLOW_BG],}}"

set -wg window-status-separator ""
set -wg window-status-current-format "$ACTIVE_ARROW$ACTIVE_TAB_PAIR#I:#W#{?window_end_flag, #[fg=#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG}#,bg=$BASE_BG],}"
set -wg window-status-format "$INACTIVE_ARROW_L$INACTIVE_STYLE#I:#W#{?@silence_triggered,$INACTIVE_ARROW_R,#{?@monitor_mode,$INACTIVE_ARROW_R,#{?#{==:#{e|+:#{window_index},1},#{active_window_index}}, ,  }}}#[default]"
```

**After** -- the separator handles all inter-window arrows with exact neighbor colors via `next_*` variables. No index arithmetic, no color approximation:

```
# This window's bg color
MY_BG="#{?window_active,#{?@monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG},#{?@silence_triggered,$GREEN_BG,#{?@monitor_mode,$DULL_YELLOW_BG,$BASE_BG}}}"

# Next window's bg color -- uses next_window_active and next_ user options
NEXT_BG="#{?next_window_active,#{?next_monitor_mode,$YELLOW_BG,$HIGHLIGHT_BG},#{?next_silence_triggered,$GREEN_BG,#{?next_monitor_mode,$DULL_YELLOW_BG,$BASE_BG}}}"

# Text colors
ACT_FG="#{?@monitor_mode,$BASE_BG,$HIGHLIGHT_FG}"
TAB_FG="#{?@silence_triggered,$BASE_BG,#{?@monitor_mode,$BASE_BG,$BASE_FG}}"

# Separator: one arrow glyph, fg from left tab's bg, bg from right tab's bg
set -wg window-status-separator "#[fg=$MY_BG,bg=$NEXT_BG]"

# Active tab (edge arrows for first/last window only)
set -wg window-status-current-format "#{?window_start_flag,#[fg=$BASE_BG#,bg=$MY_BG],}#[fg=$ACT_FG,bg=$MY_BG] #I:#W #{?window_end_flag,#[fg=$MY_BG#,bg=$BASE_BG],}"

# Inactive tab
set -wg window-status-format "#{?window_start_flag,#[fg=$BASE_BG#,bg=$MY_BG],}#[fg=$TAB_FG,bg=$MY_BG] #I:#W #{?window_end_flag,#[fg=$MY_BG#,bg=$BASE_BG],}"
```
