### PR TITLE
Fix memory leak in file.c (#4877)

### DIFF
--- a/file.c
+++ b/file.c
@@ -55,6 +55,7 @@ file_get_path(struct client *c, const char *file)
 	if (*path == '/')
 		return (path);
 	xasprintf(&full_path, "%s/%s", server_client_get_cwd(c, NULL), path);
+	free(path);
 	return (full_path);
 }
 


### PR DESCRIPTION
Fixes #4877

This PR fixes a memory leak in file.c where "path" 
was not being freed when "full_path" was being leveraged.

Changes:
- Added free() call in file_get_path to properly free allocated memory