### PR TITLE
Add vertical window list column (`status-position left`/`right`)

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -131,7 +131,34 @@ cmd_display_menu_get_pos(struct client *tc, struct cmdq_item *item,
 	 * status line position.
 	 */
 	top = status_at_line(tc);
-	if (top != -1) {
+	if (status_at_column(tc) != -1) {
+		/*
+		 * Vertical column mode: find this window's row in the column
+		 * and expose its y-coordinate for popup positioning.
+		 */
+		TAILQ_FOREACH(sr, &tc->status.vertical_ranges, entry) {
+			if (sr->type == STYLE_RANGE_WINDOW &&
+			    sr->argument == (u_int)wl->idx)
+				break;
+		}
+		if (sr != NULL) {
+			int	cxstart = status_at_column(tc);
+			u_int	cw = status_column_size(tc);
+
+			if (cxstart == 0) {
+				/* Left column: popup to the right of it. */
+				format_add(ft, "popup_window_status_line_x",
+				    "%u", cw);
+			} else {
+				/* Right column: popup to the left of it. */
+				format_add(ft, "popup_window_status_line_x",
+				    "%u", (cxstart > (int)w) ? cxstart - w : 0);
+			}
+			format_add(ft, "popup_window_status_line_y", "%u",
+			    sr->start);
+		}
+		top = 0;
+	} else if (top != -1) {
 		lines = status_line_size(tc);
 		if (top == 0)
 			top = lines;

--- a/options-table.c
+++ b/options-table.c
@@ -51,7 +51,7 @@ static const char *options_table_status_justify_list[] = {
 	"left", "centre", "right", "absolute-centre", NULL
 };
 static const char *options_table_status_position_list[] = {
-	"top", "bottom", NULL
+	"top", "bottom", "left", "right", NULL
 };
 static const char *options_table_bell_action_list[] = {
 	"none", "any", "current", "other", NULL
@@ -912,12 +912,33 @@ const struct options_table_entry options_table[] = {
 	  .text = "Style of the left side of the status line."
 	},
 
+	{ .name = "status-column-format",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_str = "#{window_index}:#{window_name}#{window_flags}",
+	  .text = "Format for each row of the vertical status column "
+		  "(used when status-position is \"left\" or \"right\")."
+	},
+
+	{ .name = "status-column-width",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 0,
+	  .maximum = SHRT_MAX,
+	  .default_num = 0,
+	  .text = "Maximum width of the vertical status column "
+		  "(used when status-position is \"left\" or \"right\"). "
+		  "0 means auto-fit to the longest window name."
+	},
+
 	{ .name = "status-position",
 	  .type = OPTIONS_TABLE_CHOICE,
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .choices = options_table_status_position_list,
 	  .default_num = 1,
-	  .text = "Position of the status line."
+	  .text = "Position of the status line. "
+		  "\"left\" and \"right\" place a vertical window list column "
+		  "at the left or right edge."
 	},
 
 	{ .name = "status-right",

--- a/resize.c
+++ b/resize.c
@@ -183,7 +183,7 @@ clients_calculate_size(int type, int current, struct client *c,
 			cx = cw->sx;
 			cy = cw->sy;
 		} else {
-			cx = loop->tty.sx;
+			cx = loop->tty.sx - status_column_size(loop);
 			cy = loop->tty.sy - status_line_size(loop);
 		}
 
@@ -289,7 +289,7 @@ default_window_size(struct client *c, struct session *s, struct window *w,
 	 * client and no window, use the default size as for manual type.
 	 */
 	if (type == WINDOW_SIZE_LATEST && c != NULL && !ignore_client_size(c)) {
-		*sx = c->tty.sx;
+		*sx = c->tty.sx - status_column_size(c);
 		*sy = c->tty.sy - status_line_size(c);
 		*xpixel = c->tty.xpixel;
 		*ypixel = c->tty.ypixel;

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -567,6 +567,8 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 
 		if (ctx->statustop)
 			yoff += ctx->statuslines;
+		if (ctx->statusleft)
+			x += ctx->statuscols;
 		tty_draw_line(tty, s, i, 0, width, x, yoff - ctx->oy,
 		    &grid_default_cell, NULL);
 	}
@@ -618,16 +620,35 @@ screen_redraw_set_context(struct client *c, struct screen_redraw_ctx *ctx)
 	struct window	*w = s->curw->window;
 	struct options	*wo = w->options;
 	u_int		 lines;
+	int		 pos;
 
 	memset(ctx, 0, sizeof *ctx);
 	ctx->c = c;
 
-	lines = status_line_size(c);
-	if (c->message_string != NULL || c->prompt_string != NULL)
-		lines = (lines == 0) ? 1 : lines;
-	if (lines != 0 && options_get_number(oo, "status-position") == 0)
-		ctx->statustop = 1;
-	ctx->statuslines = lines;
+	pos = options_get_number(oo, "status-position");
+	if (status_is_vertical(pos)) {
+		/* Vertical column mode: reserve columns, no horizontal rows. */
+		ctx->statuscols = status_column_size(c);
+		ctx->statusleft = (pos == STATUS_POSITION_LEFT) ? 1 : 0;
+		ctx->statustop = 0;
+		/*
+		 * When a message or prompt is active, reserve one row at the
+		 * bottom for it (the column remains for the window list).
+		 */
+		if (c->message_string != NULL || c->prompt_string != NULL)
+			ctx->statuslines = 1;
+		else
+			ctx->statuslines = 0;
+	} else {
+		lines = status_line_size(c);
+		if (c->message_string != NULL || c->prompt_string != NULL)
+			lines = (lines == 0) ? 1 : lines;
+		if (lines != 0 && pos == STATUS_POSITION_TOP)
+			ctx->statustop = 1;
+		ctx->statuslines = lines;
+		ctx->statuscols = 0;
+		ctx->statusleft = 0;
+	}
 
 	ctx->pane_status = options_get_number(wo, "pane-border-status");
 	ctx->pane_lines = options_get_number(wo, "pane-border-lines");
@@ -638,9 +659,11 @@ screen_redraw_set_context(struct client *c, struct screen_redraw_ctx *ctx)
 
 	tty_window_offset(&c->tty, &ctx->ox, &ctx->oy, &ctx->sx, &ctx->sy);
 
-	log_debug("%s: %s @%u ox=%u oy=%u sx=%u sy=%u %u/%d", __func__, c->name,
-	    w->id, ctx->ox, ctx->oy, ctx->sx, ctx->sy, ctx->statuslines,
-	    ctx->statustop);
+	log_debug("%s: %s @%u ox=%u oy=%u sx=%u sy=%u lines=%u top=%d "
+	    "cols=%u left=%d", __func__, c->name, w->id,
+	    ctx->ox, ctx->oy, ctx->sx, ctx->sy,
+	    ctx->statuslines, ctx->statustop,
+	    ctx->statuscols, ctx->statusleft);
 }
 
 /* Redraw entire screen. */
@@ -674,7 +697,7 @@ screen_redraw_screen(struct client *c)
 		screen_redraw_draw_panes(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
-	if (ctx.statuslines != 0 &&
+	if ((ctx.statuslines != 0 || ctx.statuscols != 0) &&
 	    (flags & (CLIENT_REDRAWSTATUS|CLIENT_REDRAWSTATUSALWAYS))) {
 		log_debug("%s: redrawing status", c->name);
 		screen_redraw_draw_status(&ctx);
@@ -866,9 +889,10 @@ screen_redraw_draw_borders_cell(struct screen_redraw_ctx *ctx, u_int i, u_int j)
 		isolates = 0;
 
 	if (ctx->statustop)
-		tty_cursor(tty, i, ctx->statuslines + j);
+		tty_cursor(tty, ctx->statuscols * ctx->statusleft + i,
+		    ctx->statuslines + j);
 	else
-		tty_cursor(tty, i, j);
+		tty_cursor(tty, ctx->statuscols * ctx->statusleft + i, j);
 	if (isolates)
 		tty_puts(tty, END_ISOLATE);
 
@@ -887,15 +911,18 @@ screen_redraw_draw_borders(struct screen_redraw_ctx *ctx)
 	struct session		*s = c->session;
 	struct window		*w = s->curw->window;
 	struct window_pane	*wp;
-	u_int			 i, j;
+	u_int			 i, j, sx;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
 
 	TAILQ_FOREACH(wp, &w->panes, entry)
 		wp->border_gc_set = 0;
 
+	/* Pane area width excludes any vertical status column. */
+	sx = c->tty.sx - ctx->statuscols;
+
 	for (j = 0; j < c->tty.sy - ctx->statuslines; j++) {
-		for (i = 0; i < c->tty.sx; i++)
+		for (i = 0; i < sx; i++)
 			screen_redraw_draw_borders_cell(ctx, i, j);
 	}
 }
@@ -916,7 +943,7 @@ screen_redraw_draw_panes(struct screen_redraw_ctx *ctx)
 	}
 }
 
-/* Draw the status line. */
+/* Draw the status line (horizontal or vertical). */
 static void
 screen_redraw_draw_status(struct screen_redraw_ctx *ctx)
 {
@@ -924,9 +951,32 @@ screen_redraw_draw_status(struct screen_redraw_ctx *ctx)
 	struct window	*w = c->session->curw->window;
 	struct tty	*tty = &c->tty;
 	struct screen	*s = c->status.active;
-	u_int		 i, y;
+	u_int		 i, x, y;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
+
+	if (ctx->statuscols > 0) {
+		/*
+		 * Vertical column: each row of the main column screen maps to
+		 * one TTY row at the left or right edge.  Always draw from
+		 * the main screen (c->status.screen), not the pushed overlay,
+		 * since the overlay is for the horizontal prompt row below.
+		 */
+		x = ctx->statusleft ? 0 : (c->tty.sx - ctx->statuscols);
+		for (i = 0; i < c->tty.sy; i++) {
+			tty_draw_line(tty, &c->status.screen, 0, i,
+			    ctx->statuscols, x, i, &grid_default_cell, NULL);
+		}
+		/*
+		 * If a message or prompt is active, draw it as a single row at
+		 * the bottom of the terminal (statuslines == 1 in this case).
+		 */
+		if (ctx->statuslines != 0 && c->status.active != &c->status.screen) {
+			tty_draw_line(tty, c->status.active, 0, 0, UINT_MAX,
+			    0, c->tty.sy - 1, &grid_default_cell, NULL);
+		}
+		return;
+	}
 
 	if (ctx->statustop)
 		y = 0;
@@ -950,7 +1000,7 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	struct grid_cell	 defaults;
 	struct visible_ranges	*r;
 	struct visible_range	*rr;
-	u_int			 i, j, k, top, x, y, width;
+	u_int			 i, j, k, top, x, y, width, left_offset;
 
 	if (wp->base.mode & MODE_SYNC)
 		screen_write_stop_sync(wp);
@@ -963,6 +1013,11 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		top = ctx->statuslines;
 	else
 		top = 0;
+	/*
+	 * left_offset shifts TTY x-coordinates when the status column is on
+	 * the left side, to leave room for the vertical status strip.
+	 */
+	left_offset = ctx->statusleft ? ctx->statuscols : 0;
 	for (j = 0; j < wp->sy; j++) {
 		if (wp->yoff + j < ctx->oy || wp->yoff + j >= ctx->oy + ctx->sy)
 			continue;
@@ -972,24 +1027,24 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		    wp->xoff + wp->sx <= ctx->ox + ctx->sx) {
 			/* All visible. */
 			i = 0;
-			x = wp->xoff - ctx->ox;
+			x = wp->xoff - ctx->ox + left_offset;
 			width = wp->sx;
 		} else if (wp->xoff < ctx->ox &&
 		    wp->xoff + wp->sx > ctx->ox + ctx->sx) {
 			/* Both left and right not visible. */
 			i = ctx->ox;
-			x = 0;
+			x = left_offset;
 			width = ctx->sx;
 		} else if (wp->xoff < ctx->ox) {
 			/* Left not visible. */
 			i = ctx->ox - wp->xoff;
-			x = 0;
+			x = left_offset;
 			width = wp->sx - i;
 		} else {
 			/* Right not visible. */
 			i = 0;
-			x = wp->xoff - ctx->ox;
-			width = ctx->sx - x;
+			x = wp->xoff - ctx->ox + left_offset;
+			width = ctx->sx - (x - left_offset);
 		}
 		log_debug("%s: %s %%%u line %u,%u at %u,%u, width %u",
 		    __func__, c->name, wp->id, i, j, x, y, width);
@@ -1000,8 +1055,9 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		for (k = 0; k < r->used; k++) {
 			rr = &r->ranges[k];
 			if (rr->nx != 0) {
-				tty_draw_line(tty, s, rr->px - wp->xoff, j,
-				    rr->nx, rr->px, y, &defaults, palette);
+				tty_draw_line(tty, s, rr->px - wp->xoff -
+				    left_offset, j, rr->nx, rr->px, y,
+				    &defaults, palette);
 			}
 		}
 	}
@@ -1065,6 +1121,9 @@ screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *ctx,
 		sb_x = xoff - sb_w - sb_pad - ox;
 	else
 		sb_x = xoff + wp->sx - ox;
+	/* Shift scrollbar x when the vertical status column is on the left. */
+	if (ctx->statusleft)
+		sb_x += (int)ctx->statuscols;
 
 	if (slider_h < 1)
 		slider_h = 1;
@@ -1097,6 +1156,11 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	if (ctx->statustop) {
 		sb_y += ctx->statuslines;
 		sy += ctx->statuslines;
+	}
+	if (ctx->statusleft) {
+		sb_x += ctx->statuscols;
+		/* Adjust the sx bound to reflect the full TTY width. */
+		sx += ctx->statuscols;
 	}
 
 	gc = sb_style->gc;

--- a/screen-write.c
+++ b/screen-write.c
@@ -165,6 +165,8 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
+	if (status_at_column(c) == 0)
+		ttyctx->xoff += status_column_size(c);
 
 	return (1);
 }

--- a/server-client.c
+++ b/server-client.c
@@ -790,6 +790,71 @@ have_event:
 	/* Is this on the status line? */
 	m->statusat = status_at_line(c);
 	m->statuslines = status_line_size(c);
+
+	/*
+	 * Check for vertical status column first. In vertical mode, the column
+	 * occupies all rows but only a band of columns on the left or right.
+	 * Use y as the row-index into the column's window list.
+	 */
+	{
+		int	statuscolat = status_at_column(c);
+		u_int	statuscols = status_column_size(c);
+
+		if (statuscolat != -1 &&
+		    x >= (u_int)statuscolat &&
+		    x < (u_int)statuscolat + statuscols) {
+			sr = status_get_range(c, x, y);
+			if (sr == NULL) {
+				loc = KEYC_MOUSE_LOCATION_STATUS_DEFAULT;
+			} else {
+				switch (sr->type) {
+				case STYLE_RANGE_NONE:
+					return (KEYC_UNKNOWN);
+				case STYLE_RANGE_LEFT:
+				case STYLE_RANGE_RIGHT:
+					loc = KEYC_MOUSE_LOCATION_STATUS_DEFAULT;
+					break;
+				case STYLE_RANGE_PANE:
+					fwp = window_pane_find_by_id(sr->argument);
+					if (fwp == NULL)
+						return (KEYC_UNKNOWN);
+					m->wp = sr->argument;
+					log_debug("mouse vert col: pane %%%u",
+					    m->wp);
+					loc = KEYC_MOUSE_LOCATION_STATUS;
+					break;
+				case STYLE_RANGE_WINDOW:
+					fwl = winlink_find_by_index(&s->windows,
+					    sr->argument);
+					if (fwl == NULL)
+						return (KEYC_UNKNOWN);
+					m->w = fwl->window->id;
+					log_debug("mouse vert col: window @%u",
+					    m->w);
+					loc = KEYC_MOUSE_LOCATION_STATUS;
+					break;
+				case STYLE_RANGE_SESSION:
+					fs = session_find_by_id(sr->argument);
+					if (fs == NULL)
+						return (KEYC_UNKNOWN);
+					m->s = sr->argument;
+					log_debug("mouse vert col: session $%u",
+					    m->s);
+					loc = KEYC_MOUSE_LOCATION_STATUS;
+					break;
+				case STYLE_RANGE_USER:
+					loc = KEYC_MOUSE_LOCATION_STATUS;
+					break;
+				case STYLE_RANGE_CONTROL:
+					n = sr->argument;
+					loc = KEYC_MOUSE_LOCATION_CONTROL0 + n;
+					break;
+				}
+			}
+			goto have_location;
+		}
+	}
+
 	if (m->statusat != -1 &&
 	    y >= (u_int)m->statusat &&
 	    y < m->statusat + m->statuslines) {
@@ -849,6 +914,7 @@ have_event:
 		}
 	}
 
+have_location:
 	/*
 	 * Not on status line. Adjust position and check for border, pane, or
 	 * scrollbar.
@@ -857,7 +923,14 @@ have_event:
 		if (c->tty.mouse_scrolling_flag)
 			loc = KEYC_MOUSE_LOCATION_SCROLLBAR_SLIDER;
 		else {
-			px = x;
+			/*
+			 * In vertical column mode, offset px past the left
+			 * status column so pane coordinates are correct.
+			 */
+			if (status_at_column(c) == 0)
+				px = x - status_column_size(c);
+			else
+				px = x;
 			if (m->statusat == 0 && y >= m->statuslines)
 				py = y - m->statuslines;
 			else if (m->statusat > 0 && y >= (u_int)m->statusat)
@@ -1766,6 +1839,8 @@ server_client_reset_state(struct client *c)
 
 			if (status_at_line(c) == 0)
 				cy += status_line_size(c);
+			if (status_at_column(c) == 0)
+				cx += status_column_size(c);
 		}
 		if (!cursor)
 			mode &= ~MODE_CURSOR;

--- a/status.c
+++ b/status.c
@@ -228,13 +228,27 @@ status_timer_start_all(void)
 void
 status_update_cache(struct session *s)
 {
-	s->statuslines = options_get_number(s->options, "status");
-	if (s->statuslines == 0)
+	int	pos;
+
+	pos = options_get_number(s->options, "status-position");
+	s->statuspos = pos;
+
+	if (status_is_vertical(pos)) {
+		/* Vertical mode: no horizontal status rows. */
+		s->statuslines = 0;
 		s->statusat = -1;
-	else if (options_get_number(s->options, "status-position") == 0)
-		s->statusat = 0;
-	else
-		s->statusat = 1;
+		/* Column count is computed per-client in status_column_size(). */
+		s->statuscols = 1; /* non-zero sentinel; real width per client */
+	} else {
+		s->statuscols = 0;
+		s->statuslines = options_get_number(s->options, "status");
+		if (s->statuslines == 0)
+			s->statusat = -1;
+		else if (pos == STATUS_POSITION_TOP)
+			s->statusat = 0;
+		else
+			s->statusat = 1;
+	}
 }
 
 /* Get screen line of status line. -1 means off. */
@@ -263,6 +277,77 @@ status_line_size(struct client *c)
 	return (s->statuslines);
 }
 
+/*
+ * Get width of the vertical status column for client's session.
+ * Returns 0 when status is top/bottom/off or client is a control client.
+ */
+u_int
+status_column_size(struct client *c)
+{
+	struct session		*s = c->session;
+	struct winlink		*wl;
+	struct format_tree	*ft;
+	const char		*fmt;
+	char			*expanded;
+	u_int			 col_w, max_w, cap;
+
+	if (c->flags & (CLIENT_STATUSOFF|CLIENT_CONTROL))
+		return (0);
+	if (s == NULL)
+		return (0);
+	if (!status_is_vertical(s->statuspos))
+		return (0);
+
+	cap = options_get_number(s->options, "status-column-width");
+	fmt = options_get_string(s->options, "status-column-format");
+
+	max_w = 0;
+	RB_FOREACH(wl, winlinks, &s->windows) {
+		if (wl->window == NULL)
+			continue; /* skip partially-initialized winlinks */
+		ft = format_create(NULL, NULL, FORMAT_NONE, 0);
+		format_defaults(ft, c, s, wl, NULL);
+		expanded = format_expand(ft, fmt);
+		col_w = utf8_cstrwidth(expanded);
+		free(expanded);
+		format_free(ft);
+		if (col_w > max_w)
+			max_w = col_w;
+	}
+
+	if (max_w == 0)
+		max_w = 1;
+	if (cap > 0 && max_w > cap)
+		max_w = cap;
+
+	return (max_w);
+}
+
+/*
+ * Get terminal x-offset of the vertical status column. -1 means not active.
+ * Returns 0 when status is on the left, tty.sx - width when on the right.
+ */
+int
+status_at_column(struct client *c)
+{
+	u_int	col_w;
+
+	if (c->flags & (CLIENT_STATUSOFF|CLIENT_CONTROL))
+		return (-1);
+	if (c->session == NULL)
+		return (-1);
+	if (!status_is_vertical(c->session->statuspos))
+		return (-1);
+
+	col_w = status_column_size(c);
+	if (col_w == 0)
+		return (-1);
+
+	if (c->session->statuspos == STATUS_POSITION_RIGHT)
+		return ((int)(c->tty.sx - col_w));
+	return (0); /* left */
+}
+
 /* Get the prompt line number for client's session. 1 means at the bottom. */
 u_int
 status_prompt_line_at(struct client *c)
@@ -285,6 +370,15 @@ status_get_range(struct client *c, u_int x, u_int y)
 {
 	struct status_line	*sl = &c->status;
 
+	if (c->session != NULL && status_is_vertical(c->session->statuspos)) {
+		/*
+		 * In vertical column mode, y is the row in the status column.
+		 * Ranges are stored in vertical_ranges with start=row, end=row+1.
+		 * We ignore x (the whole row selects the window).
+		 */
+		return (style_ranges_get_range(&sl->vertical_ranges, y));
+	}
+
 	if (y >= nitems(sl->entries))
 		return (NULL);
 	return (style_ranges_get_range(&sl->entries[y].ranges, x));
@@ -294,11 +388,19 @@ status_get_range(struct client *c, u_int x, u_int y)
 static void
 status_push_screen(struct client *c)
 {
-	struct status_line *sl = &c->status;
+	struct status_line	*sl = &c->status;
+	u_int			 lines;
 
 	if (sl->active == &sl->screen) {
 		sl->active = xmalloc(sizeof *sl->active);
-		screen_init(sl->active, c->tty.sx, status_line_size(c), 0);
+		/*
+		 * In vertical mode there is no horizontal status row, so use
+		 * a single-row screen for the message/prompt overlay.
+		 */
+		lines = status_line_size(c);
+		if (lines == 0)
+			lines = 1;
+		screen_init(sl->active, c->tty.sx, lines, 0);
 	}
 	sl->references++;
 }
@@ -325,6 +427,7 @@ status_init(struct client *c)
 
 	for (i = 0; i < nitems(sl->entries); i++)
 		style_ranges_init(&sl->entries[i].ranges);
+	style_ranges_init(&sl->vertical_ranges);
 
 	screen_init(&sl->screen, c->tty.sx, 1, 0);
 	sl->active = &sl->screen;
@@ -341,6 +444,7 @@ status_free(struct client *c)
 		style_ranges_free(&sl->entries[i].ranges);
 		free((void *)sl->entries[i].expanded);
 	}
+	style_ranges_free(&sl->vertical_ranges);
 
 	if (event_initialized(&sl->timer))
 		evtimer_del(&sl->timer);
@@ -350,6 +454,115 @@ status_free(struct client *c)
 		free(sl->active);
 	}
 	screen_free(&sl->screen);
