### PR TITLE
Make send-keys target windows consistently for bare numbers (#4850)

### DIFF
--- a/cmd-send-keys.c
+++ b/cmd-send-keys.c
@@ -37,7 +37,7 @@ const struct cmd_entry cmd_send_keys_entry = {
 	.usage = "[-FHKlMRX] [-c target-client] [-N repeat-count] "
 	         CMD_TARGET_PANE_USAGE " [key ...]",
 
-	.target = { 't', CMD_FIND_PANE, 0 },
+	.target = { 't', CMD_FIND_WINDOW, 0 },
 
 	.flags = CMD_AFTERHOOK|CMD_CLIENT_CFLAG|CMD_CLIENT_CANFAIL|
 		 CMD_READONLY,
@@ -51,7 +51,7 @@ const struct cmd_entry cmd_send_prefix_entry = {
 	.args = { "2t:", 0, 0, NULL },
 	.usage = "[-2] " CMD_TARGET_PANE_USAGE,
 
-	.target = { 't', CMD_FIND_PANE, 0 },
+	.target = { 't', CMD_FIND_WINDOW, 0 },
 
 	.flags = CMD_AFTERHOOK,
 	.exec = cmd_send_keys_exec


### PR DESCRIPTION
Fixes #4850.

The argument parsing for -t doesn't handle the value 0 well. `send-keys -t 0` sent the keys to the current window's pane 0, not window 0's active pane. This is because bare numbers were treated as pane indices for CMD_FIND_PANE, and pane 0 always exists in the current window.

For send-keys and send-prefix, a bare number should be a window index (matching the documented target-pane syntax). Change their target type from CMD_FIND_PANE to CMD_FIND_WINDOW so that -t 0, -t 1, etc. consistently target windows.

Explicit pane syntax (%1, .1, window.1) is still fully supported because cmd_find_target handles % and . prefixes as pane targets regardless of the base target type.