### PR TITLE
Only send SIGWINCH when pane terminal size actually changes (#4187)

### DIFF
--- a/window.c
+++ b/window.c
@@ -444,6 +444,10 @@ window_pane_send_resize(struct window_pane *wp, u_int sx, u_int sy)
 
 	log_debug("%s: %%%u resize to %u,%u", __func__, wp->id, sx, sy);
 
+	if (ioctl(wp->fd, TIOCGWINSZ, &ws) != -1 &&
+	    ws.ws_col == sx && ws.ws_row == sy)
+		return;
+
 	memset(&ws, 0, sizeof ws);
 	ws.ws_col = sx;
 	ws.ws_row = sy;


### PR DESCRIPTION
Fixes #4187.

When switching between zoomed panes with `select-pane -Z`, tmux sends SIGWINCH even though the visible pane size is not changing. This causes programs like scp to mess up their progress output.

Add a TIOCGWINSZ check in `window_pane_send_resize` before issuing TIOCSWINSZ. If the terminal already has the requested dimensions, skip the ioctl entirely. This is the robust fix because it handles all cases where tmux's internal size tracking and the terminal's actual size might diverge.