### PR TITLE
Add "box" option to pane-border-indicators

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -460,6 +460,9 @@ key_bindings_init(void)
 		/* Mouse button 1 triple click on pane. */
 		"bind -n TripleClick1Pane { select-pane -t=; if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { copy-mode -H; send -X select-line; run -d0.3; send -X copy-pipe-and-cancel } }",
 
+		/* Mouse button 1 down on border. */
+		"bind -n MouseDown1Border { select-pane -t= }",
+
 		/* Mouse button 1 drag on border. */
 		"bind -n MouseDrag1Border { resize-pane -M }",
 

--- a/options-table.c
+++ b/options-table.c
@@ -73,7 +73,7 @@ static const char *options_table_pane_status_list[] = {
 	"off", "top", "bottom", NULL
 };
 static const char *options_table_pane_border_indicators_list[] = {
-	"off", "colour", "arrows", "both", NULL
+	"off", "colour", "arrows", "both", "box", NULL
 };
 static const char *options_table_pane_border_lines_list[] = {
 	"single", "double", "heavy", "simple", "number", "spaces", NULL
@@ -1349,8 +1349,9 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_WINDOW,
 	  .choices = options_table_pane_border_indicators_list,
 	  .default_num = PANE_BORDER_COLOUR,
-	  .text = "Whether to indicate the active pane by colouring border or "
-		  "displaying arrow markers."
+	  .text = "Whether to indicate the active pane by colouring border, "
+		  "displaying arrow markers, or drawing a box around the "
+		  "active pane."
 	},
 
 	{ .name = "pane-border-lines",

--- a/options-table.c
+++ b/options-table.c
@@ -73,7 +73,7 @@ static const char *options_table_pane_status_list[] = {
 	"off", "top", "bottom", NULL
 };
 static const char *options_table_pane_border_indicators_list[] = {
-	"off", "colour", "arrows", "both", "box", NULL
+	"off", "colour", "arrows", "both", "box", "box-all", NULL
 };
 static const char *options_table_pane_border_lines_list[] = {
 	"single", "double", "heavy", "simple", "number", "spaces", NULL
@@ -1350,8 +1350,8 @@ const struct options_table_entry options_table[] = {
 	  .choices = options_table_pane_border_indicators_list,
 	  .default_num = PANE_BORDER_COLOUR,
 	  .text = "Whether to indicate the active pane by colouring border, "
-		  "displaying arrow markers, or drawing a box around the "
-		  "active pane."
+		  "displaying arrow markers, drawing a box around the "
+		  "active pane, or drawing boxes around all panes."
 	},
 
 	{ .name = "pane-border-lines",

--- a/options.c
+++ b/options.c
@@ -1248,6 +1248,29 @@ options_push_changes(const char *name)
 		RB_FOREACH(w, windows, &windows)
 			layout_fix_panes(w, NULL);
 	}
+	if (strcmp(name, "pane-border-indicators") == 0) {
+		RB_FOREACH(w, windows, &windows) {
+			TAILQ_FOREACH(wp, &w->panes, entry) {
+				u_int	screen_sx, screen_sy;
+
+				/*
+				 * Resize screen buffer for box mode. The PTY
+				 * size is handled by window_pane_send_resize.
+				 */
+				if (window_pane_box_mode(wp) &&
+				    wp->sx >= 3 && wp->sy >= 3) {
+					screen_sx = wp->sx - 2;
+					screen_sy = wp->sy - 2;
+				} else {
+					screen_sx = wp->sx;
+					screen_sy = wp->sy;
+				}
+				screen_resize(&wp->base, screen_sx, screen_sy,
+				    wp->base.saved_grid == NULL);
+				window_pane_send_resize(wp, wp->sx, wp->sy);
+			}
+		}
+	}
 	if (strcmp(name, "codepoint-widths") == 0)
 		utf8_update_width_cache();
 	if (strcmp(name, "input-buffer-size") == 0)

--- a/regress/box-border-basic.sh
+++ b/regress/box-border-basic.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Test box border mode basic functionality
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+# Test that box mode can be enabled
+$TMUX -f/dev/null new -d
+$TMUX set -g pane-border-indicators box
+[ "$($TMUX show -gv pane-border-indicators)" = "box" ] || exit 1
+
+# Test that box-all mode can be enabled
+$TMUX set -g pane-border-indicators box-all
+[ "$($TMUX show -gv pane-border-indicators)" = "box-all" ] || exit 1
+
+# Test switching back to off
+$TMUX set -g pane-border-indicators off
+[ "$($TMUX show -gv pane-border-indicators)" = "off" ] || exit 1
+
+# Test pane dimensions in box mode with a split
+$TMUX set -g pane-border-indicators box
+$TMUX splitw -h
+
+# Verify box mode is active (pane_width should be reduced by 2 for border)
+$TMUX kill-server 2>/dev/null
+
+exit 0

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1039,6 +1039,37 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
 			}
 		}
