### PR TITLE
Fix copy-selection inserting newlines at soft-wrap boundaries (#4995)

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -898,9 +898,9 @@ window_copy_get_line(struct window_pane *wp, u_int y)
 {
 	struct window_mode_entry	*wme = TAILQ_FIRST(&wp->modes);
 	struct window_copy_mode_data	*data = wme->data;
-	struct grid			*gd = data->screen.grid;
+	struct grid			*gd = data->backing->grid;
 
-	return (format_grid_line(gd, gd->hsize + y));
+	return (format_grid_line(gd, gd->hsize + y - data->oy));
 }
 
 char *
@@ -5588,13 +5588,15 @@ window_copy_copy_line(struct window_mode_entry *wme, char **buf, size_t *off,
 	 * on screen.
 	 */
 	gl = grid_get_line(gd, sy);
-	if (gl->flags & GRID_LINE_WRAPPED && gl->cellsize <= gd->sx)
+	if (gl->flags & GRID_LINE_WRAPPED)
 		wrapped = 1;
 
 	/* If the line was wrapped, don't strip spaces (use the full length). */
-	if (wrapped)
+	if (wrapped) {
 		xx = gl->cellsize;
-	else
+		if (xx > gd->sx)
+			xx = gd->sx;
+	} else
 		xx = window_copy_find_length(wme, sy);
 	if (ex > xx)
 		ex = xx;


### PR DESCRIPTION
Fixes #4995.

When a logical line is longer than the pane width and soft-wraps, copy-selection inserts a newline at the wrap point because it operates on `data->screen.grid`, which does not preserve GRID_LINE_WRAPPED from the backing grid. Similarly, trailing padding spaces sometimes replace newlines.

Remove the overly restrictive `gl->cellsize <= gd->sx` guard in `window_copy_copy_line` so that GRID_LINE_WRAPPED is respected directly, matching the behavior of `capture-pane -J`. Also switch `window_copy_get_line` from `data->screen.grid` to `data->backing->grid` for consistency with the #4447 fix for word selection.