### PR TITLE
Reflow saved cursor position during pane resize (#4366)

### DIFF
--- a/input.c
+++ b/input.c
@@ -853,6 +853,50 @@ input_restore_state(struct input_ctx *ictx)
 	screen_write_cursormove(sctx, ictx->old_cx, ictx->old_cy, 0);
 }
 
+/*
+ * Start reflowing the saved cursor. Returns 1 if there is a saved cursor to
+ * reflow and fills wx,wy with the wrapped position. Returns 0 if not.
+ */
+int
+input_reflow_start(struct input_ctx *ictx, struct grid *gd, u_int old_sx,
+    u_int hsize, u_int *wx, u_int *wy)
+{
+	u_int	old_cx, old_cy;
+
+	if (ictx->old_cx == UINT_MAX || ictx->old_cy == UINT_MAX)
+		return (0);
+
+	old_cx = ictx->old_cx;
+	old_cy = hsize + ictx->old_cy;
+	if (old_cx == old_sx)
+		old_cx = old_sx - 1;
+
+	grid_wrap_position(gd, old_cx, old_cy, wx, wy);
+	return (1);
+}
+
+/*
+ * Finish reflowing the saved cursor after the grid has been resized. wx,wy is
+ * the wrapped position from input_reflow_start.
+ */
+void
+input_reflow_finish(struct input_ctx *ictx, struct grid *gd, u_int sx,
+    u_int hsize, u_int wx, u_int wy)
+{
+	u_int	old_cx, old_cy;
+
+	grid_unwrap_position(gd, &old_cx, &old_cy, wx, wy);
+	if (old_cy >= hsize) {
+		ictx->old_cx = old_cx;
+		ictx->old_cy = old_cy - hsize;
+	} else {
+		ictx->old_cx = 0;
+		ictx->old_cy = 0;
+	}
+	if (ictx->old_cx >= sx)
+		ictx->old_cx = sx - 1;
+}
+
 /* Initialise input parser. */
 struct input_ctx *
 input_init(struct window_pane *wp, struct bufferevent *bev,

--- a/screen.c
+++ b/screen.c
@@ -339,6 +339,7 @@ screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
     int eat_empty, int cursor)
 {
 	u_int	cx = s->cx, cy = s->grid->hsize + s->cy;
+	u_int	old_sx = screen_size_x(s);
 
 	if (s->write_list != NULL)
 		screen_write_free_list(s);
@@ -365,8 +366,15 @@ screen_resize_cursor(struct screen *s, u_int sx, u_int sy, int reflow,
 	image_free_all(s);
 #endif
 
-	if (reflow)
+	if (reflow) {
+		if (cursor && cx == old_sx) {
+			log_debug("%s: reset pending wrap for cursor", __func__);
+			cx = old_sx - 1;
+		}
 		screen_reflow(s, sx, &cx, &cy, cursor);
+		if (cursor && cx == sx)
+			cx = sx - 1;
+	}
 
 	if (cy >= s->grid->hsize) {
 		s->cx = cx;

--- a/tmux.h
+++ b/tmux.h
@@ -1281,6 +1281,8 @@ struct window_pane {
 
 	u_int		 sb_slider_y;
 	u_int		 sb_slider_h;
+	int		 sb_x;
+	int		 sb_y;
 
 	int		 argc;
 	char	       **argv;
@@ -2037,6 +2039,7 @@ struct client {
 	size_t			 redraw;
 
 	struct event		 repeat_timer;
+	struct event		 paste_timer;
 
 	struct event		 click_timer;
 	int			 click_loc;
@@ -3132,6 +3135,10 @@ void	 input_reply_clipboard(struct bufferevent *, const char *, size_t,
 	     const char *, char);
 void	 input_set_buffer_size(size_t);
 void	 input_request_reply(struct client *, enum input_request_type, void *);
+int	 input_reflow_start(struct input_ctx *, struct grid *, u_int, u_int,
+	     u_int *, u_int *);
+void	 input_reflow_finish(struct input_ctx *, struct grid *, u_int, u_int,
+	     u_int, u_int);
 void	 input_cancel_requests(struct client *);
 
 /* input-key.c */

--- a/window.c
+++ b/window.c
@@ -1114,6 +1114,9 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 {
 	struct window_mode_entry	*wme;
 	struct window_pane_resize	*r;
+	u_int				 wx = 0, wy = 0;
+	u_int				 old_sx;
+	int				 saved_reflow = 0;
 
 	if (sx == wp->sx && sy == wp->sy)
 		return;
@@ -1131,7 +1134,19 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 	wp->sy = sy;
 
 	log_debug("%s: %%%u resize %ux%u", __func__, wp->id, sx, sy);
+
+	old_sx = screen_size_x(&wp->base);
+	if (wp->ictx != NULL) {
+		saved_reflow = input_reflow_start(wp->ictx, wp->base.grid, old_sx,
+		    wp->base.grid->hsize, &wx, &wy);
+	}
+
 	screen_resize(&wp->base, sx, sy, wp->base.saved_grid == NULL);
+
+	if (saved_reflow) {
+		input_reflow_finish(wp->ictx, wp->base.grid, sx,
+		    wp->base.grid->hsize, wx, wy);
+	}
 
 	wme = TAILQ_FIRST(&wp->modes);
 	if (wme != NULL && wme->mode->resize != NULL)


### PR DESCRIPTION
Fixes #4366.

When an application saves the cursor with DECSC (ESC 7), the terminal is resized (causing text reflow), and then the cursor is restored with DECRC (ESC 8), the restored cursor position may be incorrect. This can cause prior shell output to be overwritten.

Add `input_reflow_start` / `input_reflow_finish` helpers that convert the saved cursor to wrapped coordinates before reflow and back after reflow. Call them from `window_pane_resize` around `screen_resize`.

Also reset pending wrap state for the current cursor before and after reflow in `screen_resize_cursor`, matching the behavior of libvte.