### PR TITLE
`tty-features.c`: enable missing features for `foot`

### DIFF
--- a/tty-features.c
+++ b/tty-features.c
@@ -527,8 +527,13 @@ tty_default_features(int *feat, const char *name, u_int version)
 		},
 		{ .name = "foot",
 		  .features = TTY_FEATURES_BASE_MODERN_XTERM ","
+			      "ccolour,"
 			      "cstyle,"
-			      "extkeys"
+			      "extkeys,"
+			      "usstyle,"
+			      "sync,"
+			      "osc7,"
+			      "hyperlinks"
 		},
 		{ .name = "WezTerm",
 		  .features = TTY_FEATURES_BASE_MODERN_XTERM ","


### PR DESCRIPTION
A lot of the research for this PR was also written down in the form of this discussion post:
https://github.com/orgs/tmux/discussions/5078

~~These are two-ish separate patches, however I have chosen to bundle them together so as to not have to land *three* separate PRs (add `foot` features; fix `usstyle` sequences; add `usstyle` to foot).~~

The commit messages include rationale for the changes.

Sources:
- [Current terminfo database](https://invisible-island.net/ncurses/terminfo.src.html)
- [man 7 foot-ctlseqs](https://man.archlinux.org/man/foot-ctlseqs.7)
- tmux source code from the 3.6a git tag.