### PR TITLE
feat: Added responsive status redraws for `pane_current_command`

### DIFF
--- a/names.c
+++ b/names.c
@@ -91,13 +91,13 @@ check_window_name(struct window *w)
 		evtimer_del(&w->name_event);
 
 	w->active->flags &= ~PANE_CHANGED;
+	server_status_window(w);
 
 	name = format_window_name(w);
 	if (strcmp(name, w->name) != 0) {
 		log_debug("@%u new name %s (was %s)", w->id, name, w->name);
 		window_set_name(w, name);
 		server_redraw_window_borders(w);
-		server_status_window(w);
 	} else
 		log_debug("@%u name not changed (still %s)", w->id, w->name);
 

--- a/server-client.c
+++ b/server-client.c
@@ -50,6 +50,7 @@ static key_code	server_client_check_mouse(struct client *, struct key_event *);
 static void	server_client_repeat_timer(int, short, void *);
 static void	server_client_click_timer(int, short, void *);
 static void	server_client_check_exit(struct client *);
+static void	server_client_check_fg_pids(struct client *);
 static void	server_client_check_redraw(struct client *);
 static void	server_client_check_modes(struct client *);
 static void	server_client_set_title(struct client *);
@@ -2784,6 +2785,7 @@ server_client_loop(void)
 		server_client_check_exit(c);
 		if (c->session != NULL && c->session->curw != NULL) {
 			server_client_check_modes(c);
+			server_client_check_fg_pids(c);
 			server_client_check_redraw(c);
 			server_client_reset_state(c);
 		}
@@ -3271,6 +3273,27 @@ server_client_check_modes(struct client *c)
 		wme = TAILQ_FIRST(&wp->modes);
 		if (wme != NULL && wme->mode->update != NULL)
 			wme->mode->update(wme);
+	}
+}
+
+/* Check for client foregroup pid changes in client's panes. Used for
+ * triggering a status redraw.
+ */
+static void
+server_client_check_fg_pids(struct client *c)
+{
+	struct session		*s = c->session;
+	struct winlink		*wl = s->curw;
+	struct window		*w = wl->window;
+	struct window_pane	*wp;
+	pid_t			 pid;
+
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if ((pid = tcgetpgrp(wp->fd)) != wp->fg_pid) {
+			wp->fg_pid = pid;
+			c->flags |= CLIENT_REDRAWSTATUS;
+			return;
+		}
 	}
 }
 

--- a/server-client.c
+++ b/server-client.c
@@ -50,7 +50,6 @@ static key_code	server_client_check_mouse(struct client *, struct key_event *);
 static void	server_client_repeat_timer(int, short, void *);
 static void	server_client_click_timer(int, short, void *);
 static void	server_client_check_exit(struct client *);
-static void	server_client_check_fg_pids(struct client *);
 static void	server_client_check_redraw(struct client *);
 static void	server_client_check_modes(struct client *);
 static void	server_client_set_title(struct client *);
@@ -2763,6 +2762,7 @@ server_client_loop(void)
 	struct window_pane		*wp, *twp;
 	struct window_mode_entry	*wme;
 	u_int				 bit;
+	pid_t				 pid;
 
 	/* Check for window resize. This is done before redrawing. */
 	RB_FOREACH(w, windows, &windows)
@@ -2785,7 +2785,6 @@ server_client_loop(void)
 		server_client_check_exit(c);
 		if (c->session != NULL && c->session->curw != NULL) {
 			server_client_check_modes(c);
-			server_client_check_fg_pids(c);
 			server_client_check_redraw(c);
 			server_client_reset_state(c);
 		}
@@ -2800,6 +2799,10 @@ server_client_loop(void)
 			if (wp->fd != -1) {
 				server_client_check_pane_resize(wp);
 				server_client_check_pane_buffer(wp);
+			}
+			if ((pid = tcgetpgrp(wp->fd)) != wp->fg_pid) {
+				wp->fg_pid = pid;
+				wp->flags |= PANE_CHANGED;
 			}
 			/*
 			 * If PANE_REDRAW was set during buffer processing
@@ -3273,27 +3276,6 @@ server_client_check_modes(struct client *c)
 		wme = TAILQ_FIRST(&wp->modes);
 		if (wme != NULL && wme->mode->update != NULL)
 			wme->mode->update(wme);
-	}
-}
-
-/* Check for client foregroup pid changes in client's panes. Used for
- * triggering a status redraw.
- */
-static void
-server_client_check_fg_pids(struct client *c)
-{
-	struct session		*s = c->session;
-	struct winlink		*wl = s->curw;
-	struct window		*w = wl->window;
-	struct window_pane	*wp;
-	pid_t			 pid;
-
-	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if ((pid = tcgetpgrp(wp->fd)) != wp->fg_pid) {
-			wp->fg_pid = pid;
-			c->flags |= CLIENT_REDRAWSTATUS;
-			return;
-		}
 	}
 }
 

--- a/spawn.c
+++ b/spawn.c
@@ -387,6 +387,7 @@ spawn_pane(struct spawn_context *sc, char **cause)
 
 	/* Fork the new process. */
 	new_wp->pid = fdforkpty(ptm_fd, &new_wp->fd, new_wp->tty, NULL, &ws);
+	new_wp->fg_pid = new_wp->pid;
 	if (new_wp->pid == -1) {
 		xasprintf(cause, "fork failed: %s", strerror(errno));
 		new_wp->fd = -1;

--- a/tmux.h
+++ b/tmux.h
@@ -1248,6 +1248,7 @@ struct window_pane {
 	char		*cwd;
 
 	pid_t		 pid;
+	pid_t		 fg_pid;
 	char		 tty[TTY_NAME_MAX];
 	int		 status;
 	struct timeval	 dead_time;


### PR DESCRIPTION
The issue this PR solves is delayed redraws of the status line when using the format variable `pane_current_command`. Before, the status wouldn't be triggered to redraw when the shell had a new command ran in it. This left the format variable feeling laggy, often displaying outdated information until manual intervention.

I have added a new stateful field to `struct window_pane` to store the last "seen" foreground pid running at the pane's file descriptor. A new check is make across all clients in `server-client.c:server_client_loop`, to determine if there is a new fg pid at each of the panes being displayed by the client. Finding one such pane will exit early and trigger a status redraw.

The added complexity is minimal, but not nothing considering currently this only affects a single format variable. I find this to be the most useful format variable for panes on the status line, so I may be biased towards this feature.
@mgrant0 