### PR TITLE
feat: Panes' status format now displays title/flag information

### DIFF
--- a/format.c
+++ b/format.c
@@ -1004,6 +1004,15 @@ format_cb_pane_fg(struct format_tree *ft)
 	return (xstrdup(colour_tostring(gc.fg)));
 }
 
+/* Callback for pane_flags. */
+static void *
+format_cb_pane_flags(struct format_tree *ft)
+{
+	if (ft->wp != NULL)
+		return (xstrdup(window_pane_printable_flags(ft->wp, 1)));
+	return (NULL);
+}
+
 /* Callback for pane_floating_flag. */
 static void *
 format_cb_pane_floating_flag(struct format_tree *ft)
@@ -2205,6 +2214,21 @@ format_cb_pane_marked_set(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for pane_minimised_flag. */
+static void *
+format_cb_pane_minimised_flag(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL) {
+		if (wp->flags & PANE_MINIMISED)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
+
 /* Callback for pane_mode. */
 static void *
 format_cb_pane_mode(struct format_tree *ft)
@@ -2330,6 +2354,20 @@ format_cb_pane_width(struct format_tree *ft)
 {
 	if (ft->wp != NULL)
 		return (format_printf("%u", ft->wp->sx));
+	return (NULL);
+}
+
+/* Callback for pane_zoomed_flag. */
+static void *
+format_cb_pane_zoomed_flag(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL) {
+		if (wp->flags & PANE_ZOOMED)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
 	return (NULL);
 }
 
@@ -3309,6 +3347,9 @@ static const struct format_table_entry format_table[] = {
 	{ "pane_fg", FORMAT_TABLE_STRING,
 	  format_cb_pane_fg
 	},
+	{ "pane_flags", FORMAT_TABLE_STRING,
+	  format_cb_pane_flags
+	},
 	{ "pane_floating_flag", FORMAT_TABLE_STRING,
 	  format_cb_pane_floating_flag
 	},
@@ -3344,6 +3385,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_marked_set", FORMAT_TABLE_STRING,
 	  format_cb_pane_marked_set
+	},
+	{ "pane_minimised_flag", FORMAT_TABLE_STRING,
+	  format_cb_pane_minimised_flag
 	},
 	{ "pane_mode", FORMAT_TABLE_STRING,
 	  format_cb_pane_mode
@@ -3392,6 +3436,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_width", FORMAT_TABLE_STRING,
 	  format_cb_pane_width
+	},
+	{ "pane_zoomed_flag", FORMAT_TABLE_STRING,
+	  format_cb_pane_zoomed_flag
 	},
 	{ "pid", FORMAT_TABLE_STRING,
 	  format_cb_pid

--- a/options-table.c
+++ b/options-table.c
@@ -185,7 +185,7 @@ static const char *options_table_allow_passthrough_list[] = {
 			"#{E:pane-status-style}" \
 		"]" \
 		"#[push-default]" \
-		"#P[#{pane_width}x#{pane_height}]" \
+		"#{T:window-pane-status-format}" \
 		"#[pop-default]" \
 		"#[norange list=on default]  " \
 	"," \
@@ -196,7 +196,7 @@ static const char *options_table_allow_passthrough_list[] = {
 			"}" \
 		"]" \
 		"#[push-default]" \
-		"#P[#{pane_width}x#{pane_height}]*" \
+		"#{T:window-pane-current-status-format}" \
 		"#[pop-default]" \
 		"#[norange list=on default] " \
 	"}"
@@ -1456,6 +1456,21 @@ const struct options_table_entry options_table[] = {
 	  .flags = OPTIONS_TABLE_IS_STYLE,
 	  .separator = ",",
 	  .text = "Default style of the active pane."
+	},
+
+	{ .name = "window-pane-current-status-format",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "#P:[#T]#{?pane_flags,#{pane_flags}, }",
+	  .text = "Format of the current window pane in the status line."
+	},
+
+	{ .name = "window-pane-status-format",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .default_str = "#P:[#T]#{?pane_flags,#{pane_flags}, }",
+	  .text = "Format of window panes in the status line, except the "
+		  "current pane."
 	},
 
 	{ .name = "window-size",

--- a/tmux.1
+++ b/tmux.1
@@ -5613,6 +5613,20 @@ For how to specify
 see the
 .Sx STYLES
 section.
+.Pp
+.It Ic window-pane-status-format Ar string
+Set the format in which the window pane is displayed in the status line window
+pane list.
+See the
+.Sx FORMATS
+and
+.Sx STYLES
+sections.
+.Pp
+.It Ic window-pane-current-status-format Ar string
+Like
+.Ar window-status-format ,
+but is the format used when the window is the current window.
 .El
 .Sh HOOKS
 .Nm
@@ -6364,6 +6378,7 @@ The following variables are available, where appropriate:
 .It Li "pane_dead_status" Ta "" Ta "Exit status of process in dead pane"
 .It Li "pane_dead_time" Ta "" Ta "Exit time of process in dead pane"
 .It Li "pane_fg" Ta "" Ta "Pane foreground colour"
+.It Li "pane_flags" Ta "" Ta "Pane flags"
 .It Li "pane_floating_flag" Ta "" Ta "1 if pane is floating"
 .It Li "pane_format" Ta "" Ta "1 if format is for a pane"
 .It Li "pane_height" Ta "" Ta "Height of pane"
@@ -6376,6 +6391,7 @@ The following variables are available, where appropriate:
 .It Li "pane_left" Ta "" Ta "Left of pane"
 .It Li "pane_marked" Ta "" Ta "1 if this is the marked pane"
 .It Li "pane_marked_set" Ta "" Ta "1 if a marked pane is set"
+.It Li "pane_minimised_flag" Ta "" Ta "1 if pane is minimised"
 .It Li "pane_mode" Ta "" Ta "Name of pane mode, if any"
 .It Li "pane_path" Ta "" Ta "Path of pane (can be set by application)"
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"
@@ -6392,6 +6408,7 @@ The following variables are available, where appropriate:
 .It Li "pane_tty" Ta "" Ta "Pseudo terminal of pane"
 .It Li "pane_unseen_changes" Ta "" Ta "1 if there were changes in pane while in mode"
 .It Li "pane_width" Ta "" Ta "Width of pane"
+.It Li "pane_zoomed_flag" Ta "" Ta "1 if pane is zoomed"
 .It Li "pid" Ta "" Ta "Server PID"
 .It Li "prev_window_active" Ta "" Ta "1 if previous window in W: loop is active"
 .It Li "prev_window_index" Ta "" Ta "Index of previous window in W: loop"

--- a/tmux.h
+++ b/tmux.h
@@ -1230,6 +1230,7 @@ struct window_pane {
 #define PANE_REDRAWSCROLLBAR 0x8000
 #define PANE_FLOATING 0x10000
 #define PANE_MINIMISED 0x20000
+#define PANE_ZOOMED 0x40000
 
 	u_int		 sb_slider_y;
 	u_int		 sb_slider_h;
@@ -3396,6 +3397,7 @@ int		 window_pane_exited(struct window_pane *);
 u_int		 window_pane_search(struct window_pane *, const char *, int,
 		     int);
 const char	*window_printable_flags(struct winlink *, int);
+const char	*window_pane_printable_flags(struct window_pane *, int);
 struct window_pane *window_pane_find_up(struct window_pane *);
 struct window_pane *window_pane_find_down(struct window_pane *);
 struct window_pane *window_pane_find_left(struct window_pane *);

--- a/window.c
+++ b/window.c
@@ -738,6 +738,7 @@ window_zoom(struct window_pane *wp)
 
 	if (w->active != wp)
 		window_set_active_pane(w, wp, 1);
+	wp->flags |= PANE_ZOOMED;
 
 	/* Bring pane above other tiled panes and minimise floating panes. */
 	TAILQ_FOREACH(wp1, &w->z_index, zentry) {
@@ -791,6 +792,7 @@ window_unzoom(struct window *w, int notify)
 	TAILQ_FOREACH(wp, &w->panes, entry) {
 		wp->layout_cell = wp->saved_layout_cell;
 		wp->saved_layout_cell = NULL;
+		wp->flags &= ~PANE_ZOOMED;
 	}
 	layout_fix_panes(w, NULL);
 
@@ -1002,6 +1004,28 @@ window_printable_flags(struct winlink *wl, int escape)
 		flags[pos++] = 'M';
 	if (wl->window->flags & WINDOW_ZOOMED)
 		flags[pos++] = 'Z';
+	flags[pos] = '\0';
+	return (flags);
+}
+
+const char *
+window_pane_printable_flags(struct window_pane *wp, __unused int escape)
+{
+	static char	 flags[32];
+	struct window	*w = wp->window;
+	int		 pos = 0;
+
+	if (wp == w->active)
+		flags[pos++] = '*';
+	if (wp == TAILQ_FIRST(&w->last_panes))
+		flags[pos++] = '-';
+	if (wp->flags & PANE_ZOOMED)
+		flags[pos++] = 'Z';
+	if (wp->flags & PANE_FLOATING)
+		flags[pos++] = 'F';
+	if (wp->flags & PANE_MINIMISED)
+		flags[pos++] = 'm';
+
 	flags[pos] = '\0';
 	return (flags);
 }


### PR DESCRIPTION
This is an implementation of point 9 from issue #4800:
'Modify status line 2 to be the name of the window pane and not width x height.`

I have added two new flags, `pane_zoomed_flag` and `pane_minimised_flag` to be utilized by formats. The implementation borrows the technique and styling used by `window_flags` for formatting panes on the status line.

@mgrant0 