### PR TITLE
Add unfrozen mode for command-prompt

### DIFF
--- a/cmd-command-prompt.c
+++ b/cmd-command-prompt.c
@@ -42,8 +42,8 @@ const struct cmd_entry cmd_command_prompt_entry = {
 	.name = "command-prompt",
 	.alias = NULL,
 
-	.args = { "1beFiklI:Np:t:T:", 0, 1, cmd_command_prompt_args_parse },
-	.usage = "[-1beFiklN] [-I inputs] [-p prompts] " CMD_TARGET_CLIENT_USAGE
+	.args = { "1CbeFiklI:Np:t:T:", 0, 1, cmd_command_prompt_args_parse },
+	.usage = "[-1CbeFiklN] [-I inputs] [-p prompts] " CMD_TARGET_CLIENT_USAGE
 		 " [-T prompt-type] [template]",
 
 	.flags = CMD_CLIENT_TFLAG,
@@ -165,6 +165,8 @@ cmd_command_prompt_exec(struct cmd *self, struct cmdq_item *item)
 		cdata->flags |= PROMPT_KEY;
 	else if (args_has(args, 'e'))
 		cdata->flags |= PROMPT_BSPACE_EXIT;
+	if (args_has(args, 'C'))
+		cdata->flags |= PROMPT_NOFREEZE;
 	status_prompt_set(tc, target, cdata->prompts[0].prompt,
 	    cdata->prompts[0].input, cmd_command_prompt_callback,
 	    cmd_command_prompt_free, cdata, cdata->flags, cdata->prompt_type);

--- a/status.c
+++ b/status.c
@@ -728,7 +728,7 @@ status_prompt_set(struct client *c, struct cmd_find_state *fs,
 	c->prompt_type = prompt_type;
 	c->prompt_mode = PROMPT_ENTRY;
 
-	if (~flags & PROMPT_INCREMENTAL)
+	if ((~flags & PROMPT_INCREMENTAL) && (~flags & PROMPT_NOFREEZE))
 		c->tty.flags |= TTY_FREEZE;
 	c->flags |= CLIENT_REDRAWSTATUS;
 

--- a/tmux.1
+++ b/tmux.1
@@ -6913,7 +6913,7 @@ See
 for possible values for
 .Ar prompt\-type .
 .It Xo Ic command\-prompt
-.Op Fl 1beFiklN
+.Op Fl 1CbeFiklN
 .Op Fl I Ar inputs
 .Op Fl p Ar prompts
 .Op Fl t Ar target\-client
@@ -6983,6 +6983,9 @@ is like
 but the key press is translated to a key name.
 .Fl N
 makes the prompt only accept numeric key presses.
+If
+.Fl C
+given, panes will continue to be updated while the prompt is displayed.
 .Fl i
 executes the command every time the prompt input changes instead of when the
 user exits the command prompt.

--- a/tmux.h
+++ b/tmux.h
@@ -2147,6 +2147,7 @@ struct client {
 #define PROMPT_ACCEPT 0x20
 #define PROMPT_QUOTENEXT 0x40
 #define PROMPT_BSPACE_EXIT 0x80
+#define PROMPT_NOFREEZE 0x100
 	int			 prompt_flags;
 	enum prompt_type	 prompt_type;
 	int			 prompt_cursor;


### PR DESCRIPTION
Add an unfrozen mode for `command-prompt`.

While testing `command-prompt` on top of continuously updating panes, I noticed that it always took the frozen path. `display-message` already has `-C` for the unfrozen case, so this follows the same idea for prompts instead of changing the default behaviour globally.

Implementation-wise, `-C` just gives prompts an unfrozen path so prompt setup can skip `TTY_FREEZE` instead of taking the normal frozen path. Without `-C`, `command-prompt` keeps the current behaviour. `tmux.1` documents the new option.

## Testing

Since this is my first tmux PR I tested the crap out of it with a local tmux build.

- compared plain `command-prompt` with `command-prompt -C` over continuously updating pane output
- checked `-1`, `-k`, `-N`, and multiple prompts
- checked cancel behaviour
- checked resize while the prompt was open
- checked prompt from a popup
- checked two attached clients and verified the prompt remained local to the client where it was opened

I also noticed #4977 in my testing! (This PR does not change that behaviour)

***NOTE***: This is my first PR to tmux.
