### PR TITLE
feat: Add border buttons to panes

### DIFF
--- a/format-draw.c
+++ b/format-draw.c
@@ -50,6 +50,7 @@ format_is_type(struct format_range *fr, struct style *sy)
 	case STYLE_RANGE_LEFT:
 	case STYLE_RANGE_RIGHT:
 		return (1);
+	case STYLE_RANGE_BORDER:
 	case STYLE_RANGE_PANE:
 	case STYLE_RANGE_WINDOW:
 	case STYLE_RANGE_SESSION:
@@ -1064,6 +1065,8 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 		case STYLE_RANGE_USER:
 			log_debug("%s: range user|%u at %u-%u", __func__,
 			    sr->argument, sr->start, sr->end);
+			break;
+		case STYLE_RANGE_BORDER:
 			break;
 		}
 		format_free_range(&frs, fr);

--- a/format.c
+++ b/format.c
@@ -107,6 +107,7 @@ format_job_cmp(struct format_job *fj1, struct format_job *fj2)
 #define FORMAT_NOT 0x80000
 #define FORMAT_NOT_NOT 0x100000
 #define FORMAT_REPEAT 0x200000
+#define FORMAT_BUTTONS 0x400000
 
 /* Limit on recursion. */
 #define FORMAT_LOOP_LIMIT 100
@@ -1336,6 +1337,8 @@ format_cb_mouse_status_range(struct format_tree *ft)
 		return (xstrdup("left"));
 	case STYLE_RANGE_RIGHT:
 		return (xstrdup("right"));
+	case STYLE_RANGE_BORDER:
+		return (xstrdup("border"));
 	case STYLE_RANGE_PANE:
 		return (xstrdup("pane"));
 	case STYLE_RANGE_WINDOW:
@@ -4280,7 +4283,7 @@ format_build_modifiers(struct format_expand_state *es, const char **s,
 		}
 
 		/* Now try single character with arguments. */
-		if (strchr("mCLNPSst=pReqW", cp[0]) == NULL)
+		if (strchr("mBCLNPSst=pReqW", cp[0]) == NULL)
 			break;
 		c = cp[0];
 
@@ -4757,6 +4760,57 @@ format_loop_clients(struct format_expand_state *es, const char *fmt)
 	return (value);
 }
 
+/* Loop over buttons. */
+static char *
+format_loop_buttons(struct format_expand_state *es, const char *fmt)
+{
+	struct format_tree		 *ft = es->ft;
+	struct cmdq_item		 *item = ft->item;
+	struct format_tree		 *nft;
+	struct format_expand_state	  next;
+	struct options_entry		 *o;
+	union options_value		 *ov;
+	char				 *expanded, *value, *all, *active;
+	size_t				  valuelen;
+	int				  i;
+
+	if (ft->wp == NULL) {
+		format_log(es, "button loop but no window pane");
+		return (NULL);
+	}
+
+	if (format_choose(es, fmt, &all, &active, 0) != 0) {
+		all = xstrdup(fmt);
+		active = NULL;
+	}
+
+	value = xcalloc(1, 1);
+	valuelen = 1;
+
+	o = options_get(ft->wp->options, "pane-border-buttons");
+	if (o != NULL) {
+		for (i = 0; (ov = options_array_get(o, i)) != NULL; i++) {
+			format_log(es, "button loop: %d", i);
+			nft = format_create(ft->c, item, 0, ft->flags);
+			format_defaults(nft, ft->c, ft->s, ft->wl, ft->wp);
+			format_add(nft, "button_id", "%%%u", i);
+			format_add(nft, "button_face", "%s", ov->string);
+			format_copy_state(&next, es, 0);
+			next.ft = nft;
+			expanded = format_expand1(&next, fmt);
+			format_free(nft);
+
+			valuelen += strlen(expanded);
+			value = xrealloc(value, valuelen);
+
+			strlcat(value, expanded, valuelen);
+			free(expanded);
+		}
+	}
+
+	return (value);
+}
+
 static char *
 format_replace_expression(struct format_modifier *mexp,
     struct format_expand_state *es, const char *copy)
