### PR TITLE
Avoid crashing when a control client disconnects before identify completes

### DIFF
--- a/control.c
+++ b/control.c
@@ -828,6 +828,9 @@ control_stop(struct client *c)
 	struct control_block	*cb, *cb1;
 	struct control_sub	*csub, *csub1;
 
+	if (cs == NULL)
+		return;
+
 	if (~c->flags & CLIENT_CONTROLCONTROL)
 		bufferevent_free(cs->write_event);
 	bufferevent_free(cs->read_event);
@@ -841,6 +844,7 @@ control_stop(struct client *c)
 		control_free_block(cs, cb);
 	control_reset_offsets(c);
 
+	c->control_state = NULL;
 	free(cs);
 }
 

--- a/regress/control-client-lost-before-identify.sh
+++ b/regress/control-client-lost-before-identify.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Regression test for control clients that disconnect before MSG_IDENTIFY_DONE.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+SOCK=$(mktemp -u)
+TMUX="$TEST_TMUX -S$SOCK"
+trap "$TMUX kill-server 2>/dev/null; rm -f $SOCK" 0 1 15
+
+$TMUX -f/dev/null new -d || exit 1
+
+perl -MIO::Socket::UNIX -e '
+use strict;
+use warnings;
+
+my $socket_path            = $ARGV[0];
+my $MSG_IDENTIFY_LONGFLAGS = 111;
+my $PROTOCOL_VERSION       = 8;
+my $CLIENT_CONTROL         = 0x2000;
+
+my $sock = IO::Socket::UNIX->new(
+    Type => SOCK_STREAM,
+    Peer => $socket_path
+) or die "connect failed: $!";
+
+print {$sock} pack("LLLLQ<",
+    $MSG_IDENTIFY_LONGFLAGS,
+    16 + 8,
+    $PROTOCOL_VERSION,
+    $$,
+    $CLIENT_CONTROL
+) or die "write failed: $!";
+
+close($sock) or die "close failed: $!";
+' "$SOCK" || exit 1
+
+sleep 1
+$TMUX has || exit 1
+$TMUX kill-server 2>/dev/null
+
+exit 0


### PR DESCRIPTION
## Context
A control-mode client can set `CLIENT_CONTROL` from `MSG_IDENTIFY_LONGFLAGS` and then disconnect before `MSG_IDENTIFY_DONE`. In that state `server_client_lost()` still calls `control_stop()`, but `control_start()` has not run yet so `c->control_state` is NULL and tmux crashes dereferencing it.

## Changes
Return early from `control_stop()` when `control_state` was never initialized, and clear `c->control_state` after normal teardown. This is safe because all control-specific allocations cleaned up by `control_stop()` are rooted in `control_state` and are only created after `control_start()`: read and write bufferevents, pane offset tracking, queued output blocks, subscriptions, and the subscription timer.

Add a regression script that connects directly to the tmux socket, sends only `MSG_IDENTIFY_LONGFLAGS` with `CLIENT_CONTROL`, and disconnects before `MSG_IDENTIFY_DONE`. That reproduces the crash before the fix and verifies the server survives afterward.

## Checks

- `make -j4`
- `sh regress/control-client-lost-before-identify.sh`
- `sh regress/control-client-sanity.sh`

## Related PRs
#4980 seems to cover similar ground, but doesn't address this particular scenario.