### PR TITLE
Make -c start-dir work with `new-session -A`

### DIFF
--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -117,8 +117,9 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 			as = target->s;
 		if (as != NULL) {
 			retval = cmd_attach_session(item, as->name,
-			    args_has(args, 'D'), args_has(args, 'X'), 0, NULL,
-			    args_has(args, 'E'), args_get(args, 'f'));
+				args_has(args, 'D'), args_has(args, 'X'), 0,
+				args_get(args, 'c'), args_has(args, 'E'),
+				args_get(args, 'f'));
 			free(newname);
 			return (retval);
 		}


### PR DESCRIPTION
I've noticed that `new-session` when combined with its attach capability `-A` didn't take into account the `-c start-directory` flag.