### PR TITLE
Skip redundant scrollbar redraws to fix nano flicker (#4772)

### DIFF
--- a/options.c
+++ b/options.c
@@ -1244,6 +1244,8 @@ options_push_changes(const char *name)
 		RB_FOREACH(wp, window_pane_tree, &all_window_panes) {
 			style_set_scrollbar_style_from_option(
 			    &wp->scrollbar_style, wp->options);
+			wp->sb_x = wp->sb_y = wp->sb_slider_y =
+			    wp->sb_slider_h = 0;
 		}
 		RB_FOREACH(w, windows, &windows)
 			layout_fix_panes(w, NULL);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1087,10 +1087,20 @@ screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *ctx,
 	if (slider_y >= sb_h)
 		slider_y = sb_h - 1;
 
+	if (ctx->statustop)
+		sb_y += ctx->statuslines;
+
+	/* Skip redraw if scrollbar position and slider have not changed. */
+	if (sb_x == wp->sb_x && sb_y == wp->sb_y &&
+	    slider_y == wp->sb_slider_y && slider_h == wp->sb_slider_h)
+		return;
+
 	screen_redraw_draw_scrollbar(ctx, wp, sb_pos, sb_x, sb_y, sb_h,
 	    slider_h, slider_y);
 
 	/* Store current position and height of the slider */
+	wp->sb_x = sb_x;
+	wp->sb_y = sb_y;
 	wp->sb_slider_y = slider_y;  /* top of slider y pos in scrollbar */
 	wp->sb_slider_h = slider_h;  /* height of slider */
 }

--- a/tmux.h
+++ b/tmux.h
@@ -1281,6 +1281,8 @@ struct window_pane {
 
 	u_int		 sb_slider_y;
 	u_int		 sb_slider_h;
+	int		 sb_x;
+	int		 sb_y;
 
 	int		 argc;
 	char	       **argv;
@@ -2037,6 +2039,7 @@ struct client {
 	size_t			 redraw;
 
 	struct event		 repeat_timer;
+	struct event		 paste_timer;
 
 	struct event		 click_timer;
 	int			 click_loc;
@@ -3132,6 +3135,10 @@ void	 input_reply_clipboard(struct bufferevent *, const char *, size_t,
 	     const char *, char);
 void	 input_set_buffer_size(size_t);
 void	 input_request_reply(struct client *, enum input_request_type, void *);
+int	 input_reflow_start(struct input_ctx *, struct grid *, u_int, u_int,
+	     u_int *, u_int *);
+void	 input_reflow_finish(struct input_ctx *, struct grid *, u_int, u_int,
+	     u_int, u_int);
 void	 input_cancel_requests(struct client *);
 
 /* input-key.c */


### PR DESCRIPTION
Fixes #4772.

When pane-scrollbars is enabled, full-screen programs like nano that update frequently cause the scrollbar to be redrawn 1-2 times per second. Each redraw emits cursor-movement and cell-write sequences, which on some terminals produces visible flicker.

Add a cache in `screen_redraw_draw_pane_scrollbar` to skip the draw when sb_x, sb_y, slider_y, and slider_h are all unchanged from the previous frame. Invalidate the cache when `pane-scrollbars-style` changes.

Also move the `ctx->statustop` adjustment for sb_y from `screen_redraw_draw_scrollbar` into `screen_redraw_draw_pane_scrollbar` so that the cache comparison uses the actual screen coordinates.