### PR TITLE
Cache getpwuid results in format callbacks

### DIFF
--- a/format.c
+++ b/format.c
@@ -1605,9 +1605,13 @@ format_cb_client_user(struct format_tree *ft)
 	struct passwd	*pw;
 
 	if (ft->c != NULL) {
+		if (ft->c->peer_user != NULL)
+			return (xstrdup(ft->c->peer_user));
 		uid = proc_get_peer_uid(ft->c->peer);
-		if (uid != (uid_t)-1 && (pw = getpwuid(uid)) != NULL)
-			return (xstrdup(pw->pw_name));
+		if (uid != (uid_t)-1 && (pw = getpwuid(uid)) != NULL) {
+			ft->c->peer_user = xstrdup(pw->pw_name);
+			return (xstrdup(ft->c->peer_user));
+		}
 	}
 	return (NULL);
 }
@@ -3023,10 +3027,15 @@ format_cb_uid(__unused struct format_tree *ft)
 static void *
 format_cb_user(__unused struct format_tree *ft)
 {
+	static char	*cached;
 	struct passwd	*pw;
 
-	if ((pw = getpwuid(getuid())) != NULL)
-		return (xstrdup(pw->pw_name));
+	if (cached == NULL) {
+		if ((pw = getpwuid(getuid())) != NULL)
+			cached = xstrdup(pw->pw_name);
+	}
+	if (cached != NULL)
+		return (xstrdup(cached));
 	return (NULL);
 }
 

--- a/server-client.c
+++ b/server-client.c
@@ -533,6 +533,7 @@ server_client_free(__unused int fd, __unused short events, void *arg)
 
 	if (c->references == 0) {
 		free((void *)c->name);
+		free(c->peer_user);
 		free(c);
 	}
 }

--- a/tmux.h
+++ b/tmux.h
@@ -1944,6 +1944,7 @@ typedef void (*overlay_resize_cb)(struct client *, void *);
 struct client {
 	const char		*name;
 	struct tmuxpeer		*peer;
+	char			*peer_user;
 	struct cmdq_list	*queue;
 
 	struct client_windows	 windows;


### PR DESCRIPTION
## Summary

On Linux with nscd, each `getpwuid()` call creates a new Unix domain socket connection to the nscd daemon. The format callbacks `format_cb_user()` and `format_cb_client_user()` call `getpwuid()` on every format expansion with no caching. With many control mode clients attached (e.g. stale iTerm2 `-CC` sessions), each maintaining subscriptions that trigger periodic format expansion, the uncached calls can saturate the single-threaded event loop and make the server unresponsive.

- Cache the server username in a static variable in `format_cb_user()` since `getuid()` never changes
- Cache the peer username in `struct client` for `format_cb_client_user()` since the peer uid is fixed at connection time

This follows the same pattern already used by `find_home()` in `tmux.c`.