### PR TITLE
Preserve OSC133 prompt markers when clearing entire lines (#4918)

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -1308,6 +1308,7 @@ screen_write_clearline(struct screen_write_ctx *ctx, u_int bg)
 	struct grid_line		*gl;
 	u_int				 sx = screen_size_x(s);
 	struct screen_write_citem	*ci = ctx->item;
+	u_int				 flags;
 
 	gl = grid_get_line(s->grid, s->grid->hsize + s->cy);
 	if (gl->cellsize == 0 && COLOUR_DEFAULT(bg))
@@ -1318,7 +1319,10 @@ screen_write_clearline(struct screen_write_ctx *ctx, u_int bg)
 		ctx->wp->flags |= PANE_REDRAW;
 #endif
 
+	flags = gl->flags & (GRID_LINE_START_PROMPT|GRID_LINE_START_OUTPUT);
 	grid_view_clear(s->grid, 0, s->cy, sx, 1, bg);
+	gl = grid_get_line(s->grid, s->grid->hsize + s->cy);
+	gl->flags |= flags;
 
 	screen_write_collect_clear(ctx, s->cy, 1);
 	ci->x = 0;


### PR DESCRIPTION
Fixes #4918.

When zsh or fish emits EL0 (CSI K) at column 0, tmux calls `screen_write_clearline` which clears the entire line including OSC133 markers (GRID_LINE_START_PROMPT / GRID_LINE_START_OUTPUT). This causes `previous-prompt` / `next-prompt` in copy mode to skip prompts where the user backspaced to the beginning of the line before typing a new command.

Save and restore the OSC133 flags in `screen_write_clearline` so they survive full-line clears. `screen_write_clearendofline` and `screen_write_clearstartofline` already delegate to `screen_write_clearline` in the edge cases where the cursor is at the line boundary, so they are fixed automatically.