### PR TITLE
refactor(floating_panes): Changed 'minimised' semantics to 'hide' semantics

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,6 +102,7 @@ dist_tmux_SOURCES = \
 	cmd-display-panes.c \
 	cmd-find-window.c \
 	cmd-find.c \
+	cmd-hide-pane.c \
 	cmd-if-shell.c \
 	cmd-join-pane.c \
 	cmd-kill-pane.c \
@@ -117,7 +118,6 @@ dist_tmux_SOURCES = \
 	cmd-list-windows.c \
 	cmd-load-buffer.c \
 	cmd-lock-server.c \
-	cmd-minimise-pane.c \
 	cmd-move-window.c \
 	cmd-new-session.c \
 	cmd-new-window.c \

--- a/cmd-hide-pane.c
+++ b/cmd-hide-pane.c
@@ -1,7 +1,7 @@
 /* $OpenBSD$ */
 
 /*
- * Copyright (c) 2009 Nicholas Marriott <nicholas.marriott@gmail.com>
+ * Copyright (c) 2026 Michael Grant <mgrant@gmail.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -24,19 +24,19 @@
 #include "tmux.h"
 
 /*
- * Increase or decrease pane size.
+ * Hide or show panes.
  */
 
-static enum cmd_retval cmd_minimise_pane_minimise_exec(struct cmd *, struct cmdq_item *);
-static enum cmd_retval cmd_minimise_pane_unminimise_exec(struct cmd *, struct cmdq_item *);
+static enum cmd_retval cmd_hide_pane_hide_exec(struct cmd *, struct cmdq_item *);
+static enum cmd_retval cmd_hide_pane_show_exec(struct cmd *, struct cmdq_item *);
 
