### PR TITLE
Enable partial-width prompt overlay with additional message-* options

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -733,7 +733,10 @@ const struct options_table_entry options_table[] = {
 	{ .name = "message-format",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "#[#{E:message-style}]#{message}",
+	  .default_str = "#[#{?#{command_prompt},"
+		  "#{E:message-command-style},"
+		  "#{E:message-style}}]"
+		  "#{message}",
 	  .text = "Format string for the prompt and message area. "
 		  "The '#{message}' placeholder is replaced with the content."
 	},

--- a/options-table.c
+++ b/options-table.c
@@ -44,9 +44,6 @@ static const char *options_table_status_list[] = {
 static const char *options_table_message_line_list[] = {
 	"0", "1", "2", "3", "4", NULL
 };
-static const char *options_table_message_position_list[] = {
-	"left", "centre", "right", NULL
-};
 static const char *options_table_status_keys_list[] = {
 	"emacs", "vi", NULL
 };
@@ -726,7 +723,7 @@ const struct options_table_entry options_table[] = {
 	{ .name = "message-command-style",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "bg=black,fg=yellow",
+	  .default_str = "bg=black,fg=yellow,fill=black",
 	  .flags = OPTIONS_TABLE_IS_STYLE,
 	  .separator = ",",
 	  .text = "Style of the command prompt when in command mode, if "
@@ -736,7 +733,7 @@ const struct options_table_entry options_table[] = {
 	{ .name = "message-format",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "#{message}",
+	  .default_str = "#[#{E:message-style}]#{message}",
 	  .text = "Format string for the prompt and message area. "
 		  "The '#{message}' placeholder is replaced with the content."
 	},
@@ -749,49 +746,16 @@ const struct options_table_entry options_table[] = {
 	  .text = "Position (line) of messages and the command prompt."
 	},
 
-	{ .name = "message-margin",
-	  .type = OPTIONS_TABLE_NUMBER,
-	  .scope = OPTIONS_TABLE_SESSION,
-	  .minimum = 0,
-	  .maximum = INT_MAX,
-	  .default_num = 0,
-	  .text = "Number of columns between the message area and the "
-		  "status line edge determined by 'message-position'."
-	},
-
-	{ .name = "message-min-width",
-	  .type = OPTIONS_TABLE_NUMBER,
-	  .scope = OPTIONS_TABLE_SESSION,
-	  .minimum = 0,
-	  .maximum = INT_MAX,
-	  .default_num = 0,
-	  .text = "Minimum width of the message and command prompt area "
-		  "in columns."
-	},
-
-	{ .name = "message-position",
-	  .type = OPTIONS_TABLE_CHOICE,
-	  .scope = OPTIONS_TABLE_SESSION,
-	  .choices = options_table_message_position_list,
-	  .default_num = 0,
-	  .text = "Horizontal position of the message and command prompt area."
-	},
-
 	{ .name = "message-style",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "bg=yellow,fg=black",
+	  .default_str = "bg=yellow,fg=black,fill=yellow",
 	  .flags = OPTIONS_TABLE_IS_STYLE,
 	  .separator = ",",
-	  .text = "Style of messages and the command prompt."
-	},
-
-	{ .name = "message-width",
-	  .type = OPTIONS_TABLE_STRING,
-	  .scope = OPTIONS_TABLE_SESSION,
-	  .default_str = "100%",
-	  .text = "Width of the message and command prompt area. "
-		  "A percentage, an absolute column count, or 'auto'."
+	  .text = "Style of messages and the command prompt. "
+		  "A 'fill' attribute controls background clearing and "
+		  "a 'width' attribute (fixed or percentage) constrains "
+		  "the prompt area width."
 	},
 
 	{ .name = "mouse",

--- a/options-table.c
+++ b/options-table.c
@@ -44,6 +44,9 @@ static const char *options_table_status_list[] = {
 static const char *options_table_message_line_list[] = {
 	"0", "1", "2", "3", "4", NULL
 };
+static const char *options_table_message_position_list[] = {
+	"left", "centre", "right", NULL
+};
 static const char *options_table_status_keys_list[] = {
 	"emacs", "vi", NULL
 };
@@ -730,12 +733,48 @@ const struct options_table_entry options_table[] = {
 		  "'mode-keys' is set to 'vi'."
 	},
 
+	{ .name = "message-format",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "#{message}",
+	  .text = "Format string for the prompt and message area. "
+		  "The '#{message}' placeholder is replaced with the content."
+	},
+
 	{ .name = "message-line",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .choices = options_table_message_line_list,
 	  .default_num = 0,
 	  .text = "Position (line) of messages and the command prompt."
+	},
+
+	{ .name = "message-margin",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 0,
+	  .maximum = INT_MAX,
+	  .default_num = 0,
+	  .text = "Number of columns between the message area and the "
+		  "status line edge determined by 'message-position'."
+	},
+
+	{ .name = "message-min-width",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 0,
+	  .maximum = INT_MAX,
+	  .default_num = 0,
+	  .text = "Minimum width of the message and command prompt area "
+		  "in columns."
+	},
+
+	{ .name = "message-position",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_message_position_list,
+	  .default_num = 0,
+	  .text = "Horizontal position of the message and command prompt area."
 	},
 
 	{ .name = "message-style",
@@ -745,6 +784,14 @@ const struct options_table_entry options_table[] = {
 	  .flags = OPTIONS_TABLE_IS_STYLE,
 	  .separator = ",",
 	  .text = "Style of messages and the command prompt."
+	},
+
+	{ .name = "message-width",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "100%",
+	  .text = "Width of the message and command prompt area. "
+		  "A percentage, an absolute column count, or 'auto'."
 	},
 
 	{ .name = "mouse",

--- a/status.c
+++ b/status.c
@@ -553,40 +553,14 @@ status_message_callback(__unused int fd, __unused short event, void *data)
 
 /*
  * Calculate prompt/message area geometry from the style's width and align
- * directives: x offset and width within the status line.
+ * directives: x offset and available width within the status line.
  */
 static void
-status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
-    u_int *content_x, u_int *content_w)
+status_prompt_area(struct client *c, u_int *area_x, u_int *area_w)
 {
 	struct session		*s = c->session;
 	struct style		*sy;
-	const char		*msgfmt, *marker;
-	char			*expanded, *copy;
 	u_int			 w;
-	u_int			 left_w = 0, right_w = 0;
-	struct format_tree	*ft;
-
-	/* Parse message-format to measure decoration widths. */
-	msgfmt = options_get_string(s->options, "message-format");
-	marker = strstr(msgfmt, "#{message}");
-	if (marker != NULL) {
-		ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
-
-		copy = xstrndup(msgfmt, marker - msgfmt);
-		expanded = format_expand_time(ft, copy);
-		left_w = format_width(expanded);
-		free(expanded);
-		free(copy);
-
-		copy = xstrdup(marker + strlen("#{message}"));
-		expanded = format_expand_time(ft, copy);
-		right_w = format_width(expanded);
-		free(expanded);
-		free(copy);
-
-		format_free(ft);
-	}
 
 	/* Get width from message-style's width directive. */
 	sy = options_string_to_style(s->options, "message-style", NULL);
@@ -599,12 +573,6 @@ status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
 		w = c->tty.sx;
 	if (w == 0 || w > c->tty.sx)
 		w = c->tty.sx;
-
-	/* Ensure content area is at least 1 column. */
-	if (left_w + right_w >= w) {
-		left_w = 0;
-		right_w = 0;
-	}
 
 	/* Get horizontal position from message-style's align directive. */
 	if (sy != NULL) {
@@ -624,61 +592,28 @@ status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
 		*area_x = 0;
 
 	*area_w = w;
-	*content_x = *area_x + left_w;
-	*content_w = w - left_w - right_w;
 }
 
-/*
- * Draw the decorative parts of message-format (everything before and after
- * #{message}) into the prompt area.
- */
-static void
-status_prompt_draw_format(struct client *c, struct screen_write_ctx *ctx,
-    u_int area_x, u_int area_w, u_int line, struct grid_cell *default_gc)
+/* Escape # characters in a string so format_draw treats them as literal. */
+static char *
+status_prompt_escape(const char *s)
 {
-	struct session		*s = c->session;
-	const char		*msgfmt, *marker;
-	char			*copy, *expanded;
-	struct format_tree	*ft;
-	u_int			 left_w, right_w;
+	const char	*cp;
+	char		*out, *p;
+	size_t		 n = 0;
 
-	msgfmt = options_get_string(s->options, "message-format");
-	marker = strstr(msgfmt, "#{message}");
-	if (marker == NULL)
-		return;
-
-	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
-
-	/* Draw left decoration. */
-	copy = xstrndup(msgfmt, marker - msgfmt);
-	if (*copy != '\0') {
-		expanded = format_expand_time(ft, copy);
-		left_w = format_width(expanded);
-		if (left_w > 0) {
-			screen_write_cursormove(ctx, area_x, line, 0);
-			format_draw(ctx, default_gc, left_w, expanded,
-			    NULL, 0);
-		}
-		free(expanded);
+	for (cp = s; *cp != '\0'; cp++) {
+		if (*cp == '#')
+			n++;
 	}
-	free(copy);
-
-	/* Draw right decoration. */
-	copy = xstrdup(marker + strlen("#{message}"));
-	if (*copy != '\0') {
-		expanded = format_expand_time(ft, copy);
-		right_w = format_width(expanded);
-		if (right_w > 0) {
-			screen_write_cursormove(ctx, area_x + area_w - right_w,
-			    line, 0);
-			format_draw(ctx, default_gc, right_w, expanded,
-			    NULL, 0);
-		}
-		free(expanded);
+	p = out = xmalloc(strlen(s) + n + 1);
+	for (cp = s; *cp != '\0'; cp++) {
+		if (*cp == '#')
+			*p++ = '#';
+		*p++ = *cp;
 	}
-	free(copy);
-
-	format_free(ft);
+	*p = '\0';
+	return (out);
 }
 
 /* Draw client message on status line of present else on last line. */
@@ -689,12 +624,12 @@ status_message_redraw(struct client *c)
 	struct screen_write_ctx	 ctx;
 	struct session		*s = c->session;
 	struct screen		 old_screen;
-	size_t			 len;
-	u_int			 lines, offset, messageline;
-	u_int			 ax, aw, cx, cw;
-	struct grid_cell	 gc, fgc;
-	struct style		*sy;
+	u_int			 lines, messageline;
+	u_int			 ax, aw;
+	struct grid_cell	 gc;
 	struct format_tree	*ft;
+	const char		*msgfmt;
+	char			*expanded, *msg;
 
 	if (c->tty.sx == 0 || c->tty.sy == 0)
 		return (0);
@@ -709,35 +644,35 @@ status_message_redraw(struct client *c)
 	if (messageline > lines - 1)
 		messageline = lines - 1;
 
-	status_prompt_area(c, &ax, &aw, &cx, &cw);
-
-	len = screen_write_strlen("%s", c->message_string);
-	if (len > cw)
-		len = cw;
+	status_prompt_area(c, &ax, &aw);
 
 	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
 	style_apply(&gc, s->options, "message-style", ft);
+
+	/*
+	 * Set #{message} in the format tree. If styles should be ignored in
+	 * the message content, escape # characters so format_draw treats them
+	 * as literal text.
+	 */
+	if (c->message_ignore_styles) {
+		msg = status_prompt_escape(c->message_string);
+		format_add(ft, "message", "%s", msg);
+		free(msg);
+	} else
+		format_add(ft, "message", "%s", c->message_string);
+	format_add(ft, "command_prompt", "%d", 0);
+
+	msgfmt = options_get_string(s->options, "message-format");
+	expanded = format_expand_time(ft, msgfmt);
 	format_free(ft);
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-
-	/* Fill the area if the style has a fill directive. */
-	sy = options_string_to_style(s->options, "message-style", NULL);
-	if (sy != NULL && sy->fill != 8) {
-		memcpy(&fgc, &grid_default_cell, sizeof fgc);
-		fgc.bg = sy->fill;
-		screen_write_cursormove(&ctx, ax, messageline, 0);
-		for (offset = 0; offset < aw; offset++)
-			screen_write_putc(&ctx, &fgc, ' ');
-	}
-	status_prompt_draw_format(c, &ctx, ax, aw, messageline, &gc);
-	screen_write_cursormove(&ctx, cx, messageline, 0);
-	if (c->message_ignore_styles)
-		screen_write_nputs(&ctx, len, &gc, "%s", c->message_string);
-	else
-		format_draw(&ctx, &gc, cw, c->message_string, NULL, 0);
+	screen_write_cursormove(&ctx, ax, messageline, 0);
+	format_draw(&ctx, &gc, aw, expanded, NULL, 0);
 	screen_write_stop(&ctx);
+
+	free(expanded);
 
 	if (grid_compare(sl->active->grid, old_screen.grid) == 0) {
 		screen_free(&old_screen);
@@ -931,12 +866,10 @@ status_prompt_redraw(struct client *c)
 	struct screen		 old_screen;
 	u_int			 i, lines, offset, left, start, width, n;
 	u_int			 pcursor, pwidth, promptline;
-	u_int			 ax, aw, cx, cw;
-	struct grid_cell	 gc, fgc;
-	struct style		*sy;
-	const char		*stylename;
-	struct format_tree	*ft = c->prompt_formats;
-	char			*prompt, *tmp;
+	u_int			 ax, aw;
+	struct grid_cell	 gc;
+	const char		*stylename, *msgfmt;
+	char			*expanded, *prompt, *tmp;
 
 	if (c->tty.sx == 0 || c->tty.sy == 0)
 		return (0);
@@ -964,37 +897,38 @@ status_prompt_redraw(struct client *c)
 		stylename = "message-command-style";
 	else
 		stylename = "message-style";
-	style_apply(&gc, s->options, stylename, ft);
+	style_apply(&gc, s->options, stylename, c->prompt_formats);
 
-	status_prompt_area(c, &ax, &aw, &cx, &cw);
+	status_prompt_area(c, &ax, &aw);
 
 	tmp = utf8_tocstr(c->prompt_buffer);
 	format_add(c->prompt_formats, "prompt-input", "%s", tmp);
 	prompt = format_expand_time(c->prompt_formats, c->prompt_string);
 	free(tmp);
 
+	/*
+	 * Set #{message} to the prompt string and expand message-format.
+	 * format_draw handles fill, alignment, and decorations in one call.
+	 */
+	format_add(c->prompt_formats, "message", "%s", prompt);
+	format_add(c->prompt_formats, "command_prompt", "%d",
+	    c->prompt_mode == PROMPT_COMMAND);
+	msgfmt = options_get_string(s->options, "message-format");
+	expanded = format_expand_time(c->prompt_formats, msgfmt);
+
 	start = format_width(prompt);
-	if (start > cw)
-		start = cw;
+	if (start > aw)
+		start = aw;
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
+	screen_write_cursormove(&ctx, ax, promptline, 0);
+	format_draw(&ctx, &gc, aw, expanded, NULL, 0);
+	screen_write_cursormove(&ctx, ax + start, promptline, 0);
 
-	/* Fill the area if the style has a fill directive. */
-	sy = options_string_to_style(s->options, stylename, ft);
-	if (sy != NULL && sy->fill != 8) {
-		memcpy(&fgc, &grid_default_cell, sizeof fgc);
-		fgc.bg = sy->fill;
-		screen_write_cursormove(&ctx, ax, promptline, 0);
-		for (offset = 0; offset < aw; offset++)
-			screen_write_putc(&ctx, &fgc, ' ');
-	}
-	status_prompt_draw_format(c, &ctx, ax, aw, promptline, &gc);
-	screen_write_cursormove(&ctx, cx, promptline, 0);
-	format_draw(&ctx, &gc, start, prompt, NULL, 0);
-	screen_write_cursormove(&ctx, cx + start, promptline, 0);
+	free(expanded);
 
-	left = cw - start;
+	left = aw - start;
 	if (left == 0)
 		goto finished;
 
@@ -1013,7 +947,7 @@ status_prompt_redraw(struct client *c)
 		offset = 0;
 	if (pwidth > left)
 		pwidth = left;
-	c->prompt_cursor = cx + start + pcursor - offset;
+	c->prompt_cursor = ax + start + pcursor - offset;
 
 	width = 0;
 	for (i = 0; c->prompt_buffer[i].size != 0; i++) {
@@ -1987,7 +1921,7 @@ status_prompt_complete_list_menu(struct client *c, char **list, u_int size,
 	struct menu_item		 item;
 	struct status_prompt_menu	*spm;
 	u_int				 lines = status_line_size(c), height, i;
-	u_int				 py, ax, aw, cx, cw;
+	u_int				 py, ax, aw;
 
 	if (size <= 1)
 		return (0);
@@ -2015,13 +1949,13 @@ status_prompt_complete_list_menu(struct client *c, char **list, u_int size,
 		menu_add_item(menu, &item, NULL, c, NULL);
 	}
 
-	status_prompt_area(c, &ax, &aw, &cx, &cw);
+	status_prompt_area(c, &ax, &aw);
 	if (options_get_number(c->session->options, "status-position") == 0)
 		py = lines;
 	else
 		py = c->tty.sy - 3 - height;
 	offset += utf8_cstrwidth(c->prompt_string);
-	offset += cx;
+	offset += ax;
 	if (offset > 2)
 		offset -= 2;
 	else
@@ -2048,7 +1982,7 @@ status_prompt_complete_window_menu(struct client *c, struct session *s,
 	struct winlink			 *wl;
 	char				**list = NULL, *tmp;
 	u_int				  lines = status_line_size(c), height;
-	u_int				  py, size = 0, i, ax, aw, cx, cw;
+	u_int				  py, size = 0, i, ax, aw;
 
 	if (c->tty.sy - lines < 3)
 		return (NULL);
@@ -2113,13 +2047,13 @@ status_prompt_complete_window_menu(struct client *c, struct session *s,
 	spm->size = size;
 	spm->list = list;
 
-	status_prompt_area(c, &ax, &aw, &cx, &cw);
+	status_prompt_area(c, &ax, &aw);
 	if (options_get_number(c->session->options, "status-position") == 0)
 		py = lines;
 	else
 		py = c->tty.sy - 3 - height;
 	offset += utf8_cstrwidth(c->prompt_string);
-	offset += cx;
+	offset += ax;
 	if (offset > 2)
 		offset -= 2;
 	else

--- a/status.c
+++ b/status.c
@@ -552,20 +552,19 @@ status_message_callback(__unused int fd, __unused short event, void *data)
 }
 
 /*
- * Calculate prompt/message area geometry: x offset and width within the
- * status line.
+ * Calculate prompt/message area geometry from the style's width and align
+ * directives: x offset and width within the status line.
  */
 static void
 status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
     u_int *content_x, u_int *content_w)
 {
 	struct session		*s = c->session;
-	const char		*widthstr, *msgfmt, *marker;
+	struct style		*sy;
+	const char		*msgfmt, *marker;
 	char			*expanded, *copy;
-	u_int			 w, min_w, position, margin, content, input;
+	u_int			 w;
 	u_int			 left_w = 0, right_w = 0;
-	size_t			 slen;
-	int			 pct;
 	struct format_tree	*ft;
 
 	/* Parse message-format to measure decoration widths. */
@@ -589,37 +588,15 @@ status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
 		format_free(ft);
 	}
 
-	/* Parse message-width. */
-	widthstr = options_get_string(s->options, "message-width");
-	if (strcmp(widthstr, "auto") == 0) {
-		if (c->prompt_string != NULL) {
-			content = utf8_cstrwidth(c->prompt_string);
-			content += 20;
-			if (c->prompt_buffer != NULL) {
-				input = utf8_strwidth(c->prompt_buffer, -1);
-				if (input > 20)
-					content += input - 20;
-			}
-		} else if (c->message_string != NULL)
-			content = utf8_cstrwidth(c->message_string);
+	/* Get width from message-style's width directive. */
+	sy = options_string_to_style(s->options, "message-style", NULL);
+	if (sy != NULL && sy->width >= 0) {
+		if (sy->width_percentage)
+			w = (c->tty.sx * (u_int)sy->width) / 100;
 		else
-			content = c->tty.sx;
-		content = ((content + 9) / 10) * 10;
-		w = content + left_w + right_w;
-	} else {
-		slen = strlen(widthstr);
-		if (slen > 0 && widthstr[slen - 1] == '%') {
-			pct = atoi(widthstr);
-			if (pct <= 0)
-				pct = 100;
-			w = (c->tty.sx * pct) / 100;
-		} else {
-			w = (u_int)atoi(widthstr);
-		}
-	}
-	min_w = options_get_number(s->options, "message-min-width");
-	if (min_w > 0 && w < min_w)
-		w = min_w;
+			w = (u_int)sy->width;
+	} else
+		w = c->tty.sx;
 	if (w == 0 || w > c->tty.sx)
 		w = c->tty.sx;
 
@@ -629,25 +606,22 @@ status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
 		right_w = 0;
 	}
 
-	/* Compute horizontal position with margin. */
-	position = options_get_number(s->options, "message-position");
-	margin = options_get_number(s->options, "message-margin");
-	switch (position) {
-	case 1: /* centre */
-		*area_x = (c->tty.sx - w) / 2;
-		break;
-	case 2: /* right */
-		if (margin + w > c->tty.sx)
+	/* Get horizontal position from message-style's align directive. */
+	if (sy != NULL) {
+		switch (sy->align) {
+		case STYLE_ALIGN_CENTRE:
+		case STYLE_ALIGN_ABSOLUTE_CENTRE:
+			*area_x = (c->tty.sx - w) / 2;
+			break;
+		case STYLE_ALIGN_RIGHT:
+			*area_x = c->tty.sx - w;
+			break;
+		default:
 			*area_x = 0;
-		else
-			*area_x = c->tty.sx - w - margin;
-		break;
-	default: /* left */
-		*area_x = margin;
-		if (*area_x + w > c->tty.sx)
-			*area_x = 0;
-		break;
-	}
+			break;
+		}
+	} else
+		*area_x = 0;
 
 	*area_w = w;
 	*content_x = *area_x + left_w;
@@ -718,7 +692,8 @@ status_message_redraw(struct client *c)
 	size_t			 len;
 	u_int			 lines, offset, messageline;
 	u_int			 ax, aw, cx, cw;
-	struct grid_cell	 gc;
+	struct grid_cell	 gc, fgc;
+	struct style		*sy;
 	struct format_tree	*ft;
 
 	if (c->tty.sx == 0 || c->tty.sy == 0)
@@ -746,9 +721,16 @@ status_message_redraw(struct client *c)
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-	screen_write_cursormove(&ctx, ax, messageline, 0);
-	for (offset = 0; offset < aw; offset++)
-		screen_write_putc(&ctx, &gc, ' ');
+
+	/* Fill the area if the style has a fill directive. */
+	sy = options_string_to_style(s->options, "message-style", NULL);
+	if (sy != NULL && sy->fill != 8) {
+		memcpy(&fgc, &grid_default_cell, sizeof fgc);
+		fgc.bg = sy->fill;
+		screen_write_cursormove(&ctx, ax, messageline, 0);
+		for (offset = 0; offset < aw; offset++)
+			screen_write_putc(&ctx, &fgc, ' ');
+	}
 	status_prompt_draw_format(c, &ctx, ax, aw, messageline, &gc);
 	screen_write_cursormove(&ctx, cx, messageline, 0);
 	if (c->message_ignore_styles)
@@ -950,7 +932,9 @@ status_prompt_redraw(struct client *c)
 	u_int			 i, lines, offset, left, start, width, n;
 	u_int			 pcursor, pwidth, promptline;
 	u_int			 ax, aw, cx, cw;
-	struct grid_cell	 gc;
+	struct grid_cell	 gc, fgc;
+	struct style		*sy;
+	const char		*stylename;
 	struct format_tree	*ft = c->prompt_formats;
 	char			*prompt, *tmp;
 
@@ -977,9 +961,10 @@ status_prompt_redraw(struct client *c)
 		promptline = lines - 1;
 
 	if (c->prompt_mode == PROMPT_COMMAND)
-		style_apply(&gc, s->options, "message-command-style", ft);
+		stylename = "message-command-style";
 	else
-		style_apply(&gc, s->options, "message-style", ft);
+		stylename = "message-style";
+	style_apply(&gc, s->options, stylename, ft);
 
 	status_prompt_area(c, &ax, &aw, &cx, &cw);
 
@@ -994,9 +979,16 @@ status_prompt_redraw(struct client *c)
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-	screen_write_cursormove(&ctx, ax, promptline, 0);
-	for (offset = 0; offset < aw; offset++)
-		screen_write_putc(&ctx, &gc, ' ');
+
+	/* Fill the area if the style has a fill directive. */
+	sy = options_string_to_style(s->options, stylename, ft);
+	if (sy != NULL && sy->fill != 8) {
+		memcpy(&fgc, &grid_default_cell, sizeof fgc);
+		fgc.bg = sy->fill;
+		screen_write_cursormove(&ctx, ax, promptline, 0);
+		for (offset = 0; offset < aw; offset++)
+			screen_write_putc(&ctx, &fgc, ' ');
+	}
 	status_prompt_draw_format(c, &ctx, ax, aw, promptline, &gc);
 	screen_write_cursormove(&ctx, cx, promptline, 0);
 	format_draw(&ctx, &gc, start, prompt, NULL, 0);

--- a/status.c
+++ b/status.c
@@ -647,7 +647,7 @@ status_message_redraw(struct client *c)
 	status_prompt_area(c, &ax, &aw);
 
 	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
-	style_apply(&gc, s->options, "message-style", ft);
+	memcpy(&gc, &grid_default_cell, sizeof gc);
 
 	/*
 	 * Set #{message} in the format tree. If styles should be ignored in
@@ -868,7 +868,7 @@ status_prompt_redraw(struct client *c)
 	u_int			 pcursor, pwidth, promptline;
 	u_int			 ax, aw;
 	struct grid_cell	 gc;
-	const char		*stylename, *msgfmt;
+	const char		*msgfmt;
 	char			*expanded, *prompt, *tmp;
 
 	if (c->tty.sx == 0 || c->tty.sy == 0)
@@ -894,10 +894,9 @@ status_prompt_redraw(struct client *c)
 		promptline = lines - 1;
 
 	if (c->prompt_mode == PROMPT_COMMAND)
-		stylename = "message-command-style";
+		style_apply(&gc, s->options, "message-command-style", NULL);
 	else
-		stylename = "message-style";
-	style_apply(&gc, s->options, stylename, c->prompt_formats);
+		style_apply(&gc, s->options, "message-style", NULL);
 
 	status_prompt_area(c, &ax, &aw);
 

--- a/status.c
+++ b/status.c
@@ -551,6 +551,162 @@ status_message_callback(__unused int fd, __unused short event, void *data)
 	status_message_clear(c);
 }
 
+/*
+ * Calculate prompt/message area geometry: x offset and width within the
+ * status line.
+ */
+static void
+status_prompt_area(struct client *c, u_int *area_x, u_int *area_w,
+    u_int *content_x, u_int *content_w)
+{
+	struct session		*s = c->session;
+	const char		*widthstr, *msgfmt, *marker;
+	char			*expanded, *copy;
+	u_int			 w, min_w, position, margin, content, input;
+	u_int			 left_w = 0, right_w = 0;
+	size_t			 slen;
+	int			 pct;
+	struct format_tree	*ft;
+
+	/* Parse message-format to measure decoration widths. */
+	msgfmt = options_get_string(s->options, "message-format");
+	marker = strstr(msgfmt, "#{message}");
+	if (marker != NULL) {
+		ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
+
+		copy = xstrndup(msgfmt, marker - msgfmt);
+		expanded = format_expand_time(ft, copy);
+		left_w = format_width(expanded);
+		free(expanded);
+		free(copy);
+
+		copy = xstrdup(marker + strlen("#{message}"));
+		expanded = format_expand_time(ft, copy);
+		right_w = format_width(expanded);
+		free(expanded);
+		free(copy);
+
+		format_free(ft);
+	}
+
+	/* Parse message-width. */
+	widthstr = options_get_string(s->options, "message-width");
+	if (strcmp(widthstr, "auto") == 0) {
+		if (c->prompt_string != NULL) {
+			content = utf8_cstrwidth(c->prompt_string);
+			content += 20;
+			if (c->prompt_buffer != NULL) {
+				input = utf8_strwidth(c->prompt_buffer, -1);
+				if (input > 20)
+					content += input - 20;
+			}
+		} else if (c->message_string != NULL)
+			content = utf8_cstrwidth(c->message_string);
+		else
+			content = c->tty.sx;
+		content = ((content + 9) / 10) * 10;
+		w = content + left_w + right_w;
+	} else {
+		slen = strlen(widthstr);
+		if (slen > 0 && widthstr[slen - 1] == '%') {
+			pct = atoi(widthstr);
+			if (pct <= 0)
+				pct = 100;
+			w = (c->tty.sx * pct) / 100;
+		} else {
+			w = (u_int)atoi(widthstr);
+		}
+	}
+	min_w = options_get_number(s->options, "message-min-width");
+	if (min_w > 0 && w < min_w)
+		w = min_w;
+	if (w == 0 || w > c->tty.sx)
+		w = c->tty.sx;
+
+	/* Ensure content area is at least 1 column. */
+	if (left_w + right_w >= w) {
+		left_w = 0;
+		right_w = 0;
+	}
+
+	/* Compute horizontal position with margin. */
+	position = options_get_number(s->options, "message-position");
+	margin = options_get_number(s->options, "message-margin");
+	switch (position) {
+	case 1: /* centre */
+		*area_x = (c->tty.sx - w) / 2;
+		break;
+	case 2: /* right */
+		if (margin + w > c->tty.sx)
+			*area_x = 0;
+		else
+			*area_x = c->tty.sx - w - margin;
+		break;
+	default: /* left */
+		*area_x = margin;
+		if (*area_x + w > c->tty.sx)
+			*area_x = 0;
+		break;
+	}
+
+	*area_w = w;
+	*content_x = *area_x + left_w;
+	*content_w = w - left_w - right_w;
+}
+
+/*
+ * Draw the decorative parts of message-format (everything before and after
+ * #{message}) into the prompt area.
+ */
+static void
+status_prompt_draw_format(struct client *c, struct screen_write_ctx *ctx,
+    u_int area_x, u_int area_w, u_int line, struct grid_cell *default_gc)
+{
+	struct session		*s = c->session;
+	const char		*msgfmt, *marker;
+	char			*copy, *expanded;
+	struct format_tree	*ft;
+	u_int			 left_w, right_w;
+
+	msgfmt = options_get_string(s->options, "message-format");
+	marker = strstr(msgfmt, "#{message}");
+	if (marker == NULL)
+		return;
+
+	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
+
+	/* Draw left decoration. */
+	copy = xstrndup(msgfmt, marker - msgfmt);
+	if (*copy != '\0') {
+		expanded = format_expand_time(ft, copy);
+		left_w = format_width(expanded);
+		if (left_w > 0) {
+			screen_write_cursormove(ctx, area_x, line, 0);
+			format_draw(ctx, default_gc, left_w, expanded,
+			    NULL, 0);
+		}
+		free(expanded);
+	}
+	free(copy);
+
+	/* Draw right decoration. */
+	copy = xstrdup(marker + strlen("#{message}"));
+	if (*copy != '\0') {
+		expanded = format_expand_time(ft, copy);
+		right_w = format_width(expanded);
+		if (right_w > 0) {
+			screen_write_cursormove(ctx, area_x + area_w - right_w,
+			    line, 0);
+			format_draw(ctx, default_gc, right_w, expanded,
+			    NULL, 0);
+		}
+		free(expanded);
+	}
+	free(copy);
+
+	format_free(ft);
+}
+
 /* Draw client message on status line of present else on last line. */
 int
 status_message_redraw(struct client *c)
@@ -561,6 +717,7 @@ status_message_redraw(struct client *c)
 	struct screen		 old_screen;
 	size_t			 len;
 	u_int			 lines, offset, messageline;
+	u_int			 ax, aw, cx, cw;
 	struct grid_cell	 gc;
 	struct format_tree	*ft;
 
@@ -577,9 +734,11 @@ status_message_redraw(struct client *c)
 	if (messageline > lines - 1)
 		messageline = lines - 1;
 
+	status_prompt_area(c, &ax, &aw, &cx, &cw);
+
 	len = screen_write_strlen("%s", c->message_string);
-	if (len > c->tty.sx)
-		len = c->tty.sx;
+	if (len > cw)
+		len = cw;
 
 	ft = format_create_defaults(NULL, c, NULL, NULL, NULL);
 	style_apply(&gc, s->options, "message-style", ft);
@@ -587,14 +746,15 @@ status_message_redraw(struct client *c)
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-	screen_write_cursormove(&ctx, 0, messageline, 0);
-	for (offset = 0; offset < c->tty.sx; offset++)
+	screen_write_cursormove(&ctx, ax, messageline, 0);
+	for (offset = 0; offset < aw; offset++)
 		screen_write_putc(&ctx, &gc, ' ');
-	screen_write_cursormove(&ctx, 0, messageline, 0);
+	status_prompt_draw_format(c, &ctx, ax, aw, messageline, &gc);
+	screen_write_cursormove(&ctx, cx, messageline, 0);
 	if (c->message_ignore_styles)
 		screen_write_nputs(&ctx, len, &gc, "%s", c->message_string);
 	else
-		format_draw(&ctx, &gc, c->tty.sx, c->message_string, NULL, 0);
+		format_draw(&ctx, &gc, cw, c->message_string, NULL, 0);
 	screen_write_stop(&ctx);
 
 	if (grid_compare(sl->active->grid, old_screen.grid) == 0) {
@@ -789,6 +949,7 @@ status_prompt_redraw(struct client *c)
 	struct screen		 old_screen;
 	u_int			 i, lines, offset, left, start, width, n;
 	u_int			 pcursor, pwidth, promptline;
+	u_int			 ax, aw, cx, cw;
 	struct grid_cell	 gc;
 	struct format_tree	*ft = c->prompt_formats;
 	char			*prompt, *tmp;
@@ -820,25 +981,28 @@ status_prompt_redraw(struct client *c)
 	else
 		style_apply(&gc, s->options, "message-style", ft);
 
+	status_prompt_area(c, &ax, &aw, &cx, &cw);
+
 	tmp = utf8_tocstr(c->prompt_buffer);
 	format_add(c->prompt_formats, "prompt-input", "%s", tmp);
 	prompt = format_expand_time(c->prompt_formats, c->prompt_string);
-	free (tmp);
+	free(tmp);
 
 	start = format_width(prompt);
-	if (start > c->tty.sx)
-		start = c->tty.sx;
+	if (start > cw)
+		start = cw;
 
 	screen_write_start(&ctx, sl->active);
 	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
-	screen_write_cursormove(&ctx, 0, promptline, 0);
-	for (offset = 0; offset < c->tty.sx; offset++)
+	screen_write_cursormove(&ctx, ax, promptline, 0);
+	for (offset = 0; offset < aw; offset++)
 		screen_write_putc(&ctx, &gc, ' ');
-	screen_write_cursormove(&ctx, 0, promptline, 0);
+	status_prompt_draw_format(c, &ctx, ax, aw, promptline, &gc);
+	screen_write_cursormove(&ctx, cx, promptline, 0);
 	format_draw(&ctx, &gc, start, prompt, NULL, 0);
-	screen_write_cursormove(&ctx, start, promptline, 0);
+	screen_write_cursormove(&ctx, cx + start, promptline, 0);
 
-	left = c->tty.sx - start;
+	left = cw - start;
 	if (left == 0)
 		goto finished;
 
@@ -857,7 +1021,7 @@ status_prompt_redraw(struct client *c)
 		offset = 0;
 	if (pwidth > left)
 		pwidth = left;
-	c->prompt_cursor = start + pcursor - offset;
+	c->prompt_cursor = cx + start + pcursor - offset;
 
 	width = 0;
 	for (i = 0; c->prompt_buffer[i].size != 0; i++) {
@@ -1831,7 +1995,7 @@ status_prompt_complete_list_menu(struct client *c, char **list, u_int size,
 	struct menu_item		 item;
 	struct status_prompt_menu	*spm;
 	u_int				 lines = status_line_size(c), height, i;
-	u_int				 py;
+	u_int				 py, ax, aw, cx, cw;
 
 	if (size <= 1)
 		return (0);
@@ -1859,11 +2023,13 @@ status_prompt_complete_list_menu(struct client *c, char **list, u_int size,
 		menu_add_item(menu, &item, NULL, c, NULL);
 	}
 
+	status_prompt_area(c, &ax, &aw, &cx, &cw);
 	if (options_get_number(c->session->options, "status-position") == 0)
 		py = lines;
 	else
 		py = c->tty.sy - 3 - height;
 	offset += utf8_cstrwidth(c->prompt_string);
+	offset += cx;
 	if (offset > 2)
 		offset -= 2;
 	else
@@ -1890,7 +2056,7 @@ status_prompt_complete_window_menu(struct client *c, struct session *s,
 	struct winlink			 *wl;
 	char				**list = NULL, *tmp;
 	u_int				  lines = status_line_size(c), height;
-	u_int				  py, size = 0, i;
+	u_int				  py, size = 0, i, ax, aw, cx, cw;
 
 	if (c->tty.sy - lines < 3)
 		return (NULL);
@@ -1955,11 +2121,13 @@ status_prompt_complete_window_menu(struct client *c, struct session *s,
 	spm->size = size;
 	spm->list = list;
 
+	status_prompt_area(c, &ax, &aw, &cx, &cw);
 	if (options_get_number(c->session->options, "status-position") == 0)
 		py = lines;
 	else
 		py = c->tty.sy - 3 - height;
 	offset += utf8_cstrwidth(c->prompt_string);
+	offset += cx;
 	if (offset > 2)
 		offset -= 2;
 	else

--- a/style.c
+++ b/style.c
@@ -39,7 +39,7 @@ static struct style style_default = {
 
 	STYLE_RANGE_NONE, 0, "",
 
-	STYLE_WIDTH_DEFAULT, STYLE_PAD_DEFAULT,
+	STYLE_WIDTH_DEFAULT, 0, STYLE_PAD_DEFAULT,
 
 	STYLE_DEFAULT_BASE
 };
@@ -226,10 +226,20 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 				sy->gc.attr &= ~value;
 			}
 		} else if (end > 6 && strncasecmp(tmp, "width=", 6) == 0) {
-			n = strtonum(tmp + 6, 0, UINT_MAX, &errstr);
-			if (errstr != NULL)
-				goto error;
-			sy->width = (int)n;
+			if (end > 7 && tmp[end - 1] == '%') {
+				tmp[end - 1] = '\0';
+				n = strtonum(tmp + 6, 0, 100, &errstr);
+				if (errstr != NULL)
+					goto error;
+				sy->width = (int)n;
+				sy->width_percentage = 1;
+			} else {
+				n = strtonum(tmp + 6, 0, UINT_MAX, &errstr);
+				if (errstr != NULL)
+					goto error;
+				sy->width = (int)n;
+				sy->width_percentage = 0;
+			}
 		} else if (end > 4 && strncasecmp(tmp, "pad=", 4) == 0) {
 			n = strtonum(tmp + 4, 0, UINT_MAX, &errstr);
 			if (errstr != NULL)
@@ -343,13 +353,17 @@ style_tostring(struct style *sy)
 		comma = ",";
 	}
 	if (gc->attr != 0) {
-		xsnprintf(s + off, sizeof s - off, "%s%s", comma,
+		off += xsnprintf(s + off, sizeof s - off, "%s%s", comma,
 		    attributes_tostring(gc->attr));
 		comma = ",";
 	}
 	if (sy->width >= 0) {
-		xsnprintf(s + off, sizeof s - off, "%swidth=%u", comma,
-		    sy->width);
+		if (sy->width_percentage)
+			off += xsnprintf(s + off, sizeof s - off,
+			    "%swidth=%u%%", comma, sy->width);
+		else
+			off += xsnprintf(s + off, sizeof s - off,
+			    "%swidth=%u", comma, sy->width);
 		comma = ",";
 	}
 	if (sy->pad >= 0) {

--- a/tmux.1
+++ b/tmux.1
@@ -4748,7 +4748,7 @@ see the
 .Sx STYLES
 section.
 .It Ic message-format Ar string
-Set the format string wrapping the prompt and message content.
+Set the format string for the prompt and message area.
 The special placeholder
 .Ql #{message}
 expands to the interactive prompt or message text.
@@ -4760,61 +4760,36 @@ If
 .Ql #{message}
 is omitted, the entire area is used for content.
 The default is
-.Ql #{message} .
+.Ql #[#{E:message-style}]#{message} .
 .It Xo Ic message-line
 .Op Ic 0 | 1 | 2 | 3 | 4
 .Xc
 Set line on which status line messages and the command prompt are shown.
-.It Ic message-margin Ar columns
-Set the number of columns between the message area and the status line
-edge determined by
-.Ic message-position .
-For example, with
-.Ic message-position
-set to
-.Ic right
-and
-.Ic message-margin
-set to 20, the message area is placed 20 columns from the right edge,
-leaving room for
-.Ic status-right
-content.
-The default is 0.
-.It Ic message-min-width Ar columns
-Set the minimum width of the message and command prompt area in columns.
-If
-.Ic message-width
-resolves to fewer columns than this value, the area is expanded to
-.Ar columns .
-The default is 0 (no minimum).
-.It Xo Ic message-position
-.Op Ic left | centre | right
-.Xc
-Set the horizontal position of the message and command prompt area within
-the status line.
-The default is
-.Ic left .
 .It Ic message-style Ar style
 Set status line message style.
 This is used for messages and for the command prompt.
+The message is drawn on top of the existing status line; a
+.Ic fill
+attribute controls whether the background is cleared (the default
+includes
+.Ic fill ) .
+An
+.Ic align
+attribute
+.Pq Ic left , centre , right
+sets the horizontal position and a
+.Ic width
+attribute (a fixed number of columns or a percentage such as
+.Ql 50% )
+constrains the prompt area width.
+When the width is less than the full terminal width, the normal status
+bar content (tabs, status-left, status-right) remains visible around
+the prompt area.
 For how to specify
 .Ar style ,
 see the
 .Sx STYLES
 section.
-.It Ic message-width Ar width
-Set the width of the message and command prompt area.
-.Ar width
-may be a percentage (for example
-.Ql 50% ) ,
-an absolute column count, or
-.Ql auto
-to size to fit the content.
-When the width is less than the full terminal width, the normal status
-bar content (tabs, status-left, status-right) remains visible around
-the prompt area.
-The default is
-.Ql 100% .
 .It Xo Ic mouse
 .Op Ic on | off
 .Xc
@@ -6580,6 +6555,11 @@ is the terminal alternate character set.
 Align text to the left, centre or right of the available space if appropriate.
 .It Ic fill=colour
 Fill the available space with a background colour if appropriate.
+.It Ic width=N
+Set the width of the styled area.
+.Ar N
+may be a column count or a percentage (for example
+.Ql 50% ) .
 .It Xo Ic list=on ,
 .Ic list=focus ,
 .Ic list=left-marker ,

--- a/tmux.1
+++ b/tmux.1
@@ -4751,16 +4751,19 @@ section.
 Set the format string for the prompt and message area.
 The special placeholder
 .Ql #{message}
-expands to the interactive prompt or message text.
-Everything before
-.Ql #{message}
-is drawn as a left decoration and everything after as a right
-decoration, allowing powerline-style framing of the prompt area.
-If
-.Ql #{message}
-is omitted, the entire area is used for content.
-The default is
-.Ql #[#{E:message-style}]#{message} .
+expands to the interactive prompt or message text and
+.Ql #{command_prompt}
+is set to 1 when the prompt is in command mode (vi).
+Style directives like
+.Ic fill ,
+.Ic align ,
+and
+.Ic width
+may be used in the format string.
+The default uses a conditional to select between
+.Ic message-style
+and
+.Ic message-command-style .
 .It Xo Ic message-line
 .Op Ic 0 | 1 | 2 | 3 | 4
 .Xc
@@ -4768,23 +4771,23 @@ Set line on which status line messages and the command prompt are shown.
 .It Ic message-style Ar style
 Set status line message style.
 This is used for messages and for the command prompt.
-The message is drawn on top of the existing status line; a
-.Ic fill
-attribute controls whether the background is cleared (the default
-includes
-.Ic fill ) .
-An
-.Ic align
-attribute
-.Pq Ic left , centre , right
-sets the horizontal position and a
+The message is drawn on top of the existing status line.
+A
 .Ic width
 attribute (a fixed number of columns or a percentage such as
 .Ql 50% )
-constrains the prompt area width.
+constrains the prompt area width and an
+.Ic align
+attribute
+.Pq Ic left , centre , right
+sets its horizontal position.
 When the width is less than the full terminal width, the normal status
-bar content (tabs, status-left, status-right) remains visible around
-the prompt area.
+bar content remains visible around the prompt area.
+The
+.Ic fill
+attribute is used by the default
+.Ic message-format
+to clear the background.
 For how to specify
 .Ar style ,
 see the

--- a/tmux.1
+++ b/tmux.1
@@ -4747,10 +4747,53 @@ For how to specify
 see the
 .Sx STYLES
 section.
+.It Ic message-format Ar string
+Set the format string wrapping the prompt and message content.
+The special placeholder
+.Ql #{message}
+expands to the interactive prompt or message text.
+Everything before
+.Ql #{message}
+is drawn as a left decoration and everything after as a right
+decoration, allowing powerline-style framing of the prompt area.
+If
+.Ql #{message}
+is omitted, the entire area is used for content.
+The default is
+.Ql #{message} .
 .It Xo Ic message-line
 .Op Ic 0 | 1 | 2 | 3 | 4
 .Xc
 Set line on which status line messages and the command prompt are shown.
+.It Ic message-margin Ar columns
+Set the number of columns between the message area and the status line
+edge determined by
+.Ic message-position .
+For example, with
+.Ic message-position
+set to
+.Ic right
+and
+.Ic message-margin
+set to 20, the message area is placed 20 columns from the right edge,
+leaving room for
+.Ic status-right
+content.
+The default is 0.
+.It Ic message-min-width Ar columns
+Set the minimum width of the message and command prompt area in columns.
+If
+.Ic message-width
+resolves to fewer columns than this value, the area is expanded to
+.Ar columns .
+The default is 0 (no minimum).
+.It Xo Ic message-position
+.Op Ic left | centre | right
+.Xc
+Set the horizontal position of the message and command prompt area within
+the status line.
+The default is
+.Ic left .
 .It Ic message-style Ar style
 Set status line message style.
 This is used for messages and for the command prompt.
@@ -4759,6 +4802,19 @@ For how to specify
 see the
 .Sx STYLES
 section.
+.It Ic message-width Ar width
+Set the width of the message and command prompt area.
+.Ar width
+may be a percentage (for example
+.Ql 50% ) ,
+an absolute column count, or
+.Ql auto
+to size to fit the content.
+When the width is less than the full terminal width, the normal status
+bar content (tabs, status-left, status-right) remains visible around
+the prompt area.
+The default is
+.Ql 100% .
 .It Xo Ic mouse
 .Op Ic on | off
 .Xc

--- a/tmux.h
+++ b/tmux.h
@@ -920,6 +920,7 @@ struct style {
 	char			range_string[16];
 
 	int			width;
+	int			width_percentage;
 	int			pad;
 
 	enum style_default_type	default_type;


### PR DESCRIPTION
## Overview

Allow prompts and messages to occupy only a portion of the status bar, overlaying the normal status content rather than replacing the entire line.

Currently, when the command prompt or a message is displayed, it overwrites the entire status line. This hides all window tabs and status information. With these changes, users can configure the prompt to occupy only part of the status bar (e.g. 20% right-aligned with a margin and minimum width), keeping the surrounding status content visible.

## New options

| Option              | Type    | Default      | Description                          |
|---------------------|---------|--------------|--------------------------------------|
| `message-format`    | string  | `#{message}` | Format string wrapping prompt content with decorations |
| `message-margin`    | number  | `0`          | Column offset between the message area and the status line edge determined by `message-position` |
| `message-min-width` | number  | `0`          | Minimum width of the message area in columns |
| `message-position`  | choice  | `left`       | Horizontal position (`left`, `centre`, `right`) |
| `message-width`     | string  | `100%`       | Width of prompt/message area (percentage, absolute, or `auto`) |

## Visual example

Before (current behavior) -- the entire status line is replaced by the prompt:

```
(rename-window) bash
```

After -- the prompt overlaysonly part of the status line, tabs and clock remain visible:

```
1:bash   2:bash   3:bash   4:bash                | (rename-window) bash    | Sun Feb 15  22:20
```

## Backwards compatibility

Default values (`message-width "100%"`, `message-position "left"`, `message-margin 0`, `message-min-width 0`, `message-format "#{message}"`) produce identical behavior to the current release. No visual change for users who do not configure the new options.

## Files changed

- **options-table.c** -- Register `message-format`, `message-margin`, `message-min-width`, `message-position`, and `message-width` options
- **status.c** -- Add `status_prompt_area()` geometry calculation and `status_prompt_draw_format()` decoration helper; modify `status_prompt_redraw()`, `status_message_redraw()`, `status_prompt_complete_list_menu()`, and `status_prompt_complete_window_menu()` to use constrained prompt area
- **tmux.1** -- Document the five new options

## Implementation approach

The rendering follows the existing "copy base status, then selectively overwrite" pattern. The only change is reducing the overwrite region from full-width to the computed prompt area. The `#{message}` marker in `message-format` is handled by splitting the raw format string before `format_expand_time()` so it survives expansion as a split point, then drawing the left/right decoration parts separately via `format_draw()`.

## Testing notes

- Default configuration (no new options set): identical output to current release
- `message-width 50%` + `message-position centre`: tabs visible on both sides of prompt
- `message-width 50%` + `message-position right` + `message-margin 20`: prompt inset from right edge
- `message-width 20%` + `message-min-width 30`: area clamps to 30 columns on narrow percentages
- Long input with constrained width: existing scroll logic works within the narrower area
- Tab completion menus: correctly offset by prompt area position
- `message-width auto`: sizes to content, rounds to 10-column increments
- `message-format` with `#[style]` directives: powerline arrows render correctly
- Works with `status-position top/bottom`, multi-line status bar, and `status off`
