### PR TITLE
Fix: memory leak in format_loop_sessions() in format.c (#4874)

### DIFF
--- a/format.c
+++ b/format.c
@@ -4446,6 +4446,9 @@ format_loop_sessions(struct format_expand_state *es, const char *fmt)
 		strlcat(value, expanded, valuelen);
 		free(expanded);
 	}
+	
+	free(active);
+	free(all);
 
 	return (value);
 }


### PR DESCRIPTION
Free allocated memory for `active` and `all` variables. Refer to how `format_loop_windows()` handles its corresponding `all`/`active` strings.