### PR TITLE
Add WAYLAND_DISPLAY to default update-environment list

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -1024,7 +1024,8 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .flags = OPTIONS_TABLE_IS_ARRAY,
 	  .default_str = "DISPLAY KRB5CCNAME MSYSTEM SSH_ASKPASS SSH_AUTH_SOCK "
-			 "SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY",
+			 "SSH_AGENT_PID SSH_CONNECTION WAYLAND_DISPLAY "
+			 "WINDOWID XAUTHORITY",
 	  .text = "List of environment variables to update in the session "
 		  "environment when a client is attached."
 	},


### PR DESCRIPTION
This environment variable serves the same role as `DISPLAY` on X.

Just like with `DISPLAY`, this helps fixing the problem where the tmux server was initially started in Wayland session, but later on used through SSH, and programs incorrectly inherit this env var, displaying their GUI _somewhere_ instead of falling back to TUI or failing explicitly. Or vice versa.

 And just like with DISPLAY and other variables in the update-environment list, this change is safe if you don't use Wayland. Only harmless `-WAYLAND_DISPLAY`/`unset WAYLAND_DISPLAY` is emitted.