@@ -5104,6 +5158,9 @@ format_replace(struct format_expand_state *es, const char *key, size_t keylen,
 				else
 					sc->reversed = 0;
 				break;
+			case 'B':
+				modifiers |= FORMAT_BUTTONS;
+				break;
 			case 'R':
 				modifiers |= FORMAT_REPEAT;
 				break;
@@ -5168,6 +5225,10 @@ format_replace(struct format_expand_state *es, const char *key, size_t keylen,
 			goto fail;
 	} else if (modifiers & FORMAT_CLIENTS) {
 		value = format_loop_clients(es, copy);
+		if (value == NULL)
+			goto fail;
+	} else if (modifiers & FORMAT_BUTTONS) {
+		value = format_loop_buttons(es, copy);
 		if (value == NULL)
 			goto fail;
 	} else if (modifiers & FORMAT_WINDOW_NAME) {

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -353,6 +353,7 @@ key_bindings_init(void)
 		"bind -N 'Minimise pane' _ { minimise-pane }",
 		/* Mouse button 1 double click on status line. */
 		"bind -n DoubleClick1Status { minimise-pane -t= }",
+		"bind -n MouseDown1Border { minimise-pane -t= }",
 
 		"bind -N 'Send the prefix key' C-b { send-prefix }",
 		"bind -N 'Rotate through the panes' C-o { rotate-window }",
@@ -465,10 +466,10 @@ key_bindings_init(void)
 		"bind -n TripleClick1Pane { select-pane -t=; if -F '#{||:#{pane_in_mode},#{mouse_any_flag}}' { send -M } { copy-mode -H; send -X select-line; run -d0.3; send -X copy-pipe-and-cancel } }",
 
 		/* Mouse button 1 on border. */
-		"bind -n MouseDown1Border { select-pane -M }",
+		"bind -n MouseDown1BorderDefault { select-pane -M }",
 
 		/* Mouse button 1 drag on border. */
-		"bind -n MouseDrag1Border { resize-pane -M }",
+		"bind -n MouseDrag1BorderDefault { resize-pane -M }",
 
 		/* Mouse button 1 down on status line. */
 		"bind -n MouseDown1Status { switch-client -t= }",

--- a/options-table.c
+++ b/options-table.c
@@ -109,6 +109,21 @@ static const char *options_table_allow_passthrough_list[] = {
 	"off", "on", "all", NULL
 };
 
+#define OPTIONS_TABLE_PANE_BORDER_STATUS_FORMAT \
+	"#[align=left default]" \
+	"#[push-default]" \
+	"#{?pane_active,#[reverse],}#{pane_index}#[default] \"#{pane_title}\"" \
+	"#[pop-default]" \
+	"#[norange default]" \
+	"#[list=on align=right]" \
+	"#{B:" \
+		"#[range=border|#{button_id} default]" \
+		"#[push-default]" \
+		"[#{button_face}]" \
+		"#[pop-default]" \
+		"#[norange default]" \
+	"}"
+
 /* Status line format. */
 #define OPTIONS_TABLE_STATUS_FORMAT1 \
 	"#[align=left range=left #{E:status-left-style}]" \
@@ -1302,9 +1317,17 @@ const struct options_table_entry options_table[] = {
 	{ .name = "pane-border-format",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
-	  .default_str = "#{?pane_active,#[reverse],}#{pane_index}#[default] "
-			 "\"#{pane_title}\"",
+	  .default_str = OPTIONS_TABLE_PANE_BORDER_STATUS_FORMAT,
 	  .text = "Format of text in the pane status lines."
+	},
+
+	{ .name = "pane-border-buttons",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .flags = OPTIONS_TABLE_IS_ARRAY,
+	  .default_str = "_,^,x,",
+	  .separator = ",",
+	  .text = "Faces of the buttons on the pane border."
 	},
 
 	{ .name = "pane-border-indicators",

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -602,6 +602,7 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	struct grid_cell	 gc;
 	const char		*fmt;
 	struct format_tree	*ft;
+	struct style_line_entry	*sle;
 	char			*expanded;
 	int			 pane_status = rctx->pane_status, sb_w = 0;
 	int			 pane_scrollbars = rctx->pane_scrollbars;
@@ -651,10 +652,13 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	gc.attr &= ~GRID_ATTR_CHARSET;
 
 	screen_write_cursormove(&ctx, 0, 0, 0);
-	format_draw(&ctx, &gc, width, expanded, NULL, 0);
-	screen_write_stop(&ctx);
+	sle = &wp->border_status_line;
+	style_ranges_free_ranges(&sle->ranges);
+	format_draw(&ctx, &gc, width, expanded, &sle->ranges, 0);
+	free(sle->expanded);
+	sle->expanded = expanded;
 
-	free(expanded);
+	screen_write_stop(&ctx);
 	format_free(ft);
 
 	if (grid_compare(wp->status_screen.grid, old.grid) == 0) {

--- a/server-client.c
+++ b/server-client.c
@@ -37,6 +37,7 @@ enum mouse_where {
 	STATUS_RIGHT,
 	STATUS_DEFAULT,
 	BORDER,
+	BORDER_DEFAULT,
 	SCROLLBAR_UP,
 	SCROLLBAR_SLIDER,
 	SCROLLBAR_DOWN
@@ -639,9 +640,12 @@ server_client_check_mouse_in_pane(struct window_pane *wp, u_int px, u_int py,
 	else
 		pane_status_line = -1; /* not used */
 
+	if (pane_status != PANE_STATUS_OFF && (int)py == pane_status_line)
+		return BORDER;
+
 	/* Check if point is within the pane or scrollbar. */
 	if (((pane_status != PANE_STATUS_OFF &&
-      (int)py != pane_status_line && (int)py != wp->yoff + (int)wp->sy) ||
+	    (int)py != pane_status_line && (int)py != wp->yoff + (int)wp->sy) ||
 	    (wp->yoff == 0 && py < wp->sy) ||
 	    ((int)py >= wp->yoff && (int)py < wp->yoff + (int)wp->sy)) &&
 	    ((sb_pos == PANE_SCROLLBARS_RIGHT &&
@@ -870,6 +874,8 @@ have_event:
 			case STYLE_RANGE_USER:
 				where = STATUS;
 				break;
+			case STYLE_RANGE_BORDER:
+				break; /* unreachable */
 			}
 		}
 	}
@@ -915,9 +921,16 @@ have_event:
 			if (where == PANE) {
 				log_debug("mouse %u,%u on pane %%%u", x, y,
 				    wp->id);
-			} else if (where == BORDER)
+			} else if (where == BORDER) {
+				sr = border_get_range(wp, px);
+				if (sr != NULL) {
+					where = BORDER;
+					m->wp = wp->id;
+					m->btn = sr->argument;
+				} else
+					where = BORDER_DEFAULT;
 				log_debug("mouse on pane %%%u border", wp->id);
-			else if (where == SCROLLBAR_UP ||
+			} else if (where == SCROLLBAR_UP ||
 			    where == SCROLLBAR_SLIDER ||
 			    where == SCROLLBAR_DOWN) {
 				log_debug("mouse on pane %%%u scrollbar",
@@ -969,155 +982,48 @@ have_event:
 		c->tty.mouse_drag_release = NULL;
 		c->tty.mouse_scrolling_flag = 0;
 
+#define MOUSE_DRAG_END_CASES(n)						\
+	if (where == PANE)					\
+		key = KEYC_MOUSEDRAGEND##n##_PANE;	     	\
+	if (where == STATUS)			       		\
+		key = KEYC_MOUSEDRAGEND##n##_STATUS;       	\
+	if (where == STATUS_LEFT)		       		\
+		key = KEYC_MOUSEDRAGEND##n##_STATUS_LEFT;  	\
+	if (where == STATUS_RIGHT)		       		\
+		key = KEYC_MOUSEDRAGEND##n##_STATUS_RIGHT; 	\
+	if (where == STATUS_DEFAULT)		       		\
+		key = KEYC_MOUSEDRAGEND##n##_STATUS_DEFAULT;	\
+	if (where == SCROLLBAR_SLIDER)				\
+		key = KEYC_MOUSEDRAGEND##n##_SCROLLBAR_SLIDER;	\
+	if (where == BORDER)					\
+		key = KEYC_MOUSEDRAGEND##n##_BORDER;		\
+	if (where == BORDER_DEFAULT)				\
+		key = KEYC_MOUSEDRAGEND##n##_BORDER_DEFAULT;	\
+	break
+
 		/*
 		 * End a mouse drag by passing a MouseDragEnd key corresponding
 		 * to the button that started the drag.
 		 */
 		switch (c->tty.mouse_drag_flag - 1) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND1_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND1_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND1_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND2_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND2_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND2_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND3_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND3_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND3_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND6_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND6_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND6_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND7_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND7_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND7_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND8_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND8_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND8_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND9_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND9_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND9_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND10_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND10_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND10_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND10_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND10_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND10_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_MOUSEDRAGEND11_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDRAGEND11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDRAGEND11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDRAGEND11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDRAGEND11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDRAGEND11_SCROLLBAR_SLIDER;
-			if (where == BORDER)
-				key = KEYC_MOUSEDRAGEND11_BORDER;
-			break;
+			MOUSE_DRAG_END_CASES(11);
 		default:
 			key = KEYC_MOUSE;
 			break;
@@ -1127,6 +1033,29 @@ have_event:
 		c->tty.mouse_slider_mpos = -1;
 		goto out;
 	}
+
+#define MOUSE_ALL_CASES(t, n)				\
+	if (where == PANE)				\
+		key = KEYC_##t##n##_PANE;		\
+	if (where == STATUS)			       	\
+		key = KEYC_##t##n##_STATUS;       	\
+	if (where == STATUS_LEFT)		       	\
+		key = KEYC_##t##n##_STATUS_LEFT;  	\
+	if (where == STATUS_RIGHT)		       	\
+		key = KEYC_##t##n##_STATUS_RIGHT; 	\
+	if (where == STATUS_DEFAULT)		       	\
+		key = KEYC_##t##n##_STATUS_DEFAULT;	\
+	if (where == SCROLLBAR_UP)			\
+		key = KEYC_##t##n##_SCROLLBAR_UP;	\
+	if (where == SCROLLBAR_SLIDER)			\
+		key = KEYC_##t##n##_SCROLLBAR_SLIDER;	\
+	if (where == SCROLLBAR_DOWN)			\
+		key = KEYC_##t##n##_SCROLLBAR_DOWN;	\
+	if (where == BORDER)				\
+		key = KEYC_##t##n##_BORDER;		\
+	if (where == BORDER_DEFAULT)			\
+		key = KEYC_##t##n##_BORDER_DEFAULT;	\
+	break
 
 	/* Convert to a key binding. */
 	key = KEYC_UNKNOWN;
@@ -1155,6 +1084,8 @@ have_event:
 			key = KEYC_MOUSEMOVE_STATUS_DEFAULT;
 		if (where == BORDER)
 			key = KEYC_MOUSEMOVE_BORDER;
+		if (where == BORDER_DEFAULT)
+			key = KEYC_MOUSEMOVE_BORDER_DEFAULT;
 		break;
 	case DRAG:
 		if (c->tty.mouse_drag_update != NULL)
@@ -1162,185 +1093,23 @@ have_event:
 		else {
 			switch (MOUSE_BUTTONS(b)) {
 			case MOUSE_BUTTON_1:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG1_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG1_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG1_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG1_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG1_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG1_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG1_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG1_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG1_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 1);
 			case MOUSE_BUTTON_2:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG2_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG2_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG2_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG2_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG2_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG2_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG2_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG2_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG2_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 2);
 			case MOUSE_BUTTON_3:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG3_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG3_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG3_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG3_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG3_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG3_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG3_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG3_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG3_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 3);
 			case MOUSE_BUTTON_6:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG6_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG6_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG6_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG6_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG6_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG6_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG6_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG6_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG6_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 6);
 			case MOUSE_BUTTON_7:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG7_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG7_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG7_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG7_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG7_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG7_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG7_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG7_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG7_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 7);
 			case MOUSE_BUTTON_8:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG8_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG8_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG8_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG8_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG8_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG8_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG8_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG8_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG8_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 8);
 			case MOUSE_BUTTON_9:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG9_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG9_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG9_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG9_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG9_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG9_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG9_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG9_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG9_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 9);
 			case MOUSE_BUTTON_10:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG10_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG10_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG10_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG10_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG10_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG10_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG10_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG10_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG10_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 10);
 			case MOUSE_BUTTON_11:
-				if (where == PANE)
-					key = KEYC_MOUSEDRAG11_PANE;
-				if (where == STATUS)
-					key = KEYC_MOUSEDRAG11_STATUS;
-				if (where == STATUS_LEFT)
-					key = KEYC_MOUSEDRAG11_STATUS_LEFT;
-				if (where == STATUS_RIGHT)
-					key = KEYC_MOUSEDRAG11_STATUS_RIGHT;
-				if (where == STATUS_DEFAULT)
-					key = KEYC_MOUSEDRAG11_STATUS_DEFAULT;
-				if (where == SCROLLBAR_UP)
-					key = KEYC_MOUSEDRAG11_SCROLLBAR_UP;
-				if (where == SCROLLBAR_SLIDER)
-					key = KEYC_MOUSEDRAG11_SCROLLBAR_SLIDER;
-				if (where == SCROLLBAR_DOWN)
-					key = KEYC_MOUSEDRAG11_SCROLLBAR_DOWN;
-				if (where == BORDER)
-					key = KEYC_MOUSEDRAG11_BORDER;
-				break;
+				MOUSE_ALL_CASES(MOUSEDRAG, 11);
 			}
 		}
 
