### PR TITLE
Sanitize paste buffer names in `paste_set` and `paste_rename`.

### DIFF
--- a/paste.c
+++ b/paste.c
@@ -204,6 +204,7 @@ int
 paste_rename(const char *oldname, const char *newname, char **cause)
 {
 	struct paste_buffer	*pb, *pb_new;
+	char			*name;
 
 	if (cause != NULL)
 		*cause = NULL;
@@ -219,23 +220,33 @@ paste_rename(const char *oldname, const char *newname, char **cause)
 		return (-1);
 	}
 
+	name = clean_name(newname, "");
+	if (name == NULL) {
+		if (cause != NULL)
+			xasprintf(cause, "invalid buffer name: %s", newname);
+		return (-1);
+	}
+
 	pb = paste_get_name(oldname);
 	if (pb == NULL) {
 		if (cause != NULL)
 			xasprintf(cause, "no buffer %s", oldname);
+		free(name);
 		return (-1);
 	}
 
-	pb_new = paste_get_name(newname);
-	if (pb_new == pb)
+	pb_new = paste_get_name(name);
+	if (pb_new == pb) {
+		free(name);
 		return (0);
+	}
 	if (pb_new != NULL)
 		paste_free(pb_new);
 
 	RB_REMOVE(paste_name_tree, &paste_by_name, pb);
 
 	free(pb->name);
-	pb->name = xstrdup(newname);
+	pb->name = name;
 
 	if (pb->automatic)
 		paste_num_automatic--;
@@ -244,7 +255,7 @@ paste_rename(const char *oldname, const char *newname, char **cause)
 	RB_INSERT(paste_name_tree, &paste_by_name, pb);
 
 	notify_paste_buffer(oldname, 1);
-	notify_paste_buffer(newname, 0);
+	notify_paste_buffer(pb->name, 0);
 
 	return (0);
 }
@@ -257,6 +268,7 @@ int
 paste_set(char *data, size_t size, const char *name, char **cause)
 {
 	struct paste_buffer	*pb, *old;
+	char			*newname;
 
 	if (cause != NULL)
 		*cause = NULL;
@@ -276,9 +288,16 @@ paste_set(char *data, size_t size, const char *name, char **cause)
 		return (-1);
 	}
 
+	newname = clean_name(name, "");
+	if (newname == NULL) {
+		if (cause != NULL)
+			xasprintf(cause, "invalid buffer name: %s", name);
+		return (-1);
+	}
+
 	pb = xmalloc(sizeof *pb);
 
-	pb->name = xstrdup(name);
+	pb->name = newname;
 
 	pb->data = data;
 	pb->size = size;
@@ -288,13 +307,13 @@ paste_set(char *data, size_t size, const char *name, char **cause)
 
 	pb->created = time(NULL);
 
-	if ((old = paste_get_name(name)) != NULL)
+	if ((old = paste_get_name(pb->name)) != NULL)
 		paste_free(old);
 
 	RB_INSERT(paste_name_tree, &paste_by_name, pb);
 	RB_INSERT(paste_time_tree, &paste_by_time, pb);
 
-	notify_paste_buffer(name, 0);
+	notify_paste_buffer(pb->name, 0);
 
 	return (0);
 }


### PR DESCRIPTION
## context

poking at control mode on `master` after #5030 landed. the recent sanitize
pass (`d339ab51`) cleaned up pane titles and more stuff but
it seems that paste buffer names were missed.

## problem

control mode is newline-delimited. `paste_set` and `paste_rename` accept any
non-empty name and store it verbatim, with notifications emitting the name
"straight up":

```c
control_write(c, "%%paste-buffer-changed %s", name);
control_write(c, "%%paste-buffer-deleted %s", name);
```

I dentify the following problem: any client on the socket can rename a buffer to
`lol\n%exit getowned` and
forge a `%getowned` line in clients.

of course this leaks into adjacent paths where the buffer naame is used
(status bar, choose-buffer, etc).

## solution

clean the name with `clean_name` in the associated code flows like
`paste_{set,rename}`.

## repro

The following reproduction was made by Devin AI. No other aspects of this PR,
including the fix, were made by AI. I simply couldn't be bothered to do it
myself, and the script works (lol).

1. build master
2. save this as `repro.py` and run it:

```python
import os, selectors, subprocess, tempfile, time

t = "/path/to/built/tmux"
d = tempfile.mkdtemp(prefix="tmux-bug002.", dir="/tmp")
s = f"{d}/s"; os.mkdir(s)
e = os.environ.copy(); e["TMUX_TMPDIR"] = s

subprocess.run([t, "-L", "bug002", "-f", "/dev/null", "new", "-d", "-s", "s"], env=e, check=True)

p = subprocess.Popen([t, "-C", "-L", "bug002"], env=e, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, bufsize=1)
sel = selectors.DefaultSelector(); sel.register(p.stdout, selectors.EVENT_READ)
def grab(n):
  end = time.time() + n; out = []
  while time.time() < end:
    for k, _ in sel.select(timeout=0.2):
      l = k.fileobj.readline()
      if l: out.append(l.rstrip())
  return out

p.stdin.write("refresh-client -C 80,24\n"); p.stdin.flush(); grab(1)
subprocess.run([t, "-L", "bug002", "set-buffer", "-b", "base", "data"], env=e); grab(1)
subprocess.run([t, "-L", "bug002", "set-buffer", "-b", "base", "-n", "evil\n%exit injected"], env=e)
p.stdin.write("ls\n"); p.stdin.flush()
for line in grab(2): print(line)

subprocess.run([t, "-L", "bug002", "kill-server"], env=e)
```

before:

```text
%paste-buffer-deleted base
%paste-buffer-changed evil
%exit injected
%begin 1777056942 303 1
```

after:

```text
%begin 1777057169 301 1
```

specifically, rename is rejected with `invalid buffer name: evil\n%exit injected`

## breaking changes(?)

***PLEASE READ***: names with embedded non-UTF-8 bytes are now REJECTED.
However, afaict, this matches what `rename-session` / `new-session` already do after 
the aforementioned commit. it seems like the intended direction but i wanted to
point this out.

lmk if you'd rather escape them through instead of rejecting - would be an easy
fix.
