### PR TITLE
fix(floating_panes); Fixed null dereference inside `server-client.c:server_client_set_progress_bar`

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -2217,7 +2217,7 @@ server_client_set_progress_bar(struct client *c)
 	struct session		*s = c->session;
 	struct progress_bar	*pane_pb;
 
-	if (s->curw == NULL)
+	if (s->curw == NULL || s->curw->window->active == NULL)
 		return;
 	pane_pb = &s->curw->window->active->base.progress_bar;
 	if (pane_pb->state == c->progress_bar.state &&


### PR DESCRIPTION
When using `minimise-pane` on a lone pane, a null dereference crashes the server. Here is the backtrace:
```
#0  0x000056514c1693d3 in server_client_set_progress_bar (c=0x5651540fcf30)
    at server-client.c:2223
#1  0x000056514c169076 in server_client_check_redraw (c=0x5651540fcf30)
    at server-client.c:2146
#2  0x000056514c1673e9 in server_client_loop () at server-client.c:1523
#3  0x000056514c16cd69 in server_loop () at server.c:279
#4  0x000056514c14fb4e in proc_loop (tp=0x5651540481d0, 
    loopcb=0x56514c16ccf1 <server_loop>) at proc.c:214
#5  0x000056514c16ccd6 in server_start (client=0x565154049010, 
    flags=402718720, base=0x5651540475c0, lockfd=6, lockfile=0x565154049db0 "")
    at server.c:254
#6  0x000056514c0d789c in client_connect (base=0x5651540475c0, 
    path=0x5651540473f0 "/tmp/tmux-1000/test", flags=402718720) at client.c:164
#7  0x000056514c0d7c71 in client_main (base=0x5651540475c0, argc=2, 
    argv=0x7ffd80298688, flags=402718720, feat=0) at client.c:290
#8  0x000056514c17efa0 in main (argc=2, argv=0x7ffd80298688) at tmux.c:556
```

I have added an additional check to avoid this crash. @mgrant0 