### PR TITLE
feat(format variable): added format variable for floating panes.

### DIFF
--- a/format.c
+++ b/format.c
@@ -1004,6 +1004,20 @@ format_cb_pane_fg(struct format_tree *ft)
 	return (xstrdup(colour_tostring(gc.fg)));
 }
 
+/* Callback for pane_floating_flag. */
+static void *
+format_cb_pane_floating_flag(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL) {
+		if (wp->flags & PANE_FLOATING)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
 /* Callback for pane_bg. */
 static void *
 format_cb_pane_bg(struct format_tree *ft)
@@ -3283,6 +3297,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_fg", FORMAT_TABLE_STRING,
 	  format_cb_pane_fg
+	},
+	{ "pane_floating_flag", FORMAT_TABLE_STRING,
+	  format_cb_pane_floating_flag
 	},
 	{ "pane_format", FORMAT_TABLE_STRING,
 	  format_cb_pane_format

--- a/tmux.1
+++ b/tmux.1
@@ -6270,6 +6270,7 @@ The following variables are available, where appropriate:
 .It Li "pane_dead_status" Ta "" Ta "Exit status of process in dead pane"
 .It Li "pane_dead_time" Ta "" Ta "Exit time of process in dead pane"
 .It Li "pane_fg" Ta "" Ta "Pane foreground colour"
+.It Li "pane_floating_flag" Ta "" Ta "1 if pane is floating"
 .It Li "pane_format" Ta "" Ta "1 if format is for a pane"
 .It Li "pane_height" Ta "" Ta "Height of pane"
 .It Li "pane_id" Ta "#D" Ta "Unique pane ID"


### PR DESCRIPTION
I implemented `10` from the [floating panes issues](https://github.com/tmux/tmux/issues/4800).
```
There needs to be a format variable if a pane is floating so that formats can distinguish them.
```
Let me know how it looks!
