### PR TITLE
Fix NULL curw crash in server_redraw_window and server_redraw_window_…

### DIFF
--- a/server-fn.c
+++ b/server-fn.c
@@ -96,7 +96,8 @@ server_redraw_window(struct window *w)
 	struct client	*c;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session != NULL && c->session->curw->window == w)
+		if (c->session != NULL && c->session->curw != NULL &&
+		    c->session->curw->window == w)
 			server_redraw_client(c);
 	}
 }
@@ -107,7 +108,8 @@ server_redraw_window_borders(struct window *w)
 	struct client	*c;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session != NULL && c->session->curw->window == w)
+		if (c->session != NULL && c->session->curw != NULL &&
+		    c->session->curw->window == w)
 			c->flags |= CLIENT_REDRAWBORDERS;
 	}
 }


### PR DESCRIPTION
…borders

Both server_redraw_window() and server_redraw_window_borders() check that c->session is not NULL before accessing c->session->curw->window, but they do not check that c->session->curw itself is non-NULL. This causes a segfault (SIGSEGV) when curw is NULL, as the access to curw->window dereferences address 0x10 (the offset of the "window" field within struct winlink).

The crash was observed after triggering lock-session (C-b L by default). Upon entering the password to unlock, an OSC escape sequence is processed via input_exit_osc(), which calls
server_redraw_window_borders(). At that point, a client exists whose session has no current window (curw == NULL), leading to the segfault.

Stack trace from the crash:

  #0  server_redraw_window_borders (server-fn.c)
  #1  input_exit_osc (input.c)
  #2  input_set_state (input.c)
  #3  input_parse_buffer (input.c)
  #4  input_parse_pane (input.c)
  #5  window_pane_read_callback (window.c)
  #6  bufferevent_run_readcb_ (libevent_core)

Add NULL checks for c->session->curw in both functions.