### PR TITLE
Do not leak inherited hyperlinks in copy mode

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -463,8 +463,10 @@ window_copy_init(struct window_mode_entry *wme,
 	data->scroll_exit = args_has(args, 'e');
 	data->hide_position = args_has(args, 'H');
 
-	if (base->hyperlinks != NULL)
+	if (base->hyperlinks != NULL) {
+		hyperlinks_free(data->screen.hyperlinks);
 		data->screen.hyperlinks = hyperlinks_copy(base->hyperlinks);
+	}
 	data->screen.cx = data->cx;
 	data->screen.cy = data->cy;
 	data->mx = data->cx;


### PR DESCRIPTION
Found this memory leak while fiddling with scrollback live-reload on master.

1. Build:

```bash
./configure CFLAGS='-O0 -g -fsanitize=address,undefined' LDFLAGS='-fsanitize=address,undefined' && make
```

2. Run:

```bash
ASAN_OPTIONS='detect_leaks=1:log_path=/tmp/asan' ./tmux -L hltest -f /dev/null new-session -d -x 80 -y 24 'sleep 3' \; copy-mode \; send-keys -X cancel \; kill-server
cat /tmp/asan.*
```

3. See memory leak:

```text
=================================================================
==1357350==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 calloc
    #1 xcalloc xmalloc.c:47
    #2 hyperlinks_init hyperlinks.c:205
    #3 screen_reset_hyperlinks screen.c:143
    #4 screen_reinit screen.c:135
    #5 screen_init screen.c:100
    #6 window_copy_common_init window-copy.c:431
    #7 window_copy_init window-copy.c:450
    #8 window_pane_set_mode window.c:1163
    #9 cmd_copy_mode_exec cmd-copy-mode.c:88
    ...

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
```

This is the same bug that was fixed in popup.c earlier this year (see [popup.c#L281-L285](https://github.com/tmux/tmux/blob/31d77e29b6c9fbb07d032018da78db3a8a38d979/popup.c#L281-L285), issue #4925).

when `copy-mode` is started, the new screen gets its own empty hyperlinks table from `screen_init`. if the source pane already has some then `window_copy_init` overwrites them without freeing.

I think this means 32 bytes are leaked in almost `copy-mode` entry

P.S. here's a spinning copy-mode donut:


https://github.com/user-attachments/assets/f2df2ac2-0e83-496b-839d-df941174b47f
