### PR TITLE
Fix possible control-mode OOB read after toggling pane off

### DIFF
--- a/control.c
+++ b/control.c
@@ -352,6 +352,9 @@ control_set_pane_off(struct client *c, struct window_pane *wp)
 	struct control_pane	*cp;
 
 	cp = control_add_pane(c, wp);
+	control_discard_pane(c, cp);
+	memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
+	memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
 	cp->flags |= CONTROL_PANE_OFF;
 }
 


### PR DESCRIPTION
```mermaid
  sequenceDiagram
      participant Pane as Pane process
      participant Buf as wp->event->input
      participant Ctrl as control_pane cp
      participant Queue as cp->blocks / pending_list
      participant Drain as server_client_check_pane_buffer()
      participant Flush as control_write_pending()

      Pane->>Buf: writes pane output bytes

      Note over Ctrl,Queue: control_write_output()
      Ctrl->>Buf: window_pane_get_new_data(&cp->queued)
      Buf-->>Ctrl: "new_size = N"
      Ctrl->>Ctrl: advance cp->queued by N
      Ctrl->>Queue: enqueue cb->size = N
      Note over Queue: Bytes are not copied.<br/>Only the size is queued.

      Note over Flush: control client stdout is backed up,<br/>so queued output is not flushed yet

      Note over Ctrl: refresh-client -A %pane:off
      Ctrl->>Ctrl: set CONTROL_PANE_OFF
      Note over Ctrl,Queue: BUG: old cp->blocks remain pending<br/>cp->offset still points at old data

      Note over Drain: later pane buffer cleanup runs
      Drain->>Ctrl: control_pane_offset()
      Ctrl-->>Drain: NULL because pane is OFF
      Note over Drain: cp->offset no longer protects<br/>old pane data from being drained

      Drain->>Buf: evbuffer_drain(...)
      Drain->>Buf: wp->base_offset advances past cp->offset

      Note over Flush: later stdout becomes writable
      Flush->>Queue: take old cb->size = N
      Flush->>Buf: window_pane_get_new_data(&cp->offset)

      Note over Buf: used = cp->offset.used - wp->base_offset<br/>underflows because cp->offset < base_offset

      Buf-->>Flush: returns EVBUFFER_DATA + huge offset
      Flush->>Flush: reads new_data[i]
      Note over Flush: OOB read or crash
```
