### PR TITLE
Support DECRQM responses and existing modes

### DIFF
--- a/input.c
+++ b/input.c
@@ -281,6 +281,7 @@ enum input_csi_type {
 	INPUT_CSI_IL,
 	INPUT_CSI_MODOFF,
 	INPUT_CSI_MODSET,
+	INPUT_CSI_QUERY,
 	INPUT_CSI_QUERY_PRIVATE,
 	INPUT_CSI_RCP,
 	INPUT_CSI_REP,
@@ -336,6 +337,7 @@ static const struct input_table_entry input_csi_table[] = {
 	{ 'n', "",  INPUT_CSI_DSR },
 	{ 'n', ">", INPUT_CSI_MODOFF },
 	{ 'n', "?", INPUT_CSI_DSR_PRIVATE },
+	{ 'p', "$",  INPUT_CSI_QUERY },
 	{ 'p', "?$", INPUT_CSI_QUERY_PRIVATE },
 	{ 'q', " ", INPUT_CSI_DECSCUSR },
 	{ 'q', ">", INPUT_CSI_XDA },
@@ -1608,8 +1610,34 @@ input_csi_dispatch(struct input_ctx *ictx)
 			break;
 		}
 		break;
+	case INPUT_CSI_QUERY:
+		m = input_get(ictx, 0, 0, 0);
+		switch (m) {
+		case 4:		/* IRM */
+			n = (s->mode & MODE_INSERT) ? 1 : 2;
+			break;
+		default:
+			n = 0;
+			break;
+		}
+		if (m > 0)
+			input_reply(ictx, 1, "\033[%d;%d$y", m, n);
+		break;
 	case INPUT_CSI_QUERY_PRIVATE:
-		switch (input_get(ictx, 0, 0, 0)) {
+		m = input_get(ictx, 0, 0, 0);
+		switch (m) {
+		case 1:		/* DECCKM */
+			n = (s->mode & MODE_KCURSOR) ? 1 : 2;
+			break;
+		case 3:		/* DECCOLM: always reset */
+			n = 4;
+			break;
+		case 6:		/* DECOM */
+			n = (s->mode & MODE_ORIGIN) ? 1 : 2;
+			break;
+		case 7:		/* DECAWM */
+			n = (s->mode & MODE_WRAP) ? 1 : 2;
+			break;
 		case 12: /* cursor blink: 1 = blink, 2 = steady */
 			if (s->cstyle != SCREEN_CURSOR_DEFAULT ||
 			    s->mode & MODE_CURSOR_BLINKING_SET)
@@ -1622,30 +1650,50 @@ input_csi_dispatch(struct input_ctx *ictx)
 				p = options_get_number(oo, "cursor-style");
 
 				/* blink for 1,3,5; steady for 0,2,4,6 */
- 				n = (p == 1 || p == 3 || p == 5) ? 1 : 2;
+				n = (p == 1 || p == 3 || p == 5) ? 1 : 2;
 			}
-			input_reply(ictx, 1, "\033[?12;%d$y", n);
 			break;
-		case 1004: /* focus reporting */
+		case 25:	/* DECTCEM */
+			n = (s->mode & MODE_CURSOR) ? 1 : 2;
+			break;
+		case 47:
+		case 1047:
+		case 1049:	/* alternate screen */
+			n = SCREEN_IS_ALTERNATE(s) ? 1 : 2;
+			break;
+		case 1000:	/* mouse: normal tracking */
+			n = (s->mode & MODE_MOUSE_STANDARD) ? 1 : 2;
+			break;
+		case 1002:	/* mouse: button-event tracking */
+			n = (s->mode & MODE_MOUSE_BUTTON) ? 1 : 2;
+			break;
+		case 1003:	/* mouse: any-event tracking */
+			n = (s->mode & MODE_MOUSE_ALL) ? 1 : 2;
+			break;
+		case 1004:	/* focus reporting */
 			n = (s->mode & MODE_FOCUSON) ? 1 : 2;
-			input_reply(ictx, 1, "\033[?1004;%d$y", n);
 			break;
-		case 1006: /* SGR mouse */
+		case 1005:	/* mouse: UTF-8 */
+			n = (s->mode & MODE_MOUSE_UTF8) ? 1 : 2;
+			break;
+		case 1006:	/* mouse: SGR */
 			n = (s->mode & MODE_MOUSE_SGR) ? 1 : 2;
-			input_reply(ictx, 1, "\033[?1006;%d$y", n);
 			break;
-		case 2004: /* bracketed paste */
+		case 2004:	/* bracketed paste */
 			n = (s->mode & MODE_BRACKETPASTE) ? 1 : 2;
-			input_reply(ictx, 1, "\033[?2004;%d$y", n);
 			break;
-		case 2026: /* synchronized output */
+		case 2026:	/* synchronized output */
 			n = (s->mode & MODE_SYNC) ? 1 : 2;
-			input_reply(ictx, 1, "\033[?2026;%d$y", n);
 			break;
-		case 2031:
-			input_reply(ictx, 1, "\033[?2031;2$y");
+		case 2031:	/* theme update notifications */
+			n = (s->mode & MODE_THEME_UPDATES) ? 1 : 2;
+			break;
+		default:
+			n = 0;
 			break;
 		}
+		if (m > 0)
+			input_reply(ictx, 1, "\033[?%d;%d$y", m, n);
 		break;
 	case INPUT_CSI_DSR:
 		switch (input_get(ictx, 0, 0, 0)) {

--- a/regress/decrqm-sync.sh
+++ b/regress/decrqm-sync.sh
@@ -15,7 +15,10 @@ sleep 1
 
 TMP=$(mktemp)
 TMP2=$(mktemp)
-trap "rm -f $TMP $TMP2; $TMUX kill-server 2>/dev/null" 0 1 15
+TMP3=$(mktemp)
+TMP4=$(mktemp)
+TMP5=$(mktemp)
+trap "rm -f $TMP $TMP2 $TMP3 $TMP4 $TMP5; $TMUX kill-server 2>/dev/null" 0 1 15
 
 $TMUX -f/dev/null new -d -x80 -y24 || exit 1
 sleep 1
@@ -25,18 +28,19 @@ $TMUX set -g remain-on-exit on
 
 exit_status=0
 
-# query_decrpm <outfile> [setup_seq]
+# query_decrpm <outfile> <mode> [setup_seq]
 #   Spawn a pane that optionally sends setup_seq, then sends DECRQM for
 #   mode 2026 and captures the response into outfile in cat -v form.
-query_decrpm () {
+query_decrpm() {
 	_outfile=$1
-	_setup=$2
+	_mode=$2
+	_setup=$3
 
 	$TMUX respawnw -k -t:0 -- sh -c "
 		exec 2>/dev/null
 		stty raw -echo
 		${_setup:+printf '$_setup'; sleep 0.2}
-		printf '\033[?2026\$p'
+		printf '\033[%s\$p' "$_mode"
 		dd bs=1 count=11 2>/dev/null | cat -v > $_outfile
 		sleep 0.2
 	" || exit 1
@@ -46,7 +50,7 @@ query_decrpm () {
 # ------------------------------------------------------------------
 # Test 1: mode 2026 should be reset by default (Ps=2)
 # ------------------------------------------------------------------
-query_decrpm "$TMP"
+query_decrpm "$TMP" "?2026"
 
 actual=$(cat "$TMP")
 expected='^[[?2026;2$y'
@@ -63,7 +67,7 @@ fi
 # ------------------------------------------------------------------
 # Test 2: set mode 2026 (SM ?2026), then query (expect Ps=1)
 # ------------------------------------------------------------------
-query_decrpm "$TMP2" '\033[?2026h'
+query_decrpm "$TMP2" "?2026" '\033[?2026h'
 
 actual=$(cat "$TMP2")
 expected='^[[?2026;1$y'
@@ -74,6 +78,61 @@ if [ "$actual" = "$expected" ]; then
 	fi
 else
 	echo "[FAIL] DECRQM 2026 (set): expected '$expected', got '$actual'"
+	exit_status=1
+fi
+
+# ------------------------------------------------------------------
+# Test 3: mode 25 should return current value
+# ------------------------------------------------------------------
+query_decrpm "$TMP3" "?25" '\033[?25l'
+
+actual=$(cat "$TMP3")
+expected='^[[?25;2$y'
+
+if [ "$actual" = "$expected" ]; then
+	if [ -n "$VERBOSE" ]; then
+		echo "[PASS] DECTCEM 25 (reset) -> $actual"
+	fi
+else
+	echo "[FAIL] DECTCEM 25 (reset): expected '$expected', got '$actual'"
+	exit_status=1
+fi
+
+# ------------------------------------------------------------------
+# Test 4: mode ?9999 should return not recognized
+# ------------------------------------------------------------------
+query_decrpm "$TMP4" "?9999" '\033[?9999h'
+
+actual=$(cat "$TMP4")
+expected='^[[?9999;0$y'
+
+if [ "$actual" = "$expected" ]; then
+	if [ -n "$VERBOSE" ]; then
+		echo "[PASS] DECSM 9999 (not recognized) -> $actual"
+	fi
+else
+	echo "[FAIL] DECSM 9999 (not recognized): expected '$expected', got '$actual'"
+	exit_status=1
+fi
+
+$TMUX kill-server 2>/dev/null
+
+exit $exit_status
+
+# ------------------------------------------------------------------
+# Test 5: mode 4 is reset by default
+# ------------------------------------------------------------------
+query_decrpm "$TMP5" "4" '\033[4h'
+
+actual=$(cat "$TMP5")
+expected='^[[4;1$y'
+
+if [ "$actual" = "$expected" ]; then
+	if [ -n "$VERBOSE" ]; then
+		echo "[PASS] SM 4 (is set) -> $actual"
+	fi
+else
+	echo "[FAIL] SM 4 (is set): expected '$expected', got '$actual'"
 	exit_status=1
 fi
 


### PR DESCRIPTION
This adds support to ANSI and DEC DECRQM responses for existing known and unknown modes. With this, querying for unknown modes would still return a valid DECRPM response.

Before, querying for an existing not DECRQM supported mode wouldn't return anything. This example would hang and not return any input.
```sh
cat | printf '\x1b[?25$p'

```

But for mode `?2026` it would work.
```sh
cat | printf '\x1b[?2026$p'
^[[?2026;2$y
```

After this, both examples would return a value. Unknown modes would return `0` which means _mode not recognized_.

See: https://vt100.net/docs/vt510-rm/DECRQM.html https://vt100.net/docs/vt510-rm/DECRPM.html
Related: https://github.com/tmux/tmux/pull/4887 https://github.com/tmux/tmux/pull/4618