### PR TITLE
Fix underflow in pane status redraw with left scrollbars (#5063)

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -571,7 +571,7 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 			/* Right not visible. */
 			i = 0;
 			x = xoff - ctx->ox;
-			width = size - x;
+			width = ctx->sx - x;
 		}
 
 		if (ctx->statustop)


### PR DESCRIPTION
Fixes #5063.

When pane-scrollbars-position is left and pane-border-status is not off, the pane-border status line can extend past the right edge of the screen. In `screen_redraw_draw_pane_status`, the "right not visible" branch computes `width = size - x`, where `x` is the on-screen offset of the status line. When `x > size`, this unsigned subtraction wraps around to a huge value like 4294967290, causing `tty_draw_line` to loop almost forever.

Use `ctx->sx - x` instead, which clips to the visible screen boundary and prevents underflow. This matches how `screen_redraw_draw_pane` already handles the same case.