### PR TITLE
Fix unsigned integer underflow in scrollbar and border drawing

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -155,11 +155,11 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	 */
 	if ((wp->yoff == 0 || py >= wp->yoff - 1) && py <= ey) {
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if (wp->xoff - sb_w == 0 && px == wp->sx + sb_w)
+			if ((int)wp->xoff - sb_w == 0 && px == wp->sx + sb_w)
 				if (!hsplit || (hsplit && py <= wp->sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
-			if (wp->xoff - sb_w != 0) {
-				if (px == wp->xoff - sb_w - 1 &&
+			if ((int)wp->xoff - sb_w != 0) {
+				if (px == (int)wp->xoff - sb_w - 1 &&
 				    (!hsplit || (hsplit && py > wp->sy / 2)))
 					return (SCREEN_REDRAW_BORDER_LEFT);
 				if (px == wp->xoff + wp->sx + sb_w - 1)
@@ -187,7 +187,7 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 			return (SCREEN_REDRAW_BORDER_TOP);
 	} else {
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if ((wp->xoff - sb_w == 0 || px >= wp->xoff - sb_w) &&
+			if (((int)wp->xoff - sb_w == 0 || (int)px >= (int)wp->xoff - sb_w) &&
 			    (px <= ex || (sb_w != 0 && px < ex + sb_w))) {
 				if (wp->yoff != 0 && py == wp->yoff - 1)
 					return (SCREEN_REDRAW_BORDER_TOP);
@@ -358,9 +358,11 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, u_int px, u_int py,
 			if (!window_pane_visible(wp))
 				goto next1;
 
-			if (pane_status == PANE_STATUS_TOP)
+			if (pane_status == PANE_STATUS_TOP) {
+				if (wp->yoff == 0)
+					goto next1;
 				line = wp->yoff - 1;
-			else
+			} else
 				line = wp->yoff + sy;
 			right = wp->xoff + 2 + wp->status_size - 1;
 
@@ -382,9 +384,11 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, u_int px, u_int py,
 
 		/* Check if CELL_SCROLLBAR */
 		if (window_pane_show_scrollbar(wp, pane_scrollbars)) {
-			if (pane_status == PANE_STATUS_TOP)
+			if (pane_status == PANE_STATUS_TOP) {
+				if (wp->yoff == 0)
+					goto next2;
 				line = wp->yoff - 1;
-			else
+			} else
 				line = wp->yoff + wp->sy;
 
 			/*
@@ -402,7 +406,7 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, u_int px, u_int py,
 				     (px >= wp->xoff + wp->sx &&
 				      px < wp->xoff + wp->sx + sb_w)) ||
 				    (sb_pos == PANE_SCROLLBARS_LEFT &&
-				     (px >= wp->xoff - sb_w &&
+				     ((int)px >= (int)wp->xoff - sb_w &&
 				      px < wp->xoff)))
 					return (CELL_SCROLLBAR);
 			}
@@ -483,9 +487,11 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 
 	for (i = 0; i < width; i++) {
 		px = wp->xoff + 2 + i;
-		if (pane_status == PANE_STATUS_TOP)
+		if (pane_status == PANE_STATUS_TOP) {
+			if (wp->yoff == 0)
+				break;
 			py = wp->yoff - 1;
-		else
+		} else
 			py = wp->yoff + wp->sy;
 		cell_type = screen_redraw_type_of_cell(rctx, px, py);
 		screen_redraw_border_set(w, wp, pane_lines, cell_type, &gc);
@@ -527,9 +533,11 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 		s = &wp->status_screen;
 
 		size = wp->status_size;
-		if (ctx->pane_status == PANE_STATUS_TOP)
+		if (ctx->pane_status == PANE_STATUS_TOP) {
+			if (wp->yoff == 0)
+				continue;
 			yoff = wp->yoff - 1;
-		else
+		} else
 			yoff = wp->yoff + wp->sy;
 		xoff = wp->xoff + 2;
 
@@ -890,9 +898,11 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	TAILQ_FOREACH(wp, &w->panes, entry)
 		wp->border_gc_set = 0;
 
-	for (j = 0; j < c->tty.sy - ctx->statuslines; j++) {
-		for (i = 0; i < c->tty.sx; i++)
-			screen_redraw_draw_borders_cell(ctx, i, j);
+	if (c->tty.sy > ctx->statuslines) {
+		for (j = 0; j < c->tty.sy - ctx->statuslines; j++) {
+			for (i = 0; i < c->tty.sx; i++)
+				screen_redraw_draw_borders_cell(ctx, i, j);
+		}
 	}
 }
 
@@ -926,8 +936,10 @@ screen_redraw_draw_status(struct screen_redraw_ctx *ctx)
 
 	if (ctx->statustop)
 		y = 0;
-	else
+	else if (c->tty.sy > ctx->statuslines)
 		y = c->tty.sy - ctx->statuslines;
+	else
+		y = 0;
 	for (i = 0; i < ctx->statuslines; i++) {
 		tty_draw_line(tty, s, 0, i, UINT_MAX, 0, y + i,
 		    &grid_default_cell, NULL);
@@ -1102,11 +1114,17 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	slgc.bg = gc.fg;
 
 	imax = sb_w + sb_pad;
-	if ((int)imax + sb_x > sx)
+	if ((int)imax + sb_x > sx) {
+		if (sb_x >= sx)
+			return;
 		imax = sx - sb_x;
+	}
 	jmax = sb_h;
-	if ((int)jmax + sb_y > sy)
+	if ((int)jmax + sb_y > sy) {
+		if (sb_y >= sy)
+			return;
 		jmax = sy - sb_y;
+	}
 
 	for (j = 0; j < jmax; j++) {
 		py = sb_y + j;


### PR DESCRIPTION
## Summary

Fix several unsigned integer underflow bugs in `screen-redraw.c` that can cause the tmux server to enter an infinite CPU loop, becoming completely unresponsive to all client connections (`tmux attach`, `tmux ls`, etc.).

Fixes #4932.

## Root Cause

Functions in `screen-redraw.c` compute loop bounds by subtracting signed `int` values and storing the result in `u_int` variables. When the subtraction yields a negative result, the value wraps to ~4 billion, and subsequent loops iterate for hours.

The primary bug is in `screen_redraw_draw_scrollbar()`:

```c
u_int  imax, jmax;
int    sx, sb_x, sy, sb_y;

imax = sb_w + sb_pad;
if ((int)imax + sb_x > sx)
    imax = sx - sb_x;       /* wraps when sb_x > sx */
```

When `sb_x > sx` (scrollbar position beyond screen width), `sx - sb_x` is negative, wrapping to `0xFFFFFFFD` (~4 billion) when assigned to `u_int imax`. The loop `for (i = 0; i < imax; i++)` then spins ~4 billion iterations.

## Diagnosis

Found by attaching to a live hung tmux 3.6a server process on Oracle Linux 10.1 (kernel 6.12.0). The diagnosis used multiple tools:

### strace (10-second capture)
```
$ timeout 10 strace -p 2148 -c
(no syscalls captured)
```
Zero syscalls in 10 seconds — pure userspace CPU spin.

### /proc state
```
State:  R (running)
wchan:  0
voluntary_ctxt_switches:   195532
nonvoluntary_ctxt_switches: 5653
```

### GDB backtrace
```
#0  screen_redraw_draw_pane_scrollbar+752
#1  screen_redraw_draw_pane_scrollbars
#2  screen_redraw_screen
#3  server_client_loop
#4  server_loop
#5  proc_loop
#6  server_start
#7  client_main
#8  main
```

### GDB register dump at hang point
```
r15d (i counter) = 0x77053e78  (~2 billion, still incrementing)
ebx  (imax)      = 0xfffffffd  (4294967293 = -3 as signed)
```

### Disassembly confirms tight increment loop
```asm
<+752>:  add    $0x1,%r15d        ; i++
<+756>:  add    $0x1,%r12d        ; px++
<+760>:  cmp    %ebx,%r15d        ; i != 0xfffffffd?
<+763>:  jne    <+592>            ; continue loop
```

All bounds checks at +592 through +636 evaluate to "skip" (px values are OOB), so every iteration just increments counters.

### Static analysis (inside ioplane-base container with GCC-15, cppcheck 2.20, flawfinder)

GCC-15 `-fanalyzer` and cppcheck do not flag signed→unsigned assignment patterns. The bugs were found through manual code audit of the scrollbar drawing path.

## Changes

1. **`screen_redraw_draw_scrollbar()`**: Add `sb_x >= sx` and `sb_y >= sy` early returns before the unsigned subtraction that computes `imax` and `jmax`.

2. **`screen_redraw_draw_borders()`**: Guard `c->tty.sy - ctx->statuslines` loop bound with `if (c->tty.sy > ctx->statuslines)` to prevent underflow when terminal height is less than status line count.

3. **`screen_redraw_draw_status()`**: Guard `c->tty.sy - ctx->statuslines` status y-position calculation similarly.

4. **Pane status functions** (`screen_redraw_check_cell`, `screen_redraw_set_pane_status`, `screen_redraw_draw_pane_statuses`): Guard `wp->yoff - 1` against underflow when `yoff == 0`.

5. **`screen_redraw_pane_border()`**: Cast `wp->xoff` to `int` before subtracting `sb_w` to prevent C unsigned promotion rules from wrapping the result.

All changes are minimal and follow existing code style.

## Testing

- Built cleanly with GCC 14.3.1 (system), GCC-15 (`-O2 -fanalyzer`), and Clang 22.1.0 inside container.
- No new warnings introduced.
- Verified the fix addresses the exact instruction sequence observed in GDB.