### PR TITLE
Fix NULL dereference in control_write when control_state is not yet initialized

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -24,7 +24,8 @@
 #include "tmux.h"
 
 #define CONTROL_SHOULD_NOTIFY_CLIENT(c) \
-	((c) != NULL && ((c)->flags & CLIENT_CONTROL))
+	((c) != NULL && ((c)->flags & CLIENT_CONTROL) && \
+	 (c)->control_state != NULL)
 
 void
 control_notify_pane_mode_changed(int pane)


### PR DESCRIPTION
## Summary

Fix a server crash (SIGSEGV at `si_addr=0x20`) caused by `control_write()` dereferencing a NULL `control_state` pointer on a client that has `CLIENT_CONTROL` set but has not yet completed identification.

## The Bug

`CONTROL_SHOULD_NOTIFY_CLIENT()` checks `c->flags & CLIENT_CONTROL` but does not verify that `c->control_state` has been initialized. There is a window between `MSG_IDENTIFY_FLAGS` (which sets `CLIENT_CONTROL`) and `MSG_IDENTIFY_DONE` (which calls `control_start()` to allocate `control_state`) where the client is visible to control notification iterators but has `control_state == NULL`.

If a notification callback runs during this window, `control_write()` dereferences the NULL `control_state`:

```c
void
control_write(struct client *c, const char *fmt, ...)
{
    struct control_state *cs = c->control_state;  // NULL
    ...
    if (TAILQ_EMPTY(&cs->all_blocks)) {           // SIGSEGV reading 0x20
```

## How I Found It

I had a tmux 3.5a server that had been running for 27 days. It became unresponsive (hung in `wait_woken` in the kernel, not processing socket commands). Multiple `tmux -CC new -A -s main` clients were queued waiting for the server to respond.

When I attached `strace` to debug the hang, the SIGSTOP/SIGCONT from strace woke the server. It processed a burst of deferred work — accepting queued client connections, dispatching identify messages, and running the notification command queue — then immediately crashed:

```
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0x20} ---
+++ killed by SIGSEGV (core dumped) +++
```

## Crash Analysis

From the core dump (`eu-readelf -n`):

- **Fault address**: `0x20` — offset of `control_state` within `struct client`
- **RIP**: `0x5600d72c6317` → binary offset `0x4c317`

Disassembly at the crash point:

```asm
4c2f9: mov    0x20(%rbp),%r12      # r12 = c->control_state (cs)
4c317: cmpq   $0x0,0x20(%r12)      # TAILQ_EMPTY(&cs->all_blocks) — CRASH, r12=0
```

Register state confirmed `r12 = 0` (NULL control_state) and `rbp = 0x5600d8213690` (valid client pointer).

The return address on the stack (`0x70886`) pointed to `control_notify_session_window_changed`, confirmed by the format string at the loaded address: `%%session-window-changed $%u @%u`.

I built tmux from the 3.5a tag with debug symbols and used `addr2line` to confirm:

```
$ addr2line -f -e tmux 0x4262d0
control_write
/home/bmaurer/tmux/control.c:414
```

## Sequence of Events

1. Server had been running 27 days with accumulated zombie client connections
2. Server event loop became stuck (separate issue — likely related to stale file descriptors)
3. Multiple `tmux -CC new -A -s main` clients connected and queued on the socket
4. `strace -p` woke the server via SIGSTOP/SIGCONT
5. In the burst of processing:
   - `server_accept()` created new client structs, added them to the `clients` list
   - `proc_event_cb()` processed identify messages — `MSG_IDENTIFY_FLAGS` set `CLIENT_CONTROL`
   - Before `MSG_IDENTIFY_DONE` could call `control_start()`, the command queue ran
   - A queued `session-window-changed` notification iterated the clients list
   - `CONTROL_SHOULD_NOTIFY_CLIENT()` saw `CLIENT_CONTROL` on the partially-identified client
   - `control_write()` dereferenced the NULL `control_state` → SIGSEGV

## Fix

Add `(c)->control_state != NULL` to the `CONTROL_SHOULD_NOTIFY_CLIENT` macro, ensuring notifications are only sent to clients that have completed control mode initialization.