+}
+
+/* Draw the vertical status column (window list on left or right). */
+static int
+status_redraw_vertical(struct client *c)
+{
+	struct status_line		*sl = &c->status;
+	struct session			*s = c->session;
+	struct options			*wo = s->curw->window->options;
+	struct screen_write_ctx		 ctx;
+	struct grid_cell		 gc, wgc;
+	struct winlink			*wl;
+	struct format_tree		*ft;
+	struct style_ranges		 row_srs;
+	struct style_range		*sr;
+	char				*expanded;
+	const char			*fmt;
+	u_int				 col_w, row, n, flags;
+	int				 force = 0, changed = 0;
+
+	/* Shouldn't get here if not the active screen. */
+	if (sl->active != &sl->screen)
+		fatalx("not the active screen");
+
+	col_w = status_column_size(c);
+	if (c->tty.sy == 0 || col_w == 0)
+		return (1);
+
+	/* Create base format tree and resolve style. */
+	flags = FORMAT_STATUS;
+	if (c->flags & CLIENT_STATUSFORCE)
+		flags |= FORMAT_FORCE;
+	ft = format_create(c, NULL, FORMAT_NONE, flags);
+	format_defaults(ft, c, NULL, NULL, NULL);
+	style_apply(&gc, s->options, "status-style", ft);
+	format_free(ft);
+
+	if (!grid_cells_equal(&gc, &sl->style)) {
+		force = 1;
+		memcpy(&sl->style, &gc, sizeof sl->style);
+	}
+
+	/* Resize the status screen to a tall, narrow column. */
+	if (screen_size_x(&sl->screen) != col_w ||
+	    screen_size_y(&sl->screen) != c->tty.sy) {
+		screen_resize(&sl->screen, col_w, c->tty.sy, 0);
+		changed = force = 1;
+	}
+	screen_write_start(&ctx, &sl->screen);
+
+	/* Fill background. */
+	screen_write_cursormove(&ctx, 0, 0, 0);
+	for (n = 0; n < col_w * c->tty.sy; n++)
+		screen_write_putc(&ctx, &gc, ' ');
+
+	/* Rebuild vertical_ranges from scratch. */
+	style_ranges_free(&sl->vertical_ranges);
+
+	fmt = options_get_string(s->options, "status-column-format");
+
+	row = 0;
+	RB_FOREACH(wl, winlinks, &s->windows) {
+		if (row >= c->tty.sy)
+			break;
+		if (wl->window == NULL)
+			continue; /* skip partially-initialized winlinks */
+
+		/* Per-window format tree. */
+		ft = format_create(c, NULL, FORMAT_NONE, flags);
+		format_defaults(ft, c, s, wl, NULL);
+
+		/* Determine cell style for this window. */
+		wgc = gc;
+		if (wl == s->curw)
+			style_apply(&wgc, wo, "window-status-current-style", ft);
+		else
+			style_apply(&wgc, wo, "window-status-style", ft);
+
+		expanded = format_expand_time(ft, fmt);
+		format_free(ft);
+
+		/* Draw this window's row. Clear first, then draw. */
+		screen_write_cursormove(&ctx, 0, row, 0);
+		for (n = 0; n < col_w; n++)
+			screen_write_putc(&ctx, &wgc, ' ');
+		screen_write_cursormove(&ctx, 0, row, 0);
+
+		style_ranges_init(&row_srs);
+		format_draw(&ctx, &wgc, col_w, expanded, &row_srs, 0);
+		style_ranges_free(&row_srs);
+
+		free(expanded);
+
+		/* Track row → window mapping for mouse clicks. */
+		sr = xcalloc(1, sizeof *sr);
+		sr->type = STYLE_RANGE_WINDOW;
+		sr->argument = wl->idx;
+		sr->start = row;
+		sr->end = row + 1;
+		TAILQ_INSERT_TAIL(&sl->vertical_ranges, sr, entry);
+
+		row++;
+		changed = 1;
+	}
+
+	screen_write_stop(&ctx);
+
+	log_debug("%s exit: force=%d, changed=%d", __func__, force, changed);
+	return (force || changed);
 }
 
 /* Draw status line for client. */