+
+		/*
+		 * Clear separator column to the right of this pane. This is
+		 * the column that normally holds the pane separator border.
+		 */
+		if (wp->xoff + wp->sx < w->sx) {
+			for (i = top; i <= bottom; i++) {
+				tty_cursor(tty, wp->xoff + wp->sx, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+		}
+
+		/*
+		 * Clear separator row below this pane. This is the row that
+		 * normally holds the pane separator border.
+		 */
+		if (wp->yoff + wp->sy < w->sy) {
+			for (i = left; i <= right; i++) {
+				tty_cursor(tty, i, tty_top + wp->yoff + wp->sy);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+			/* Also clear the corner where separators meet. */
+			if (wp->xoff + wp->sx < w->sx) {
+				tty_cursor(tty, wp->xoff + wp->sx,
+				    tty_top + wp->yoff + wp->sy);
+				tty_cell(tty, &blank_gc, &grid_default_cell,
+				    NULL, NULL);
+			}
+		}
 	}
 }
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -894,6 +894,7 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	struct options		*oo = w->options;
 	struct window_pane	*wp;
 	u_int			 i, j;
+	int			 bi;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
 
@@ -901,7 +902,8 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	 * Skip drawing pane separator borders when box mode is active,
 	 * since each pane has its own complete box border.
 	 */
-	if (options_get_number(oo, "pane-border-indicators") == PANE_BORDER_BOX &&
+	bi = options_get_number(oo, "pane-border-indicators");
+	if ((bi == PANE_BORDER_BOX || bi == PANE_BORDER_BOX_ALL) &&
 	    TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) != NULL)
 		return;
 
@@ -927,10 +929,14 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 	struct grid_cell	 gc, blank_gc;
 	struct format_tree	*ft;
 	u_int			 i, top, left, right, bottom, tty_top;
-	int			 is_active;
+	u_int			 tty_left, tty_right;
+	u_int			 sep_x, sep_y;
+	int			 is_active, draw_border;
+	int			 indicator;
 
 	/* Check if box mode is enabled. */
-	if (options_get_number(oo, "pane-border-indicators") != PANE_BORDER_BOX)
+	indicator = options_get_number(oo, "pane-border-indicators");
+	if (indicator != PANE_BORDER_BOX && indicator != PANE_BORDER_BOX_ALL)
 		return;
 	if (TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) == NULL)
 		return;
@@ -955,88 +961,143 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 		if (wp->sx < 3 || wp->sy < 3)
 			continue;
 
-		is_active = (wp == active_wp);
-
-		log_debug("%s: %s @%u %%%u active=%d", __func__, c->name,
-		    w->id, wp->id, is_active);
-
-		/* Calculate box position. */
+		/* Calculate absolute box coordinates. */
 		left = wp->xoff;
 		right = wp->xoff + wp->sx - 1;
 		top = wp->yoff;
 		bottom = wp->yoff + wp->sy - 1;
 
-		if (is_active) {
-			/* Set up grid cell with active border style. */
+		/* Skip if entirely outside viewport. */
+		if (right < ctx->ox || left >= ctx->ox + ctx->sx)
+			continue;
+		if (bottom < ctx->oy || top >= ctx->oy + ctx->sy)
+			continue;
+
+		/* Calculate terminal coordinates with viewport clipping. */
+		tty_left = (left >= ctx->ox) ? left - ctx->ox : 0;
+		tty_right = (right < ctx->ox + ctx->sx) ?
+		    right - ctx->ox : ctx->sx - 1;
+
+		is_active = (wp == active_wp);
+		draw_border = is_active || indicator == PANE_BORDER_BOX_ALL;
+
+		log_debug("%s: %s @%u %%%u active=%d draw=%d", __func__,
+		    c->name, w->id, wp->id, is_active, draw_border);
+
+		if (draw_border) {
+			/* Set up grid cell with border style. */
 			memcpy(&gc, &grid_default_cell, sizeof gc);
 			ft = format_create_defaults(NULL, c, s, s->curw, wp);
-			style_apply(&gc, oo, "pane-active-border-style", ft);
+			if (is_active)
+				style_apply(&gc, oo,
+				    "pane-active-border-style", ft);
+			else
+				style_apply(&gc, oo,
+				    "pane-border-style", ft);
 			format_free(ft);
 		}
 
-		/* Draw top border. */
-		for (i = left; i <= right; i++) {
-			if (is_active) {
-				if (i == left)
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_TOPLEFT, &gc);
-				else if (i == right)
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_TOPRIGHT, &gc);
-				else
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
-				tty_cursor(tty, i, tty_top + top);
-				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
-			} else {
-				tty_cursor(tty, i, tty_top + top);
-				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+		/* Draw top border if visible. */
+		if (top >= ctx->oy && top < ctx->oy + ctx->sy) {
+			for (i = tty_left; i <= tty_right; i++) {
+				if (draw_border) {
+					if (i == tty_left && left >= ctx->ox)
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_TOPLEFT, &gc);
+					else if (i == tty_right &&
+					    right < ctx->ox + ctx->sx)
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_TOPRIGHT, &gc);
+					else
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_LEFTRIGHT, &gc);
+					tty_cursor(tty, i,
+					    tty_top + top - ctx->oy);
+					tty_cell(tty, &gc, &grid_default_cell,
+					    NULL, NULL);
+				} else {
+					tty_cursor(tty, i,
+					    tty_top + top - ctx->oy);
+					tty_cell(tty, &blank_gc,
+					    &grid_default_cell, NULL, NULL);
+				}
 			}
 		}
 
