### PR TITLE
utf8: support ranges in codepoint-widths option

### DIFF
--- a/regress/codepoint-widths-range.sh
+++ b/regress/codepoint-widths-range.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(cd .. && pwd)/tmux
+tmux() { "$TEST_TMUX" -Ltest "$@"; }
+tmux kill-server 2>/dev/null
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; tmux kill-server 2>/dev/null; exit 1; }
+
+# Helper: start server, run set command, kill server
+try() {
+	desc="$1"; shift
+	tmux new-session -d -s test 2>/dev/null || fail "$desc (new-session)"
+	tmux "$@" 2>/dev/null
+	rc=$?
+	tmux kill-server 2>/dev/null
+	return $rc
+}
+
+# 1. Single codepoint (existing behaviour must still work)
+try "single codepoint" set -sa codepoint-widths "U+2665=2" \
+	&& pass "single codepoint" || fail "single codepoint"
+
+# 2. Single-point range (start == end)
+try "single-point range" set -sa codepoint-widths "U+2665-U+2665=2" \
+	&& pass "single-point range" || fail "single-point range"
+
+# 3. Small range
+try "small range" set -sa codepoint-widths "U+E000-U+E00F=2" \
+	&& pass "small range" || fail "small range"
+
+# 4. Full Nerd Fonts ranges from the issue
+tmux new-session -d -s test 2>/dev/null || fail "nerd fonts ranges (new-session)"
+tmux set -sa codepoint-widths "U+23FB-U+23FE=2" && \
+tmux set -sa codepoint-widths "U+2665-U+2665=2" && \
+tmux set -sa codepoint-widths "U+2B58-U+2B58=2" && \
+tmux set -sa codepoint-widths "U+E000-U+E09F=2" && \
+tmux set -sa codepoint-widths "U+E0C0-U+F8FF=2" && \
+tmux set -sa codepoint-widths "U+F0001-U+FFFFF=2" \
+	&& pass "nerd fonts ranges" || fail "nerd fonts ranges"
+tmux kill-server 2>/dev/null
+
+# 5. Invalid range (end < start) must be rejected without crash
+try "invalid range end<start" set -sa codepoint-widths "U+E00F-U+E000=2" \
+	&& pass "invalid range end<start rejected" || pass "invalid range end<start rejected"
+
+echo "all tests passed"
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -4241,9 +4241,10 @@ An array option allowing widths of Unicode codepoints to be overridden.
 Note the new width applies to all clients.
 Each entry is of the form
 .Em codepoint=width ,
-where codepoint may be a UTF-8 character or an identifier of the form
+where codepoint may be a UTF-8 character, an identifier of the form
 .Ql U+number
-where the number is a hexadecimal number.
+where the number is a hexadecimal number, or a range of the form
+.Ql U+number-U+number .
 .It Ic copy-command Ar shell-command
 Give the command to pipe to if the
 .Ic copy-pipe

--- a/utf8.c
+++ b/utf8.c
@@ -301,7 +301,7 @@ utf8_add_to_width_cache(const char *s)
 	u_int			 width;
 	const char		*errstr;
 	struct utf8_data	*ud;
-	wchar_t			 wc;
+	wchar_t			 wc, wc_start, wc_end;
 	unsigned long long	 n;
 
 	copy = xstrdup(s);
@@ -321,14 +321,58 @@ utf8_add_to_width_cache(const char *s)
 		errno = 0;
 		n = strtoull(copy + 2, &endptr, 16);
 		if (copy[2] == '\0' ||
-		    *endptr != '\0' ||
 		    n == 0 ||
 		    n > WCHAR_MAX ||
 		    (errno == ERANGE && n == ULLONG_MAX)) {
 			free(copy);
 			return;
 		}
-		wc = n;
+		wc_start = n;
+
+		if (*endptr == '-') {
+			endptr++;
+			if (strncmp(endptr, "U+", 2) != 0) {
+				free(copy);
+				return;
+			}
+			errno = 0;
+			n = strtoull(endptr + 2, &endptr, 16);
+			if (*endptr != '\0' ||
+			    n == 0 ||
+			    n > WCHAR_MAX ||
+			    (errno == ERANGE && n == ULLONG_MAX) ||
+			    n < wc_start) {
+				free(copy);
+				return;
+			}
+			wc_end = n;
+		} else if (*endptr != '\0') {
+			free(copy);
+			return;
+		} else {
+			wc_end = wc_start;
+		}
+
+		for (wc = wc_start; wc <= wc_end; wc++) {
+			log_debug("Unicode width cache: %08X=%u", (u_int)wc,
+			    width);
+
+			uw = xcalloc(1, sizeof *uw);
+			uw->wc = wc;
+			uw->width = width;
+			uw->allocated = 1;
+
+			old = RB_INSERT(utf8_width_cache, &utf8_width_cache,
+			    uw);
+			if (old != NULL) {
+				RB_REMOVE(utf8_width_cache, &utf8_width_cache,
+				    old);
+				if (old->allocated)
+					free(old);
+				RB_INSERT(utf8_width_cache, &utf8_width_cache,
+				    uw);
+			}
+		}
 	} else {
 		utf8_no_width = 1;
 		ud = utf8_fromcstr(copy);
@@ -348,21 +392,21 @@ utf8_add_to_width_cache(const char *s)
 			return;
 		}
 		free(ud);
-	}
 
-	log_debug("Unicode width cache: %08X=%u", (u_int)wc, width);
+		log_debug("Unicode width cache: %08X=%u", (u_int)wc, width);
 
-	uw = xcalloc(1, sizeof *uw);
-	uw->wc = wc;
-	uw->width = width;
-	uw->allocated = 1;
+		uw = xcalloc(1, sizeof *uw);
+		uw->wc = wc;
+		uw->width = width;
+		uw->allocated = 1;
 
-	old = RB_INSERT(utf8_width_cache, &utf8_width_cache, uw);
-	if (old != NULL) {
-		RB_REMOVE(utf8_width_cache, &utf8_width_cache, old);
-		if (old->allocated)
-			free(old);
-		RB_INSERT(utf8_width_cache, &utf8_width_cache, uw);
+		old = RB_INSERT(utf8_width_cache, &utf8_width_cache, uw);
+		if (old != NULL) {
+			RB_REMOVE(utf8_width_cache, &utf8_width_cache, old);
+			if (old->allocated)
+				free(old);
+			RB_INSERT(utf8_width_cache, &utf8_width_cache, uw);
+		}
 	}
 
 	free(copy);


### PR DESCRIPTION
Currently, codepoint-widths only accepts individual codepoints, requiring one entry per codepoint. With Nerd Fonts v3 "Propo" variant having 10741 wide icons, setting them one-by-one causes ~10 second delay on tmux start.

This adds support for ranges in the U+XXXX-U+YYYY format, allowing the same configuration with just a few entries:

      set -sa codepoint-widths "U+E000-U+E09F=2"
      set -sa codepoint-widths "U+E0C0-U+F8FF=2"
      set -sa codepoint-widths "U+F0001-U+FFFFF=2"

Requested by users configuring Nerd Fonts v3 "Propo" variant, which requires setting ~10k wide codepoints individually.