### PR TITLE
Wait for more input when key sequence prefix is torn across reads (#5089)

### DIFF
--- a/tty-keys.c
+++ b/tty-keys.c
@@ -633,6 +633,14 @@ tty_keys_next1(struct tty *tty, const char *buf, size_t len, key_code *key,
 		return (0);
 	}
 
+	/*
+	 * Is this a partial key? If we have matched a prefix of a known key,
+	 * wait for more data. Do not wait for a lone escape.
+	 */
+	if (tk != NULL && tk->key == KEYC_UNKNOWN && tk->next != NULL &&
+	    !expired && *size > 1)
+		return (1);
+
 	/* Is this valid UTF-8? */
 	more = utf8_open(&ud, (u_char)*buf);
 	if (more == UTF8_MORE) {


### PR DESCRIPTION
Fixes #5089.

When a large paste splits the bracketed-paste end sequence `\e[201~` across multiple reads (e.g. `\e[` at the end of one chunk, `201~` at the start of the next), the client-side key parser would consume `\e[` as the single key M-[ because it did not recognize the prefix as incomplete. The remaining `201~` then had no leading `\e[`, so KEYC_PASTE_END was never generated. CLIENT_BRACKETPASTING stayed set forever, causing every subsequent keystroke—including the tmux prefix key—to be forwarded as paste data.

Add a check in `tty_keys_next1()` to return "partial" when the buffer matches a prefix in the key tree that is not itself a valid key but has longer sequences sharing that prefix, and the escape timer has not expired. The `*> 1` guard intentionally excludes a lone ESC so the Escape key is not delayed.

When more data arrives before the timer expires, the full `\e[201~` is assembled and correctly recognized. If the timer expires first, the bytes are consumed as before, preserving backward compatibility.