### PR TITLE
copy-mode: add option to disable one-past-EOL cursor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 CHANGES FROM 3.6 TO 3.6a
 
-* Add a copy-mode-virtual-edit window option (off or onemore) to control
-  whether copy mode cursor-right can move one cell past end of line.
+* Do not allow copy mode cursor-right to move one cell past end of line with
+  vi keys.
 
 * Fix a buffer overread and an infinite loop in format processing (reported by
   Giorgi Kobakhia, issue 4735).

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 CHANGES FROM 3.6 TO 3.6a
 
+* Add a copy-mode-virtual-edit window option (off or onemore) to control
+  whether copy mode cursor-right can move one cell past end of line.
+
 * Fix a buffer overread and an infinite loop in format processing (reported by
   Giorgi Kobakhia, issue 4735).
 

--- a/grid-reader.c
+++ b/grid-reader.c
@@ -45,15 +45,21 @@ grid_reader_line_length(struct grid_reader *gr)
 
 /* Move cursor forward one position. */
 void
-grid_reader_cursor_right(struct grid_reader *gr, int wrap, int all)
+grid_reader_cursor_right(struct grid_reader *gr, int wrap, int all,
+    int onemore)
 {
 	u_int			px;
 	struct grid_cell	gc;
 
 	if (all)
 		px = gr->gd->sx;
-	else
+	else if (onemore)
 		px = grid_reader_line_length(gr);
+	else {
+		px = grid_reader_line_length(gr);
+		if (px != 0)
+			px--;
+	}
 
 	if (wrap && gr->cx >= px && gr->cy < gr->gd->hsize + gr->gd->sy - 1) {
 		grid_reader_cursor_start_of_line(gr, 0);

--- a/options-table.c
+++ b/options-table.c
@@ -111,9 +111,6 @@ static const char *options_table_allow_passthrough_list[] = {
 static const char *options_table_copy_mode_line_numbers_list[] = {
 	"off", "default", "absolute", "relative", "hybrid", NULL
 };
-static const char *options_table_copy_mode_virtual_edit_list[] = {
-	"off", "onemore", NULL
-};
 
 /* Status line format. */
 #define OPTIONS_TABLE_STATUS_FORMAT1 \
@@ -1231,14 +1228,6 @@ const struct options_table_entry options_table[] = {
 	  .choices = options_table_copy_mode_line_numbers_list,
 	  .default_num = 0,
 	  .text = "Line number mode in copy mode."
-	},
-
-	{ .name = "copy-mode-virtual-edit",
-	  .type = OPTIONS_TABLE_CHOICE,
-	  .scope = OPTIONS_TABLE_WINDOW,
-	  .choices = options_table_copy_mode_virtual_edit_list,
-	  .default_num = 1,
-	  .text = "Whether copy mode cursor may move one cell past end of line."
 	},
 
 	{ .name = "fill-character",

--- a/options-table.c
+++ b/options-table.c
@@ -111,6 +111,9 @@ static const char *options_table_allow_passthrough_list[] = {
 static const char *options_table_copy_mode_line_numbers_list[] = {
 	"off", "default", "absolute", "relative", "hybrid", NULL
 };
+static const char *options_table_copy_mode_virtual_edit_list[] = {
+	"off", "onemore", NULL
+};
 
 /* Status line format. */
 #define OPTIONS_TABLE_STATUS_FORMAT1 \
@@ -1228,6 +1231,14 @@ const struct options_table_entry options_table[] = {
 	  .choices = options_table_copy_mode_line_numbers_list,
 	  .default_num = 0,
 	  .text = "Line number mode in copy mode."
+	},
+
+	{ .name = "copy-mode-virtual-edit",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_WINDOW,
+	  .choices = options_table_copy_mode_virtual_edit_list,
+	  .default_num = 1,
+	  .text = "Whether copy mode cursor may move one cell past end of line."
 	},
 
 	{ .name = "fill-character",

--- a/tmux.h
+++ b/tmux.h
@@ -3206,7 +3206,7 @@ void	 grid_reader_start(struct grid_reader *, struct grid *, u_int, u_int);
 void	 grid_reader_get_cursor(struct grid_reader *, u_int *, u_int *);
 u_int	 grid_reader_line_length(struct grid_reader *);
 int	 grid_reader_in_set(struct grid_reader *, const char *);
-void	 grid_reader_cursor_right(struct grid_reader *, int, int);
+void	 grid_reader_cursor_right(struct grid_reader *, int, int, int);
 void	 grid_reader_cursor_left(struct grid_reader *, int);
 void	 grid_reader_cursor_down(struct grid_reader *);
 void	 grid_reader_cursor_up(struct grid_reader *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -119,6 +119,8 @@ static void	window_copy_copy_line(struct window_mode_entry *, char **,
 static int	window_copy_in_set(struct window_mode_entry *, u_int, u_int,
 		    const char *);
 static u_int	window_copy_find_length(struct window_mode_entry *, u_int);
+static u_int	window_copy_cursor_limit(struct window_mode_entry *, u_int,
+		    int);
 static void	window_copy_cursor_start_of_line(struct window_mode_entry *);
 static void	window_copy_cursor_back_to_indentation(
 		    struct window_mode_entry *);
@@ -1662,7 +1664,7 @@ window_copy_cmd_history_bottom(struct window_copy_cmd_state *cs)
 		window_copy_other_end(wme);
 
 	data->cy = screen_size_y(&data->screen) - 1;
-	data->cx = window_copy_find_length(wme, screen_hsize(s) + data->cy);
+	data->cx = window_copy_cursor_limit(wme, screen_hsize(s) + data->cy, 0);
 	data->oy = 0;
 
 	if (data->searchmark != NULL && !data->timeout)
@@ -2683,6 +2685,8 @@ window_copy_cmd_search_backward_incremental(struct window_copy_cmd_state *cs)
 		data->cx = data->searchx;
 		data->cy = data->searchy;
 		data->oy = data->searcho;
+		data->cx = window_copy_cursor_limit(wme,
+		    screen_hsize(data->backing) + data->cy - data->oy, 0);
 		action = WINDOW_COPY_CMD_REDRAW;
 	}
 	if (*arg0 == '\0') {
@@ -2738,6 +2742,8 @@ window_copy_cmd_search_forward_incremental(struct window_copy_cmd_state *cs)
 		data->cx = data->searchx;
 		data->cy = data->searchy;
 		data->oy = data->searcho;
+		data->cx = window_copy_cursor_limit(wme,
+		    screen_hsize(data->backing) + data->cy - data->oy, 0);
 		action = WINDOW_COPY_CMD_REDRAW;
 	}
 	if (*arg0 == '\0') {
@@ -5151,7 +5157,16 @@ window_copy_update_cursor(struct window_mode_entry *wme, u_int cx, u_int cy)
 	struct window_copy_mode_data	*data = wme->data;
 	struct screen			*s = &data->screen;
 	struct screen_write_ctx		 ctx;
-	u_int				 old_cx, old_cy, width, content_sx;
+	u_int				 old_cx, old_cy, py, width, content_sx, maxx;
+	int				 allow_onemore;
+
+	allow_onemore = (data->screen.sel != NULL && data->rectflag);
+	if (cy < screen_size_y(s)) {
+		py = screen_hsize(data->backing) + cy - data->oy;
+		maxx = window_copy_cursor_limit(wme, py, allow_onemore);
+		if (cx > maxx)
+			cx = maxx;
+	}
 
 	old_cx = data->cx; old_cy = data->cy;
 	data->cx = cx; data->cy = cy;
@@ -5644,7 +5659,7 @@ window_copy_clear_selection(struct window_mode_entry *wme)
 	data->selflag = SEL_CHAR;
 
 	py = screen_hsize(data->backing) + data->cy - data->oy;
-	px = window_copy_find_length(wme, py);
+	px = window_copy_cursor_limit(wme, py, data->rectflag);
 	if (data->cx > px)
 		window_copy_update_cursor(wme, px, data->cy);
 }
@@ -5664,6 +5679,21 @@ window_copy_find_length(struct window_mode_entry *wme, u_int py)
 	struct window_copy_mode_data	*data = wme->data;
 
 	return (grid_line_length(data->backing->grid, py));
+}
+
+static u_int
+window_copy_cursor_limit(struct window_mode_entry *wme, u_int py,
+    int allow_onemore)
+{
+	struct options			*oo = wme->wp->window->options;
+	u_int				 len;
+
+	len = window_copy_find_length(wme, py);
+	if (allow_onemore || options_get_number(oo, "copy-mode-virtual-edit") != 0)
+		return (len);
+	if (len == 0)
+		return (0);
+	return (len - 1);
 }
 
 static void
@@ -5723,6 +5753,8 @@ window_copy_cursor_end_of_line(struct window_mode_entry *wme)
 	else
 		grid_reader_cursor_end_of_line(&gr, 1, 0);
 	grid_reader_get_cursor(&gr, &px, &py);
+	if (!(data->screen.sel != NULL && data->rectflag))
+		px = window_copy_cursor_limit(wme, py, 0);
 	window_copy_acquire_cursor_down(wme, hsize, screen_size_y(back_s),
 	    data->oy, oldy, px, py, 0);
 }
@@ -5773,6 +5805,10 @@ window_copy_other_end(struct window_mode_entry *wme)
 		data->cy = screen_size_y(s) - 1;
 	} else
 		data->cy = cy + sely - yy;
+	yy = screen_hsize(data->backing) + data->cy - data->oy;
+	hsize = window_copy_cursor_limit(wme, yy, data->rectflag);
+	if (data->cx > hsize)
+		data->cx = hsize;
 
 	window_copy_update_selection(wme, 1, 1);
 	window_copy_redraw_screen(wme);
@@ -6030,20 +6066,23 @@ static void
 window_copy_cursor_jump_to_back(struct window_mode_entry *wme)
 {
 	struct window_copy_mode_data	*data = wme->data;
+	struct options			*oo = wme->wp->window->options;
 	struct screen			*back_s = data->backing;
 	struct grid_reader		 gr;
 	u_int				 px, py, oldy, hsize;
+	int				 onemore;
 
 	px = data->cx;
 	hsize = screen_hsize(back_s);
 	py = hsize + data->cy - data->oy;
 	oldy = data->cy;
+	onemore = (options_get_number(oo, "copy-mode-virtual-edit") != 0);
 
 	grid_reader_start(&gr, back_s->grid, px, py);
 	grid_reader_cursor_left(&gr, 0);
 	grid_reader_cursor_left(&gr, 0);
 	if (grid_reader_cursor_jump_back(&gr, data->jumpchar)) {
-		grid_reader_cursor_right(&gr, 1, 0, 1);
+		grid_reader_cursor_right(&gr, 1, 0, onemore);
 		grid_reader_get_cursor(&gr, &px, &py);
 		window_copy_acquire_cursor_up(wme, hsize, data->oy, oldy, px,
 		    py);
@@ -6090,7 +6129,8 @@ window_copy_cursor_next_word_end_pos(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0, 1);
+			grid_reader_cursor_right(&gr, 0, 0,
+			    options_get_number(oo, "copy-mode-virtual-edit") != 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else
@@ -6120,7 +6160,8 @@ window_copy_cursor_next_word_end(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0, 1);
+			grid_reader_cursor_right(&gr, 0, 0,
+			    options_get_number(oo, "copy-mode-virtual-edit") != 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else
@@ -6354,7 +6395,7 @@ window_copy_rectangle_set(struct window_mode_entry *wme, int rectflag)
 	data->rectflag = rectflag;
 
 	py = screen_hsize(data->backing) + data->cy - data->oy;
-	px = window_copy_find_length(wme, py);
+	px = window_copy_cursor_limit(wme, py, data->rectflag);
 	if (data->cx > px)
 		window_copy_update_cursor(wme, px, data->cy);
 

--- a/window-copy.c
+++ b/window-copy.c
@@ -5689,7 +5689,8 @@ window_copy_cursor_limit(struct window_mode_entry *wme, u_int py,
 	u_int				 len;
 
 	len = window_copy_find_length(wme, py);
-	if (allow_onemore || options_get_number(oo, "copy-mode-virtual-edit") != 0)
+	if (allow_onemore ||
+	    options_get_number(oo, "mode-keys") != MODEKEY_VI)
 		return (len);
 	if (len == 0)
 		return (0);
@@ -5848,7 +5849,7 @@ window_copy_cursor_right(struct window_mode_entry *wme, int all)
 	hsize = screen_hsize(back_s);
 	py = hsize + data->cy - data->oy;
 	oldy = data->cy;
-	onemore = (options_get_number(oo, "copy-mode-virtual-edit") != 0);
+	onemore = (options_get_number(oo, "mode-keys") != MODEKEY_VI);
 
 	grid_reader_start(&gr, back_s->grid, px, py);
 	grid_reader_cursor_right(&gr, 1, all, onemore);
@@ -6076,7 +6077,7 @@ window_copy_cursor_jump_to_back(struct window_mode_entry *wme)
 	hsize = screen_hsize(back_s);
 	py = hsize + data->cy - data->oy;
 	oldy = data->cy;
-	onemore = (options_get_number(oo, "copy-mode-virtual-edit") != 0);
+	onemore = (options_get_number(oo, "mode-keys") != MODEKEY_VI);
 
 	grid_reader_start(&gr, back_s->grid, px, py);
 	grid_reader_cursor_left(&gr, 0);
@@ -6129,8 +6130,7 @@ window_copy_cursor_next_word_end_pos(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0,
-			    options_get_number(oo, "copy-mode-virtual-edit") != 0);
+			grid_reader_cursor_right(&gr, 0, 0, 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else
@@ -6160,8 +6160,7 @@ window_copy_cursor_next_word_end(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0,
-			    options_get_number(oo, "copy-mode-virtual-edit") != 0);
+			grid_reader_cursor_right(&gr, 0, 0, 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else

--- a/window-copy.c
+++ b/window-copy.c
@@ -5800,18 +5800,22 @@ window_copy_cursor_left(struct window_mode_entry *wme)
 static void
 window_copy_cursor_right(struct window_mode_entry *wme, int all)
 {
+	struct window_pane		*wp = wme->wp;
 	struct window_copy_mode_data	*data = wme->data;
+	struct options			*oo = wp->window->options;
 	struct screen			*back_s = data->backing;
 	struct grid_reader		 gr;
 	u_int				 px, py, oldy, hsize;
+	int				 onemore;
 
 	px = data->cx;
 	hsize = screen_hsize(back_s);
 	py = hsize + data->cy - data->oy;
 	oldy = data->cy;
+	onemore = (options_get_number(oo, "copy-mode-virtual-edit") != 0);
 
 	grid_reader_start(&gr, back_s->grid, px, py);
-	grid_reader_cursor_right(&gr, 1, all);
+	grid_reader_cursor_right(&gr, 1, all, onemore);
 	grid_reader_get_cursor(&gr, &px, &py);
 	window_copy_acquire_cursor_down(wme, hsize, screen_size_y(back_s),
 	    data->oy, oldy, px, py, 0);
@@ -6039,7 +6043,7 @@ window_copy_cursor_jump_to_back(struct window_mode_entry *wme)
 	grid_reader_cursor_left(&gr, 0);
 	grid_reader_cursor_left(&gr, 0);
 	if (grid_reader_cursor_jump_back(&gr, data->jumpchar)) {
-		grid_reader_cursor_right(&gr, 1, 0);
+		grid_reader_cursor_right(&gr, 1, 0, 1);
 		grid_reader_get_cursor(&gr, &px, &py);
 		window_copy_acquire_cursor_up(wme, hsize, data->oy, oldy, px,
 		    py);
@@ -6086,7 +6090,7 @@ window_copy_cursor_next_word_end_pos(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0);
+			grid_reader_cursor_right(&gr, 0, 0, 1);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else
@@ -6116,7 +6120,7 @@ window_copy_cursor_next_word_end(struct window_mode_entry *wme,
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0);
+			grid_reader_cursor_right(&gr, 0, 0, 1);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else


### PR DESCRIPTION
## Summary

- adds a new window option, `copy-mode-virtual-edit`, with values `off` and `onemore`
- defaults to `onemore` to preserve existing behavior
- when set to `off`, `cursor-right` in copy mode no longer moves into a virtual cell past end of line

## Motivation

In vi-style copy mode, many users expect horizontal movement to stay on real text columns. Today, tmux always allows one-past-EOL movement and there is no built-in way to disable it.

This change keeps current behavior by default, but allows strict motion for users who want it.

## Details

- adds option definition in `options-table.c`
- threads an `onemore` flag through `grid_reader_cursor_right()`
- applies `copy-mode-virtual-edit` consistently in copy-mode cursor placement paths in `window-copy.c`
  (including end-of-line, history bottom, incremental-search reset, and relevant helper motions)
- preserves rectangle-selection behavior

## Compatibility

No behavior changes unless `copy-mode-virtual-edit` is explicitly set to `off`.

## Notes

- `CHANGES` includes a short entry for the new option.
- build verified locally in nix shell:
  - `nix-shell -p autoconf automake pkg-config libevent ncurses bison --run './autogen.sh && ./configure && make -j4'`