@@ -1398,921 +1167,111 @@ have_event:
 	case UP:
 		switch (MOUSE_BUTTONS(b)) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_MOUSEUP1_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP1_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP1_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP1_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_MOUSEUP2_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP2_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP2_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP2_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP2_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_MOUSEUP3_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP3_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP3_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP3_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP3_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_MOUSEUP6_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP6_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP6_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP6_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP6_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_MOUSEUP7_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP7_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP7_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP7_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP7_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_MOUSEUP8_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP8_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP8_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP8_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP8_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_MOUSEUP9_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP9_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP9_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP9_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP9_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_MOUSEUP1_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP10_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP10_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP1_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_MOUSEUP11_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEUP11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEUP11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEUP11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEUP11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEUP11_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEUP11_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEUP11_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEUP11_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEUP, 11);
 		}
 		break;
 	case DOWN:
 		switch (MOUSE_BUTTONS(b)) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN1_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN1_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN1_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN1_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN2_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN2_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN2_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN2_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN2_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN3_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN3_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN3_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN3_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN3_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN6_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN6_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN6_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN6_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN6_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN7_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN7_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN7_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN7_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN7_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN8_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN8_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN8_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN8_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN8_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN9_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN9_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN9_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN9_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN9_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN10_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN10_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN10_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN10_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN10_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN10_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN10_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN10_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_MOUSEDOWN11_PANE;
