### PR TITLE
feat(copy-mode): Added presistent cursor scroll state through refreshing in copy mode.

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -2714,11 +2714,10 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 	data->backing = window_copy_clone_screen(&wp->base, &data->screen, NULL,
 	    NULL, wme->swp != wme->wp);
 
+	data->oy = screen_hsize(data->backing) - oy_from_top;
 	if (data->oy > screen_hsize(data->backing)) {
 		data->cy = 0;
 		data->oy = screen_hsize(data->backing);
-	} else {
-		data->oy = screen_hsize(data->backing) - oy_from_top;
 	}
 
 	window_copy_size_changed(wme);

--- a/window-copy.c
+++ b/window-copy.c
@@ -2702,9 +2702,12 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 	struct window_mode_entry	*wme = cs->wme;
 	struct window_pane		*wp = wme->swp;
 	struct window_copy_mode_data	*data = wme->data;
+	u_int				 oy_from_top;
 
 	if (data->viewmode)
 		return (WINDOW_COPY_CMD_NOTHING);
+
+	oy_from_top = screen_hsize(data->backing) - data->oy;
 
 	screen_free(data->backing);
 	free(data->backing);
@@ -2714,6 +2717,8 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 	if (data->oy > screen_hsize(data->backing)) {
 		data->cy = 0;
 		data->oy = screen_hsize(data->backing);
+	} else {
+		data->oy = screen_hsize(data->backing) - oy_from_top;
 	}
 
 	window_copy_size_changed(wme);

--- a/window-copy.c
+++ b/window-copy.c
@@ -2708,6 +2708,8 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 		return (WINDOW_COPY_CMD_NOTHING);
 
 	oy_from_top = screen_hsize(data->backing) - data->oy;
+	if (oy_from_top > screen_hsize(data->backing))
+		oy_from_top = 0;
 
 	screen_free(data->backing);
 	free(data->backing);


### PR DESCRIPTION
Added the feature from this point of the todo list:
```
In copy mode, refresh (r) will update the content but not move the scroll position, 
so the text appears to jump. It would be better to also move the position so there 
was no apparent movement.
```