### PR TITLE
Clarify that set-environment -r is a fork-time exclusion flag.

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -6807,8 +6807,7 @@ The
 .Fl u
 flag unsets a variable.
 .Fl r
-indicates the variable is to be removed from the environment before starting a
-new process.
+marks the variable to be excluded from the environment passed to a forked child process; it does not delete the variable from the tmux session.
 .Fl h
 marks the variable as hidden.
 .Tg showenv


### PR DESCRIPTION
The current documentation for set-environment -r states that variables are "removed from the environment before starting a new process." This is ambiguous as it implies the variable is deleted from the tmux environment block entirely. In practice, the variable remains in the session/global environment but is filtered out only during the creation of child processes.

Additionally, this flag is cleared if the variable is subsequently updated (e.g., via update-environment).  This distinction is critical for users debugging why variables 'reappear' after a client attachment triggers an update-environment event, which clears the exclusion mark.