-			if (where == STATUS)
-				key = KEYC_MOUSEDOWN11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_MOUSEDOWN11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_MOUSEDOWN11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_MOUSEDOWN11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_MOUSEDOWN11_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_MOUSEDOWN11_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_MOUSEDOWN11_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_MOUSEDOWN11_BORDER;
-			break;
+			MOUSE_ALL_CASES(MOUSEDOWN, 11);
 		}
 		break;
 	case SECOND:
 		switch (MOUSE_BUTTONS(b)) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK1_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK1_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK1_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK1_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK2_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK2_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK2_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK2_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK2_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK3_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK3_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK3_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK3_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK3_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK6_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK6_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK6_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK6_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK6_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK7_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK7_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK7_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK7_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK7_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK8_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK8_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK8_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK8_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK8_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK9_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK9_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK9_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK9_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK9_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK10_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK10_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK10_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK10_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK10_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK10_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK10_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK10_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_SECONDCLICK11_PANE;
-			if (where == STATUS)
-				key = KEYC_SECONDCLICK11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_SECONDCLICK11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_SECONDCLICK11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_SECONDCLICK11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_SECONDCLICK11_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_SECONDCLICK11_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_SECONDCLICK11_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_SECONDCLICK11_BORDER;
-			break;
+			MOUSE_ALL_CASES(SECONDCLICK, 11);
 		}
 		break;
 	case DOUBLE:
 		switch (MOUSE_BUTTONS(b)) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK1_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK1_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK1_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK1_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK2_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK2_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK2_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK2_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK2_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK3_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK3_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK3_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK3_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK3_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK6_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK6_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK6_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK6_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK6_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK7_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK7_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK7_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK7_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK7_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK8_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK8_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK8_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK8_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK8_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK9_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK9_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK9_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK9_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK9_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK10_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK10_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK10_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK10_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK10_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK10_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK10_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK10_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_DOUBLECLICK11_PANE;
