### PR TITLE
Do not leak socketpair fds in `pipe-pane` when `fork()` fails.

### DIFF
--- a/cmd-pipe-pane.c
+++ b/cmd-pipe-pane.c
@@ -128,6 +128,8 @@ cmd_pipe_pane_exec(struct cmd *self, struct cmdq_item *item)
 		sigprocmask(SIG_SETMASK, &oldset, NULL);
 		cmdq_error(item, "fork error: %s", strerror(errno));
 
+		close(pipe_fd[0]);
+		close(pipe_fd[1]);
 		free(cmd);
 		return (CMD_RETURN_ERROR);
 	case 0:


### PR DESCRIPTION
see [cmd-pipe-pane](https://github.com/tmux/tmux/blob/bcd17cf99afd564c559d04d1cb01ed7fc7e2749c/cmd-pipe-pane.c#L127-L132)

`fork()`, when failing doesn't close the pipe on both ends

(this one is a bit stupid but I'm trying to familiarize myself with the codebase :sweat_smile:)