### PR TITLE
Fix get-clipboard 'both' option in manpage

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -4366,7 +4366,7 @@ causes
 .Nm
 to request the clipboard from the most recently used client (if possible) and
 send the reply (if any) back to the application;
-.Ic buffer
+.Ic both
 is the same as
 .Ic request
 but also creates a paste buffer.


### PR DESCRIPTION
Looks like `buffer` was written a second time when it was meant to be `both`.