-			if (where == STATUS)
-				key = KEYC_DOUBLECLICK11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_DOUBLECLICK11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_DOUBLECLICK11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_DOUBLECLICK11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_DOUBLECLICK11_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_DOUBLECLICK11_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_DOUBLECLICK11_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_DOUBLECLICK11_BORDER;
-			break;
+			MOUSE_ALL_CASES(DOUBLECLICK, 11);
 		}
 		break;
 	case TRIPLE:
 		switch (MOUSE_BUTTONS(b)) {
 		case MOUSE_BUTTON_1:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK1_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK1_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK1_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK1_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK1_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK1_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK1_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK1_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK1_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 1);
 		case MOUSE_BUTTON_2:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK2_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK2_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK2_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK2_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK2_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK2_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK2_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK2_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK2_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 2);
 		case MOUSE_BUTTON_3:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK3_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK3_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK3_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK3_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK3_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK3_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK3_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK3_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK3_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 3);
 		case MOUSE_BUTTON_6:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK6_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK6_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK6_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK6_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK6_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK6_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK6_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK6_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK6_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 6);
 		case MOUSE_BUTTON_7:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK7_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK7_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK7_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK7_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK7_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK7_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK7_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK7_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK7_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 7);
 		case MOUSE_BUTTON_8:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK8_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK8_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK8_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK8_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK8_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK8_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK8_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK8_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK8_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 8);
 		case MOUSE_BUTTON_9:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK9_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK9_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK9_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK9_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK9_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK9_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK9_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK9_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK9_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 9);
 		case MOUSE_BUTTON_10:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK10_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK10_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK10_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK10_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK10_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK10_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK10_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK10_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK10_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 10);
 		case MOUSE_BUTTON_11:
