### PR TITLE
Add OSC 9;4 progress bar support

### DIFF
--- a/format.c
+++ b/format.c
@@ -2250,6 +2250,39 @@ format_cb_pane_pipe_pid(struct format_tree *ft)
 	return (value);
 }
 
+/* Callback for pane_pb_progress. */
+static void *
+format_cb_pane_pb_progress(struct format_tree *ft)
+{
+	char    *value = NULL;
+
+	if (ft->wp != NULL) {
+		xasprintf(&value, "%d", ft->wp->base.progress_bar.progress);
+	}
+	return (value);
+}
+
+/* Callback for pane_pb_state. */
+static void *
+format_cb_pane_pb_state(struct format_tree *ft)
+{
+	if (ft->wp != NULL) {
+		switch (ft->wp->base.progress_bar.state) {
+			case PROGRESS_BAR_HIDDEN:
+				return xstrdup("hidden");
+			case PROGRESS_BAR_NORMAL:
+				return xstrdup("normal");
+			case PROGRESS_BAR_ERROR:
+				return xstrdup("error");
+			case PROGRESS_BAR_INDETERMINATE:
+				return xstrdup("indeterminate");
+			case PROGRESS_BAR_PAUSED:
+				return xstrdup("paused");
+		}
+	}
+	return (NULL);
+}
+
 /* Callback for pane_right. */
 static void *
 format_cb_pane_right(struct format_tree *ft)
@@ -3342,6 +3375,12 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_pipe_pid", FORMAT_TABLE_STRING,
 	  format_cb_pane_pipe_pid
+	},
+	{ "pane_pb_progress", FORMAT_TABLE_STRING,
+	  format_cb_pane_pb_progress
+	},
+	{ "pane_pb_state", FORMAT_TABLE_STRING,
+	  format_cb_pane_pb_state
 	},
 	{ "pane_right", FORMAT_TABLE_STRING,
 	  format_cb_pane_right

--- a/input.c
+++ b/input.c
@@ -164,6 +164,7 @@ static void	input_reset_cell(struct input_ctx *);
 static void	input_report_current_theme(struct input_ctx *);
 static void	input_osc_4(struct input_ctx *, const char *);
 static void	input_osc_8(struct input_ctx *, const char *);
+static void	input_osc_9(struct input_ctx *, const char *);
 static void	input_osc_10(struct input_ctx *, const char *);
 static void	input_osc_11(struct input_ctx *, const char *);
 static void	input_osc_12(struct input_ctx *, const char *);
@@ -2673,6 +2674,9 @@ input_exit_osc(struct input_ctx *ictx)
 	case 8:
 		input_osc_8(ictx, p);
 		break;
+	case 9:
+		input_osc_9(ictx, p);
+		break;
 	case 10:
 		input_osc_10(ictx, p);
 		break;
@@ -2941,6 +2945,65 @@ bad:
 	free(id);
 }
 
+/* Helper to handle setting the progress bar and redrawing. */
+static void
+set_progress_bar(struct input_ctx *ictx, enum progress_bar_state s, int p) {
+	screen_set_progress_bar(ictx->ctx.s, s, p);
+ 	if (ictx->wp != NULL) {
+		server_redraw_window_borders(ictx->wp->window);
+		server_status_window(ictx->wp->window);
+	}
+}
+	
+
+/* Handle the OSC 9;4 sequence for progress bars. */
+static void
+input_osc_9(struct input_ctx *ictx, const char *p)
+{
+	const char			*pb = p;
+	enum progress_bar_state		state;
+	int				progress = 0;
+
+	if (*pb++ != '4')
+		return;
+
+	/* With no further parameters just hide the bar. */
+	if (*pb == '\0' || (*pb == ';' && pb[1] == '\0')) {
+		set_progress_bar(ictx, PROGRESS_BAR_HIDDEN, 0);
+		return;
+	}
+
+	if (*pb++ != ';')
+		return;
+
+	if (*pb < '0' || *pb > '4') {
+		log_debug("bad OSC 9;4 %s", p);
+		return;
+	}
+	state = *pb++ - '0';
+
+	if (*pb == '\0' || (*pb == ';' && pb[1] == '\0')) {
+		set_progress_bar(ictx, state, -1);
+		return;
+	}
+
+	if (*pb++ != ';') {
+		log_debug("bad OSC 9;4 %s", p);
+		return;
+	}
+
+	while (*pb >= '0' && *pb <= '9')
+		progress = progress * 10 + *pb++ - '0';
+	if (*pb != '\0') {
+		log_debug("bad OSC 9;4 %s", p);
+		return;
+	}
+	if (progress < 0 || progress > 100) {
+		log_debug("bad OSC 9;4 progress number %d", progress);
+		return;
+	}
+	set_progress_bar(ictx, state, progress);
+}
 
 /* Handle the OSC 10 sequence for setting and querying foreground colour. */
 static void

