### PR TITLE
Add scroll-exit-on, scroll-exit-off, and scroll-exit-toggle copy_cmd

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -2230,6 +2230,18 @@ Toggle rectangle selection mode.
 .Xc
 Refresh the content from the pane.
 .It Xo
+.Ic scroll-exit-on
+.Xc
+Turn on exiting copy mode when scrolling to the end of the buffer.
+.It Xo
+.Ic scroll-exit-off
+.Xc
+Turn off exiting copy mode when scrolling to the end of the buffer.
+.It Xo
+.Ic scroll-exit-toggle
+.Xc
+Toggle exiting copy mode when scrolling to the end of the buffer.
+.It Xo
 .Ic scroll-bottom
 .Xc
 Scroll up until the current line is at the bottom while keeping the cursor on

--- a/window-copy.c
+++ b/window-copy.c
@@ -2128,6 +2128,36 @@ window_copy_cmd_rectangle_toggle(struct window_copy_cmd_state *cs)
 }
 
 static enum window_copy_cmd_action
+window_copy_cmd_scroll_exit_on(struct window_copy_cmd_state *cs)
+{
+	struct window_copy_mode_data	*data = cs->wme->data;
+
+	data->scroll_exit = 1;
+
+	return (WINDOW_COPY_CMD_NOTHING);
+}
+
+static enum window_copy_cmd_action
+window_copy_cmd_scroll_exit_off(struct window_copy_cmd_state *cs)
+{
+	struct window_copy_mode_data	*data = cs->wme->data;
+
+	data->scroll_exit = 0;
+
+	return (WINDOW_COPY_CMD_NOTHING);
+}
+
+static enum window_copy_cmd_action
+window_copy_cmd_scroll_exit_toggle(struct window_copy_cmd_state *cs)
+{
+	struct window_copy_mode_data	*data = cs->wme->data;
+
+	data->scroll_exit = !data->scroll_exit;
+
+	return (WINDOW_COPY_CMD_NOTHING);
+}
+
+static enum window_copy_cmd_action
 window_copy_cmd_scroll_down(struct window_copy_cmd_state *cs)
 {
 	struct window_mode_entry	*wme = cs->wme;
@@ -3057,6 +3087,21 @@ static const struct {
 	  .args = { "", 0, 0, NULL },
 	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
 	  .f = window_copy_cmd_refresh_from_pane
+	},
+	{ .command = "scroll-exit-on",
+	  .args = { "", 0, 0, NULL },
+	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
+	  .f = window_copy_cmd_scroll_exit_on
+	},
+	{ .command = "scroll-exit-off",
+	  .args = { "", 0, 0, NULL },
+	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
+	  .f = window_copy_cmd_scroll_exit_off
+	},
+	{ .command = "scroll-exit-toggle",
+	  .args = { "", 0, 0, NULL },
+	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
+	  .f = window_copy_cmd_scroll_exit_toggle
 	},
 	{ .command = "scroll-bottom",
 	  .args = { "", 0, 0, NULL },


### PR DESCRIPTION
This allows me to temporarily disable scroll-exit when I'm dragging to select text so that tmux won't accidentally quit copy-mode when I'm also scrolling down at the same time.