### PR TITLE
Do not leak name in `window_set_name`.

### DIFF
--- a/window.c
+++ b/window.c
@@ -411,7 +411,7 @@ window_set_name(struct window *w, const char *new_name)
 	name = clean_name(new_name, "#");
 	if (name != NULL) {
 		free(w->name);
-		utf8_stravis(&w->name, new_name, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
+		w->name = name;
 		notify_window("window-renamed", w);
 	}
 }


### PR DESCRIPTION
## context

found this while daily driving an asan `master` build and renaming windows n
stuff

## problem

on window rename, the cleaned window name is thrown away and a second escaped
copy of the original `new_name` is stored. the `clean_name()` allocation on
EVERY rename is leaked, AND the `#` is unsanitized in the stored window name

## solution

just keep the `clean_name()` result and store that directly

this comes off as rather naive, tbh - so lmk if i'm missing anything obvious

regardless... the identification of the leak is better than nothing!

## repro

1. build with asan
2. run this from the repo root:

```bash
t=$PWD/build-asan/tmux
d=$(mktemp -d)
mkdir $d/s

cat >$d/c <<EOF
set -g exit-empty off
new -d -s leaktest
EOF

TMUX_TMPDIR=$d/s ASAN_OPTIONS="detect_leaks=1:abort_on_error=0:log_path=$d/l" $t -D -L bug001 -f $d/c &
p=$!

sleep 2
TMUX_TMPDIR=$d/s $t -L bug001 ls

for i in $(seq 1 200); do
  TMUX_TMPDIR=$d/s $t -L bug001 renamew -t leaktest:0 name#$i
done

TMUX_TMPDIR=$d/s $t -L bug001 kill-server || true
wait $p || true

sed -n '1,40p' $d/l.*
```

lsan output:

```text
=================================================================
==88800==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1692 byte(s) in 200 object(s) allocated from:
    #0 0x7f117bf20b4b in realloc.part.0
    #1 0x55fa404ff369 in reallocarray ../compat/reallocarray.c:39
    #2 0x55fa404fca83 in xreallocarray ../xmalloc.c:67
    #3 0x55fa404fca2e in xrealloc ../xmalloc.c:57
    #4 0x55fa4043444c in utf8_stravis ../utf8.c:736
    #5 0x55fa403bf258 in clean_name ../tmux.c:296
    #6 0x55fa404e2f9f in window_set_name ../window.c:411
    #7 0x55fa400c1c9b in cmd_rename_window_exec ../cmd-rename-window.c:54
```

***NOTE**: this pr restores the `#` sanitization in window names.

for example, renaming a window to `a#b` now stores `a_b` again, which I'm pretty
sure it was always supposed to do (please check this assumption).