@@ -369,6 +582,10 @@ status_redraw(struct client *c)
 	char				*expanded;
 
 	log_debug("%s enter", __func__);
+
+	/* Vertical column mode has its own redraw path. */
+	if (s != NULL && status_is_vertical(s->statuspos))
+		return (status_redraw_vertical(c));
 
 	/* Shouldn't get here if not the active screen. */
 	if (sl->active != &sl->screen)
@@ -650,7 +867,12 @@ status_message_redraw(struct client *c)
 	format_free(ft);
 
 	screen_write_start(&ctx, sl->active);
-	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
+	/*
+	 * In vertical column mode, the column and the message row are drawn
+	 * separately; do not copy the column screen as background here.
+	 */
+	if (s == NULL || !status_is_vertical(s->statuspos))
+		screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
 	screen_write_cursormove(&ctx, ax, messageline, 0);
 	format_draw(&ctx, &gc, aw, expanded, NULL, 0);
 	screen_write_stop(&ctx);
@@ -903,7 +1125,8 @@ status_prompt_redraw(struct client *c)
 		start = aw;
 
 	screen_write_start(&ctx, sl->active);
-	screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
+	if (s == NULL || !status_is_vertical(s->statuspos))
+		screen_write_fast_copy(&ctx, &sl->screen, 0, 0, c->tty.sx, lines);
 	screen_write_cursormove(&ctx, ax, promptline, 0);
 	format_draw(&ctx, &gc, aw, expanded, NULL, 0);
 	screen_write_cursormove(&ctx, ax + start, promptline, 0);

