### PR TITLE
Do not free SIXEL images from `s->images` when they live on `s->saved_images`.

### DIFF
--- a/image.c
+++ b/image.c
@@ -53,14 +53,12 @@ image_log(struct image *im, const char* from, const char* fmt, ...)
 static void
 image_free(struct image *im)
 {
-	struct screen	*s = im->s;
-
 	image_log(im, __func__, NULL);
 
 	TAILQ_REMOVE(&all_images, im, all_entry);
 	all_images_count--;
 
-	TAILQ_REMOVE(&s->images, im, entry);
+	TAILQ_REMOVE(im->queue, im, entry);
 	sixel_free(im->data);
 	free(im->fallback);
 	free(im);
@@ -128,6 +126,7 @@ image_store(struct screen *s, struct sixel_image *si)
 
 	im = xcalloc(1, sizeof *im);
 	im->s = s;
+	im->queue = &s->images;
 	im->data = si;
 
 	im->px = s->cx;

--- a/screen.c
+++ b/screen.c
@@ -658,6 +658,9 @@ void
 screen_alternate_on(struct screen *s, struct grid_cell *gc, int cursor)
 {
 	u_int	sx, sy;
+#ifdef ENABLE_SIXEL
+	struct image	*im;
+#endif
 
 	if (SCREEN_IS_ALTERNATE(s))
 		return;
@@ -674,6 +677,8 @@ screen_alternate_on(struct screen *s, struct grid_cell *gc, int cursor)
 
 #ifdef ENABLE_SIXEL
 	TAILQ_CONCAT(&s->saved_images, &s->images, entry);
+	TAILQ_FOREACH(im, &s->saved_images, entry)
+		im->queue = &s->saved_images;
 #endif
 
 	grid_view_clear(s->grid, 0, 0, sx, sy, 8);
@@ -687,6 +692,9 @@ void
 screen_alternate_off(struct screen *s, struct grid_cell *gc, int cursor)
 {
 	u_int	sx = screen_size_x(s), sy = screen_size_y(s);
+#ifdef ENABLE_SIXEL
+	struct image	*im;
+#endif
 
 	/*
 	 * If the current size is different, temporarily resize to the old size
@@ -733,6 +741,8 @@ screen_alternate_off(struct screen *s, struct grid_cell *gc, int cursor)
 #ifdef ENABLE_SIXEL
 	image_free_all(s);
 	TAILQ_CONCAT(&s->images, &s->saved_images, entry);
+	TAILQ_FOREACH(im, &s->images, entry)
+		im->queue = &s->images;
 #endif
 
 	if (s->cx > screen_size_x(s) - 1)

--- a/tmux.h
+++ b/tmux.h
@@ -963,6 +963,7 @@ struct style {
 /* Image. */
 struct image {
 	struct screen		*s;
+	struct images		*queue;
 	struct sixel_image	*data;
 	char			*fallback;
 


### PR DESCRIPTION
## context

was browsing my wallpapers in yazi. earlier i opened an image in the same
pane that i was browsing in with `chafa`.

my server just crashed...

luckily, i've been continuing to drive ASAN tmux as mentioned in #5032

## problem

consider the sixel image code paths when built with `--enable-sixel`

`image_free` unconditionally removes the image from the list via
`TAILQ_REMOVE(&s->images, im, entry)`,
which is wrong when the global eviction in `image_store` [here](https://github.com/tmux/tmux/blob/bcd17cf99afd564c559d04d1cb01ed7fc7e2749c/image.c#L142-L144)
picks an image that `screen_alternate_on` moved to the `s->saved_images`- 
both heads end up corrupted.

```text
==757094==ERROR: AddressSanitizer: heap-use-after-free
WRITE of size 8 at 0x... thread T0 (tmux: server)
    #0 image_store ../image.c:140
    #1 screen_write_sixelimage ../screen-write.c:2453
    #2 input_dcs_dispatch ../input.c:2585
freed by:
    #1 image_free ../image.c:66
    #2 image_store ../image.c:144
```

## solution

stash the owning per-screen queue on the *image* with a new `struct images *queue`
on `struct image`.

## repro

build with `--enable-sixel` as well as address sanitizer asan and run the below
script pointing at the binary like `./<path>/<to>/repro.sh <path>/<to>/tmux`:

```sh
#!/bin/sh
t=$1
d=$(mktemp -d)
s=$d/s
cat >$s <<'X'
#!/bin/sh
# smallest possible sixel image
im=$(printf '\033Pq"1;1;1;1#1;2;100;0;0~\033\\')
printf %s "$im"
printf '\033[?1049h'
n=0; while [ $n -lt 23 ]; do printf %s "$im"; n=$((n+1)); done
printf '\033[?1049l'
printf %s "$im"
sleep 5
X
chmod +x $s
export TMUX_TMPDIR=$d
export ASAN_OPTIONS=abort_on_error=1:detect_leaks=0:log_path=$d/a
$t -L b4 -f /dev/null new-session -d $s
sleep 3
$t -L b4 has-session 2>/dev/null; echo rc=$?
head -3 $d/a.* 2>/dev/null
$t -L b4 kill-server 2>/dev/null
```

```text
rc=1
==757094==ERROR: AddressSanitizer: heap-use-after-free on address 0x...
WRITE of size 8 at 0x... thread T0 (tmux: server)
```
