### PR TITLE
Fix unsigned underflow in window-copy scroll calculations

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -4237,13 +4237,19 @@ window_copy_visible_lines(struct window_copy_mode_data *data, u_int *start,
 {
 	struct grid		*gd = data->backing->grid;
 	const struct grid_line	*gl;
+	u_int			 base;
 
-	for (*start = gd->hsize - data->oy; *start > 0; (*start)--) {
+	if (data->oy > gd->hsize)
+		base = 0;
+	else
+		base = gd->hsize - data->oy;
+
+	for (*start = base; *start > 0; (*start)--) {
 		gl = grid_peek_line(gd, (*start) - 1);
 		if (gl == NULL || ~gl->flags & GRID_LINE_WRAPPED)
 			break;
 	}
-	*end = gd->hsize - data->oy + gd->sy;
+	*end = base + gd->sy;
 }
 
 static int
@@ -4252,12 +4258,18 @@ window_copy_search_mark_at(struct window_copy_mode_data *data, u_int px,
 {
 	struct screen	*s = data->backing;
 	struct grid	*gd = s->grid;
+	u_int		 base;
 
-	if (py < gd->hsize - data->oy)
+	if (data->oy > gd->hsize)
+		base = 0;
+	else
+		base = gd->hsize - data->oy;
+
+	if (py < base)
 		return (-1);
-	if (py > gd->hsize - data->oy + gd->sy - 1)
+	if (py > base + gd->sy - 1)
 		return (-1);
-	*at = ((py - (gd->hsize - data->oy)) * gd->sx) + px;
+	*at = ((py - base) * gd->sx) + px;
 	return (0);
 }
 
@@ -4473,8 +4485,13 @@ window_copy_match_start_end(struct window_copy_mode_data *data, u_int at,
     u_int *start, u_int *end)
 {
 	struct grid	*gd = data->backing->grid;
-	u_int		 last = (gd->sy * gd->sx) - 1;
+	u_int		 last;
 	u_char		 mark = data->searchmark[at];
+
+	if (gd->sy == 0 || gd->sx == 0)
+		last = 0;
+	else
+		last = (gd->sy * gd->sx) - 1;
 
 	*start = *end = at;
 	while (*start != 0 && data->searchmark[*start] == mark)
@@ -4675,6 +4692,10 @@ window_copy_write_line(struct window_mode_entry *wme,
 	style_apply(&mkgc, oo, "copy-mode-mark-style", ft);
 	mkgc.flags |= GRID_FLAG_NOPALETTE;
 
+	if (data->oy > hsize) {
+		format_free(ft);
+		return;
+	}
 	window_copy_write_one(wme, ctx, py, hsize - data->oy + py,
 	    screen_size_x(s), &mgc, &cgc, &mkgc);
 
@@ -5857,8 +5878,14 @@ window_copy_cursor_prompt(struct window_mode_entry *wme, int direction,
 	struct screen			*s = data->backing;
 	struct grid			*gd = s->grid;
 	u_int				 end_line;
-	u_int				 line = gd->hsize - data->oy + data->cy;
+	u_int				 base, line;
 	int				 add, line_flag;
+
+	if (data->oy > gd->hsize)
+		base = 0;
+	else
+		base = gd->hsize - data->oy;
+	line = base + data->cy;
 
 	if (start_output)
 		line_flag = GRID_LINE_START_OUTPUT;


### PR DESCRIPTION
## Summary

Fix unsigned integer underflow in multiple window-copy.c functions
where `gd->hsize - data->oy` is computed without checking that
`oy <= hsize`, causing out-of-bounds grid access during resize
races.

## Changes

Affected functions:
- `window_copy_visible_lines()` — loop start/end from wrapped value
- `window_copy_search_mark_at()` — array index from wrapped value
- `window_copy_match_start_end()` — `(sy * sx) - 1` wraps when grid empty
- `window_copy_write_line()` — grid line offset from wrapped value
- `window_copy_cursor_prompt()` — grid line index from wrapped value

Fix: compute base offset into a local variable with guard
`if (oy > hsize) base = 0; else base = hsize - oy`.

## Testing

- Builds clean with GCC 14, GCC-15 (-fanalyzer), Clang 22
- No new warnings from GCC-15 -fanalyzer on window-copy.c