### PR TITLE
fix: check wp for NULL before dereferencing in window.c

### DIFF
--- a/window.c
+++ b/window.c
@@ -2009,13 +2009,15 @@ struct style_range *
 window_pane_border_status_get_range(struct window_pane *wp, u_int x, u_int y)
 {
 	struct style_ranges	*srs;
-	struct window		*w = wp->window;
-	struct options		*wo = w->options;
+	struct window		*w;
+	struct options		*wo;
 	u_int			 line;
 	int			 pane_status;
 
 	if (wp == NULL)
 		return (NULL);
+	w = wp->window;
+	wo = w->options;
 	srs = &wp->border_status_line.ranges;
 
 	pane_status = options_get_number(wo, "pane-border-status");


### PR DESCRIPTION
## Problem

`wp` is dereferenced at line 2012 before the null check at line 2017.
If `wp` is NULL, the program crashes before reaching the guard.

Detected by Cppcheck static analysis [nullPointerRedundantCheck].

## Fix

Declared `w` and `wo` without initialization, moved the null check 
for `wp` before any dereference, then initialized `w` and `wo` safely.

## Verification

Verified with Cppcheck — warning no longer appears after this fix.