-			if (where == PANE)
-				key = KEYC_TRIPLECLICK11_PANE;
-			if (where == STATUS)
-				key = KEYC_TRIPLECLICK11_STATUS;
-			if (where == STATUS_LEFT)
-				key = KEYC_TRIPLECLICK11_STATUS_LEFT;
-			if (where == STATUS_RIGHT)
-				key = KEYC_TRIPLECLICK11_STATUS_RIGHT;
-			if (where == STATUS_DEFAULT)
-				key = KEYC_TRIPLECLICK11_STATUS_DEFAULT;
-			if (where == SCROLLBAR_UP)
-				key = KEYC_TRIPLECLICK11_SCROLLBAR_UP;
-			if (where == SCROLLBAR_SLIDER)
-				key = KEYC_TRIPLECLICK11_SCROLLBAR_SLIDER;
-			if (where == SCROLLBAR_DOWN)
-				key = KEYC_TRIPLECLICK11_SCROLLBAR_DOWN;
-			if (where == BORDER)
-				key = KEYC_TRIPLECLICK11_BORDER;
-			break;
+			MOUSE_ALL_CASES(TRIPLECLICK, 11);
 		}
 		break;
 	}

--- a/status.c
+++ b/status.c
@@ -284,27 +284,12 @@ struct style_range *
 status_get_range(struct client *c, u_int x, u_int y)
 {
 	struct status_line	*sl = &c->status;
-	struct style_range	*sr;
+	struct style_ranges	*srs;
 
 	if (y >= nitems(sl->entries))
 		return (NULL);
-	TAILQ_FOREACH(sr, &sl->entries[y].ranges, entry) {
-		if (x >= sr->start && x < sr->end)
-			return (sr);
-	}
-	return (NULL);
-}
-
-/* Free all ranges. */
-static void
-status_free_ranges(struct style_ranges *srs)
-{
-	struct style_range	*sr, *sr1;
-
-	TAILQ_FOREACH_SAFE(sr, srs, entry, sr1) {
-		TAILQ_REMOVE(srs, sr, entry);
-		free(sr);
-	}
+	srs = &sl->entries[y].ranges;
+	return (style_ranges_get_range(srs, x));
 }
 
 /* Save old status line. */
@@ -341,7 +326,7 @@ status_init(struct client *c)
 	u_int			 i;
 
 	for (i = 0; i < nitems(sl->entries); i++)
-		TAILQ_INIT(&sl->entries[i].ranges);
+		style_ranges_init(&sl->entries[i].ranges);
 
 	screen_init(&sl->screen, c->tty.sx, 1, 0);
 	sl->active = &sl->screen;
@@ -355,7 +340,7 @@ status_free(struct client *c)
 	u_int			 i;
 
 	for (i = 0; i < nitems(sl->entries); i++) {
-		status_free_ranges(&sl->entries[i].ranges);
+		style_ranges_free_ranges(&sl->entries[i].ranges);
 		free((void *)sl->entries[i].expanded);
 	}
 
@@ -374,7 +359,7 @@ int
 status_redraw(struct client *c)
 {
 	struct status_line		*sl = &c->status;
-	struct status_line_entry	*sle;
+	struct style_line_entry		*sle;
 	struct session			*s = c->session;
 	struct screen_write_ctx		 ctx;
 	struct grid_cell		 gc;
@@ -454,7 +439,7 @@ status_redraw(struct client *c)
 				screen_write_putc(&ctx, &gc, ' ');
 			screen_write_cursormove(&ctx, 0, i, 0);
 
-			status_free_ranges(&sle->ranges);
+			style_ranges_free_ranges(&sle->ranges);
 			format_draw(&ctx, &gc, width, expanded, &sle->ranges,
 			    0);
 

--- a/style.c
+++ b/style.c
@@ -137,6 +137,17 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 				sy->range_type = STYLE_RANGE_RIGHT;
 				sy->range_argument = 0;
 				style_set_range_string(sy, "");
+			} else if (strcasecmp(tmp + 6, "border") == 0) {
+				if (found == NULL)
+					goto error;
+				if (*found != '%' || found[1] == '\0')
+					goto error;
+				n = strtonum(found + 1, 0, UINT_MAX, &errstr);
+				if (errstr != NULL)
+					goto error;
+				sy->range_type = STYLE_RANGE_BORDER;
+				sy->range_argument = n;
+				style_set_range_string(sy, "");
 			} else if (strcasecmp(tmp + 6, "pane") == 0) {
 				if (found == NULL)
 					goto error;
@@ -446,3 +457,35 @@ style_set_scrollbar_style_from_option(struct style *sb_style, struct options *oo
 		utf8_set(&sb_style->gc.data, PANE_SCROLLBARS_CHARACTER);
 	}
 }
