### PR TITLE
Guard screen_mode_to_string against 1-byte underflow for unlisted mode bits

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -807,7 +807,17 @@ screen_mode_to_string(int mode)
 		strlcat(tmp, "KEYS_EXTENDED_2,", sizeof tmp);
 	if (mode & MODE_THEME_UPDATES)
 		strlcat(tmp, "THEME_UPDATES,", sizeof tmp);
-	tmp[strlen(tmp) - 1] = '\0';
+	/*
+	 * Trim the trailing comma left by the strlcat chain above.  Guard the
+	 * empty case: when mode is non-zero but matches none of the listed
+	 * MODE_* flags, no strlcat ran and tmp stays "".  strlen(tmp) is then
+	 * 0 and the unguarded tmp[strlen(tmp) - 1] would compute tmp[(size_t)-1]
+	 * and write one byte before the buffer.  The currently-exercised case
+	 * is MODE_CURSOR_BLINKING_SET (0x20000), passed alone from input.c when
+	 * handling DECSCUSR (Ps=0), DECRST ?12, and DECSET ?12.
+	 */
+	if (tmp[0] != '\0')
+		tmp[strlen(tmp) - 1] = '\0';
 	return (tmp);
 }
 


### PR DESCRIPTION
Fixes #5059.

`screen_mode_to_string` writes 1 byte before its 1024-byte static buffer when called with a `mode` that is non-zero, not equal to `ALL_MODES`, and contains only bits unlisted in the function's `strlcat` chain. The currently-exercised case is `MODE_CURSOR_BLINKING_SET` (`0x20000`), passed alone to `screen_write_mode_set/clear` from:

- `input.c:1809` — `DECSCUSR` (`\e[Ps SP q`, Ps=0), cursor style reset
- `input.c:1878` — `DECRST ?12` (`\e[?12l`), disable cursor blink
- `input.c:1977` — `DECSET ?12` (`\e[?12h`), enable cursor blink

With that single-bit input every `if (mode & MODE_X)` misses, `tmp` stays empty, and `tmp[strlen(tmp) - 1] = '\0'` becomes `tmp[(size_t)-1] = '\0'`.

`MODE_SYNC` (`0x100000`) is also defined in `tmux.h` and missing from the chain, but it is manipulated directly via `wp->base.mode |= MODE_SYNC` in `screen-write.c` and is not currently routed through `screen_write_mode_set/clear`, so it is a latent missing entry rather than a live trigger today.

The path is gated on `log_get_level() != 0`, so only `tmux -v` builds tickle it; AddressSanitizer caught it on the first input parse.

The patch keeps the trim-trailing-comma semantics and just guards the empty case. It deliberately does **not** add `CURSOR_BLINKING_SET,` (or `SYNC,`) entries to the strlcat chain — that is a cosmetic decision left to the maintainer. Scope here is only the underflow.

ASAN reports and verified reproduction script in the linked issue.

---

Analysed and written with assistance from Claude (Anthropic).