--- a/tmux.h
+++ b/tmux.h
@@ -1093,12 +1093,23 @@ enum pane_lines {
 #define WINDOW_PANE_COPY_MODE 1
 #define WINDOW_PANE_VIEW_MODE 2
 
+/* Status position constants. */
+#define STATUS_POSITION_TOP    0
+#define STATUS_POSITION_BOTTOM 1
+#define STATUS_POSITION_LEFT   2
+#define STATUS_POSITION_RIGHT  3
+#define status_is_vertical(pos) ((pos) == STATUS_POSITION_LEFT || \
+    (pos) == STATUS_POSITION_RIGHT)
+
 /* Screen redraw context. */
 struct screen_redraw_ctx {
 	struct client	*c;
 
 	u_int		 statuslines;
 	int		 statustop;
+
+	u_int		 statuscols;
+	int		 statusleft;
 
 	int		 pane_status;
 	enum pane_lines	 pane_lines;
@@ -1497,6 +1508,8 @@ struct session {
 
 	int		 statusat;
 	u_int		 statuslines;
+	int		 statuspos;
+	u_int		 statuscols;
 
 	struct options	*options;
 
@@ -1929,6 +1942,9 @@ struct status_line {
 
 	struct grid_cell	 style;
 	struct style_line_entry entries[STATUS_LINES_LIMIT];
+
+	/* Ranges for vertical column mode (row -> window mapping). */
+	struct style_ranges	 vertical_ranges;
 };
 
 /* Prompt type. */
@@ -3082,6 +3098,8 @@ void	 status_update_cache(struct session *);
 u_int	 status_prompt_line_at(struct client *);
 int	 status_at_line(struct client *);
 u_int	 status_line_size(struct client *);
+u_int	 status_column_size(struct client *);
+int	 status_at_column(struct client *);
 struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);

--- a/tty.c
+++ b/tty.c
@@ -931,7 +931,8 @@ tty_window_bigger(struct tty *tty)
 	struct client	*c = tty->client;
 	struct window	*w = c->session->curw->window;
 
-	return (tty->sx < w->sx || tty->sy - status_line_size(c) < w->sy);
+	return (tty->sx - status_column_size(c) < w->sx ||
+	    tty->sy - status_line_size(c) < w->sy);
 }
 
 /* What offset should this window be drawn at? */
