### PR TITLE
Fix NULL pointer dereference when client ttyname is NULL

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -3708,7 +3708,7 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 		c->term_name = xstrdup("unknown");
 	}
 
-	if (c->ttyname == NULL || *c->ttyname != '\0')
+	if (c->ttyname != NULL && *c->ttyname != '\0')
 		name = xstrdup(c->ttyname);
 	else
 		xasprintf(&name, "client-%ld", (long)c->pid);


### PR DESCRIPTION
## Fix NULL pointer dereference when client ttyname is NULL

In `server_client_dispatch_identify()`, the condition at line 3711 is inverted:

```c
if (c->ttyname == NULL || *c->ttyname != '\0')
    name = xstrdup(c->ttyname);
```

When `c->ttyname` is `NULL`, the `||` short-circuits to true, and `xstrdup(NULL)` is called, passing `NULL` to `strdup()` — **undefined behavior** that will crash on most platforms (SIGSEGV).

### Root cause

The operator and logic are inverted. Compare with the correct pattern four lines above:

```c
if (c->term_name == NULL || *c->term_name == '\0') {  // "if missing or empty"
    free(c->term_name);
    c->term_name = xstrdup("unknown");
}
```

The `ttyname` condition should read: *"if available AND non-empty, use it"*:

```c
if (c->ttyname != NULL && *c->ttyname != '\0')
    name = xstrdup(c->ttyname);
else
    xasprintf(&name, "client-%ld", (long)c->pid);
```

### How to reproduce

This can be triggered when a client connects without a tty (e.g., via `tmux new-session -d` in certain environments where ttyname resolution fails), leaving `c->ttyname` as `NULL`.

### Detection

Found by CppCheck (v2.20) static analysis with cross-translation-unit analysis (`ctunullpointer`).
