### PR TITLE
Added clock-mode-timezone option and added per pane clock options

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -36,7 +36,7 @@ static const char *options_table_mode_keys_list[] = {
 	"emacs", "vi", NULL
 };
 static const char *options_table_clock_mode_style_list[] = {
-	"12", "24", "12-with-seconds", "24-with-seconds", NULL
+	"12", "12-with-seconds", "12-with-timezone", "12-with-seconds-and-timezone", "24", "24-with-seconds", "24-with-timezone", "24-with-seconds-and-timezone", NULL
 };
 static const char *options_table_status_list[] = {
 	"off", "on", "2", "3", "4", "5", NULL
@@ -1130,17 +1130,24 @@ const struct options_table_entry options_table[] = {
 
 	{ .name = "clock-mode-colour",
 	  .type = OPTIONS_TABLE_COLOUR,
-	  .scope = OPTIONS_TABLE_WINDOW,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_num = 4,
 	  .text = "Colour of the clock in clock mode."
 	},
 
 	{ .name = "clock-mode-style",
 	  .type = OPTIONS_TABLE_CHOICE,
-	  .scope = OPTIONS_TABLE_WINDOW,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .choices = options_table_clock_mode_style_list,
 	  .default_num = 1,
 	  .text = "Time format of the clock in clock mode."
+	},
+
+	{ .name = "clock-mode-timezone",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .default_str = "GMT",
+	  .text = "Timezone of the clock in clock mode."
 	},
 
 	{ .name = "copy-mode-match-style",

--- a/tmux.1
+++ b/tmux.1
@@ -5098,9 +5098,14 @@ option is enabled.
 Set clock colour.
 .Pp
 .It Xo Ic clock-mode-style
-.Op Ic 12 | 24 | 12-with-seconds | 24-with-seconds
+.Op Ic 12 | 12-with-seconds | 12-with-timezone | 12-with-seconds-and-timezone | 24 | 24-with-seconds | 24-with-timezone | 24-with-seconds-and-timezone
 .Xc
 Set clock hour format.
+.Pp
+.It Xo Ic clock-mode-timezone
+.Op Ic TZ
+.Xc
+Set clock timezone.
 .Pp
 .It Ic fill-character Ar character
 Set the character used to fill areas of the terminal unused by a window.

--- a/tmux.h
+++ b/tmux.h
@@ -3504,7 +3504,7 @@ extern const struct window_mode window_tree_mode;
 
 /* window-clock.c */
 extern const struct window_mode window_clock_mode;
-extern const char window_clock_table[14][5][5];
+extern const char window_clock_table[37][5][5];
 
 /* window-client.c */
 extern const struct window_mode window_client_mode;

--- a/window-clock.c
+++ b/window-clock.c
@@ -48,9 +48,10 @@ struct window_clock_mode_data {
 	struct screen		screen;
 	time_t			tim;
 	struct event		timer;
+	int 			style;
 };
 
-const char window_clock_table[14][5][5] = {
+const char window_clock_table[37][5][5] = {
 	{ { 1,1,1,1,1 }, /* 0 */
 	  { 1,0,0,0,1 },
 	  { 1,0,0,0,1 },
@@ -111,16 +112,131 @@ const char window_clock_table[14][5][5] = {
 	  { 1,1,1,1,1 },
 	  { 1,0,0,0,1 },
 	  { 1,0,0,0,1 } },
-	{ { 1,1,1,1,1 }, /* P */
+	{ { 1,1,1,1,0 }, /* B */
 	  { 1,0,0,0,1 },
-	  { 1,1,1,1,1 },
+	  { 1,1,1,1,0 },
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,0 } },
+	{ { 1,1,1,1,1 }, /* C */
+	  { 1,0,0,0,0 },
+	  { 1,0,0,0,0 },
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,1 } },
+	{ { 1,1,1,1,0 }, /* D */
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,0 } },
+	{ { 1,1,1,1,1 }, /* E */
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,0 },
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,1 } },
+	{ { 1,1,1,1,1 }, /* F */
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,0 },
 	  { 1,0,0,0,0 },
 	  { 1,0,0,0,0 } },
+	{ { 1,1,1,1,1 }, /* G */
+	  { 1,0,0,0,0 },
+	  { 1,0,1,1,1 },
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 } },
+	{ { 1,0,0,0,1 }, /* H */
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 },
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 } },
+	{ { 1,1,1,1,1 }, /* I */
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 },
+	  { 1,1,1,1,1 } },
+	{ { 0,0,0,0,1 }, /* J */
+	  { 0,0,0,0,1 },
+	  { 0,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 0,1,1,1,0 } },
+	{ { 1,0,0,0,1 }, /* K */
+	  { 1,0,0,1,0 },
+	  { 1,1,1,0,0 },
+	  { 1,0,0,1,0 },
+	  { 1,0,0,0,1 } },
+	{ { 1,0,0,0,0 }, /* L */
+	  { 1,0,0,0,0 },
+	  { 1,0,0,0,0 },
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,1 } },
 	{ { 1,0,0,0,1 }, /* M */
 	  { 1,1,0,1,1 },
 	  { 1,0,1,0,1 },
 	  { 1,0,0,0,1 },
 	  { 1,0,0,0,1 } },
