### PR TITLE
Support starting copy mode directly in rectangular selection

### DIFF
--- a/cmd-copy-mode.c
+++ b/cmd-copy-mode.c
@@ -30,8 +30,8 @@ const struct cmd_entry cmd_copy_mode_entry = {
 	.name = "copy-mode",
 	.alias = NULL,
 
-	.args = { "deHMqSs:t:u", 0, 0, NULL },
-	.usage = "[-deHMqSu] [-s src-pane] " CMD_TARGET_PANE_USAGE,
+	.args = { "deHMqrSs:t:u", 0, 0, NULL },
+	.usage = "[-deHMqrsSu] [-s src-pane] " CMD_TARGET_PANE_USAGE,
 
 	.source =  { 's', CMD_FIND_PANE, 0 },
 	.target = { 't', CMD_FIND_PANE, 0 },

--- a/regress/copy-mode-test-rect.sh
+++ b/regress/copy-mode-test-rect.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+# This test verifies rectangular selection in copy mode.
+# It tests both 'copy-mode -r' and 'begin-selection -r'.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+# Ensure we are in the regress directory
+cd "$(dirname "$0")" || exit 1
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -f/dev/null -Ltest"
+
+# Test 1: copy-mode -r
+$TMUX kill-server 2>/dev/null
+
+# Start a new tmux session with a specific size (40x10).
+# The command runs 'cat copy-mode-test.txt' to fill the screen with content.
+# Finally, 'cat' runs without arguments to keep the pane open and waiting for input.
+$TMUX new -d -x40 -y10 \
+      "cat copy-mode-test.txt; cat" || exit 1
+$TMUX set -g window-size manual || exit 1
+
+$TMUX set-window-option -g mode-keys vi
+
+# Enter copy mode with rectangular selection enabled
+$TMUX copy-mode -r
+
+# Navigate to the start of the 3rd line
+$TMUX send-keys -X history-top
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X start-of-line
+
+# Begin selection (already in rectangular mode due to copy-mode -r)
+$TMUX send-keys -X begin-selection
+
+# Move cursor to expand selection to a 3x6 rectangle (down 2, right 5)
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+
+# Copy the rectangular selection
+$TMUX send-keys -X copy-selection
+
+result=$($TMUX show-buffer)
+$TMUX kill-server 2>/dev/null
+
+expected=$(printf "Anothe\n... @n\n ?? 50")
+
+if [ "$result" != "$expected" ]; then
+    echo "copy-mode -r test failed"
+    echo "Expected: '$expected'"
+    echo "Result: '$result'"
+    exit 1
+fi
+
+# Test 2: begin-selection -r
+# Start a new tmux session with a specific size (40x10).
+# The command runs 'cat copy-mode-test.txt' to fill the screen with content.
+# Finally, 'cat' runs without arguments to keep the pane open and waiting for input.
+$TMUX new -d -x40 -y10 \
+      "cat copy-mode-test.txt; cat" || exit 1
+$TMUX set -g window-size manual || exit 1
+
+$TMUX set-window-option -g mode-keys vi
+
+# Enter copy mode (standard mode)
+$TMUX copy-mode
+
+# Navigate to the start of the 3rd line
+$TMUX send-keys -X history-top
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X start-of-line
+
+# Begin selection explicitly in rectangular mode (-r flag)
+$TMUX send-keys -X begin-selection -r
+
+# Move cursor to expand selection to a 3x6 rectangle (down 2, right 5)
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-down
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+$TMUX send-keys -X cursor-right
+
+# Copy the rectangular selection
+$TMUX send-keys -X copy-selection
+
+result=$($TMUX show-buffer)
+$TMUX kill-server 2>/dev/null
+
+if [ "$result" != "$expected" ]; then
+    echo "begin-selection -r test failed"
+    echo "Expected: '$expected'"
+    echo "Result: '$result'"
+    exit 1
+fi
+
+echo "All rectangular selection tests passed"
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -1822,10 +1822,14 @@ Append the selection to the top paste buffer and exit copy mode.
 Move the cursor back to the indentation.
 .It Xo
 .Ic begin\-selection
+.Op Fl r
 (vi: Space)
 (emacs: C\-Space)
 .Xc
 Begin selection.
+If
+.Fl r
+is given, the selection is rectangular.
 .It Xo
 .Ic bottom\-line
 (vi: L)
@@ -2490,7 +2494,7 @@ The synopsis for the
 command is:
 .Bl -tag -width Ds
 .It Xo Ic copy\-mode
-.Op Fl deHMqSu
+.Op Fl deHMqrSu
 .Op Fl s Ar src\-pane
 .Op Fl t Ar target\-pane
 .Xc
@@ -2512,6 +2516,9 @@ begins a mouse drag (only valid if bound to a mouse key binding, see
 .Fl S
 enters copy\-mode and scrolls when bound to a mouse drag event; See
 .Ic scroll\-to\-mouse .
+.Pp
+.Fl r
+starts copy mode in rectangular selection mode.
 .Pp
 .Fl s
 copies from

--- a/window-copy.c
+++ b/window-copy.c
@@ -448,6 +448,8 @@ window_copy_init(struct window_mode_entry *wme,
 	u_int				 i, cx, cy;
 
 	data = window_copy_common_init(wme);
+	if (args != NULL && args_has(args, 'r'))
+		data->rectflag = 1;
 	data->backing = window_copy_clone_screen(base, &data->screen, &cx, &cy,
 	    wme->swp != wme->wp);
 
@@ -1125,6 +1127,9 @@ window_copy_cmd_begin_selection(struct window_copy_cmd_state *cs)
 	struct client			*c = cs->c;
 	struct mouse_event		*m = cs->m;
 	struct window_copy_mode_data	*data = wme->data;
+
+	if (args_has(cs->wargs, 'r'))
+		data->rectflag = 1;
 
 	if (m != NULL) {
 		window_copy_start_drag(c, m);
@@ -2789,7 +2794,7 @@ static const struct {
 	  .f = window_copy_cmd_back_to_indentation
 	},
 	{ .command = "begin-selection",
-	  .args = { "", 0, 0, NULL },
+	  .args = { "r", 0, 0, NULL },
 	  .flags = 0,
 	  .clear = WINDOW_COPY_CMD_CLEAR_ALWAYS,
 	  .f = window_copy_cmd_begin_selection


### PR DESCRIPTION
Add -r flag to copy-mode and begin-selection to allow keybindings that immediately start a rectangular selection.

I use this to implement Ctrl-Click and drag for a rectangular selection:

```
bind-key -T root C-MouseDrag1Pane copy-mode -M -r
bind-key -T copy-mode-vi C-MouseDrag1Pane send-keys -X begin-selection -r
bind-key -T copy-mode-vi C-MouseDragEnd1Pane send-keys -X copy-selection-and-cancel
```

Disclosure: implemented with the help of AI (Gemini)