### PR TITLE
feat: Default behavior for pane border buttons

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -468,6 +468,7 @@ key_bindings_init(void)
 
 		/* Mouse button 1 down on default pane-border-format */
 		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O -T 'Kill pane #{pane_index}?' 'Yes' 'y' { kill-pane -t= } 'No' 'n' {}}",
+		"bind -n MouseDown1Control8 { resize-pane -Z }",
 
 		/* Mouse wheel down on status line. */
 		"bind -n WheelDownStatus { next-window }",

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -467,7 +467,7 @@ key_bindings_init(void)
 		"bind -n C-MouseDown1Status { swap-window -t@ }",
 
 		/* Mouse button 1 down on default pane-border-format */
-		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O -T 'Kill pane #{pane_id}?' 'Yes' 'y' { kill-pane -t= } 'No' 'n' {}}",
+		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O -T 'Kill pane #{pane_index}?' 'Yes' 'y' { kill-pane -t= } 'No' 'n' {}}",
 
 		/* Mouse wheel down on status line. */
 		"bind -n WheelDownStatus { next-window }",

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -467,7 +467,7 @@ key_bindings_init(void)
 		"bind -n C-MouseDown1Status { swap-window -t@ }",
 
 		/* Mouse button 1 down on default pane-border-format */
-		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O 'Confim kill pane?' 'y' { kill-pane -t= } 'No' 'n' {}}",
+		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O -T 'Kill pane #{pane_id}?' 'Yes' 'y' { kill-pane -t= } 'No' 'n' {}}",
 
 		/* Mouse wheel down on status line. */
 		"bind -n WheelDownStatus { next-window }",

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -467,7 +467,7 @@ key_bindings_init(void)
 		"bind -n C-MouseDown1Status { swap-window -t@ }",
 
 		/* Mouse button 1 down on default pane-border-format */
-		"bind -n MouseDown1Control9 { kill-pane -t= }",
+		"bind -n MouseDown1Control9 { display-menu -t= -xM -yM -O 'Confim kill pane?' 'y' { kill-pane -t= } 'No' 'n' {}}",
 
 		/* Mouse wheel down on status line. */
 		"bind -n WheelDownStatus { next-window }",

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -466,6 +466,9 @@ key_bindings_init(void)
 		"bind -n MouseDown1Status { switch-client -t= }",
 		"bind -n C-MouseDown1Status { swap-window -t@ }",
 
+		/* Mouse button 1 down on default pane-border-format */
+		"bind -n MouseDown1Control9 { kill-pane -t= }",
+
 		/* Mouse wheel down on status line. */
 		"bind -n WheelDownStatus { next-window }",
 

--- a/options-table.c
+++ b/options-table.c
@@ -1306,6 +1306,7 @@ const struct options_table_entry options_table[] = {
 			 "\"#{pane_title}\""
 			 "#{?#{mouse},"
 				"#[align=right]"
+				"#[range=control|8][^]#[norange]"
 				"#[range=control|9][x]#[norange]"
 			",}",
 	  .text = "Format of text in the pane status lines."

--- a/options-table.c
+++ b/options-table.c
@@ -1306,7 +1306,7 @@ const struct options_table_entry options_table[] = {
 			 "\"#{pane_title}\""
 			 "#{?#{mouse},"
 				"#[align=right]"
-				"#[range=control|8][^]#[norange]"
+				"#[range=control|8][z]#[norange]"
 				"#[range=control|9][x]#[norange]"
 			",}",
 	  .text = "Format of text in the pane status lines."

--- a/options-table.c
+++ b/options-table.c
@@ -1306,7 +1306,9 @@ const struct options_table_entry options_table[] = {
 			 "\"#{pane_title}\""
 			 "#{?#{mouse},"
 				"#[align=right]"
-				"#[range=control|8][z]#[norange]"
+				"#[range=control|8]["
+					"#{?#{window_zoomed_flag},u,z}"
+				"]#[norange]"
 				"#[range=control|9][x]#[norange]"
 			",}",
 	  .text = "Format of text in the pane status lines."

--- a/options-table.c
+++ b/options-table.c
@@ -1304,7 +1304,7 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_str = "#{?pane_active,#[reverse],}#{pane_index}#[default] "
 			 "\"#{pane_title}\""
-			 "#{?#{mouse_on},"
+			 "#{?#{==:#{mouse},1},"
 				"#[align=right]"
 				"#[range=control|9][x]#[norange]"
 			",}",

--- a/options-table.c
+++ b/options-table.c
@@ -1303,7 +1303,11 @@ const struct options_table_entry options_table[] = {
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_str = "#{?pane_active,#[reverse],}#{pane_index}#[default] "
-			 "\"#{pane_title}\"",
+			 "\"#{pane_title}\""
+			 "#{?#{mouse_on},"
+				"#[align=right]"
+				"#[range=control|9][x]#[norange]"
+			",}",
 	  .text = "Format of text in the pane status lines."
 	},
 

--- a/options-table.c
+++ b/options-table.c
@@ -1304,7 +1304,7 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
 	  .default_str = "#{?pane_active,#[reverse],}#{pane_index}#[default] "
 			 "\"#{pane_title}\""
-			 "#{?#{==:#{mouse},1},"
+			 "#{?#{mouse},"
 				"#[align=right]"
 				"#[range=control|9][x]#[norange]"
 			",}",


### PR DESCRIPTION
I have added a simple format variable to track whether or not the use has set the mouse on, and a default `[x]` button to kill the pane to `pane-border-format`. 

Is this aesthetic appropriate for the default behavior?