### PR TITLE
Fix division by zero and null dereference in grid.c

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -1117,7 +1117,8 @@ grid_string_cells(struct grid *gd, u_int px, u_int py, u_int nx,
 		if (gc.flags & GRID_FLAG_PADDING)
 			continue;
 
-		if (flags & GRID_STRING_WITH_SEQUENCES) {
+		if (lastgc != NULL &&
+		    (flags & GRID_STRING_WITH_SEQUENCES)) {
 			grid_string_cells_code(*lastgc, &gc, code, sizeof code,
 			    flags, s, &has_link);
 			codelen = strlen(code);
@@ -1370,6 +1371,8 @@ grid_reflow_split(struct grid *target, struct grid *gd, u_int sx, u_int yy,
 	int			 flags = gl->flags;
 
 	/* How many lines do we need to insert? We know we need at least two. */
+	if (sx == 0)
+		return;
 	if (~gl->flags & GRID_LINE_EXTENDED)
 		lines = 1 + (gl->cellused - 1) / sx;
 	else {


### PR DESCRIPTION
## Summary

Fix a division by zero in `grid_reflow_split()` and a null pointer
dereference in `grid_string_cells()`.

## Changes

**grid_reflow_split() — division by zero (line ~1374):**

`(gl->cellused - 1) / sx` divides by `sx` (target screen width)
without checking for zero.  If a reflow is triggered with a
zero-width screen (degenerate resize), this causes SIGFPE.  Add an
early return when `sx == 0`.

**grid_string_cells() — null dereference (line ~1121):**

`lastgc` (pointer-to-pointer parameter) can be NULL when
`GRID_STRING_WITH_SEQUENCES` is set.  The initialization guard at
line 1095 checks `lastgc != NULL` but the dereference further down
at line 1120 did not, leading to a null pointer dereference.  Add
the missing NULL check.

## Detection

Found by Clang scan-build with `core.DivideZero` and
`core.NullDereference` checkers.

## Testing

- Builds clean with GCC 14, GCC-15 (`-fanalyzer`), Clang 22
- No new warnings on grid.c from GCC-15 `-fanalyzer`