### PR TITLE
memory fix leak in menu.c issue #4878

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -90,6 +90,7 @@ menu_add_item(struct menu *menu, const struct menu_item *item,
 	else
 		s = format_single(qitem, item->name, c, NULL, NULL, NULL);
 	if (*s == '\0') { /* no item if empty after format expanded */
+		free(s);
 		menu->count--;
 		return;
 	}


### PR DESCRIPTION
Free allocated memory for s after function early return
link to issue description 
[#4878](https://github.com/tmux/tmux/issues/4878)