### PR TITLE
fix: changed 'Rename' keybind in session menu to avoid conflict.

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -29,7 +29,7 @@
 	" 'Previous' 'p' {switch-client -p}" \
 	" ''" \
 	" 'Renumber' 'N' {move-window -r}" \
-	" 'Rename' 'n' {command-prompt -I \"#S\" {rename-session -- '%%'}}" \
+	" 'Rename' 'r' {command-prompt -I \"#S\" {rename-session -- '%%'}}" \
 	" ''" \
 	" 'New Session' 's' {new-session}" \
 	" 'New Window' 'w' {new-window}"


### PR DESCRIPTION
Addresses part of #4987.