### PR TITLE
Pass through which clipboard to set for OSC 52 paste

### DIFF
--- a/input.c
+++ b/input.c
@@ -3089,7 +3089,7 @@ input_osc_133(struct input_ctx *ictx, const char *p)
 
 /* Handle OSC 52 reply. */
 static void
-input_osc_52_reply(struct input_ctx *ictx)
+input_osc_52_reply(struct input_ctx *ictx, char clip)
 {
 	struct paste_buffer	*pb;
 	int			 state;
@@ -3104,9 +3104,9 @@ input_osc_52_reply(struct input_ctx *ictx)
 			return;
 		buf = paste_buffer_data(pb, &len);
 		if (ictx->input_end == INPUT_END_BEL)
-			input_reply_clipboard(ictx->event, buf, len, "\007");
+			input_reply_clipboard(ictx->event, buf, len, "\007", clip);
 		else
-			input_reply_clipboard(ictx->event, buf, len, "\033\\");
+			input_reply_clipboard(ictx->event, buf, len, "\033\\", clip);
 		return;
 	}
 	input_add_request(ictx, INPUT_REQUEST_CLIPBOARD, ictx->input_end);
@@ -3143,7 +3143,7 @@ input_osc_52_parse(struct input_ctx *ictx, const char *p, u_char **out,
 	log_debug("%s: %.*s %s", __func__, (int)(end - p - 1), p, flags);
 
 	if (strcmp(end, "?") == 0) {
-		input_osc_52_reply(ictx);
+		input_osc_52_reply(ictx, flags[0]);
 		return (0);
 	}
 
@@ -3233,7 +3233,7 @@ input_osc_104(struct input_ctx *ictx, const char *p)
 /* Send a clipboard reply. */
 void
 input_reply_clipboard(struct bufferevent *bev, const char *buf, size_t len,
-    const char *end)
+    const char *end, char clip)
 {
 	char	*out = NULL;
 	int	 outlen = 0;
@@ -3249,7 +3249,10 @@ input_reply_clipboard(struct bufferevent *bev, const char *buf, size_t len,
 		}
 	}
 
-	bufferevent_write(bev, "\033]52;;", 6);
+	bufferevent_write(bev, "\033]52;", 5);
+	if (clip != 0)
+		bufferevent_write(bev, &clip, 1);
+	bufferevent_write(bev, ";", 1);
 	if (outlen != 0)
 		bufferevent_write(bev, out, outlen);
 	bufferevent_write(bev, end, strlen(end));
@@ -3405,9 +3408,9 @@ input_request_clipboard_reply(struct input_request *ir, void *data)
 	}
 
 	if (ir->idx == INPUT_END_BEL)
-		input_reply_clipboard(ictx->event, cd->buf, cd->len, "\007");
+		input_reply_clipboard(ictx->event, cd->buf, cd->len, "\007", cd->clip);
 	else
-		input_reply_clipboard(ictx->event, cd->buf, cd->len, "\033\\");
+		input_reply_clipboard(ictx->event, cd->buf, cd->len, "\033\\", cd->clip);
 }
 
 /* Handle a reply to a request. */

--- a/tmux.h
+++ b/tmux.h
@@ -1146,6 +1146,7 @@ struct input_request_palette_data {
 struct input_request_clipboard_data {
 	char	*buf;
 	size_t	 len;
+	char	 clip;
 };
 
 /* Request sent to client on behalf of pane. */
@@ -3066,7 +3067,7 @@ void	 input_parse_buffer(struct window_pane *, u_char *, size_t);
 void	 input_parse_screen(struct input_ctx *, struct screen *,
 	     screen_write_init_ctx_cb, void *, u_char *, size_t);
 void	 input_reply_clipboard(struct bufferevent *, const char *, size_t,
-	     const char *);
+	     const char *, char);
 void	 input_set_buffer_size(size_t);
 void	 input_request_reply(struct client *, enum input_request_type, void *);
 void	 input_cancel_requests(struct client *);

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1310,7 +1310,7 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 {
 	struct client				*c = tty->client;
 	size_t					 end, terminator = 0, needed;
-	char					*copy, *out;
+	char					*copy, *out, clip = 0;
 	int					 outlen;
 	struct input_request_clipboard_data	 cd;
 
@@ -1360,6 +1360,11 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 	/* Adjust end so that it points to the start of the terminator. */
 	end -= terminator - 1;
 
+	/* Save which clipboard was used */
+	if (end >= 2 && buf[0] != ';' && buf[1] == ';') {
+		clip = buf[0];
+	}
+
 	/* Get the second argument. */
 	while (end != 0 && *buf != ';') {
 		buf++;
@@ -1393,6 +1398,7 @@ tty_keys_clipboard(struct tty *tty, const char *buf, size_t len, size_t *size)
 	/* Set reply if any. */
 	cd.buf = out;
 	cd.len = outlen;
+	cd.clip = clip;
 	input_request_reply(c, INPUT_REQUEST_CLIPBOARD, &cd);
 
 	/* Create a buffer if requested. */


### PR DESCRIPTION
Currently tmux will pass through the clipboard list on OSC 52 copy events, however it seems like paste events where hardcoded to reply without the clipboard that was used. This seems extra relevant with the introduction of the get-clipboard command where this feature might serve some purpose with the outer terminal, compared to just pasting from a tmux buffer. My primary reason for this PR however is that emacs expects this behavior and with how it is now, emacs can't paste with OSC 52 in tmux.

With this PR, tmux passes through the first clipboard found in the paste reply from the terminal if get-clipboard is not "buffer", otherwise it just uses the first one found in the paste query from the application.

There is no extra allocations here since the clipboard is not supposed to be a list in the reply (compared to the query, from how i understand it), so we just pass a char along to input_reply_clipboard.

Feedback is appreciated!