### PR TITLE
Do not deref NULL job in `window_copy_pipe_run` when `job_run()` fails.

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -5171,7 +5171,8 @@ window_copy_pipe_run(struct window_mode_entry *wme, struct session *s,
 	if (cmd != NULL && *cmd != '\0') {
 		job = job_run(cmd, 0, NULL, NULL, s, NULL, NULL, NULL, NULL,
 		    NULL, JOB_NOWAIT, -1, -1);
-		bufferevent_write(job_get_event(job), buf, *len);
+		if (job != NULL)
+			bufferevent_write(job_get_event(job), buf, *len);
 	}
 	return (buf);
 }


### PR DESCRIPTION
this one is pretty self-explanatory