### PR TITLE
Fix unsigned underflow in window pane buffer offset

### DIFF
--- a/window.c
+++ b/window.c
@@ -1729,7 +1729,13 @@ void *
 window_pane_get_new_data(struct window_pane *wp,
     struct window_pane_offset *wpo, size_t *size)
 {
-	size_t	used = wpo->used - wp->base_offset;
+	size_t	used;
+
+	if (wp->base_offset > wpo->used) {
+		*size = 0;
+		return (NULL);
+	}
+	used = wpo->used - wp->base_offset;
 
 	*size = EVBUFFER_LENGTH(wp->event->input) - used;
 	return (EVBUFFER_DATA(wp->event->input) + used);
@@ -1739,7 +1745,11 @@ void
 window_pane_update_used_data(struct window_pane *wp,
     struct window_pane_offset *wpo, size_t size)
 {
-	size_t	used = wpo->used - wp->base_offset;
+	size_t	used;
+
+	if (wp->base_offset > wpo->used)
+		return;
+	used = wpo->used - wp->base_offset;
 
 	if (size > EVBUFFER_LENGTH(wp->event->input) - used)
 		size = EVBUFFER_LENGTH(wp->event->input) - used;


### PR DESCRIPTION
## Summary

Fix unsigned integer underflow in `window_pane_get_new_data()` and
`window_pane_update_used_data()` where `wpo->used - wp->base_offset`
wraps when `base_offset > used`, causing out-of-bounds buffer access.

## Changes

Add guards to return early (with `*size = 0` and `NULL` for the
getter, plain return for the updater) when `base_offset > used`.

## Testing

- Builds clean with GCC 14, GCC-15 (-fanalyzer), Clang 22
- No new warnings from GCC-15 -fanalyzer on window.c