### PR TITLE
Add window context to pane notification

### DIFF
--- a/notify.c
+++ b/notify.c
@@ -210,6 +210,8 @@ notify_add(const char *name, struct cmd_find_state *fs, struct client *c,
 	}
 	if (wp != NULL)
 		format_add(ne->formats, "hook_pane", "%%%d", wp->id);
+		format_add(ne->formats, "hook_window", "@%u", wp->window->id);
+		format_add(ne->formats, "hook_window_name", "%s", wp->window->name);
 	format_log_debug(ne->formats, __func__);
 
 	if (c != NULL)


### PR DESCRIPTION
Given that a pane correspond to only one window, populate the appropriate fields when possible. Fixes #4985