### PR TITLE
Fix pane border corruption with popup overlays

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -950,7 +950,7 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	struct grid_cell	 defaults;
 	struct visible_ranges	*r;
 	struct visible_range	*rr;
-	u_int			 i, j, k, top, x, y, width;
+	u_int			 i, j, k, top, x, y, width, used;
 
 	if (wp->base.mode & MODE_SYNC)
 		screen_write_stop_sync(wp);
@@ -997,13 +997,16 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		tty_default_colours(&defaults, wp);
 
 		r = tty_check_overlay_range(tty, x, y, width);
-		for (k = 0; k < r->used; k++) {
-			rr = &r->ranges[k];
-			if (rr->nx != 0) {
-				tty_draw_line(tty, s, rr->px - wp->xoff, j,
-				    rr->nx, rr->px, y, &defaults, palette);
+		used = r->used;
+		rr = xcalloc(used, sizeof(struct visible_range));
+		memcpy(rr, r->ranges, used * sizeof(struct visible_range));
+		for (k = 0; k < used; k++) {
+			if (rr[k].nx != 0) {
+				tty_draw_line(tty, s, rr[k].px - wp->xoff, j,
+				    rr[k].nx, rr[k].px, y, &defaults, palette);
 			}
 		}
+		free(rr);
 	}
 
 #ifdef ENABLE_SIXEL


### PR DESCRIPTION
## Problem

When a window is split and a popup is displayed, pane borders may not be
redrawn correctly. In particular, stale borders can remain visible next
to the popup.

`tty_check_overlay_range()` is invoked multiple times during line drawing,
including from `tty_draw_line_clear()`.

This causes previously computed overlay range data to be overwritten,
leading to inconsistent rendering when popups overlap pane borders.

This is a regression introduced by PR #4920.

## Reproduction

1. split a window into two panes
2. open a popup
3. resizep from the popup
<img width="741" height="436" alt="2026-04-09_0x30000cx436" src="https://github.com/user-attachments/assets/bc73a948-c74a-4f93-a11d-a0a10a9d7976" />

---

I was not able to reproduce the original issue fixed by PR #4920, so it
would be good if @taylorconor could confirm that this change does not
interfere with that fix.