### PR TITLE
fix: plural "windows" when session has only one window

### DIFF
--- a/cmd-list-sessions.c
+++ b/cmd-list-sessions.c
@@ -29,7 +29,7 @@
  */
 
 #define LIST_SESSIONS_TEMPLATE				\
-	"#{session_name}: #{session_windows} windows "	\
+	"#{session_name}: #{session_windows} #{?#{==:#{session_windows},1},window,windows} "	\
 	"(created #{t:session_created})"		\
 	"#{?session_grouped, (group ,}"			\
 	"#{session_group}#{?session_grouped,),}"	\

--- a/window-tree.c
+++ b/window-tree.c
@@ -46,7 +46,7 @@ static void		 window_tree_key(struct window_mode_entry *,
 		"#{window_name}#{window_flags}" \
 		"#{?#{&&:#{==:#{window_panes},1},#{&&:#{pane_title},#{!=:#{pane_title},#{host_short}}}},: \"#{pane_title}\",}" \
 	"," \
-		"#{session_windows} windows" \
+		"#{session_windows} #{?#{==:#{session_windows},1},window,windows}" \
 		"#{?session_grouped, " \
 			"(group #{session_group}: " \
 			"#{session_group_list})," \


### PR DESCRIPTION
### Summary
Fix plural "windows" string output displayed when session has only one window 

### The bug
Simple plural "windows" is displayed instead of single "window"

### How i found it
I just created a new session and when listing it it should have displayed "1 window" instead I saw the plural "windows"

### Fix

Use conditional format to choose what display in list-sessions choose-tree output (instead of "1 windows" it's now "1 window")

### Platform
I'm on macos but Its the same on other platforms

### Before Fix / After Fix
<img width="1765" height="172" alt="Screenshot 2026-04-09 at 8 15 19 AM" src="https://github.com/user-attachments/assets/abd09bb6-3bb4-4e19-83b5-b9e6e3cb9205" />
