### PR TITLE
Fix issue where popup window gets overwritten by background updates.

### DIFF
--- a/regress/popup-overlap.sh
+++ b/regress/popup-overlap.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Test for popup getting overwritten by background updates
+# We use a nested tmux to capture what the inner tmux actually draws to the terminal.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+TMUX_OUTER="$TEST_TMUX -Ltest2"
+$TMUX_OUTER kill-server 2>/dev/null
+
+trap "$TMUX kill-server 2>/dev/null; $TMUX_OUTER kill-server 2>/dev/null" 0 1 15
+
+# Start outer tmux that will capture the inner tmux's rendering
+$TMUX_OUTER -f/dev/null new -d -x80 -y24 "$TMUX -f/dev/null new -x80 -y24" || exit 1
+sleep 1
+
+# Start a background process in the inner tmux that writes to the middle of the screen
+$TMUX send-keys 'while true; do for i in $(seq 1 20); do printf "\033[H\033[2JBACKGROUND_NOISE\n"; done; sleep 0.1; done' Enter
+sleep 1
+
+# Open a popup in the inner tmux
+$TMUX popup -w 40 -h 10 -d "$PWD" -E "sleep 5" &
+sleep 2
+
+# Capture the output from the outer tmux (which shows what inner tmux drew)
+output=$($TMUX_OUTER capturep -p)
+
+# Clean up
+$TMUX kill-server 2>/dev/null
+$TMUX_OUTER kill-server 2>/dev/null
+
+# If the background overwrites the popup completely, there will be no '│' or '─' characters.
+count_border=$(echo "$output" | grep -c "│")
+if [ "$count_border" -eq 0 ]; then
+    echo "Popup borders missing! It was overwritten by background noise."
+    exit 1
+fi
+
+echo "Popup correctly resisted being overwritten."
+exit 0

--- a/tty-draw.c
+++ b/tty-draw.c
@@ -48,12 +48,16 @@ static void
 tty_draw_line_clear(struct tty *tty, u_int px, u_int py, u_int nx,
     const struct grid_cell *defaults, u_int bg, int wrapped)
 {
+	struct visible_ranges	*r;
+	struct visible_range	*rr;
+	u_int			 i;
+
 	/* Nothing to clear. */
 	if (nx == 0)
 		return;
 
 	/* If genuine BCE is available, can try escape sequences. */
-	if (!wrapped && nx >= 10 && !tty_fake_bce(tty, defaults, bg)) {
+	if (tty->client->overlay_check == NULL && !wrapped && nx >= 10 && !tty_fake_bce(tty, defaults, bg)) {
 		/* Off the end of the line, use EL if available. */
 		if (px + nx >= tty->sx && tty_term_has(tty->term, TTYC_EL)) {
 			tty_cursor(tty, px, py);
@@ -77,14 +81,20 @@ tty_draw_line_clear(struct tty *tty, u_int px, u_int py, u_int nx,
 	}
 
         /* Couldn't use an escape sequence, use spaces. */
-	if (px != 0 || !wrapped)
-		tty_cursor(tty, px, py);
-	if (nx == 1)
-		tty_putc(tty, ' ');
-	else if (nx == 2)
-		tty_putn(tty, "  ", 2, 2);
-	else
-		tty_repeat_space(tty, nx);
+	r = tty_check_overlay_range(tty, px, py, nx);
+	for (i = 0; i < r->used; i++) {
+		rr = &r->ranges[i];
+		if (rr->nx != 0) {
+			if (rr->px != 0 || !wrapped)
+				tty_cursor(tty, rr->px, py);
+			if (rr->nx == 1)
+				tty_putc(tty, ' ');
+			else if (rr->nx == 2)
+				tty_putn(tty, "  ", 2, 2);
+			else
+				tty_repeat_space(tty, rr->nx);
+		}
+	}
 }
 
 /* Is this cell empty? */

--- a/tty.c
+++ b/tty.c
@@ -1162,6 +1162,9 @@ tty_clear_line(struct tty *tty, const struct grid_cell *defaults, u_int py,
     u_int px, u_int nx, u_int bg)
 {
 	struct client		*c = tty->client;
+	struct visible_ranges	*r;
+	struct visible_range	*rr;
+	u_int			 i;
 
 	log_debug("%s: %s, %u at %u,%u", __func__, c->name, nx, px, py);
 
@@ -1197,8 +1200,14 @@ tty_clear_line(struct tty *tty, const struct grid_cell *defaults, u_int py,
 	 * Couldn't use an escape sequence, use spaces. Clear only the visible
 	 * bit if there is an overlay.
 	 */
-	tty_cursor(tty, px, py);
-	tty_repeat_space(tty, nx);
+	r = tty_check_overlay_range(tty, px, py, nx);
+	for (i = 0; i < r->used; i++) {
+		rr = &r->ranges[i];
+		if (rr->nx != 0) {
+			tty_cursor(tty, rr->px, py);
+			tty_repeat_space(tty, rr->nx);
+		}
+	}
 }
 
 /* Clear a line, adjusting to visible part of pane. */
@@ -1364,18 +1373,34 @@ static void
 tty_draw_pane(struct tty *tty, const struct tty_ctx *ctx, u_int py)
 {
 	struct screen	*s = ctx->s;
-	u_int		 nx = ctx->sx, i, x, rx, ry;
+	u_int		 nx = ctx->sx, i, x, rx, ry, j;
+	struct visible_ranges	*r;
+	struct visible_range	*rr;
 
 	log_debug("%s: %s %u %d", __func__, tty->client->name, py, ctx->bigger);
 
 	if (!ctx->bigger) {
-		tty_draw_line(tty, s, 0, py, nx, ctx->xoff, ctx->yoff + py,
-		    &ctx->defaults, ctx->palette);
+		r = tty_check_overlay_range(tty, ctx->xoff, ctx->yoff + py, nx);
+		for (j = 0; j < r->used; j++) {
+			rr = &r->ranges[j];
+			if (rr->nx != 0) {
+				tty_draw_line(tty, s, rr->px - ctx->xoff, py,
+				    rr->nx, rr->px, ctx->yoff + py,
+				    &ctx->defaults, ctx->palette);
+			}
+		}
 		return;
 	}
 	if (tty_clamp_line(tty, ctx, 0, py, nx, &i, &x, &rx, &ry)) {
-		tty_draw_line(tty, s, i, py, rx, x, ry, &ctx->defaults,
-		    ctx->palette);
+		r = tty_check_overlay_range(tty, x, ry, rx);
+		for (j = 0; j < r->used; j++) {
+			rr = &r->ranges[j];
+			if (rr->nx != 0) {
+				tty_draw_line(tty, s, i + (rr->px - x), py,
+				    rr->nx, rr->px, ry, &ctx->defaults,
+				    ctx->palette);
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes an issue I've noticed where the pane behind a popup window occasionally draws over the popup window. This is especially noticeable when `htop` is running in the background pane, and a something like an empty emacs buffer is in the popup window.