### PR TITLE
Translate keypad keys to text in prompt input

### DIFF
--- a/regress/tty-keys.sh
+++ b/regress/tty-keys.sh
@@ -60,6 +60,31 @@ assert_key () {
 
 }
 
+assert_prompt () {
+	flags=$1
+	keys=$2
+	expected=$3
+
+	$TMUX2 command-prompt $flags 'display-message -pl "%1"' > "$TMP" &
+	sleep 0.05
+
+	$TMUX send-keys $keys
+
+	wait
+
+	keys=$(printf '%s' "$keys" | sed -e 's/Escape/\\\\033/g' | tr -d '[:space:]')
+	actual=$(tr -d '[:space:]' < "$TMP")
+
+	if [ "$actual" = "$expected" ]; then
+		if [ -n "$VERBOSE" ]; then
+			echo "[PASS] $keys -> $actual"
+		fi
+	else
+		echo "[FAIL] $keys -> $expected (Got: '$actual')"
+		exit_status=1
+	fi
+}
+
 assert_key 0x00 'C-Space' # -- 'Escape 0x00' 'C-M-Space'
 assert_key 0x01 'C-a'	  -- 'Escape 0x01' 'C-M-a'
 assert_key 0x02 'C-b'	  -- 'Escape 0x02' 'C-M-b'
@@ -206,6 +231,9 @@ assert_key 'Escape Ov' 'KP6'	 -- 'Escape Escape Ov' 'M-KP6'
 assert_key 'Escape Ow' 'KP7'	 -- 'Escape Escape Ow' 'M-KP7'
 assert_key 'Escape Ox' 'KP8'	 -- 'Escape Escape Ox' 'M-KP8'
 assert_key 'Escape Oy' 'KP9'	 -- 'Escape Escape Oy' 'M-KP9'
+assert_prompt '' 'Escape Oq Escape Or Enter' '12'
+assert_prompt '-N' 'Escape Oq Escape Or Enter' '12'
+assert_prompt '-1' 'Escape Oq 2' '1'
 
 # Arrow keys
 assert_key 'Escape OA' 'Up'    -- 'Escape Escape OA' 'M-Up'

--- a/status.c
+++ b/status.c
@@ -972,6 +972,49 @@ status_prompt_space(const struct utf8_data *ud)
 	return (*ud->data == ' ');
 }
 
+static key_code
+status_prompt_keypad_key(key_code key)
+{
+	if (key & KEYC_MASK_MODIFIERS)
+		return (key);
+
+	switch (key) {
+	case KEYC_KP_SLASH:
+		return ('/');
+	case KEYC_KP_STAR:
+		return ('*');
+	case KEYC_KP_MINUS:
+		return ('-');
+	case KEYC_KP_SEVEN:
+		return ('7');
+	case KEYC_KP_EIGHT:
+		return ('8');
+	case KEYC_KP_NINE:
+		return ('9');
+	case KEYC_KP_PLUS:
+		return ('+');
+	case KEYC_KP_FOUR:
+		return ('4');
+	case KEYC_KP_FIVE:
+		return ('5');
+	case KEYC_KP_SIX:
+		return ('6');
+	case KEYC_KP_ONE:
+		return ('1');
+	case KEYC_KP_TWO:
+		return ('2');
+	case KEYC_KP_THREE:
+		return ('3');
+	case KEYC_KP_ENTER:
+		return ('\r');
+	case KEYC_KP_ZERO:
+		return ('0');
+	case KEYC_KP_PERIOD:
+		return ('.');
+	}
+	return (key);
+}
+
 /*
  * Translate key from vi to emacs. Return 0 to drop key, 1 to process the key
  * as an emacs key; return 2 to append to the buffer.
@@ -1383,6 +1426,9 @@ status_prompt_key(struct client *c, key_code key)
 	}
 	size = utf8_strlen(c->prompt_buffer);
 
+	key &= ~KEYC_MASK_FLAGS;
+	key = status_prompt_keypad_key(key);
+
 	if (c->prompt_flags & PROMPT_NUMERIC) {
 		if (key >= '0' && key <= '9')
 			goto append_key;
@@ -1392,7 +1438,6 @@ status_prompt_key(struct client *c, key_code key)
 		free(s);
 		return (1);
 	}
-	key &= ~KEYC_MASK_FLAGS;
 
 	if (c->prompt_flags & (PROMPT_SINGLE|PROMPT_QUOTENEXT)) {
 		if ((key & KEYC_MASK_KEY) == KEYC_BSPACE)


### PR DESCRIPTION
Translate keypad keys to text in prompt input.

While testing `command-prompt` with keypad input, I noticed prompt entry bypasses the normal pane key translation path. This PR is related to #4977 but doesn't fully fix it.

Keypad keys arrive as `KEYC_KP_*` rather than actual printable chars. Plain prompts, `-N` and `-1` do not handle keypad entry either.

## Implementation

just normalize unmodified keypad keys` before prompt processing, so prompts then see keypad input as its printable equivalent. For example, consider `KPEnter`, which now reaches the existing prompt accept path as an ordinary `Enter` instead of being an unhandled key.

I tested this a bunch with a local tmux build, including `-1`, `-N` `-k`, keypad punctuation (`KP{.,/,*,+,-}`)