### PR TITLE
Fix control client hang on exit after toggling no-output

### DIFF
--- a/control.c
+++ b/control.c
@@ -298,6 +298,7 @@ control_reset_offsets(struct client *c)
 	struct control_pane	*cp, *cp1;
 
 	RB_FOREACH_SAFE(cp, control_panes, &cs->panes, cp1) {
+		control_discard_pane(c, cp);
 		RB_REMOVE(control_panes, &cs->panes, cp);
 		free(cp);
 	}


### PR DESCRIPTION
A control-client exit wedge is possible, reproducible by:

1. queue some pane %output blocks
2. execute `refresh-client -f no-output`
3. perform a control-client exit

On an unfixed tmux, control_reset_offsets() frees the control_pane objects without removing their queued control_block entries from all_blocks. The control client then waits forever in server_client_check_exit() because control_all_done() never becomes true.
