### PR TITLE
screen-redraw: fix integer underflow in scrollbar drawing

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1100,7 +1100,8 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	memcpy(&slgc, &gc, sizeof slgc);
 	slgc.fg = gc.bg;
 	slgc.bg = gc.fg;
-
+	if (sb_x >= (int)sx)
+		return;
 	imax = sb_w + sb_pad;
 	if ((int)imax + sb_x > sx)
 		imax = sx - sb_x;


### PR DESCRIPTION
When sb_x >= sx, the expression sx - sb_x produces a negative value which is assigned to u_int imax, wrapping it to ~4 billion. This causes the drawing loop to run ~4 billion iterations, hanging the server at 100% CPU.

Fix by returning early if the scrollbar's x position is beyond the screen width.

Fixes #4932.