### PR TITLE
Add bracket_paste_flag format variable

### DIFF
--- a/format.c
+++ b/format.c
@@ -1355,6 +1355,18 @@ format_cb_alternate_saved_y(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for bracket_paste_flag. */
+static void *
+format_cb_bracket_paste_flag(struct format_tree *ft)
+{
+	if (ft->wp != NULL && ft->wp->screen != NULL) {
+		if (ft->wp->screen->mode & MODE_BRACKETPASTE)
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
 /* Callback for buffer_name. */
 static void *
 format_cb_buffer_name(struct format_tree *ft)
@@ -3048,6 +3060,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "alternate_saved_y", FORMAT_TABLE_STRING,
 	  format_cb_alternate_saved_y
+	},
+	{ "bracket_paste_flag", FORMAT_TABLE_STRING,
+	  format_cb_bracket_paste_flag
 	},
 	{ "buffer_created", FORMAT_TABLE_TIME,
 	  format_cb_buffer_created

--- a/tmux.1
+++ b/tmux.1
@@ -6259,6 +6259,7 @@ The following variables are available, where appropriate:
 .It Li "alternate_on" Ta "" Ta "1 if pane is in alternate screen"
 .It Li "alternate_saved_x" Ta "" Ta "Saved cursor X in alternate screen"
 .It Li "alternate_saved_y" Ta "" Ta "Saved cursor Y in alternate screen"
+.It Li "bracket_paste_flag" Ta "" Ta "Pane bracketed paste flag"
 .It Li "buffer_created" Ta "" Ta "Time buffer created"
 .It Li "buffer_full" Ta "" Ta "Full buffer content"
 .It Li "buffer_name" Ta "" Ta "Name of buffer"


### PR DESCRIPTION
Add `#{bracket_paste_flag}` to query whether a pane has bracketed paste mode enabled (`ESC[?2004h`). Returns 1 if set, 0 if not.

This is needed by iTerm2's tmux integration.