@@ -955,9 +956,12 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 	struct window_pane	*wp = server_client_get_pane(c);
 	u_int			 cx, cy, lines;
 
-	lines = status_line_size(c);
+	u_int	cols;
 
-	if (tty->sx >= w->sx && tty->sy - lines >= w->sy) {
+	lines = status_line_size(c);
+	cols = status_column_size(c);
+
+	if (tty->sx - cols >= w->sx && tty->sy - lines >= w->sy) {
 		*ox = 0;
 		*oy = 0;
 		*sx = w->sx;
@@ -967,7 +971,7 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 		return (0);
 	}
 
-	*sx = tty->sx;
+	*sx = tty->sx - cols;
 	*sy = tty->sy - lines;
 
 	if (c->pan_window == w) {
@@ -1483,9 +1487,12 @@ tty_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	ttyctx->bigger = tty_window_offset(&c->tty, &ttyctx->wox, &ttyctx->woy,
 	    &ttyctx->wsx, &ttyctx->wsy);
 
+	ttyctx->xoff = ttyctx->rxoff = wp->xoff;
 	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
+	if (status_at_column(c) == 0)
+		ttyctx->xoff += status_column_size(c);
 
 	return (1);
 }


### PR DESCRIPTION
### Summary

`status-position` currently accepts only `top` and `bottom`. This PR extends it with `left` and `right` values that replace the horizontal status bar with a narrow vertical column on the left or right edge of the terminal, listing session windows one per row — like a sidebar tab strip.

### New options

| Option | Type | Default | Description |
|---|---|---|---|
| `status-position` | choice | `bottom` | Extended to accept `"left"` and `"right"` |
| `status-column-format` | string | `#{window_index}:#{window_name}#{window_flags}` | Format string for each row of the vertical column |
| `status-column-width` | number | `0` (auto) | Maximum column width; `0` auto-fits to the longest rendered entry |

### How it works

**Layout reservation** — `status_column_size()` computes the column width per-client by expanding `status-column-format` for every window and taking the widest result (capped by `status-column-width` when set). This width is subtracted from the usable terminal width in `resize.c` (`clients_calculate_size`, `default_window_size`) and in `tty.c` (`tty_window_bigger`, `tty_window_offset1`) so windows are sized to fit the remaining area.

**Drawing** — `status_redraw_vertical()` renders a `col_w × tty.sy` screen with one row per window, styled with `window-status-current-style` / `window-status-style` and `status-style` as background. `screen_redraw_draw_status()` blits this screen to the left or right TTY edge each frame. Pane, border, scrollbar, and pane-status drawing all shift their x-coordinates by `statuscols` when the column sits on the left.

**Mouse click-through** — Each window row is registered in a new `vertical_ranges` list on `struct status_line`. `status_get_range()` and the mouse-event path in `server-client.c` use this list to translate a click anywhere on the row into a window-select action, matching the behaviour of the horizontal status bar.

**Message and prompt overlay** — When the session has a message or command prompt active, a single row is reserved at the bottom of the terminal (overlaid on top of the last window row) for the text, while the window list column remains visible on the side.

**Popup menu positioning** — `cmd-display-menu.c` detects vertical mode and positions the window popup to the left or right of the column rather than above or below a horizontal status line.

### Bug fixed

`winlink_add()` inserts a new winlink into `s->windows` *before* the backing `struct window` is created. `status_column_size()` and `status_redraw_vertical()` iterate that tree, so they now skip any winlink with `wl->window == NULL` to avoid a null-pointer dereference in `format_defaults()` that caused an immediate server crash on every `new-window` invocation with a vertical status position.