### PR TITLE
tty: force c->fd non-blocking before writing to prevent server wedge on dead tty master

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -238,6 +238,35 @@ tty_block_maybe(struct tty *tty)
 	return (1);
 }
 
+/*
+ * Force c->fd non-blocking just before writing to it.
+ *
+ * c->fd is a dup of the client's stdin received via SCM_RIGHTS, so it
+ * shares its O_NONBLOCK state with the client process (and the parent
+ * shell) through the underlying struct file. tty_stop_tty() restores
+ * blocking mode on the way out for shell etiquette, and other paths
+ * may flip the flag without us noticing. If c->fd is blocking when
+ * the kernel TTY buffer fills (e.g. the master-side reader is dead
+ * or paused), writev() will park in n_tty_write() and never return -
+ * freezing the entire single-threaded server.
+ *
+ * Forcing non-blocking just before the write turns that wedge into a
+ * clean EAGAIN. The race window where the client's stdin would also
+ * read as non-blocking is bounded to one writev() call, which is
+ * acceptable for tty stdin (cooked-mode reads are paced by VMIN/VTIME,
+ * not O_NONBLOCK).
+ */
+static void
+tty_force_nonblock(int fd)
+{
+	int mode;
+
+	if (fd == -1)
+		return;
+	if ((mode = fcntl(fd, F_GETFL)) != -1 && !(mode & O_NONBLOCK))
+		fcntl(fd, F_SETFL, mode | O_NONBLOCK);
+}
+
 static void
 tty_write_callback(__unused int fd, __unused short events, void *data)
 {
@@ -246,6 +275,7 @@ tty_write_callback(__unused int fd, __unused short events, void *data)
 	size_t		 size = EVBUFFER_LENGTH(tty->out);
 	int		 nwrite;
 
+	tty_force_nonblock(c->fd);
 	nwrite = evbuffer_write(tty->out, c->fd);
 	if (nwrite == -1)
 		return;
@@ -558,6 +588,7 @@ tty_raw(struct tty *tty, const char *s)
 	ssize_t		 n, slen;
 	u_int		 i;
 
+	tty_force_nonblock(c->fd);
 	slen = strlen(s);
 	for (i = 0; i < 5; i++) {
 		n = write(c->fd, s, slen);


### PR DESCRIPTION
## Summary

This patch makes the server force `O_NONBLOCK` on `c->fd` immediately before each write to it. It prevents a class of hang where the single-threaded server gets parked inside `n_tty_write()` indefinitely because the client tty's master-side reader has died or stalled, freezing every other client.

## The bug

I hit this in production: a `tmux -CC` session went unresponsive. `tmux list-sessions`, `tmux attach`, every command hung. The server process was at 0% CPU, sleeping. There was nothing in `tmux -v` logs because the event loop had not run an iteration in ~30 minutes.

The diagnosis:

```
$ cat /proc/<server-pid>/syscall
20 0x5 0x7ffe3cc068b0 0x1 ...            # syscall 20 = writev, arg0 = fd 5

$ sudo cat /proc/<server-pid>/stack
[<0>] wait_woken+0x33/0x50
[<0>] n_tty_write+0x402/0x460
[<0>] file_tty_write+0x11e/0x330
[<0>] do_iter_readv_writev+0x7a/0x1c0
[<0>] vfs_writev+0xc9/0x230
[<0>] do_writev+0x5e/0xe0

$ ls -l /proc/<server-pid>/fd/5
... 5 -> /dev/pts/0
```

The server was blocked inside the kernel TTY line-discipline write path, waiting for buffer space on `/dev/pts/0`. The master side of `/dev/pts/0` was held by an orphaned `etterminal` (EternalTerminal) process whose network session had died days earlier — the daemon was still alive, still holding the master fd, but no longer reading from it. The slave-side n_tty buffer filled up, the server's `writev()` blocked, and because the server is single-threaded (`proc.c:212` — `do { event_loop(EVLOOP_ONCE); } while (...)`), every other client request queued behind it.

## Root cause

`c->fd` is a `dup` of the client's stdin (`client.c:477-479`), passed to the server via `SCM_RIGHTS` in `MSG_IDENTIFY_STDIN`:

```c
if ((fd = dup(STDIN_FILENO)) == -1)
    fatal("dup failed");
proc_send(client_peer, MSG_IDENTIFY_STDIN, fd, NULL, 0);
```

On the server side this lands in `c->fd` (`server-client.c:2385`).

Crucially, `O_NONBLOCK` is a property of the underlying `struct file`, shared across all dups. tmux is aware of this — `tty_stop_tty()` deliberately restores blocking mode at teardown for shell etiquette (`tty.c:497`):

```c
setblocking(c->fd, 1);
```

But this creates a window where, between client teardown / detach / suspend and the eventual `close(c->fd)`, the server-side fd is blocking. Other paths (e.g. control mode `setblocking()` calls, intermediate state transitions, third-party tools `fcntl`'ing on the same struct file) can also leave the fd blocking unexpectedly.

When the fd is blocking AND the slave-side line discipline buffer is full AND nothing is draining the master, the next `writev()` from the server parks in `n_tty_write()` forever. tmux's existing defenses don't help:

- `tty_block_maybe()` (`tty.c:212`) only handles userspace evbuffer pressure, not kernel buffer stalls.
- `tty_raw()` (`tty.c:555`) has a 5×100µs retry loop that handles EAGAIN, but only works if the fd is non-blocking — if blocking, the first `write()` never returns.
- There is no wall-clock watchdog on writes.

## Why not other approaches?

- **`pwritev2(RWF_NOWAIT)`** — does not work on ttys. The kernel rejects positional writes on character devices with `ESPIPE` before ever evaluating the flag, and the n_tty write path doesn't honor `IOCB_NOWAIT` anyway. Verified empirically.
- **`send(MSG_DONTWAIT)`** — only for sockets.
- **Removing the `setblocking(c->fd, 1)` in `tty_stop_tty()`** — would leak non-blocking semantics back to the client's stdin and parent shell, breaking interactive shells after detach.
- **Reopening `c->fd` via `openat("/proc/self/fd/N", O_RDWR|O_NONBLOCK)`** — would give the server an independent `struct file`, but is Linux-specific and a larger change.
- **`poll(POLLOUT, 0)` pre-check** — POSIX doesn't guarantee a subsequent `write()` of more than 1 byte won't block, so it's not by itself sufficient.

The chosen approach — `fcntl(F_SETFL, O_NONBLOCK)` immediately before the write — works on every platform tmux supports and is independent of how the fd ended up blocking.

## Trade-off

The race window where the client's stdin also reads as non-blocking is bounded to one `writev()` call (microseconds). For tty stdin this is benign: cooked-mode reads in the client process are paced by `VMIN`/`VTIME` line-discipline timing, not `O_NONBLOCK`, so a brief flip is invisible. Only programs doing direct `read()` on raw-mode stdin during that microsecond window could observe an `EAGAIN`; in practice nothing else in the system shares this struct file in that pattern.

The patch is purely additive — it does not change `tty_stop_tty()`'s blocking-restore behavior, so the contract with the client process and its parent shell is unchanged on the happy path.

## Test plan

- `make` cleanly: ✓
- Smoke: `./tmux -L smoketest new-session -d -s test`; `list-sessions`; `kill-server` → all return immediately: ✓
- The in-the-wild wedge that motivated this patch was fixed by killing the orphan `etterminal`; with this patch in place, the same scenario would yield `EAGAIN` on the next `writev` instead of an indefinite kernel sleep.
- Verified empirically that `pwritev2(RWF_NOWAIT)` and other per-syscall non-blocking primitives don't apply to ttys, justifying the per-write `fcntl` approach: see the `poll(POLLOUT, 0)` + `pwritev2 RWF_NOWAIT` test results in the linked discussion.

## Diff

Two call sites, one new helper, 31 lines added, 0 removed.
