### PR TITLE
fix: hyperlink loss in popup redraw

### DIFF
--- a/popup.c
+++ b/popup.c
@@ -279,6 +279,10 @@ popup_draw_cb(struct client *c, void *data, struct screen_redraw_ctx *rctx)
 	popup_reapply_styles(pd);
 
 	screen_init(&s, pd->sx, pd->sy, 0);
+	if (pd->s.hyperlinks != NULL) {
+		hyperlinks_free(s.hyperlinks);
+		s.hyperlinks = hyperlinks_copy(pd->s.hyperlinks);
+	}
 	screen_write_start(&ctx, &s);
 	screen_write_clearscreen(&ctx, 8);
 

--- a/regress/popup-hyperlink.sh
+++ b/regress/popup-hyperlink.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Test that OSC 8 hyperlinks in display-popup survive a redraw.
+#
+# Uses nested tmux: an outer server captures terminal output from an inner
+# server whose popup contains a hyperlink. After forcing a full redraw of
+# the inner server (which exercises popup_draw_cb), the outer pane's
+# captured content must still contain the hyperlink URI.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+TMUX2="$TEST_TMUX -Ltest2"
+TMP=$(mktemp)
+trap "rm -f $TMP; $TMUX kill-server 2>/dev/null; $TMUX2 kill-server 2>/dev/null" 0 1 15
+
+$TMUX kill-server 2>/dev/null
+$TMUX2 kill-server 2>/dev/null
+
+# Start the inner tmux session (detached).
+$TMUX2 -f/dev/null new -d -x60 -y20 || exit 1
+
+# Start the outer tmux with the inner tmux attached as its pane command.
+# The inner tmux draws to the outer pane's PTY so we can capture its output.
+$TMUX -f/dev/null new -d -x80 -y24 "$TMUX2 a" || exit 1
+sleep 1
+
+# Open a popup in the inner tmux containing an OSC 8 hyperlink.
+# display-popup blocks until the popup closes, so run it in the background.
+$TMUX2 display-popup -w40 -h6 \
+  "printf '\033]8;;https://example.com\033\\Click\033]8;;\033\\\n'; sleep 30" &
+sleep 1
+
+# Force a full client redraw, which triggers popup_draw_cb.
+$TMUX2 refresh-client
+sleep 1
+
+# Capture the outer pane content with escape sequences (-e includes OSC 8).
+$TMUX capturep -peS0 -E23 >$TMP
+
+# The captured content must contain the hyperlink URI after the redraw.
+grep -q 'example.com' $TMP || exit 1
+
+exit 0


### PR DESCRIPTION
Linux unknown // It's Arch Linux / Omarchy
tmux 3.6a
tmux-256color

I was running into an issue with https://github.com/tmuxpack/tpack/issues/8 (tpm replacement) where the hyperlinks (OSC-8) would disappear after a few seconds. It uses the display-popup functionality of tmux and when running directly in a normal terminal it would not be an issue.

To replicate simply do `:display popup` and run `printf "\e]8;;https://example.com\aClick\e]8;;\a\n";`.
Then move the mouse over the hyperlink (holding whatever keys you need to in your terminal) and you will see the hyperlink disappear.

I tracked it down to the redraw of the popup, which would not copy over the hyperlinks.
I have accompanied the change with a test!

Let me know if any adjustments are needed. 