### PR TITLE
Avoid infinite loop in tty_draw_line on width-0 PADDING cell

### DIFF
--- a/tty-draw.c
+++ b/tty-draw.c
@@ -328,8 +328,10 @@ tty_draw_line(struct tty *tty, struct screen *s, u_int px, u_int py, u_int nx,
 		memcpy(&last, gcp, sizeof last);
 		if (empty != 0)
 			i += empty;
-		else
+		else if (gcp->data.width > 0)
 			i += gcp->data.width;
+		else
+			i += 1;	/* Orphan PADDING; advance to avoid infinite loop. */
 	}
 
 out:


### PR DESCRIPTION
## The bug

`tty_draw_line`'s main loop advances the cell index with `i += gcp->data.width`. A PADDING cell always has `data.width == 0`, so if an orphan PADDING cell appears mid-line, `i` never advances and the loop spins forever. The server pegs at 100% CPU with all IPC blocked (`tmux ls` times out).

The pre-pass at the top of `tty_draw_line` already handles this for **leading** orphan PADDING (comment: *"If there is padding at the start, we must have truncated a wide character. Clear it."*). The same guard is missing in the main loop for the mid-line case.

## Reproducer

Generate a test file (requires U+2003 EM SPACE between emoji, not plain ASCII spaces):

```sh
python3 -c "print(('\u26a0\ufe0f\u2003' * 500 + '\n') * 1000)" > /tmp/bug.txt

Start a clean outer tmux session and open a popup with a nested tmux inside:

tmux -Ltest -f/dev/null new-session
tmux -Ltest -f/dev/null display-popup -E "tmux -Ltest2 -f/dev/null new-session"

Inside the popup, open nvim with no config and set a statuscolumn containing
a click region followed by %l and a trailing space:

nvim --clean /tmp/bug.txt

:set number
:lua vim.wo.statuscolumn = "%@Fake@  %T%l "

Press Ctrl-D / Ctrl-U rapidly. The outer tmux server hangs within a few keystrokes;
timeout 3 tmux -Ltest -f/dev/null ls exits 124.
```

## Fix

Guard the loop increment so `i` always advances by at least 1, mirroring the existing handling of orphan PADDING at the line start.