### PR TITLE
Fix scrollbar slider calculation for floating panes

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1427,7 +1427,7 @@ screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *ctx,
 		total_height = cm_size + sb_h;
 		percent_view = (double)sb_h / (cm_size + sb_h);
 		slider_h = (double)sb_h * percent_view;
-		slider_y = (sb_h + 1) * ((double)cm_y / (total_height));
+		slider_y = sb_h * ((double)cm_y / total_height);
 	}
 
 	if (sb_pos == PANE_SCROLLBARS_LEFT)


### PR DESCRIPTION
## Fix scrollbar slider calculation for floating panes

The slider position formula in `screen_redraw_draw_pane_scrollbar` was incorrectly using `(sb_h + 1) * ((double)cm_y / total_height)`, causing the slider to be positioned too low when at the bottom of the scrollbar in copy mode. This meant the slider couldn't reach the very bottom of the scrollbar, making it impossible to scroll to the last content.

### Fix

Changed line 1430 in `screen-redraw.c` from:
```
slider_y = (sb_h + 1) * ((double)cm_y / (total_height));
```
to:
```
slider_y = sb_h * ((double)cm_y / total_height);
```

This correctly maps the current offset to the scrollbar height and is the inverse of the formula in `window_copy_scroll_to` which correctly maps slider position back to content offset.

### References
- Fixes tmux/tmux issue #4800