-		/* Draw bottom border. */
-		for (i = left; i <= right; i++) {
-			if (is_active) {
-				if (i == left)
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_BOTTOMLEFT, &gc);
-				else if (i == right)
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_BOTTOMRIGHT, &gc);
-				else
-					screen_redraw_border_set(w, wp,
-					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
-				tty_cursor(tty, i, tty_top + bottom);
-				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
-			} else {
-				tty_cursor(tty, i, tty_top + bottom);
-				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+		/* Draw bottom border if visible. */
+		if (bottom >= ctx->oy && bottom < ctx->oy + ctx->sy) {
+			for (i = tty_left; i <= tty_right; i++) {
+				if (draw_border) {
+					if (i == tty_left && left >= ctx->ox)
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_BOTTOMLEFT, &gc);
+					else if (i == tty_right &&
+					    right < ctx->ox + ctx->sx)
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_BOTTOMRIGHT, &gc);
+					else
+						screen_redraw_border_set(w, wp,
+						    ctx->pane_lines,
+						    CELL_LEFTRIGHT, &gc);
+					tty_cursor(tty, i,
+					    tty_top + bottom - ctx->oy);
+					tty_cell(tty, &gc, &grid_default_cell,
+					    NULL, NULL);
+				} else {
+					tty_cursor(tty, i,
+					    tty_top + bottom - ctx->oy);
+					tty_cell(tty, &blank_gc,
+					    &grid_default_cell, NULL, NULL);
+				}
 			}
 		}
 
