### PR TITLE
Do not hang `run-shell` when `job_run()` fails.

### DIFF
--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -198,8 +198,17 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 		}
 		if (job_run(cmd, 0, NULL, NULL, cdata->s, cdata->cwd, NULL,
 		    cmd_run_shell_callback, cmd_run_shell_free, cdata,
-		    cdata->flags, -1, -1) == NULL)
+		    cdata->flags, -1, -1) == NULL) {
+			if (cdata->item == NULL)
+				status_message_set(c, -1, 1, 0, 0,
+				    "failed to run command: %s", cmd);
+			else {
+				cmdq_error(cdata->item,
+				    "failed to run command: %s", cmd);
+				cmdq_continue(cdata->item);
+			}
 			cmd_run_shell_free(cdata);
+		}
 		return;
 	}
 


### PR DESCRIPTION
i caught in the same audit pass that turned up #5034 / #5036.

foreground `run-shell` hangs forever if `job_run` fails... which realistically only happens if your server is right up against its fd cap (this will almost certainly never happen).

this is the same shape of contract violation as in `67e6f824` though, so better safe than sorry!
