### PR TITLE
Fix NULL dereference in tilde expansion, control client crash, and sixel parse memory leak

### DIFF
--- a/cmd-parse.y
+++ b/cmd-parse.y
@@ -1604,7 +1604,8 @@ yylex_token_tilde(char **buf, size_t *len)
 
 	if (*name == '\0') {
 		envent = environ_find(global_environ, "HOME");
-		if (envent != NULL && *envent->value != '\0')
+		if (envent != NULL && envent->value != NULL &&
+		    *envent->value != '\0')
 			home = envent->value;
 		else if ((pw = getpwuid(getuid())) != NULL)
 			home = pw->pw_dir;

--- a/control.c
+++ b/control.c
@@ -1045,6 +1045,9 @@ control_check_subs_timer(__unused int fd, __unused short events, void *data)
 	log_debug("%s: timer fired", __func__);
 	evtimer_add(&cs->subs_timer, &tv);
 
+	if (s == NULL)
+		return;
+
 	/* Find which subscription types are present. */
 	RB_FOREACH(csub, control_subs, &cs->subs) {
 		switch (csub->type) {

--- a/image-sixel.c
+++ b/image-sixel.c
@@ -357,7 +357,7 @@ sixel_parse(const char *buf, size_t len, u_int p2, u_int xpixel, u_int ypixel)
 	return (si);
 
 bad:
-	free(si);
+	sixel_free(si);
 	return (NULL);
 }
 


### PR DESCRIPTION
Three bug fixes found during code review:

**1. Check for NULL value in tilde expansion before dereferencing (cmd-parse.y)**

`yylex_token_tilde()` dereferences `envent->value` without checking for NULL after `environ_find()`. When a variable is cleared with `set-environment -g -r HOME`, the environ entry exists but has a NULL value. Any subsequent command containing `~` crashes the server.

Fix: add `envent->value != NULL` check before dereferencing, matching the existing pattern in `yylex_token_variable()`.

**2. Fix memory leak in sixel_parse() on error path (image-sixel.c)**

The `bad` label in `sixel_parse()` used `free(si)` which only frees the struct itself, leaking all dynamically allocated members (`si->lines`, `si->lines[y].data`, `si->colours`).

This is triggered in normal usage when a sixel-emitting program is killed mid-output, or when a buggy sixel generator produces malformed data. The leak can be significant for large images.

Fix: use `sixel_free(si)` instead of `free(si)`. `sixel_free()` handles partially initialized structs safely since `sixel_parse()` allocates with `xcalloc`.

**3. Fix server crash when control client session is destroyed (control.c)**

When a control mode client's session is destroyed and no replacement session is available, `c->session` becomes NULL. The subscription timer (`control_check_subs_timer`) fires every second and multiple code paths dereference `c->session` without a NULL check, crashing the server.

This is triggered in normal usage when, for example, an iTerm2 control client is connected to the only session and that session is destroyed.

Fix: return early from `control_check_subs_timer` if `c->session` is NULL.