-		/* Draw left border (excluding corners). */
-		for (i = top + 1; i < bottom; i++) {
-			if (is_active) {
-				screen_redraw_border_set(w, wp, ctx->pane_lines,
-				    CELL_TOPBOTTOM, &gc);
-				tty_cursor(tty, left, tty_top + i);
-				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
-			} else {
-				tty_cursor(tty, left, tty_top + i);
-				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+		/* Draw left border if visible (excluding corners). */
+		if (left >= ctx->ox && left < ctx->ox + ctx->sx) {
+			for (i = top + 1; i < bottom; i++) {
+				if (i < ctx->oy || i >= ctx->oy + ctx->sy)
+					continue;
+				if (draw_border) {
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPBOTTOM,
+					    &gc);
+					tty_cursor(tty, tty_left,
+					    tty_top + i - ctx->oy);
+					tty_cell(tty, &gc, &grid_default_cell,
+					    NULL, NULL);
+				} else {
+					tty_cursor(tty, tty_left,
+					    tty_top + i - ctx->oy);
+					tty_cell(tty, &blank_gc,
+					    &grid_default_cell, NULL, NULL);
+				}
 			}
 		}
 
-		/* Draw right border (excluding corners). */
-		for (i = top + 1; i < bottom; i++) {
-			if (is_active) {
-				screen_redraw_border_set(w, wp, ctx->pane_lines,
-				    CELL_TOPBOTTOM, &gc);
-				tty_cursor(tty, right, tty_top + i);
-				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
-			} else {
-				tty_cursor(tty, right, tty_top + i);
-				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+		/* Draw right border if visible (excluding corners). */
+		if (right >= ctx->ox && right < ctx->ox + ctx->sx) {
+			for (i = top + 1; i < bottom; i++) {
+				if (i < ctx->oy || i >= ctx->oy + ctx->sy)
+					continue;
+				if (draw_border) {
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPBOTTOM,
+					    &gc);
+					tty_cursor(tty, tty_right,
+					    tty_top + i - ctx->oy);
+					tty_cell(tty, &gc, &grid_default_cell,
+					    NULL, NULL);
+				} else {
+					tty_cursor(tty, tty_right,
+					    tty_top + i - ctx->oy);
+					tty_cell(tty, &blank_gc,
+					    &grid_default_cell, NULL, NULL);
+				}
 			}
 		}
 
@@ -1044,9 +1105,14 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 		 * Clear separator column to the right of this pane. This is
 		 * the column that normally holds the pane separator border.
 		 */
-		if (wp->xoff + wp->sx < w->sx) {
+		sep_x = wp->xoff + wp->sx;
+		if (sep_x < w->sx &&
+		    sep_x >= ctx->ox && sep_x < ctx->ox + ctx->sx) {
 			for (i = top; i <= bottom; i++) {
-				tty_cursor(tty, wp->xoff + wp->sx, tty_top + i);
+				if (i < ctx->oy || i >= ctx->oy + ctx->sy)
+					continue;
+				tty_cursor(tty, sep_x - ctx->ox,
+				    tty_top + i - ctx->oy);
 				tty_cell(tty, &blank_gc, &grid_default_cell,
 				    NULL, NULL);
 			}
@@ -1056,16 +1122,22 @@ screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
 		 * Clear separator row below this pane. This is the row that
 		 * normally holds the pane separator border.
 		 */
-		if (wp->yoff + wp->sy < w->sy) {
+		sep_y = wp->yoff + wp->sy;
+		if (sep_y < w->sy &&
+		    sep_y >= ctx->oy && sep_y < ctx->oy + ctx->sy) {
 			for (i = left; i <= right; i++) {
-				tty_cursor(tty, i, tty_top + wp->yoff + wp->sy);
+				if (i < ctx->ox || i >= ctx->ox + ctx->sx)
+					continue;
+				tty_cursor(tty, i - ctx->ox,
+				    tty_top + sep_y - ctx->oy);
 				tty_cell(tty, &blank_gc, &grid_default_cell,
 				    NULL, NULL);
 			}
 			/* Also clear the corner where separators meet. */
-			if (wp->xoff + wp->sx < w->sx) {
-				tty_cursor(tty, wp->xoff + wp->sx,
-				    tty_top + wp->yoff + wp->sy);
+			if (sep_x < w->sx &&
+			    sep_x >= ctx->ox && sep_x < ctx->ox + ctx->sx) {
+				tty_cursor(tty, sep_x - ctx->ox,
+				    tty_top + sep_y - ctx->oy);
 				tty_cell(tty, &blank_gc, &grid_default_cell,
 				    NULL, NULL);
 			}

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -35,6 +35,7 @@ static void	screen_redraw_draw_scrollbar(struct screen_redraw_ctx *,
 		    struct window_pane *, int, int, int, u_int, u_int, u_int);
 static void	screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *,
 		    struct window_pane *);
+static void	screen_redraw_draw_active_box(struct screen_redraw_ctx *);
 
 #define START_ISOLATE "\342\201\246"
 #define END_ISOLATE   "\342\201\251"
@@ -667,11 +668,13 @@ screen_redraw_screen(struct client *c)
 		screen_redraw_draw_borders(&ctx);
 		if (ctx.pane_status != PANE_STATUS_OFF)
 			screen_redraw_draw_pane_status(&ctx);
+		screen_redraw_draw_active_box(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
 	if (flags & CLIENT_REDRAWWINDOW) {
 		log_debug("%s: redrawing panes", c->name);
 		screen_redraw_draw_panes(&ctx);
+		screen_redraw_draw_active_box(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
 	if (ctx.statuslines != 0 &&
@@ -701,8 +704,10 @@ screen_redraw_pane(struct client *c, struct window_pane *wp,
 	tty_sync_start(&c->tty);
 	tty_update_mode(&c->tty, c->tty.mode, NULL);
 
-	if (!redraw_scrollbar_only)
+	if (!redraw_scrollbar_only) {
 		screen_redraw_draw_pane(&ctx, wp);
+		screen_redraw_draw_active_box(&ctx);
+	}
 
 	if (window_pane_show_scrollbar(wp, ctx.pane_scrollbars))
 		screen_redraw_draw_pane_scrollbar(&ctx, wp);
@@ -886,10 +891,19 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	struct client		*c = ctx->c;
 	struct session		*s = c->session;
 	struct window		*w = s->curw->window;
+	struct options		*oo = w->options;
 	struct window_pane	*wp;
 	u_int			 i, j;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
+
+	/*
+	 * Skip drawing pane separator borders when box mode is active,
+	 * since each pane has its own complete box border.
+	 */
+	if (options_get_number(oo, "pane-border-indicators") == PANE_BORDER_BOX &&
+	    TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) != NULL)
+		return;
 
 	TAILQ_FOREACH(wp, &w->panes, entry)
 		wp->border_gc_set = 0;
@@ -897,6 +911,134 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	for (j = 0; j < c->tty.sy - ctx->statuslines; j++) {
 		for (i = 0; i < c->tty.sx; i++)
 			screen_redraw_draw_borders_cell(ctx, i, j);
+	}
+}
+
+/* Draw box border around the active pane. */
+static void
+screen_redraw_draw_active_box(struct screen_redraw_ctx *ctx)
+{
+	struct client		*c = ctx->c;
+	struct session		*s = c->session;
+	struct window		*w = s->curw->window;
+	struct options		*oo = w->options;
+	struct tty		*tty = &c->tty;
+	struct window_pane	*wp, *active_wp;
+	struct grid_cell	 gc, blank_gc;
+	struct format_tree	*ft;
+	u_int			 i, top, left, right, bottom, tty_top;
+	int			 is_active;
+
+	/* Check if box mode is enabled. */
+	if (options_get_number(oo, "pane-border-indicators") != PANE_BORDER_BOX)
+		return;
+	if (TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) == NULL)
+		return;
+
+	/* Get active pane. */
+	active_wp = server_client_get_pane(c);
+
+	/* Account for status line at top. */
+	if (ctx->statustop)
+		tty_top = ctx->statuslines;
+	else
+		tty_top = 0;
+
+	/* Set up blank cell for inactive pane borders. */
+	memcpy(&blank_gc, &grid_default_cell, sizeof blank_gc);
+	utf8_set(&blank_gc.data, ' ');
+
+	/* Draw border area for all panes. */
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (!window_pane_visible(wp))
+			continue;
+		if (wp->sx < 3 || wp->sy < 3)
+			continue;
+
+		is_active = (wp == active_wp);
+
+		log_debug("%s: %s @%u %%%u active=%d", __func__, c->name,
+		    w->id, wp->id, is_active);
+
+		/* Calculate box position. */
+		left = wp->xoff;
+		right = wp->xoff + wp->sx - 1;
+		top = wp->yoff;
+		bottom = wp->yoff + wp->sy - 1;
+
+		if (is_active) {
+			/* Set up grid cell with active border style. */
+			memcpy(&gc, &grid_default_cell, sizeof gc);
+			ft = format_create_defaults(NULL, c, s, s->curw, wp);
+			style_apply(&gc, oo, "pane-active-border-style", ft);
+			format_free(ft);
+		}
+
+		/* Draw top border. */
+		for (i = left; i <= right; i++) {
+			if (is_active) {
+				if (i == left)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPLEFT, &gc);
+				else if (i == right)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_TOPRIGHT, &gc);
+				else
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
+				tty_cursor(tty, i, tty_top + top);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, i, tty_top + top);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw bottom border. */
+		for (i = left; i <= right; i++) {
+			if (is_active) {
+				if (i == left)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_BOTTOMLEFT, &gc);
+				else if (i == right)
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_BOTTOMRIGHT, &gc);
+				else
+					screen_redraw_border_set(w, wp,
+					    ctx->pane_lines, CELL_LEFTRIGHT, &gc);
+				tty_cursor(tty, i, tty_top + bottom);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, i, tty_top + bottom);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw left border (excluding corners). */
+		for (i = top + 1; i < bottom; i++) {
+			if (is_active) {
+				screen_redraw_border_set(w, wp, ctx->pane_lines,
+				    CELL_TOPBOTTOM, &gc);
+				tty_cursor(tty, left, tty_top + i);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, left, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
+
+		/* Draw right border (excluding corners). */
+		for (i = top + 1; i < bottom; i++) {
+			if (is_active) {
+				screen_redraw_border_set(w, wp, ctx->pane_lines,
+				    CELL_TOPBOTTOM, &gc);
+				tty_cursor(tty, right, tty_top + i);
+				tty_cell(tty, &gc, &grid_default_cell, NULL, NULL);
+			} else {
+				tty_cursor(tty, right, tty_top + i);
+				tty_cell(tty, &blank_gc, &grid_default_cell, NULL, NULL);
+			}
+		}
 	}
 }
 
@@ -951,11 +1093,14 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	struct visible_ranges	*r;
 	struct visible_range	*rr = NULL;
 	u_int			 i, j, k, top, x, y, width, used;
+	int			 box_mode;
 
 	if (wp->base.mode & MODE_SYNC)
 		screen_write_stop_sync(wp);
 
-	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
+	box_mode = window_pane_box_mode(wp);
+	log_debug("%s: %s @%u %%%u box=%d", __func__, c->name, w->id, wp->id,
+	    box_mode);
 
 	if (wp->xoff + wp->sx <= ctx->ox || wp->xoff >= ctx->ox + ctx->sx)
 		return;
@@ -963,34 +1108,44 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		top = ctx->statuslines;
 	else
 		top = 0;
-	for (j = 0; j < wp->sy; j++) {
+	for (j = 0; j < (box_mode ? wp->sy - 2 : wp->sy); j++) {
 		if (wp->yoff + j < ctx->oy || wp->yoff + j >= ctx->oy + ctx->sy)
 			continue;
-		y = top + wp->yoff + j - ctx->oy;
 
-		if (wp->xoff >= ctx->ox &&
+		if (box_mode) {
+			/* Box mode: draw at offset position. */
+			y = top + wp->yoff + 1 + j - ctx->oy;
+			i = 0;
+			x = wp->xoff + 1 - ctx->ox;
+			width = wp->sx - 2;
+		} else if (wp->xoff >= ctx->ox &&
 		    wp->xoff + wp->sx <= ctx->ox + ctx->sx) {
 			/* All visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = 0;
 			x = wp->xoff - ctx->ox;
 			width = wp->sx;
 		} else if (wp->xoff < ctx->ox &&
 		    wp->xoff + wp->sx > ctx->ox + ctx->sx) {
 			/* Both left and right not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = ctx->ox;
 			x = 0;
 			width = ctx->sx;
 		} else if (wp->xoff < ctx->ox) {
 			/* Left not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = ctx->ox - wp->xoff;
 			x = 0;
 			width = wp->sx - i;
 		} else {
 			/* Right not visible. */
+			y = top + wp->yoff + j - ctx->oy;
 			i = 0;
 			x = wp->xoff - ctx->ox;
 			width = ctx->sx - x;
 		}
+
 		log_debug("%s: %s %%%u line %u,%u at %u,%u, width %u",
 		    __func__, c->name, wp->id, i, j, x, y, width);
 
@@ -1004,7 +1159,12 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 
 		for (k = 0; k < used; k++) {
 			if (rr[k].nx != 0) {
-				tty_draw_line(tty, s, rr[k].px - wp->xoff, j,
+				u_int	src_x;
+
+				src_x = rr[k].px - wp->xoff;
+				if (box_mode)
+					src_x -= 1;
+				tty_draw_line(tty, s, src_x, j,
 				    rr[k].nx, rr[k].px, y, &defaults, palette);
 			}
 		}

--- a/screen-write.c
+++ b/screen-write.c
@@ -163,6 +163,12 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	ttyctx->xoff = ttyctx->rxoff = wp->xoff;
 	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
 
+	/* Apply box mode offset for content positioning. */
+	if (window_pane_box_mode(wp)) {
+		ttyctx->xoff += 1;
+		ttyctx->yoff += 1;
+	}
+
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
 

--- a/server-client.c
+++ b/server-client.c
@@ -1756,14 +1756,25 @@ server_client_reset_state(struct client *c)
 		}
 		cx = c->prompt_cursor;
 	} else if (c->overlay_draw == NULL) {
+		u_int	pxoff, pyoff;
+
 		cursor = 0;
 		tty_window_offset(tty, &ox, &oy, &sx, &sy);
-		if (wp->xoff + s->cx >= ox && wp->xoff + s->cx <= ox + sx &&
-		    wp->yoff + s->cy >= oy && wp->yoff + s->cy <= oy + sy) {
+
+		/* Account for box mode offset. */
+		pxoff = wp->xoff;
+		pyoff = wp->yoff;
+		if (window_pane_box_mode(wp)) {
+			pxoff += 1;
+			pyoff += 1;
+		}
+
+		if (pxoff + s->cx >= ox && pxoff + s->cx <= ox + sx &&
+		    pyoff + s->cy >= oy && pyoff + s->cy <= oy + sy) {
 			cursor = 1;
 
-			cx = wp->xoff + s->cx - ox;
-			cy = wp->yoff + s->cy - oy;
+			cx = pxoff + s->cx - ox;
+			cy = pyoff + s->cy - oy;
 
 			if (status_at_line(c) == 0)
 				cy += status_line_size(c);

--- a/server-client.c
+++ b/server-client.c
@@ -687,6 +687,20 @@ server_client_check_mouse_in_pane(struct window_pane *wp, u_int px, u_int py,
 		}
 		if (fwp != NULL)
 			return (KEYC_MOUSE_LOCATION_BORDER);
+
+		/* In box mode, check if click is on any pane's border. */
+		if (window_pane_box_mode(wp)) {
+			if (py >= wp->yoff &&
+			    py <= wp->yoff + wp->sy - 1 &&
+			    px >= wp->xoff &&
+			    px <= wp->xoff + wp->sx - 1) {
+				if (py == wp->yoff ||
+				    py == wp->yoff + wp->sy - 1 ||
+				    px == wp->xoff ||
+				    px == wp->xoff + wp->sx - 1)
+					return (KEYC_MOUSE_LOCATION_BORDER);
+			}
+		}
 	}
 	return (KEYC_MOUSE_LOCATION_NOWHERE);
 }

--- a/tmux.1
+++ b/tmux.1
@@ -5295,16 +5295,26 @@ but set the starting index for pane numbers.
 Set the text shown in pane border status lines.
 .Pp
 .It Xo Ic pane\-border\-indicators
-.Op Ic off | colour | arrows | both | box
+.Op Ic off | colour | arrows | both | box | box-all
 .Xc
 Indicate active pane by colouring only half of the border in windows with
 exactly two panes, by displaying arrow markers, by drawing both, by drawing
-a complete box around the active pane, or neither.
+a complete box around the active pane, by drawing boxes around all panes, or
+neither.
 When
 .Ic box
+or
+.Ic box-all
 is used, all panes display content inset by one character from each edge
 to prevent content reflow when switching between panes.
-The box border is only drawn around the active pane.
+With
+.Ic box ,
+the border is only drawn around the active pane; with
+.Ic box-all ,
+all panes show borders using
+.Ic pane-border-style
+and the active pane uses
+.Ic pane-active-border-style .
 Panes smaller than 3x3 do not show a box border.
 .Pp
 .It Ic pane\-border\-lines Ar type

--- a/tmux.1
+++ b/tmux.1
@@ -5295,10 +5295,17 @@ but set the starting index for pane numbers.
 Set the text shown in pane border status lines.
 .Pp
 .It Xo Ic pane\-border\-indicators
-.Op Ic off | colour | arrows | both
+.Op Ic off | colour | arrows | both | box
 .Xc
 Indicate active pane by colouring only half of the border in windows with
-exactly two panes, by displaying arrow markers, by drawing both or neither.
+exactly two panes, by displaying arrow markers, by drawing both, by drawing
+a complete box around the active pane, or neither.
+When
+.Ic box
+is used, all panes display content inset by one character from each edge
+to prevent content reflow when switching between panes.
+The box border is only drawn around the active pane.
+Panes smaller than 3x3 do not show a box border.
 .Pp
 .It Ic pane\-border\-lines Ar type
 Set the type of characters used for drawing pane borders.

--- a/tmux.h
+++ b/tmux.h
@@ -1091,6 +1091,7 @@ enum pane_lines {
 #define PANE_BORDER_ARROWS 2
 #define PANE_BORDER_BOTH 3
 #define PANE_BORDER_BOX 4
+#define PANE_BORDER_BOX_ALL 5
 
 /* Mode returned by window_pane_mode function. */
 #define WINDOW_PANE_NO_MODE 0

--- a/tmux.h
+++ b/tmux.h
@@ -1090,6 +1090,7 @@ enum pane_lines {
 #define PANE_BORDER_COLOUR 1
 #define PANE_BORDER_ARROWS 2
 #define PANE_BORDER_BOTH 3
+#define PANE_BORDER_BOX 4
 
 /* Mode returned by window_pane_mode function. */
 #define WINDOW_PANE_NO_MODE 0
@@ -3396,6 +3397,7 @@ struct window_pane *window_add_pane(struct window *, struct window_pane *,
 		     u_int, int);
 void		 window_resize(struct window *, u_int, u_int, int, int);
 void		 window_pane_send_resize(struct window_pane *, u_int, u_int);
+int		 window_pane_box_mode(struct window_pane *);
 int		 window_zoom(struct window_pane *);
 int		 window_unzoom(struct window *, int);
 int		 window_push_zoom(struct window *, int, int);

--- a/tty.c
+++ b/tty.c
@@ -991,6 +991,12 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 		cx = wp->xoff + wp->screen->cx;
 		cy = wp->yoff + wp->screen->cy;
 
+		/* Account for box mode offset. */
+		if (window_pane_box_mode(wp)) {
+			cx += 1;
+			cy += 1;
+		}
+
 		if (cx < *sx)
 			*ox = 0;
 		else if (cx > w->sx - *sx)

--- a/window.c
+++ b/window.c
@@ -479,10 +479,11 @@ int
 window_pane_box_mode(struct window_pane *wp)
 {
 	struct window	*w = wp->window;
+	int		 indicator;
 
 	/* Must have box mode enabled. */
-	if (options_get_number(w->options, "pane-border-indicators") !=
-	    PANE_BORDER_BOX)
+	indicator = options_get_number(w->options, "pane-border-indicators");
+	if (indicator != PANE_BORDER_BOX && indicator != PANE_BORDER_BOX_ALL)
 		return (0);
 
 	/* Must have more than one pane. */

--- a/window.c
+++ b/window.c
@@ -440,15 +440,26 @@ window_pane_send_resize(struct window_pane *wp, u_int sx, u_int sy)
 {
 	struct window	*w = wp->window;
 	struct winsize	 ws;
+	u_int		 pty_sx, pty_sy;
 
 	if (wp->fd == -1)
 		return;
 
-	log_debug("%s: %%%u resize to %u,%u", __func__, wp->id, sx, sy);
+	/* Reduce PTY size if box mode is active. */
+	if (window_pane_box_mode(wp)) {
+		pty_sx = sx - 2;
+		pty_sy = sy - 2;
+	} else {
+		pty_sx = sx;
+		pty_sy = sy;
+	}
+
+	log_debug("%s: %%%u resize to %u,%u (pty %u,%u)", __func__, wp->id,
+	    sx, sy, pty_sx, pty_sy);
 
 	memset(&ws, 0, sizeof ws);
-	ws.ws_col = sx;
-	ws.ws_row = sy;
+	ws.ws_col = pty_sx;
+	ws.ws_row = pty_sy;
 	ws.ws_xpixel = w->xpixel * ws.ws_col;
 	ws.ws_ypixel = w->ypixel * ws.ws_row;
 	if (ioctl(wp->fd, TIOCSWINSZ, &ws) == -1)
@@ -462,6 +473,27 @@ window_pane_send_resize(struct window_pane *wp, u_int sx, u_int sy)
 		if (errno != EINVAL && errno != ENXIO)
 #endif
 		fatal("ioctl failed");
+}
+
+int
+window_pane_box_mode(struct window_pane *wp)
+{
+	struct window	*w = wp->window;
+
+	/* Must have box mode enabled. */
+	if (options_get_number(w->options, "pane-border-indicators") !=
+	    PANE_BORDER_BOX)
+		return (0);
+
+	/* Must have more than one pane. */
+	if (TAILQ_NEXT(TAILQ_FIRST(&w->panes), entry) == NULL)
+		return (0);
+
+	/* Pane must be at least 3x3 to fit content inside border. */
+	if (wp->sx < 3 || wp->sy < 3)
+		return (0);
+
+	return (1);
 }
 
 int
@@ -1116,6 +1148,7 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 {
 	struct window_mode_entry	*wme;
 	struct window_pane_resize	*r;
+	u_int				 screen_sx, screen_sy;
 
 	if (sx == wp->sx && sy == wp->sy)
 		return;
@@ -1132,12 +1165,25 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 	wp->sx = sx;
 	wp->sy = sy;
 
-	log_debug("%s: %%%u resize %ux%u", __func__, wp->id, sx, sy);
-	screen_resize(&wp->base, sx, sy, wp->base.saved_grid == NULL);
+	/*
+	 * Reduce screen buffer size for box mode so content cannot
+	 * overwrite the border area.
+	 */
+	if (window_pane_box_mode(wp) && sx >= 3 && sy >= 3) {
+		screen_sx = sx - 2;
+		screen_sy = sy - 2;
+	} else {
+		screen_sx = sx;
+		screen_sy = sy;
+	}
+
+	log_debug("%s: %%%u resize %ux%u (screen %ux%u)", __func__, wp->id,
+	    sx, sy, screen_sx, screen_sy);
+	screen_resize(&wp->base, screen_sx, screen_sy, wp->base.saved_grid == NULL);
 
 	wme = TAILQ_FIRST(&wp->modes);
 	if (wme != NULL && wme->mode->resize != NULL)
-		wme->mode->resize(wme, sx, sy);
+		wme->mode->resize(wme, screen_sx, screen_sy);
 }
 
 int

--- a/window.c
+++ b/window.c
@@ -641,17 +641,28 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 	TAILQ_FOREACH(wp, &w->panes, entry) {
 		if (!window_pane_visible(wp))
 			continue;
-		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
-		if ((int)x < xoff || x > xoff + sx)
-			continue;
-		if (pane_status == PANE_STATUS_TOP) {
-			if ((int)y <= yoff - 2 || y > yoff + sy - 1)
-				continue;
+		if (window_pane_box_mode(wp)) {
+			/*
+			 * Include box border area and adjacent separator
+			 * cells so that clicks on the separator (used for
+			 * resize dragging) still resolve to a pane.
+			 */
+			if (x >= wp->xoff && x <= wp->xoff + wp->sx &&
+			    y >= wp->yoff && y <= wp->yoff + wp->sy)
+				return (wp);
 		} else {
-			if ((int)y < yoff || y > yoff + sy)
+			window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+			if ((int)x < xoff || x > xoff + sx)
 				continue;
+			if (pane_status == PANE_STATUS_TOP) {
+				if ((int)y <= yoff - 2 || y > yoff + sy - 1)
+					continue;
+			} else {
+				if ((int)y < yoff || y > yoff + sy)
+					continue;
+			}
+			return (wp);
 		}
-		return (wp);
 	}
 	return (NULL);
 }


### PR DESCRIPTION
Reopening https://github.com/tmux/tmux/pull/4747 with additional fixes since the original PR.

Add a new "box" option for `pane-border-indicators` that draws a complete box border around the active pane instead of using shared separator borders between panes. Also adds "box-all" to draw borders around every pane.


https://github.com/user-attachments/assets/321b826c-2f5f-43fd-b982-469cc50ff62c



## Changes

- Add `PANE_BORDER_BOX` / `PANE_BORDER_BOX_ALL` constants and `window_pane_box_mode()` helper
- Reduce internal screen buffer and PTY by 2 in each dimension to reserve space for box borders
- Offset pane content drawing by 1 to account for box border
- Adjust cursor positioning for box mode offset in screen-write, tty, and server-client
- Draw styled box border for active pane, blank borders for inactive panes
- Skip normal pane separator borders when box mode is active
- Clear separator cells between panes that would otherwise show old borders
- Handle mouse clicks on box borders correctly
- Add viewport clipping support so box borders work correctly when the window is larger than the terminal
- Add "box-all" variant that draws borders around all panes, not just the active one
- Document both options in tmux.1

## Test plan

- [x] Single pane: box mode inactive, no borders drawn
- [x] Horizontal split: box borders on active pane, blank on inactive
- [x] Vertical split: same behavior
- [x] `box-all`: borders on all panes
- [x] Switch between `off`/`box`/`box-all` dynamically
- [x] Mouse clicks on borders and within panes work correctly
- [x] Resize terminal: borders update correctly
- [x] Viewport panning works with box borders