### PR TITLE
Gate tty_write on MODE_SYNC to fix #4983

### DIFF
--- a/tty.c
+++ b/tty.c
@@ -1587,6 +1587,11 @@ tty_write(void (*cmdfn)(struct tty *, const struct tty_ctx *),
 				break;
 			if (state == 0)
 				continue;
+			if (ctx->s != NULL && (ctx->s->mode & MODE_SYNC) &&
+			    cmdfn != tty_cmd_syncstart &&
+			    cmdfn != tty_cmd_setselection &&
+			    cmdfn != tty_cmd_rawstring)
+				continue;
 			cmdfn(&c->tty, ctx);
 		}
 	}


### PR DESCRIPTION
Fixes #4983.

When an application wraps a redraw in DECSET 2026 synchronized updates and the bytes span more than one `input_parse_buffer` call, structural commands like clearscreen reach the outer terminal even though cell writes are already dropped by `screen_write_collect_flush`.

This causes the outer terminal to commit a partial intermediate frame (e.g. an empty screen) instead of waiting for the atomic transition.

Fix by gating `tty_write` itself on `MODE_SYNC`, with a small bypass list for commands that need to reach the terminal during sync:
- `tty_cmd_syncstart`: so tmux can start its own sync on the outer terminal
- `tty_cmd_setselection`: OSC 52 clipboard side-channel
- `tty_cmd_rawstring`: DCS and other passthrough sequences

This also fixes two pre-existing holes in the cell path:
- `screen_write_cell:2170` (`tty_cmd_insertcharacter` leaked in MODE_INSERT)
- `screen_write_combine:2293` (`tty_cmd_cell` leaked for combining chars)