-static enum cmd_retval cmd_minimise_pane_minimise(struct window *, struct window_pane *,
+static enum cmd_retval cmd_hide_pane_hide(struct window *, struct window_pane *,
     struct cmdq_item *);
-static enum cmd_retval cmd_minimise_pane_unminimise(struct window *, struct window_pane *);
+static enum cmd_retval cmd_hide_pane_show(struct window *, struct window_pane *);
 
-const struct cmd_entry cmd_minimise_pane_entry = {
-	.name = "minimise-pane",
-	.alias = "minimize-pane",
+const struct cmd_entry cmd_hide_pane_entry = {
+	.name = "hide-pane",
+	.alias = "hidep",
 
 	.args = { "at:", 0, 1, NULL },
 	.usage = "[-a] " CMD_TARGET_PANE_USAGE,
@@ -44,12 +44,12 @@ const struct cmd_entry cmd_minimise_pane_entry = {
 	.target = { 't', CMD_FIND_PANE, 0 },
 
 	.flags = CMD_AFTERHOOK,
-	.exec = cmd_minimise_pane_minimise_exec
+	.exec = cmd_hide_pane_hide_exec
 };
 
-const struct cmd_entry cmd_unminimise_pane_entry = {
-	.name = "unminimise-pane",
-	.alias = "unminimize-pane",
+const struct cmd_entry cmd_show_pane_entry = {
+	.name = "show-pane",
+	.alias = "showp",
 
 	.args = { "at:", 0, 1, NULL },
 	.usage = "[-a] " CMD_TARGET_PANE_USAGE,
@@ -57,28 +57,27 @@ const struct cmd_entry cmd_unminimise_pane_entry = {
 	.target = { 't', CMD_FIND_PANE, 0 },
 
 	.flags = CMD_AFTERHOOK,
-	.exec = cmd_minimise_pane_unminimise_exec
+	.exec = cmd_hide_pane_show_exec
 };
 
 
 static enum cmd_retval
-cmd_minimise_pane_minimise_exec(struct cmd *self, struct cmdq_item *item)
+cmd_hide_pane_hide_exec(struct cmd *self, struct cmdq_item *item)
 {
-	__attribute((unused)) struct args	*args = cmd_get_args(self);
-	struct cmd_find_state			*target = cmdq_get_target(item);
-	struct winlink				*wl = target->wl;
-	struct window				*w = wl->window;
-	struct window_pane			*wp;
-	u_int					 id;
-	char					*cause = NULL;
-	enum cmd_retval				 rv;
+	struct args		*args = cmd_get_args(self);
+	struct cmd_find_state	*target = cmdq_get_target(item);
+	struct winlink		*wl = target->wl;
+	struct window		*w = wl->window;
+	struct window_pane	*wp, *active_pane = w->active;
+	u_int			 id;
+	char			*cause = NULL;
+	enum cmd_retval		 rv;
 
 	if (args_has(args, 'a')) {
-		struct window_pane *active_pane = w->active;
 		TAILQ_FOREACH(wp, &w->z_index, zentry) {
 			if (!window_pane_visible(wp) || wp == active_pane)
 				continue;
-			rv = cmd_minimise_pane_minimise(w, wp, item);
+			rv = cmd_hide_pane_hide(w, wp, item);
 			if (rv != CMD_RETURN_NORMAL)
 				return (rv);
 		}
@@ -86,7 +85,8 @@ cmd_minimise_pane_minimise_exec(struct cmd *self, struct cmdq_item *item)
 	} else {
 		wp = target->wp;
 		if (wp == NULL) {
-			id = args_strtonum_and_expand(args, 't', 0, INT_MAX, item, &cause);
+			id = args_strtonum_and_expand(args, 't', 0, INT_MAX,
+			    item, &cause);
 			if (cause != NULL) {
 				cmdq_error(item, "%s target pane", cause);
 				return (CMD_RETURN_ERROR);
@@ -94,30 +94,30 @@ cmd_minimise_pane_minimise_exec(struct cmd *self, struct cmdq_item *item)
 			wp = window_pane_find_by_id(id);
 		}
 		if (wp == NULL) {
-			cmdq_error(item, "No target pane to miminise.");
+			cmdq_error(item, "No target pane to hide.");
 			return (CMD_RETURN_ERROR);
 		}
-		return (cmd_minimise_pane_minimise(w, wp, item));
+		return (cmd_hide_pane_hide(w, wp, item));
 	}
 }
 
 static enum cmd_retval
-cmd_minimise_pane_unminimise_exec(struct cmd *self, struct cmdq_item *item)
+cmd_hide_pane_show_exec(struct cmd *self, struct cmdq_item *item)
 {
-	__attribute((unused)) struct args	*args = cmd_get_args(self);
-	struct cmd_find_state			*target = cmdq_get_target(item);
-	struct winlink				*wl = target->wl;
-	struct window				*w = wl->window;
-	struct window_pane			*wp;
-	u_int					 id;
-	char					*cause = NULL;
-	enum cmd_retval				 rv;
+	struct args		*args = cmd_get_args(self);
+	struct cmd_find_state	*target = cmdq_get_target(item);
+	struct winlink		*wl = target->wl;
+	struct window		*w = wl->window;
+	struct window_pane	*wp;
+	u_int			 id;
+	char			*cause = NULL;
+	enum cmd_retval		 rv;
 
 	if (args_has(args, 'a')) {
 		TAILQ_FOREACH(wp, &w->z_index, zentry) {
 			if (!window_pane_visible(wp))
 				continue;
-			rv = cmd_minimise_pane_unminimise(w, wp);
+			rv = cmd_hide_pane_show(w, wp);
 			if (rv != CMD_RETURN_NORMAL)
 				return (rv);
 		}
@@ -125,7 +125,8 @@ cmd_minimise_pane_unminimise_exec(struct cmd *self, struct cmdq_item *item)
 	} else {
 		wp = target->wp;
 		if (wp == NULL) {
-			id = args_strtonum_and_expand(args, 't', 0, INT_MAX, item, &cause);
+			id = args_strtonum_and_expand(args, 't', 0, INT_MAX,
+			    item, &cause);
 			if (cause != NULL) {
 				cmdq_error(item, "%s target pane", cause);
 				return (CMD_RETURN_ERROR);
@@ -133,20 +134,20 @@ cmd_minimise_pane_unminimise_exec(struct cmd *self, struct cmdq_item *item)
 			wp = window_pane_find_by_id(id);
 		}
 		if (wp == NULL) {
-			cmdq_error(item, "No target pane to unmiminise.");
+			cmdq_error(item, "No target pane to show.");
 			return (CMD_RETURN_ERROR);
 		}
-		return (cmd_minimise_pane_unminimise(w, wp));
+		return (cmd_hide_pane_show(w, wp));
 	}
 }
 
 static enum cmd_retval
-cmd_minimise_pane_minimise(struct window *w, struct window_pane *wp,
-    __attribute__((unused)) struct cmdq_item *item)
+cmd_hide_pane_hide(struct window *w, struct window_pane *wp,
+    __unused struct cmdq_item *item)
 {
 	struct window_pane	*pwp = NULL;
 
-	if (wp->flags & PANE_MINIMISED)
+	if (wp->flags & PANE_HIDDEN)
 		return (CMD_RETURN_NORMAL);
 
 	if (wp == w->active) {
@@ -170,11 +171,11 @@ cmd_minimise_pane_minimise(struct window *w, struct window_pane *wp,
 		}
 	}
 
-	wp->flags |= PANE_MINIMISED;
+	wp->flags |= PANE_HIDDEN;
 
 	if (w->layout_root != NULL) {
 		wp->saved_layout_cell = wp->layout_cell;
-		layout_minimise_cell(w, wp->layout_cell);
+		layout_hide_cell(w, wp->layout_cell);
 		layout_fix_offsets(w);
 		layout_fix_panes(w, NULL);
 	}
@@ -200,15 +201,15 @@ cmd_minimise_pane_minimise(struct window *w, struct window_pane *wp,
 }
 
 static enum cmd_retval
-cmd_minimise_pane_unminimise(struct window *w, struct window_pane *wp)
+cmd_hide_pane_show(struct window *w, struct window_pane *wp)
 {
-	wp->flags &= ~PANE_MINIMISED;
+	wp->flags &= ~PANE_HIDDEN;
 
 	/* Fix pane offsets and sizes. */
 	if (w->layout_root != NULL && wp->saved_layout_cell != NULL) {
 		wp->layout_cell = wp->saved_layout_cell;
 		wp->saved_layout_cell = NULL;
-		layout_unminimise_cell(w, wp->layout_cell);
+		layout_show_cell(w, wp->layout_cell);
 		layout_fix_offsets(w);
 		layout_fix_panes(w, NULL);
 	}

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -110,8 +110,8 @@ cmd_split_window_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	if (wp->flags & PANE_MINIMISED) {
-		cmdq_error(item, "can't split a minimised pane");
+	if (wp->flags & PANE_HIDDEN) {
+		cmdq_error(item, "can't split a hidden pane");
 		return (NULL);
 	}
 

--- a/cmd-tile-float-pane.c
+++ b/cmd-tile-float-pane.c
@@ -28,7 +28,7 @@
  * tile-pane: insert a floating pane back into the tiled layout.
  *
  * saved_layout_cell is reused to remember the pane's tiled slot while it is
- * floating, using the same mechanism as minimise-pane.  The cell's wp pointer
+ * floating, using the same mechanism as hide-pane.  The cell's wp pointer
  * is cleared while the pane is floating so that layout helpers treat the slot
  * as empty.
  */
@@ -163,8 +163,8 @@ cmd_float_pane_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "pane is already floating");
 		return (CMD_RETURN_ERROR);
 	}
-	if (wp->flags & PANE_MINIMISED) {
-		cmdq_error(item, "can't float a minimised pane");
+	if (wp->flags & PANE_HIDDEN) {
+		cmdq_error(item, "can't float a hidden pane");
 		return (CMD_RETURN_ERROR);
 	}
 	if (w->flags & WINDOW_ZOOMED) {
@@ -229,7 +229,7 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane			*wp = target->wp;
 	struct window_pane	*target_wp, *wpiter;
 	struct layout_cell	*float_lc, *lc;
-	int			 was_minimised;
+	int			 was_hidden;
 
 	if (!(wp->flags & PANE_FLOATING)) {
 		cmdq_error(item, "pane is not floating");
@@ -240,7 +240,7 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-	was_minimised = (wp->flags & PANE_MINIMISED) != 0;
+	was_hidden = (wp->flags & PANE_HIDDEN) != 0;
 
 	/*
 	 * Save the floating geometry so we can restore it next time this pane
@@ -254,10 +254,10 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	wp->flags |= PANE_SAVED_FLOAT;
 
 	/*
-	 * If the pane is also minimised, clear saved_layout_cell before
+	 * If the pane is also hidden, clear saved_layout_cell before
 	 * freeing the floating cell — otherwise the pointer would dangle.
 	 */
-	if (was_minimised)
+	if (was_hidden)
 		wp->saved_layout_cell = NULL;
 
 	/*
@@ -270,17 +270,17 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	/*
 	 * Find the best tiled pane to split after, prefer a visible (non-
-	 * minimised) tiled pane.  If all tiled panes are minimised, fall back
+	 * hidden) tiled pane.  If all tiled panes are hidden, fall back
 	 * to any tiled pane so the new pane enters the existing tree rather
 	 * than becoming a disconnected root.
 	 */
 	target_wp = NULL;
 	if (w->active != NULL && !(w->active->flags & PANE_FLOATING) &&
-	    !(w->active->flags & PANE_MINIMISED))
+	    !(w->active->flags & PANE_HIDDEN))
 		target_wp = w->active;
 	if (target_wp == NULL) {
 		TAILQ_FOREACH(wpiter, &w->last_panes, sentry) {
-			if (!(wpiter->flags & (PANE_FLOATING|PANE_MINIMISED)) &&
+			if (!(wpiter->flags & (PANE_FLOATING|PANE_HIDDEN)) &&
 			    window_pane_visible(wpiter)) {
 				target_wp = wpiter;
 				break;
@@ -289,14 +289,14 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	if (target_wp == NULL) {
 		TAILQ_FOREACH(wpiter, &w->panes, entry) {
-			if (!(wpiter->flags & (PANE_FLOATING|PANE_MINIMISED)) &&
+			if (!(wpiter->flags & (PANE_FLOATING|PANE_HIDDEN)) &&
 			    window_pane_visible(wpiter)) {
 				target_wp = wpiter;
 				break;
 			}
 		}
 	}
-	/* Fall back to any tiled pane (even minimised) to stay in the tree. */
+	/* Fall back to any tiled pane (even hidden) to stay in the tree. */
 	if (target_wp == NULL) {
 		TAILQ_FOREACH(wpiter, &w->panes, entry) {
 			if (!(wpiter->flags & PANE_FLOATING)) {
@@ -338,17 +338,17 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	/*
-	 * If the pane was minimised while floating, record its new tiled cell
-	 * as the saved cell so unminimise can restore it correctly.
+	 * If the pane was hidden while floating, record its new tiled cell
+	 * as the saved cell so 'show' can restore it correctly.
 	 */
-	if (was_minimised)
+	if (was_hidden)
 		wp->saved_layout_cell = wp->layout_cell;
 
 	wp->flags &= ~PANE_FLOATING;
 	TAILQ_REMOVE(&w->z_index, wp, zentry);
 	TAILQ_INSERT_TAIL(&w->z_index, wp, zentry);
 
-	if (!(wp->flags & PANE_MINIMISED))
+	if (!(wp->flags & PANE_HIDDEN))
 		window_set_active_pane(w, wp, 1);
 
 	if (w->layout_root != NULL)

--- a/cmd.c
+++ b/cmd.c
@@ -70,7 +70,7 @@ extern const struct cmd_entry cmd_lock_client_entry;
 extern const struct cmd_entry cmd_lock_server_entry;
 extern const struct cmd_entry cmd_lock_session_entry;
 extern const struct cmd_entry cmd_float_pane_entry;
-extern const struct cmd_entry cmd_minimise_pane_entry;
+extern const struct cmd_entry cmd_hide_pane_entry;
 extern const struct cmd_entry cmd_move_pane_entry;
 extern const struct cmd_entry cmd_move_window_entry;
 extern const struct cmd_entry cmd_new_pane_entry;
@@ -108,6 +108,7 @@ extern const struct cmd_entry cmd_show_environment_entry;
 extern const struct cmd_entry cmd_show_hooks_entry;
 extern const struct cmd_entry cmd_show_messages_entry;
 extern const struct cmd_entry cmd_show_options_entry;
+extern const struct cmd_entry cmd_show_pane_entry;
 extern const struct cmd_entry cmd_show_prompt_history_entry;
 extern const struct cmd_entry cmd_show_window_options_entry;
 extern const struct cmd_entry cmd_source_file_entry;
@@ -120,7 +121,6 @@ extern const struct cmd_entry cmd_switch_client_entry;
 extern const struct cmd_entry cmd_unbind_key_entry;
 extern const struct cmd_entry cmd_unlink_window_entry;
 extern const struct cmd_entry cmd_tile_pane_entry;
-extern const struct cmd_entry cmd_unminimise_pane_entry;
 extern const struct cmd_entry cmd_wait_for_entry;
 
 const struct cmd_entry *cmd_table[] = {
@@ -167,7 +167,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_lock_server_entry,
 	&cmd_lock_session_entry,
 	&cmd_float_pane_entry,
-	&cmd_minimise_pane_entry,
+	&cmd_hide_pane_entry,
 	&cmd_move_pane_entry,
 	&cmd_move_window_entry,
 	&cmd_new_pane_entry,
@@ -205,6 +205,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_show_hooks_entry,
 	&cmd_show_messages_entry,
 	&cmd_show_options_entry,
+	&cmd_show_pane_entry,
 	&cmd_show_prompt_history_entry,
 	&cmd_show_window_options_entry,
 	&cmd_source_file_entry,
@@ -217,7 +218,6 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_unbind_key_entry,
 	&cmd_unlink_window_entry,
 	&cmd_tile_pane_entry,
-	&cmd_unminimise_pane_entry,
 	&cmd_wait_for_entry,
 	NULL
 };

--- a/format.c
+++ b/format.c
@@ -2249,14 +2249,14 @@ format_cb_pane_marked_set(struct format_tree *ft)
 	return (NULL);
 }
 
-/* Callback for pane_minimised_flag. */
+/* Callback for pane_hidden_flag. */
 static void *
-format_cb_pane_minimised_flag(struct format_tree *ft)
+format_cb_pane_hidden_flag(struct format_tree *ft)
 {
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL) {
-		if (wp->flags & PANE_MINIMISED)
+		if (wp->flags & PANE_HIDDEN)
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}
@@ -3460,8 +3460,8 @@ static const struct format_table_entry format_table[] = {
 	{ "pane_marked_set", FORMAT_TABLE_STRING,
 	  format_cb_pane_marked_set
 	},
-	{ "pane_minimised_flag", FORMAT_TABLE_STRING,
-	  format_cb_pane_minimised_flag
+	{ "pane_hidden_flag", FORMAT_TABLE_STRING,
+	  format_cb_pane_hidden_flag
 	},
 	{ "pane_mode", FORMAT_TABLE_STRING,
 	  format_cb_pane_mode

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -351,7 +351,7 @@ key_bindings_init(void)
 {
 	static const char *const defaults[] = {
 		/* Prefix keys. */
-		"bind -N 'Minimise pane' _ { minimise-pane }",
+		"bind -N 'Hide pane' _ { hide-pane }",
 
 		"bind -N 'Send the prefix key' C-b { send-prefix }",
 		"bind -N 'Rotate through the panes' C-o { rotate-window }",
@@ -471,7 +471,7 @@ key_bindings_init(void)
 		"bind -n MouseDrag1Border { resize-pane -M }",
 
 		/* Mouse button 1 down on status line. */
-		"bind -n MouseDown1Status { if -F '#{&&:#{pane_active},#{!#{pane_minimised_flag}}}' { minimise-pane -t= } { switch-client -t= } }",
+		"bind -n MouseDown1Status { if -F '#{&&:#{pane_active},#{!#{pane_hidden_flag}}}' { hide-pane -t= } { switch-client -t= } }",
 		"bind -n C-MouseDown1Status { swap-window -t@ }",
 
 		/* Mouse button 1 down on default pane-border-format */

--- a/layout.c
+++ b/layout.c
@@ -270,7 +270,7 @@ layout_fix_offsets1(struct layout_cell *lc)
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 			if (lcchild->type == LAYOUT_WINDOWPANE &&
 			    lcchild->wp != NULL &&
-			    lcchild->wp->flags & PANE_MINIMISED)
+			    lcchild->wp->flags & PANE_HIDDEN)
 				continue;
 			lcchild->xoff = xoff;
 			lcchild->yoff = lc->yoff;
@@ -283,7 +283,7 @@ layout_fix_offsets1(struct layout_cell *lc)
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 			if (lcchild->type == LAYOUT_WINDOWPANE &&
 			    lcchild->wp != NULL &&
-			    lcchild->wp->flags & PANE_MINIMISED)
+			    lcchild->wp->flags & PANE_HIDDEN)
 				continue;
 			lcchild->xoff = lc->xoff;
 			lcchild->yoff = yoff;
@@ -536,7 +536,7 @@ layout_resize_adjust(struct window *w, struct layout_cell *lc,
 }
 
 /*
- * Return the nearest sibling of lc that is not a minimised WINDOWPANE leaf,
+ * Return the nearest sibling of lc that is not a hidden WINDOWPANE leaf,
  * walking forward (direction=1) or backward (direction=0) in the parent's list.
  * Container cells (TOPBOTTOM/LEFTRIGHT) are never skipped.
  */
@@ -554,9 +554,9 @@ layout_active_neighbour(struct layout_cell *lc, int direction)
 		if (lcother->type != LAYOUT_WINDOWPANE)
 			return (lcother);		/* container — not skipped */
 		if (lcother->wp == NULL ||
-		    (~lcother->wp->flags & PANE_MINIMISED))
+		    (~lcother->wp->flags & PANE_HIDDEN))
 			return (lcother);		/* visible leaf */
-		/* minimised leaf — keep walking */
+		/* hidden leaf — keep walking */
 		if (direction)
 			lcother = TAILQ_NEXT(lcother, entry);
 		else
@@ -566,12 +566,12 @@ layout_active_neighbour(struct layout_cell *lc, int direction)
 }
 
 /*
- * Redistribute space equally among all visible (non-minimised WINDOWPANE)
- * children of lcparent in the given direction.  Minimised WINDOWPANE leaves
+ * Redistribute space equally among all visible (non-hidden WINDOWPANE)
+ * children of lcparent in the given direction.  Hidden WINDOWPANE leaves
  * are skipped; their stored sizes are left untouched.  Container children
  * have their own children resized proportionally via layout_resize_child_cells.
  *
- * If all children happen to be minimised (n==0), nothing is done.
+ * If all children happen to be hidden (n==0), nothing is done.
  */
 void
 layout_redistribute_cells(struct window *w, struct layout_cell *lcparent,
@@ -585,7 +585,7 @@ layout_redistribute_cells(struct window *w, struct layout_cell *lcparent,
 	TAILQ_FOREACH(lc, &lcparent->cells, entry) {
 		if (lc->type == LAYOUT_WINDOWPANE &&
 		    lc->wp != NULL &&
-		    (lc->wp->flags & PANE_MINIMISED))
+		    (lc->wp->flags & PANE_HIDDEN))
 			continue;
 		n++;
 	}
@@ -608,7 +608,7 @@ layout_redistribute_cells(struct window *w, struct layout_cell *lcparent,
 	TAILQ_FOREACH(lc, &lcparent->cells, entry) {
 		if (lc->type == LAYOUT_WINDOWPANE &&
 		    lc->wp != NULL &&
-		    (lc->wp->flags & PANE_MINIMISED))
+		    (lc->wp->flags & PANE_HIDDEN))
 			continue;
 		target = each + (i < rem ? 1 : 0);
 		if (type == LAYOUT_LEFTRIGHT)
@@ -628,7 +628,7 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 {
 	struct layout_cell     *lcother, *lcparent;
 	int			direction;
-	int			is_minimised;
+	int			is_hidden;
 
 	/*
 	 * If no parent, this is either a floating pane or the last
@@ -652,15 +652,15 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 
 	/* In tiled layouts, merge the space into the previous or next cell. */
 	if (lcparent->type != LAYOUT_FLOATING) {
-		is_minimised = (lc->wp != NULL && (lc->wp->flags & PANE_MINIMISED));
+		is_hidden = (lc->wp != NULL && (lc->wp->flags & PANE_HIDDEN));
 		direction = (lc == TAILQ_FIRST(&lcparent->cells)) ? 1 : 0;
 		lcother = layout_active_neighbour(lc, direction);
 		if (lcother == NULL)
 			lcother = layout_active_neighbour(lc, !direction);
 		if (lcother != NULL && lcparent->type == LAYOUT_LEFTRIGHT &&
-		    !is_minimised)
+		    !is_hidden)
 			layout_resize_adjust(w, lcother, lcparent->type, lc->sx + 1);
-		else if (lcother != NULL && !is_minimised)
+		else if (lcother != NULL && !is_hidden)
 			layout_resize_adjust(w, lcother, lcparent->type, lc->sy + 1);
 	}
 
@@ -685,15 +685,15 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 			lc->yoff = 0;
 
 			/*
-			 * If the sole remaining child is a minimised
+			 * If the sole remaining child is a hidden
 			 * WINDOWPANE, its stored size may be stale (it never
 			 * received the space that was given to the removed
-			 * cell). Restore the full window size so that
-			 * unminimise can reclaim the correct amount.
+			 * cell).  Restore the full window size so that
+			 * 'show' can reclaim the correct amount.
 			 */
 			if (lc->type == LAYOUT_WINDOWPANE &&
 			    lc->wp != NULL &&
-			    (lc->wp->flags & PANE_MINIMISED)) {
+			    (lc->wp->flags & PANE_HIDDEN)) {
 				lc->sx = lcparent->sx;
 				lc->sy = lcparent->sy;
 			}
@@ -705,9 +705,9 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 	}
 }
 
-/* Minimise a cell and redistribute the space in tiled cells. */
+/* Hide a cell and redistribute the space in tiled cells. */
 void
-layout_minimise_cell(struct window *w, struct layout_cell *lc)
+layout_hide_cell(struct window *w, struct layout_cell *lc)
 {
 	struct layout_cell     *lcother, *lcparent, *lcchild;
 	u_int			space = 0;
@@ -719,7 +719,7 @@ layout_minimise_cell(struct window *w, struct layout_cell *lc)
 		return;
 	}
 
-	/* Merge the space into the nearest non-minimised sibling. */
+	/* Merge the space into the nearest non-hidden sibling. */
 	{
 		direction = (lc == TAILQ_FIRST(&lcparent->cells)) ? 1 : 0;
 		lcother = layout_active_neighbour(lc, direction);
@@ -731,11 +731,11 @@ layout_minimise_cell(struct window *w, struct layout_cell *lc)
 	else if (lcother != NULL)
 		layout_resize_adjust(w, lcother, lcparent->type, lc->sy + 1);
 
-	/* If the parent cells are all minimised, minimise it too. */
+	/* If the parent cells are all hidden, hide it too. */
 	if (lcparent != NULL) {
 		TAILQ_FOREACH(lcchild, &lcparent->cells, entry) {
 			if (lcchild->wp == NULL ||
-			    lcchild->wp->flags & PANE_MINIMISED)
+			    lcchild->wp->flags & PANE_HIDDEN)
 				continue;
 			if (lcparent->type == LAYOUT_LEFTRIGHT) {
 				space += lcchild->sx;
@@ -744,13 +744,13 @@ layout_minimise_cell(struct window *w, struct layout_cell *lc)
 			}
 		}
 		if (space == 0)
-			layout_minimise_cell(w, lcparent);
+			layout_hide_cell(w, lcparent);
 	}
 }
 
-/* Unminimise a cell and redistribute the space in tiled cells. */
+/* Show a cell and redistribute the space in tiled cells. */
 void
-layout_unminimise_cell(struct window *w, struct layout_cell *lc)
+layout_show_cell(struct window *w, struct layout_cell *lc)
 {
 	struct layout_cell	*lcparent;
 
@@ -762,7 +762,7 @@ layout_unminimise_cell(struct window *w, struct layout_cell *lc)
 
 	/*
 	 * Redistribute the parent's space equally among all visible (non-
-	 * minimised) children, including lc which has just been unminimised.
+	 * hidden) children, including lc which has just been shown.
 	 * This ensures every pane at this level gets an equal share rather
 	 * than one pane losing most of its space to the restored pane.
 	 */

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -461,14 +461,14 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, u_int px, u_int py,
 		sb_w = wp->scrollbar_style.width +
 			wp->scrollbar_style.pad;
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if (~wp->flags & PANE_MINIMISED &&
+			if (~wp->flags & PANE_HIDDEN &&
 			    ((int)px >= (int)wp->xoff - 1 - sb_w &&
 			    (int)px <= wp->xoff + (int)wp->sx) &&
 			    ((int)py >= (int)wp->yoff - 1 &&
 			    (int)py <= wp->yoff + (int)wp->sy))
 				break;
 		} else { /* PANE_SCROLLBARS_RIGHT or none. */
-			if (~wp->flags & PANE_MINIMISED &&
+			if (~wp->flags & PANE_HIDDEN &&
 			    ((int)px >= (int)wp->xoff - 1 &&
 			    (int)px <= wp->xoff + (int)wp->sx + sb_w) &&
 			    ((int)py >= (int)wp->yoff - 1 &&
@@ -1165,7 +1165,7 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, u_int px,
 	u_int				 lb, rb, tb, bb;
 	u_int				 i, s;
 
-	if (base_wp == NULL || base_wp->flags & PANE_MINIMISED) {
+	if (base_wp == NULL || base_wp->flags & PANE_HIDDEN) {
 		if (r != NULL) {
 			return (r);
 		} else {
@@ -1196,7 +1196,7 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, u_int px,
 
 	found_self = 0;
 	TAILQ_FOREACH_REVERSE(wp, &w->z_index, window_panes_zindex, zentry) {
-		if (wp->flags & PANE_MINIMISED)
+		if (wp->flags & PANE_HIDDEN)
 			continue;
 		if (wp == base_wp) {
 			found_self = 1;

--- a/screen-write.c
+++ b/screen-write.c
@@ -145,7 +145,7 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	if (wp->layout_cell == NULL)
 		return (0);
 
-	if (wp->flags & PANE_MINIMISED)
+	if (wp->flags & PANE_HIDDEN)
 		return (0);
 
 	if (wp->flags & (PANE_REDRAW|PANE_DROP))
@@ -1999,7 +1999,7 @@ screen_write_pane_obscured(struct window_pane *base_wp)
 			continue;
 		}
 		if (found_self && wp->flags & PANE_FLOATING &&
-		    ! (wp->flags & PANE_MINIMISED) &&
+		    ! (wp->flags & PANE_HIDDEN) &&
 		    ((wp->yoff >= base_wp->yoff &&
 		    wp->yoff <= base_wp->yoff + (int)base_wp->sy) ||
 		    (wp->yoff + (int)wp->sy >= base_wp->yoff &&

--- a/tmux.1
+++ b/tmux.1
@@ -3042,7 +3042,7 @@ are all omitted and the pane was previously returned to the tiled layout
 with
 .Ic tile\-pane ,
 its last floating position and size are restored.
-The pane must not already be floating or minimised, and the window must not
+The pane must not already be floating or hidden, and the window must not
 be zoomed.
 .Tg joinp
 .It Xo Ic join\-pane
@@ -3228,23 +3228,23 @@ or
 (time).
 .Fl r
 reverses the sort order.
-.Tg minp
-.It Xo Ic minimise\-pane
+.Tg hidep
+.It Xo Ic hide\-pane
 .Op Fl a
 .Op Fl t Ar target\-pane
 .Xc
-.D1 Pq alias: Ic minimize\-pane
+.D1 Pq alias: Ic hidep
 Hide
 .Ar target\-pane
 from the tiled layout without closing it.
 The pane continues to run but is no longer visible and does not occupy any
 screen space.
-Minimised panes are shown in the status line and can be restored with
-.Ic unminimise\-pane .
+Hidden panes are shown in the status line and can be restored with
+.Ic show\-pane .
 With
 .Fl a ,
-all visible panes in the window are minimised.
-The pane must not already be minimised.
+all visible panes in the window are hidden.
+The pane must not already be hidden.
 .Tg movep
 .It Xo Ic move\-pane
 .Op Fl bdfhv
@@ -3860,17 +3860,17 @@ a subsequent
 .Ic float\-pane
 command with no geometry options.
 The pane must be floating and the window must not be zoomed.
-.Tg unminp
-.It Xo Ic unminimise\-pane
+.Tg showp
+.It Xo Ic show\-pane
 .Op Fl t Ar target\-pane
 .Xc
-.D1 Pq alias: Ic unminimize\-pane
-Restore a minimised
+.D1 Pq alias: Ic showp
+Restore a hidden
 .Ar target\-pane
 to the tiled layout.
 Space is redistributed equally among all visible panes at the same layout
 level after the pane is restored.
-The pane must be minimised.
+The pane must be hidden.
 .Tg unlinkw
 .It Xo Ic unlink\-window
 .Op Fl k
@@ -6670,7 +6670,7 @@ The following variables are available, where appropriate:
 .It Li "pane_left" Ta "" Ta "Left of pane"
 .It Li "pane_marked" Ta "" Ta "1 if this is the marked pane"
 .It Li "pane_marked_set" Ta "" Ta "1 if a marked pane is set"
-.It Li "pane_minimised_flag" Ta "" Ta "1 if pane is minimised"
+.It Li "pane_hidden_flag" Ta "" Ta "1 if pane is hidden"
 .It Li "pane_mode" Ta "" Ta "Name of pane mode, if any"
 .It Li "pane_path" Ta "" Ta "Path of pane (can be set by application)"
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"

--- a/tmux.h
+++ b/tmux.h
@@ -1279,7 +1279,7 @@ struct window_pane {
 #define PANE_THEMECHANGED 0x2000
 #define PANE_UNSEENCHANGES 0x4000
 #define PANE_REDRAWSCROLLBAR 0x8000
-#define PANE_MINIMISED 0x20000
+#define PANE_HIDDEN 0x20000
 #define PANE_SAVED_FLOAT 0x80000	/* saved_float_* fields are valid */
 
 	/* Last floating position/size, saved when the pane is tiled. */
@@ -3507,8 +3507,8 @@ void		 layout_free_cell(struct layout_cell *);
 void		 layout_print_cell(struct layout_cell *, const char *, u_int);
 void		 layout_destroy_cell(struct window *, struct layout_cell *,
 		     struct layout_cell **);
-void		 layout_minimise_cell(struct window *, struct layout_cell *);
-void		 layout_unminimise_cell(struct window *, struct layout_cell *);
+void		 layout_hide_cell(struct window *, struct layout_cell *);
+void		 layout_show_cell(struct window *, struct layout_cell *);
 void		 layout_redistribute_cells(struct window *, struct layout_cell *,
 		     enum layout_type);
 void		 layout_resize_layout(struct window *, struct layout_cell *,

--- a/window-tree.c
+++ b/window-tree.c
@@ -269,7 +269,7 @@ window_tree_build_window(struct session *s, struct winlink *wl,
 	if (data->type == WINDOW_TREE_SESSION ||
 	    data->type == WINDOW_TREE_WINDOW) {
 		expanded = 0;
-		/* Without this, the only way to reach a minimised
+		/* Without this, the only way to reach a hidden
 		 * floating pane would be to first expand the window
 		 * manually (with the right-arrow key) and then press
 		 * its number — which is non-obvious and breaks the

--- a/window.c
+++ b/window.c
@@ -542,12 +542,12 @@ window_set_active_pane(struct window *w, struct window_pane *wp, int notify)
 	w->active->active_point = next_active_point++;
 	w->active->flags |= PANE_CHANGED;
 
-	if (wp->flags & PANE_MINIMISED) {
-		wp->flags &= ~PANE_MINIMISED;
+	if (wp->flags & PANE_HIDDEN) {
+		wp->flags &= ~PANE_HIDDEN;
 		if (w->layout_root != NULL && wp->saved_layout_cell != NULL) {
 			wp->layout_cell = wp->saved_layout_cell;
 			wp->saved_layout_cell = NULL;
-			layout_unminimise_cell(w, wp->layout_cell);
+			layout_show_cell(w, wp->layout_cell);
 			layout_fix_offsets(w);
 			layout_fix_panes(w, NULL);
 		}
@@ -718,16 +718,16 @@ window_zoom(struct window_pane *wp)
 		window_set_active_pane(w, wp, 1);
 	wp->flags |= PANE_ZOOMED;
 
-	/* Bring pane above other tiled panes and minimise floating panes. */
+	/* Bring pane above other tiled panes and hide floating panes. */
 	TAILQ_FOREACH(wp1, &w->z_index, zentry) {
 		if (wp1 == wp) {
-			wp1->saved_flags |= (wp1->flags & PANE_MINIMISED);
-			wp1->flags &= ~PANE_MINIMISED;
+			wp1->saved_flags |= (wp1->flags & PANE_HIDDEN);
+			wp1->flags &= ~PANE_HIDDEN;
 			continue;
 		}
 		if (wp1->flags & PANE_FLOATING) {
-			wp1->saved_flags |= (wp1->flags & PANE_MINIMISED);
-			wp1->flags |= PANE_MINIMISED;
+			wp1->saved_flags |= (wp1->flags & PANE_HIDDEN);
+			wp1->flags |= PANE_HIDDEN;
 			continue;
 		}
 		break;
@@ -761,7 +761,7 @@ window_unzoom(struct window *w, int notify)
 
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
 		if (wp->flags & PANE_FLOATING) {
-			wp->flags &= ~PANE_MINIMISED | (wp->saved_flags & PANE_MINIMISED);
+			wp->flags &= ~PANE_HIDDEN | (wp->saved_flags & PANE_HIDDEN);
 			continue;
 		}
 		break;
@@ -769,7 +769,7 @@ window_unzoom(struct window *w, int notify)
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
 		wp->layout_cell = wp->saved_layout_cell;
-		if (wp->flags & PANE_MINIMISED)
+		if (wp->flags & PANE_HIDDEN)
 			wp->saved_layout_cell = wp->layout_cell;
 		else
 			wp->saved_layout_cell = NULL;
@@ -1003,7 +1003,7 @@ window_pane_printable_flags(struct window_pane *wp)
 		flags[pos++] = 'Z';
 	if (wp->flags & PANE_FLOATING)
 		flags[pos++] = 'F';
-	if (wp->flags & PANE_MINIMISED)
+	if (wp->flags & PANE_HIDDEN)
 		flags[pos++] = 'm';
 
 	flags[pos] = '\0';
@@ -1382,7 +1382,7 @@ int
 window_pane_visible(struct window_pane *wp)
 {
 	if (~wp->window->flags & WINDOW_ZOOMED &&
-	    ~wp->flags & PANE_MINIMISED)
+	    ~wp->flags & PANE_HIDDEN)
 		return (1);
 
 	return (wp == wp->window->active);


### PR DESCRIPTION
In discussing #5043, it was agreed upon to keep `un/minimise-pane` as their own commands, but change the semantics around them to `hide-pane` and `show-pane`. This affects the commands themselves, but also a number of other functions and flags. @mgrant0 