+
+void
+style_ranges_init(struct style_ranges *ranges)
+{
+	TAILQ_INIT(ranges);
+}
+
+struct style_range *
+style_ranges_get_range(struct style_ranges *ranges, u_int x)
+{
+	struct style_range	*sr;
+
+	if (ranges == NULL)
+		return (NULL);
+	TAILQ_FOREACH(sr, ranges, entry) {
+		if (x >= sr->start && x < sr->end)
+			return (sr);
+	}
+	return (NULL);
+}
+
+void
+style_ranges_free_ranges(struct style_ranges *srs)
+{
+	struct style_range	*sr, *sr1;
+
+	TAILQ_FOREACH_SAFE(sr, srs, entry, sr1) {
+		TAILQ_REMOVE(srs, sr, entry);
+		free(sr);
+	}
+}
+

--- a/tmux.h
+++ b/tmux.h
@@ -194,7 +194,8 @@ struct winlink;
 	KEYC_ ## name ## _SCROLLBAR_UP,	    \
 	KEYC_ ## name ## _SCROLLBAR_SLIDER, \
 	KEYC_ ## name ## _SCROLLBAR_DOWN,   \
-	KEYC_ ## name ## _BORDER
+	KEYC_ ## name ## _BORDER,	    \
+	KEYC_ ## name ## _BORDER_DEFAULT
 #define KEYC_MOUSE_STRING(name, s)				      \
 	{ #s "Pane", KEYC_ ## name ## _PANE },			      \
 	{ #s "Status", KEYC_ ## name ## _STATUS },		      \
@@ -204,7 +205,8 @@ struct winlink;
 	{ #s "ScrollbarUp", KEYC_ ## name ## _SCROLLBAR_UP },         \
 	{ #s "ScrollbarSlider", KEYC_ ## name ## _SCROLLBAR_SLIDER }, \
 	{ #s "ScrollbarDown", KEYC_ ## name ## _SCROLLBAR_DOWN },     \
-	{ #s "Border", KEYC_ ## name ## _BORDER }
+	{ #s "Border", KEYC_ ## name ## _BORDER },		      \
+	{ #s "BorderDefault", KEYC_ ## name ## _BORDER_DEFAULT }
 
 /*
  * A single key. This can be ASCII or Unicode or one of the keys between
@@ -877,6 +879,7 @@ enum style_range_type {
 	STYLE_RANGE_NONE,
 	STYLE_RANGE_LEFT,
 	STYLE_RANGE_RIGHT,
+	STYLE_RANGE_BORDER,
 	STYLE_RANGE_PANE,
 	STYLE_RANGE_WINDOW,
 	STYLE_RANGE_SESSION,
@@ -893,6 +896,11 @@ struct style_range {
 	TAILQ_ENTRY(style_range) entry;
 };
 TAILQ_HEAD(style_ranges, style_range);
+
+struct style_line_entry {
+	char			*expanded;
+	struct style_ranges	 ranges;
+};
 
 /* Default style width and pad. */
 #define STYLE_WIDTH_DEFAULT -1
@@ -1210,8 +1218,8 @@ struct window_pane {
 	int		 xoff;
 	int		 yoff;
 
-	int		 flags;
-	int		 saved_flags;
+	long		 flags;
+	long		 saved_flags;
 #define PANE_REDRAW 0x1
 #define PANE_DROP 0x2
 #define PANE_FOCUSED 0x4
@@ -1261,6 +1269,7 @@ struct window_pane {
 	struct grid_cell cached_active_gc;
 	struct colour_palette palette;
 	enum client_theme last_theme;
+	struct style_line_entry border_status_line;
 
 	int		 pipe_fd;
 	pid_t		 pipe_pid;
@@ -1546,6 +1555,7 @@ struct mouse_event {
 	int		s;
 	int		w;
 	int		wp;
+	int		btn;
 
 	u_int		sgr_type;
 	u_int		sgr_b;
@@ -1885,10 +1895,6 @@ struct cmd_entry {
 
 /* Status line. */
 #define STATUS_LINES_LIMIT 5
-struct status_line_entry {
-	char			*expanded;
-	struct style_ranges	 ranges;
-};
 struct status_line {
 	struct event		 timer;
 
@@ -1897,7 +1903,7 @@ struct status_line {
 	int			 references;
 
 	struct grid_cell	 style;
-	struct status_line_entry entries[STATUS_LINES_LIMIT];
+	struct style_line_entry entries[STATUS_LINES_LIMIT];
 };
 
 /* Prompt type. */
@@ -3348,6 +3354,7 @@ struct window	*window_find_by_id(u_int);
 void		 window_update_activity(struct window *);
 struct window	*window_create(u_int, u_int, u_int, u_int);
 void		 window_pane_set_event(struct window_pane *);
+struct style_range *border_get_range(struct window_pane *, u_int);
 struct window_pane *window_get_active_at(struct window *, u_int, u_int);
 struct window_pane *window_find_string(struct window *, const char *);
 int		 window_has_pane(struct window *, struct window_pane *);
@@ -3747,6 +3754,9 @@ void		 style_set(struct style *, const struct grid_cell *);
 void		 style_copy(struct style *, struct style *);
 void		 style_set_scrollbar_style_from_option(struct style *,
 		     struct options *);
+void		 style_ranges_init(struct style_ranges *);
+struct style_range *style_ranges_get_range(struct style_ranges *, u_int);
+void		 style_ranges_free_ranges(struct style_ranges *);
 
 /* spawn.c */
 struct winlink	*spawn_window(struct spawn_context *, char **);

--- a/window.c
+++ b/window.c
@@ -649,6 +649,19 @@ window_redraw_active_switch(struct window *w, struct window_pane *wp)
 	}
 }
 
+struct style_range *
+border_get_range(struct window_pane *wp, u_int x)
+{
+	struct style_ranges	*srs;
+
+	if (wp == NULL)
+		return (NULL);
+	srs = &wp->border_status_line.ranges;
+
+	/* Hacky. Format offset for border status is off by 3. Figure out why */
+	return (style_ranges_get_range(srs, x - wp->xoff - 3));
+}
+
 struct window_pane *
 window_get_active_at(struct window *w, u_int x, u_int y)
 {
@@ -668,7 +681,7 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 			if ((int)x < xoff || x > xoff + sx)
 				continue;
 			if (status == PANE_STATUS_TOP) {
-				if ((int)y < yoff - 1 || y > yoff + sy)
+				if ((int)y < yoff - 1 || y > yoff + sy - 1)
 					continue;
 			} else {
 				if ((int)y < yoff || y > yoff + sy)
@@ -1092,6 +1105,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	wp->screen = &wp->base;
 	window_pane_default_cursor(wp);
 
+	style_ranges_init(&wp->border_status_line.ranges);
 	screen_init(&wp->status_screen, 1, 1, 0);
 
 	if (gethostname(host, sizeof host) == 0)
@@ -1145,6 +1159,7 @@ window_pane_destroy(struct window_pane *wp)
 	free(wp->shell);
 	cmd_free_argv(wp->argc, wp->argv);
 	colour_palette_free(&wp->palette);
+	style_ranges_free_ranges(&wp->border_status_line.ranges);
 	free(wp);
 }
 


### PR DESCRIPTION
This is a WIP implementation of point 8 from #4800:
`Add some buttons to the border: - ^ x to minimise, zoom, and close a pane.`

The wiring is mostly done. The current progress is at linking behavior to the button press. 

Some context: button "faces" are loaded from an options array. Upon a successful mouse event on a button, that index is stored in `struct mouse_event` in a new field `btn`.

A goal of the implementation is to allow uses to not only customize the number and faces of buttons, but the behavior as well. In service of that, I was thinking about adding another options string array which holds tmux commands. Each command is "linked" to its button by its index in the array (There will be some bookkeeping). Those commands can then be passed directly to `run -C` or through an intermediary which gets the tmux command string from the options array indexed at `event->mouse_event->btn`.

I also factored out around 1k lines in `server-client.c:server_client_check_mouse` through a macro. It was faster to factor it out than to add a new check to everything. More could be done, but I think it's a happy medium at the moment.

Let me know how it looks! @mgrant0 