### PR TITLE
systemd: ensure pane scopes survive during server shutdown

### DIFF
--- a/compat/systemd.c
+++ b/compat/systemd.c
@@ -109,7 +109,7 @@ systemd_move_to_new_cgroup(char **cause)
 	sd_bus_message		*m = NULL, *reply = NULL;
 	sd_bus 			*bus = NULL;
 	sd_bus_slot		*slot = NULL;
-	char			*name, *desc, *slice;
+	char			*name, *desc, *slice, *unit;
 	sd_id128_t		 uuid;
 	int			 r;
 	uint64_t		 elapsed_usec;
@@ -239,6 +239,25 @@ systemd_move_to_new_cgroup(char **cause)
 		xasprintf(cause, "failed to append to properties: %s",
 		    strerror(-r));
 		goto finish;
+	}
+
+	/*
+	 * Try locating systemd unit that started the server, and mark
+	 * pane units as dependent on it. Use "Before" to make sure
+	 * systemd will not try to kill them first.
+	 */
+	if (sd_pid_get_user_unit(parent_pid, &unit) == 0 ||
+	    sd_pid_get_unit(parent_pid, &unit) == 0) {
+		r = sd_bus_message_append(m, "(sv)", "Before", "as", 1, unit);
+		if (r >= 0)
+			r = sd_bus_message_append(m, "(sv)", "PartOf", "as", 1,
+			    unit);
+		free(unit);
+		if (r < 0) {
+			xasprintf(cause, "failed to append to properties: %s",
+			    strerror(-r));
+			goto finish;
+		}
 	}
 
 	/* End properties array. */


### PR DESCRIPTION
Previously, systemd transient scopes for tmux panes were sibling units to the tmux server process. During system shutdown, systemd would often terminate these pane scopes in parallel with the server, causing state-saving plugins (like tmux-resurrect) to fail properly save sessions state because the panes would be already gone. Typical symptoms of this situation are 'no server running' error messages in the journal, a failed tmux service, and 0-length resurrect state on disk.

Fix the problem by ensuring that panes are not killed too early by discovering the systemd unit that started tmux service (if any), favoring user-level units over system-level ones, and attaching 'Before=' and 'PartOf=' properties to the transient pane scopes.

These annotations establish a strict dependency: systemd is now explicitly barred from stopping the panes until the server process's unit has finished its shutdown sequence (including all ExecStop hooks).

This ensures that state-saving scripts can reliably query all panes before the server is finally killed.