--- a/regress/osc-9-4-progress-bars.sh
+++ b/regress/osc-9-4-progress-bars.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+$TMUX new -d
+$TMUX set -g remain-on-exit on
+
+do_test() {
+	$TMUX splitw "printf '$1'"
+	sleep 0.25
+	pbs="$($TMUX display -p '#{pane_pb_state}')"
+	pbp="$($TMUX display -p '#{pane_pb_progress}')"
+	$TMUX kill-pane
+	[ "$pbs" != "$2" ] && \
+		printf "test '%s' expected: $2, actual: $pbs\n" "$1" && return 1
+	[ "$pbp" != "$3" ] && \
+		printf "test '%s' expected: $3, actual: $pbp\n" "$1" && return 1
+	return 0
+}
+
+# Initial state
+do_test '' 'hidden' '0' || exit 1
+
+# Zero progress
+do_test '\033]9;4;0;0\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;0\007' 'normal' '0' || exit 1
+do_test '\033]9;4;2;0\007' 'error' '0' || exit 1
+do_test '\033]9;4;3;0\007' 'indeterminate' '0' | exit 1
+do_test '\033]9;4;4;0\007' 'paused' '0' || exit 1
+
+# 1% progress
+do_test '\033]9;4;0;1\007' 'hidden' '1' || exit 1
+do_test '\033]9;4;1;1\007' 'normal' '1' || exit 1
+do_test '\033]9;4;2;1\007' 'error' '1' || exit 1
+do_test '\033]9;4;3;1\007' 'indeterminate' '0' | exit 1
+do_test '\033]9;4;4;1\007' 'paused' '1' || exit 1
+
+# 50% progress
+do_test '\033]9;4;0;50\007' 'hidden' '50' || exit 1
+do_test '\033]9;4;1;50\007' 'normal' '50' || exit 1
+do_test '\033]9;4;2;50\007' 'error' '50' || exit 1
+do_test '\033]9;4;3;50\007' 'indeterminate' '0' | exit 1
+do_test '\033]9;4;4;50\007' 'paused' '50' || exit 1
+
+# 100% progress
+do_test '\033]9;4;0;100\007' 'hidden' '100' || exit 1
+do_test '\033]9;4;1;100\007' 'normal' '100' || exit 1
+do_test '\033]9;4;2;100\007' 'error' '100' || exit 1
+do_test '\033]9;4;3;100\007' 'indeterminate' '0' | exit 1
+do_test '\033]9;4;4;100\007' 'paused' '100' || exit 1
+
+# Short sequences
+do_test '\033]9;4;1;50\007\033]9;4\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;50\007\033]9;4;\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;50\007\033]9;4;4\007' 'paused' '50' || exit 1
+do_test '\033]9;4;1;50\007\033]9;4;4;\007' 'paused' '50' || exit 1
+
+# Invalid codes, should be ignored
+do_test '\033]9;4;foo\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;foo;10\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;foo\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;5;10\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;50;10\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;101\007' 'hidden' '0' || exit 1
+do_test '\033]9;4;1;1000\007' 'hidden' '0' || exit 1
+
+$TMUX -f/dev/null kill-server 2>/dev/null
+exit 0

