### PR TITLE
Fix control mode teardown ordering for queued pane output

### DIFF
--- a/control.c
+++ b/control.c
@@ -846,9 +846,9 @@ control_stop(struct client *c)
 	if (evtimer_initialized(&cs->subs_timer))
 		evtimer_del(&cs->subs_timer);
 
+	control_reset_offsets(c);
 	TAILQ_FOREACH_SAFE(cb, &cs->all_blocks, all_entry, cb1)
 		control_free_block(cs, cb);
-	control_reset_offsets(c);
 
 	c->control_state = NULL;
 	free(cs);


### PR DESCRIPTION
`%output` blocks are on two queues:

```
TAILQ_INSERT_TAIL(&cs->all_blocks, cb, all_entry);
TAILQ_INSERT_TAIL(&cp->blocks, cb, entry);
```

But control_free_block() only removes from `all_blocks`:

```
TAILQ_REMOVE(&cs->all_blocks, cb, all_entry);
free(cb);
```

Previously, control_stop() freed `all_blocks` first, then reset panes:

```
TAILQ_FOREACH_SAFE(cb, &cs->all_blocks, all_entry, cb1)
    control_free_block(cs, cb);
control_reset_offsets(c);
```

So any `%output` block was freed while still linked from `cp->blocks`; control_reset_offsets() later walked `cp->blocks` and touched/freed the dangling pointer.

Fixed order:

```
control_reset_offsets(c);
TAILQ_FOREACH_SAFE(cb, &cs->all_blocks, all_entry, cb1)
  control_free_block(cs, cb);
```

Now pane-owned blocks are removed through the pane path first; only client-only queued lines remain in `all_blocks`.
