### PR TITLE
fix clock-mode rendering without colour-change capability

### DIFF
--- a/window-clock.c
+++ b/window-clock.c
@@ -279,6 +279,7 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 	memcpy(&gc, &grid_default_cell, sizeof gc);
 	gc.flags |= GRID_FLAG_NOPALETTE;
 	gc.bg = colour;
+	gc.fg = colour;
 	for (ptr = tim; *ptr != '\0'; ptr++) {
 		if (*ptr >= '0' && *ptr <= '9')
 			idx = *ptr - '0';
@@ -299,7 +300,7 @@ window_clock_draw_screen(struct window_mode_entry *wme)
 			for (i = 0; i < 5; i++) {
 				screen_write_cursormove(&ctx, x + i, y + j, 0);
 				if (window_clock_table[idx][j][i])
-					screen_write_putc(&ctx, &gc, ' ');
+					screen_write_putc(&ctx, &gc, '#');
 			}
 		}
 		x += 6;


### PR DESCRIPTION
Ensures clock-mode works in terminals without ANSI colour-change support. Fixes issue #4837.