### PR TITLE
feat(target flag): -t expands formats

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -683,6 +683,32 @@ args_get(struct args *args, u_char flag)
 	return (TAILQ_LAST(&entry->values, args_values)->string);
 }
 
+/* Get arguement target value. Will be NULL if it isn't present */
+const char *
+args_get_target(struct args *args, struct cmdq_item *item)
+{
+	char			*target;
+	u_int			 len;
+	static char		*t = NULL;
+	static u_int		 tsz = 0;
+
+	target = format_single_from_target(item, args_get(args, 't'));
+	if (*target == '\0') {
+		free(target);
+		return (NULL);
+	}
+
+	len = strlen(target);
+	if (tsz <= len) {
+		tsz = len + 100;
+		t = xreallocarray(t, sizeof *t, tsz);
+	}
+	memcpy(t, target, len);
+	t[len] = '\0';
+	free(target);
+	return (t);
+}
+
 /* Get first argument. */
 u_char
 args_first(struct args *args, struct args_entry **entry)

--- a/cmd-attach-session.c
+++ b/cmd-attach-session.c
@@ -169,7 +169,7 @@ cmd_attach_session_exec(struct cmd *self, struct cmdq_item *item)
 {
 	struct args	*args = cmd_get_args(self);
 
-	return (cmd_attach_session(item, args_get(args, 't'),
+	return (cmd_attach_session(item, args_get_target(args, item),
 	    args_has(args, 'd'), args_has(args, 'x'), args_has(args, 'r'),
 	    args_get(args, 'c'), args_has(args, 'E'), args_get(args, 'f')));
 }

--- a/cmd-move-window.c
+++ b/cmd-move-window.c
@@ -62,7 +62,7 @@ cmd_move_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct args		*args = cmd_get_args(self);
 	struct cmd_find_state	*source = cmdq_get_source(item);
 	struct cmd_find_state	 target;
-	const char		*tflag = args_get(args, 't');
+	const char		*tflag = args_get_target(args, item);
 	struct session		*src = source->s;
 	struct session		*dst;
 	struct winlink		*wl = source->wl;

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -129,7 +129,7 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	/* Is this going to be part of a session group? */
-	group = args_get(args, 't');
+	group = args_get_target(args, item);
 	if (group != NULL) {
 		groupwith = target->s;
 		if (groupwith == NULL)

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -549,10 +549,12 @@ cmdq_find_flag(struct cmdq_item *item, struct cmd_find_state *fs,
 	}
 
 	value = args_get(cmd_get_args(item->cmd), flag->flag);
+	value = format_single_from_target(item, value);
 	if (cmd_find_target(fs, item, value, flag->type, flag->flags) != 0) {
 		cmd_find_clear_state(fs, 0);
 		return (CMD_RETURN_ERROR);
 	}
+	free((void *)value);
 	return (CMD_RETURN_NORMAL);
 }
 
@@ -630,7 +632,7 @@ cmdq_fire_command(struct cmdq_item *item)
 			goto out;
 		}
 	} else if (entry->flags & CMD_CLIENT_TFLAG) {
-		tc = cmd_find_client(item, args_get(args, 't'), quiet);
+		tc = cmd_find_client(item, args_get_target(args, item), quiet);
 		if (tc == NULL && !quiet) {
 			retval = CMD_RETURN_ERROR;
 			goto out;

--- a/cmd-set-environment.c
+++ b/cmd-set-environment.c
@@ -75,7 +75,7 @@ cmd_set_environment_exec(struct cmd *self, struct cmdq_item *item)
 		env = global_environ;
 	else {
 		if (target->s == NULL) {
-			tflag = args_get(args, 't');
+			tflag = args_get_target(args, item);
 			if (tflag != NULL)
 				cmdq_error(item, "no such session: %s", tflag);
 			else

--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -128,7 +128,7 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	/* Get the scope and table for the option .*/
-	scope = options_scope_from_name(args, window, name, target, &oo,
+	scope = options_scope_from_name(args, window, name, item, &oo,
 	    &cause);
 	if (scope == OPTIONS_TABLE_NONE) {
 		if (args_has(args, 'q'))

--- a/cmd-show-environment.c
+++ b/cmd-show-environment.c
@@ -103,7 +103,7 @@ cmd_show_environment_exec(struct cmd *self, struct cmdq_item *item)
 	struct environ_entry	*envent;
 	const char		*tflag, *name = args_string(args, 0);
 
-	if ((tflag = args_get(args, 't')) != NULL) {
+	if ((tflag = args_get_target(args, item)) != NULL) {
 		if (target->s == NULL) {
 			cmdq_error(item, "no such session: %s", tflag);
 			return (CMD_RETURN_ERROR);
@@ -114,7 +114,6 @@ cmd_show_environment_exec(struct cmd *self, struct cmdq_item *item)
 		env = global_environ;
 	else {
 		if (target->s == NULL) {
-			tflag = args_get(args, 't');
 			if (tflag != NULL)
 				cmdq_error(item, "no such session: %s", tflag);
 			else

--- a/cmd-show-options.c
+++ b/cmd-show-options.c
@@ -77,7 +77,6 @@ static enum cmd_retval
 cmd_show_options_exec(struct cmd *self, struct cmdq_item *item)
 {
 	struct args			*args = cmd_get_args(self);
-	struct cmd_find_state		*target = cmdq_get_target(item);
 	struct options			*oo;
 	char				*argument, *name = NULL, *cause;
 	int				 window, idx, ambiguous, parent, scope;
@@ -86,7 +85,7 @@ cmd_show_options_exec(struct cmd *self, struct cmdq_item *item)
 	window = (cmd_get_entry(self) == &cmd_show_window_options_entry);
 
 	if (args_count(args) == 0) {
-		scope = options_scope_from_flags(args, window, target, &oo,
+		scope = options_scope_from_flags(args, window, item, &oo,
 		    &cause);
 		if (scope == OPTIONS_TABLE_NONE) {
 			if (args_has(args, 'q'))
@@ -109,7 +108,7 @@ cmd_show_options_exec(struct cmd *self, struct cmdq_item *item)
 			cmdq_error(item, "invalid option: %s", argument);
 		goto fail;
 	}
-	scope = options_scope_from_name(args, window, name, target, &oo,
+	scope = options_scope_from_name(args, window, name, item, &oo,
 	    &cause);
 	if (scope == OPTIONS_TABLE_NONE) {
 		if (args_has(args, 'q'))

--- a/cmd-switch-client.c
+++ b/cmd-switch-client.c
@@ -50,7 +50,7 @@ cmd_switch_client_exec(struct cmd *self, struct cmdq_item *item)
 	struct args		*args = cmd_get_args(self);
 	struct cmd_find_state	*current = cmdq_get_current(item);
 	struct cmd_find_state	 target;
-	const char		*tflag = args_get(args, 't');
+	const char		*tflag = args_get_target(args, item);
 	enum cmd_find_type	 type;
 	int			 flags;
 	struct client		*tc = cmdq_get_target_client(item);

--- a/options.c
+++ b/options.c
@@ -848,19 +848,19 @@ options_set_command(struct options *oo, const char *name,
 }
 
 int
-options_scope_from_name(struct args *args, int window,
-    const char *name, struct cmd_find_state *fs, struct options **oo,
-    char **cause)
+options_scope_from_name(struct args *args, int window, const char *name,
+    struct cmdq_item *item, struct options **oo, char **cause)
 {
+	struct cmd_find_state			*fs = cmdq_get_target(item);
 	struct session				*s = fs->s;
 	struct winlink				*wl = fs->wl;
 	struct window_pane			*wp = fs->wp;
-	const char				*target = args_get(args, 't');
+	const char				*target = args_get_target(args, item);
 	const struct options_table_entry	*oe;
 	int					 scope = OPTIONS_TABLE_NONE;
 
 	if (*name == '@')
-		return (options_scope_from_flags(args, window, fs, oo, cause));
+		return (options_scope_from_flags(args, window, item, oo, cause));
 
 	for (oe = options_table; oe->name != NULL; oe++) {
 		if (strcmp(oe->name, name) == 0)
@@ -919,13 +919,14 @@ options_scope_from_name(struct args *args, int window,
 }
 
 int
-options_scope_from_flags(struct args *args, int window,
-    struct cmd_find_state *fs, struct options **oo, char **cause)
+options_scope_from_flags(struct args *args, int window, struct cmdq_item *item,
+    struct options **oo, char **cause)
 {
+	struct cmd_find_state	*fs = cmdq_get_target(item);
 	struct session		*s = fs->s;
 	struct winlink		*wl = fs->wl;
 	struct window_pane	*wp = fs->wp;
-	const char		*target = args_get(args, 't');
+	const char		*target = args_get_target(args, item);
 
 	if (args_has(args, 's')) {
 		*oo = global_options;

--- a/tmux.h
+++ b/tmux.h
@@ -2507,11 +2507,10 @@ struct options_entry *options_set_number(struct options *, const char *,
 		     long long);
 struct options_entry *options_set_command(struct options *, const char *,
 		     struct cmd_list *);
-int		 options_scope_from_name(struct args *, int,
-		     const char *, struct cmd_find_state *, struct options **,
-		     char **);
+int		 options_scope_from_name(struct args *, int, const char *,
+		     struct cmdq_item *, struct options **, char **);
 int		 options_scope_from_flags(struct args *, int,
-		     struct cmd_find_state *, struct options **, char **);
+		     struct cmdq_item *, struct options **, char **);
 struct style	*options_string_to_style(struct options *, const char *,
 		     struct format_tree *);
 int		 options_from_string(struct options *,
@@ -2722,6 +2721,7 @@ char		*args_print(struct args *);
 char		*args_escape(const char *);
 int		 args_has(struct args *, u_char);
 const char	*args_get(struct args *, u_char);
+const char	*args_get_target(struct args *, struct cmdq_item *);
 u_char		 args_first(struct args *, struct args_entry **);
 u_char		 args_next(struct args_entry **);
 u_int		 args_count(struct args *);


### PR DESCRIPTION
This is an implementation of the todo list item:
```Expand targets as formats. Should this be done by default or require a prefix (maybe a leading + or just look for #{)?```
which is feature request from issue #3407. The code treats targets as formats, though this behavior can easily be adjusted to look for a prefix like '+'. The new function `args_get_target` has the same behavior as `args_get` and is a drop-in replacement for calls to `args_get(args, 't')`.

One part that I'm not sure about is in `cmdq_find_flag` where I expand both targets and sources to keep the code footprint light. I believe that this would amount to a no-op on sources, but I am unsure of potential side effects. If there are unwanted side effects, I would either add if checks or split it into two functions.

Am I on the right track?