--- a/screen.c
+++ b/screen.c
@@ -131,6 +131,8 @@ screen_reinit(struct screen *s)
 	image_free_all(s);
 #endif
 
+	screen_set_progress_bar(s, PROGRESS_BAR_HIDDEN, 0);
+
 	screen_reset_hyperlinks(s);
 }
 
@@ -295,6 +297,19 @@ screen_pop_title(struct screen *s)
 		free(title_entry);
 	}
 }
+
+/*
+ * Set the progress bar state and progress. The progress will not be updated
+ * if p is negative.
+ */
+void
+screen_set_progress_bar(struct screen *s, enum progress_bar_state pbs, int p)
+{
+	s->progress_bar.state = pbs;
+	if (p >= 0 && pbs != PROGRESS_BAR_INDETERMINATE)
+		s->progress_bar.progress = p;
+}
+
 
 /* Resize screen with options. */
 void

--- a/tmux.1
+++ b/tmux.1
@@ -6381,6 +6381,8 @@ The following variables are available, where appropriate:
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"
 .It Li "pane_pipe" Ta "" Ta "1 if pane is being piped"
 .It Li "pane_pipe_pid" Ta "" Ta "PID of pipe process, if any"
+.It Li "pane_pb_state" Ta "" Ta "Pane progress bar state, one of hidden, normal, error, indeterminate, paused (can be set by application)"
+.It Li "pane_pb_progress" Ta "" Ta "Pane progress bar progress percentage, 0-100 (can be set by application)"
 .It Li "pane_right" Ta "" Ta "Right of pane"
 .It Li "pane_search_string" Ta "" Ta "Last search string in copy mode"
 .It Li "pane_start_command" Ta "" Ta "Command pane started with"

--- a/tmux.h
+++ b/tmux.h
@@ -952,6 +952,21 @@ enum screen_cursor_style {
 	SCREEN_CURSOR_BAR
 };
 
+
+/* Progress Bars, OSC 9;4. */
+enum progress_bar_state {
+	PROGRESS_BAR_HIDDEN = 0,
+	PROGRESS_BAR_NORMAL = 1,
+	PROGRESS_BAR_ERROR  = 2,
+	PROGRESS_BAR_INDETERMINATE = 3,
+	PROGRESS_BAR_PAUSED = 4,
+};
+
+struct progress_bar {
+	enum	progress_bar_state state;
+	int	progress;
+};
+
 /* Virtual screen. */
 struct screen_sel;
 struct screen_titles;
@@ -993,6 +1008,8 @@ struct screen {
 	struct screen_write_cline	*write_list;
 
 	struct hyperlinks		*hyperlinks;
+
+	struct progress_bar		progress_bar;
 };
 
 /* Screen write context. */
@@ -3287,6 +3304,8 @@ int	 screen_set_title(struct screen *, const char *);
 void	 screen_set_path(struct screen *, const char *);
 void	 screen_push_title(struct screen *);
 void	 screen_pop_title(struct screen *);
+void	 screen_set_progress_bar(struct screen *s, enum progress_bar_state pbs, 
+	     int p);
 void	 screen_resize(struct screen *, u_int, u_int, int);
 void	 screen_resize_cursor(struct screen *, u_int, u_int, int, int, int);
 void	 screen_set_selection(struct screen *, u_int, u_int, u_int, u_int,


### PR DESCRIPTION
Exports two format variables, `pane_progress_bar_state` and `pane_progress_bar_progress`. `pane_progress_bar_state` possible values are `hidden`, `normal`, `error`, `indeterminate` and `paused`. `pane_progress_bar_progress` is a numerical value between 0-100.

Fixes #4833.

Documented here: https://learn.microsoft.com/en-us/windows/terminal/tutorials/progress-bar-sequences#progress-bar-sequence-format.