### PR TITLE
Unescape #: in format modifier arguments

### DIFF
--- a/format.c
+++ b/format.c
@@ -4327,7 +4327,7 @@ format_build_modifiers(struct format_expand_state *es, const char **s,
 {
 	const char		*cp = *s, *end;
 	struct format_modifier	*list = NULL;
-	char			 c, last[] = "X;:", **argv, *value;
+	char			 c, last[] = "X;:", **argv, *value, *unescaped;
 	int			 argc;
 
 	/*
@@ -4394,8 +4394,10 @@ format_build_modifiers(struct format_expand_state *es, const char **s,
 
 			argv = xcalloc(1, sizeof *argv);
 			value = xstrndup(cp + 1, end - (cp + 1));
-			argv[0] = format_expand1(es, value);
+			unescaped = format_unescape(es, value);
 			free(value);
+			argv[0] = format_expand1(es, unescaped);
+			free(unescaped);
 			argc = 1;
 
 			format_add_modifier(&list, count, &c, 1, argv, argc);
@@ -4418,8 +4420,10 @@ format_build_modifiers(struct format_expand_state *es, const char **s,
 
 			argv = xreallocarray(argv, argc + 1, sizeof *argv);
 			value = xstrndup(cp, end - cp);
-			argv[argc++] = format_expand1(es, value);
+			unescaped = format_unescape(es, value);
 			free(value);
+			argv[argc++] = format_expand1(es, unescaped);
+			free(unescaped);
 
 			cp = end;
 		} while (!format_is_end(cp[0]));

--- a/regress/format-strings.sh
+++ b/regress/format-strings.sh
@@ -231,4 +231,9 @@ test_format "#{l:#{#}}}" "#{#}}"
 #test_format "#{l:#{}" ""
 #test_format "#{l:#{#}}" ""
 
+# Substitution modifier with escaped colons in pattern and replacement.
+$TMUX set @colon 'foo:bar' || exit 1
+test_format "#{s/#:/_/:@colon}" "foo_bar"
+test_format "#{s/o/#:/:@colon}" "f:::bar"
+
 exit 0


### PR DESCRIPTION
Fixes #4073.

#: is used to escape : in format modifiers like #{s/#:/_/:@v},
but after format_skip1() handles the escape during parsing, the raw
#: string was passed to format_expand1() which left it unchanged.

Run modifier arguments through format_unescape() before expansion,
so #: correctly becomes : in substitution patterns and replacements.

Also add test cases for escaped colons in regress/format-strings.sh.