+	{ { 1,0,0,0,1 }, /* N */
+	  { 1,1,0,0,1 },
+	  { 1,0,1,0,1 },
+	  { 1,0,0,1,1 },
+	  { 1,0,0,0,1 } },
+	{ { 1,1,1,1,1 }, /* O */
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 } },
+	{ { 1,1,1,1,1 }, /* P */
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 },
+	  { 1,0,0,0,0 },
+	  { 1,0,0,0,0 } },
+	{ { 1,1,1,1,1 }, /* Q */
+	  { 1,0,0,0,1 },
+	  { 1,0,1,0,1 },
+	  { 1,0,0,1,1 },
+	  { 1,1,1,1,1 } },
+	{ { 1,1,1,1,1 }, /* R */
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 },
+	  { 1,0,0,1,0 },
+	  { 1,0,0,0,1 } },
+	{ { 1,1,1,1,1 }, /* S */
+	  { 1,0,0,0,0 },
+	  { 1,1,1,1,1 },
+	  { 0,0,0,0,1 },
+	  { 1,1,1,1,1 } },
+	{ { 1,1,1,1,1 }, /* T */
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 } },
+	{ { 1,0,0,0,1 }, /* U */
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 1,1,1,1,1 } },
+	{ { 1,0,0,0,1 }, /* V */
+	  { 1,0,0,0,1 },
+	  { 1,0,0,0,1 },
+	  { 0,1,0,1,0 },
+	  { 0,0,1,0,0 } },
+	{ { 1,0,0,0,1 }, /* W */
+	  { 1,0,0,0,1 },
+	  { 1,0,1,0,1 },
+	  { 1,1,0,1,1 },
+	  { 1,0,0,0,1 } },
+	{ { 1,0,0,0,1 }, /* X */
+	  { 0,1,0,1,0 },
+	  { 0,0,1,0,0 },
+	  { 0,1,0,1,0 },
+	  { 1,0,0,0,1 } },
+	{ { 1,0,0,0,1 }, /* Y */
+	  { 0,1,0,1,0 },
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 },
+	  { 0,0,1,0,0 } },
+	{ { 1,1,1,1,1 }, /* Z */
+	  { 0,0,0,1,0 },
+	  { 0,0,1,0,0 },
+	  { 0,1,0,0,0 },
+	  { 1,1,1,1,1 } },
 };
 
 static void
@@ -227,33 +343,47 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 	int				 colour, style;
 	struct screen			*s = &data->screen;
 	struct grid_cell		 gc;
-	char				 tim[64], *ptr;
-	time_t				 t;
-	struct tm			*tm;
+	char				 tim[64], *ptr, *old_tz;
+	const char			*timeformat, *timezone;
+	struct tm			 tm_buf;
 	u_int				 i, j, x, y, idx;
 
-	colour = options_get_number(wp->window->options, "clock-mode-colour");
-	style = options_get_number(wp->window->options, "clock-mode-style");
+	colour = options_get_number(wp->options, "clock-mode-colour");
+	style = options_get_number(wp->options, "clock-mode-style");
+	timezone = options_get_string(wp->options, "clock-mode-timezone");
 
 	screen_write_start(&ctx, s);
 
-	t = time(NULL);
-	tm = localtime(&t);
-	if (style == 0 || style == 2) {
-		if (style == 2)
-			strftime(tim, sizeof tim, "%l:%M:%S ", localtime(&t));
-		else
-			strftime(tim, sizeof tim, "%l:%M ", localtime(&t));
-		if (tm->tm_hour >= 12)
-			strlcat(tim, "PM", sizeof tim);
-		else
-			strlcat(tim, "AM", sizeof tim);
-	} else {
-		if (style == 3)
-			strftime(tim, sizeof tim, "%H:%M:%S", tm);
-		else
-			strftime(tim, sizeof tim, "%H:%M", tm);
+	old_tz = getenv("TZ");
+	if (old_tz != NULL)
+		old_tz = xstrdup(old_tz);
+	if (timezone != NULL && *timezone != '\0')
+		setenv("TZ", timezone, 1);
+	else
+		unsetenv("TZ");
+	tzset();
+
+	localtime_r(&data->tim, &tm_buf);
+	switch (style) {
+		case 0: timeformat = "%l:%M %p";        break;
+		case 1: timeformat = "%l:%M:%S %p";     break;
+		case 2: timeformat = "%l:%M %p %Z";     break;
+		case 3: timeformat = "%l:%M:%S %p %Z";  break;
+		case 4: timeformat = "%H:%M";           break;
+		case 5: timeformat = "%H:%M:%S";        break;
+		case 6: timeformat = "%H:%M %Z";        break;
+		case 7: timeformat = "%H:%M:%S %Z";     break;
+		default: timeformat = "%H:%M";
 	}
+
+	strftime(tim, sizeof tim, timeformat, &tm_buf);
+
+	if (old_tz != NULL) {
+		setenv("TZ", old_tz, 1);
+		free(old_tz);
+	} else
+		unsetenv("TZ");
+	tzset();
 
 	screen_write_clearscreen(&ctx, 8);
 
@@ -284,12 +414,8 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 			idx = *ptr - '0';
 		else if (*ptr == ':')
 			idx = 10;
-		else if (*ptr == 'A')
-			idx = 11;
-		else if (*ptr == 'P')
-			idx = 12;
-		else if (*ptr == 'M')
-			idx = 13;
+		else if (*ptr >= 'A' && *ptr <= 'Z')
+			idx = 11 + (*ptr - 'A');
 		else {
 			x += 6;
 			continue;


### PR DESCRIPTION
Added option to change timezone in clock mode with the `clock-mode-timezone` option. I also added arguments `12-with-timezone`, `24-with-timezone`, `24-with-seconds-and-timezone` and `12-with-seconds-and-timezone` to the `clock-mode-style` option.

The options `clock-mode-color`, `clock-mode-style` and `clock-mode-timezone` now also works per pane, such that it is possible to display different time zones with different styles and colors in different panes using the `-p` flag.

<img width="1887" height="836" alt="image" src="https://github.com/user-attachments/assets/f9da1455-e2b6-45d5-a9fd-8567ca20be5b" />