### PR TITLE
Feature/run-shell with arguments

### DIFF
--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -140,9 +140,6 @@ cmd_run_shell_exec(struct cmd *self, struct cmdq_item *item)
 				xsnprintf(key, sizeof key, "%u", i);
 				format_add(ft, key, "%s",
 				    args_string(args, i));
-				xsnprintf(key, sizeof key, "argument%u", i);
-				format_add(ft, key, "%s",
-				    args_string(args, i));
 			}
 			cdata->cmd = format_expand(ft, cmd);
 			format_free(ft);

--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -44,9 +44,9 @@ const struct cmd_entry cmd_run_shell_entry = {
 	.name = "run-shell",
 	.alias = "run",
 
-	.args = { "bd:Ct:Es:c:", 0, 1, cmd_run_shell_args_parse },
+	.args = { "bd:Ct:Es:c:", 0, -1, cmd_run_shell_args_parse },
 	.usage = "[-bCE] [-c start-directory] [-d delay] " CMD_TARGET_PANE_USAGE
-	         " [shell-command]",
+	         " [shell-command [argument ...]]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
 
@@ -115,9 +115,11 @@ cmd_run_shell_exec(struct cmd *self, struct cmdq_item *item)
 	struct session			*s = target->s;
 	struct window_pane		*wp = target->wp;
 	const char			*delay, *cmd;
+	struct format_tree		*ft;
 	double				 d;
 	struct timeval			 tv;
-	char				*end;
+	char				*end, key[16];
+	u_int				 i;
 	int				 wait = !args_has(args, 'b');
 
 	if ((delay = args_get(args, 'd')) != NULL) {
@@ -132,8 +134,19 @@ cmd_run_shell_exec(struct cmd *self, struct cmdq_item *item)
 	cdata = xcalloc(1, sizeof *cdata);
 	if (!args_has(args, 'C')) {
 		cmd = args_string(args, 0);
-		if (cmd != NULL)
-			cdata->cmd = format_single_from_target(item, cmd);
+		if (cmd != NULL) {
+			ft = format_create_from_target(item);
+			for (i = 1; i < args_count(args); i++) {
+				xsnprintf(key, sizeof key, "%u", i);
+				format_add(ft, key, "%s",
+				    args_string(args, i));
+				xsnprintf(key, sizeof key, "argument%u", i);
+				format_add(ft, key, "%s",
+				    args_string(args, i));
+			}
+			cdata->cmd = format_expand(ft, cmd);
+			format_free(ft);
+		}
 	} else {
 		cdata->state = args_make_commands_prepare(self, item, 0, NULL,
 		    wait, 1);

--- a/format.c
+++ b/format.c
@@ -5709,22 +5709,12 @@ format_expand1(struct format_expand_state *es, const char *fmt)
 		default:
 			s = NULL;
 			if (ch >= '1' && ch <= '9') {
-				char	 numkey[2] = { ch, '\0' };
-				char	*numval;
+				char	numkey[2] = { ch, '\0' };
 
-				numval = format_find(ft, numkey, 0, NULL);
-				if (numval != NULL) {
-					format_log(es, "found #%c: %s", ch,
-					    numval);
-					if (format_replace(es, numval,
-					    strlen(numval), &buf, &len,
-					    &off) != 0) {
-						free(numval);
-						break;
-					}
-					free(numval);
-					continue;
-				}
+				if (format_replace(es, numkey, 1, &buf, &len,
+				    &off) != 0)
+					break;
+				continue;
 			}
 			if (fmt > style_end) { /* skip inside #[] */
 				if (ch >= 'A' && ch <= 'Z')

--- a/format.c
+++ b/format.c
@@ -5708,6 +5708,24 @@ format_expand1(struct format_expand_state *es, const char *fmt)
 			continue;
 		default:
 			s = NULL;
+			if (ch >= '1' && ch <= '9') {
+				char	 numkey[2] = { ch, '\0' };
+				char	*numval;
+
+				numval = format_find(ft, numkey, 0, NULL);
+				if (numval != NULL) {
+					format_log(es, "found #%c: %s", ch,
+					    numval);
+					if (format_replace(es, numval,
+					    strlen(numval), &buf, &len,
+					    &off) != 0) {
+						free(numval);
+						break;
+					}
+					free(numval);
+					continue;
+				}
+			}
 			if (fmt > style_end) { /* skip inside #[] */
 				if (ch >= 'A' && ch <= 'Z')
 					s = format_upper[ch - 'A'];

--- a/regress/run-shell-args.sh
+++ b/regress/run-shell-args.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# run-shell argument interpolation: #1, #{1}, #{argumentN}
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap "rm -f $TMP" 0 1 15
+
+# #1 shorthand: first argument
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo #1 >$TMP" hello || exit 1
+sleep 1 && [ "$(cat $TMP)" = "hello" ] || exit 1
+
+# #{1} format syntax: first argument
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo #{1} >$TMP" world || exit 1
+sleep 1 && [ "$(cat $TMP)" = "world" ] || exit 1
+
+# #{argument1} named form
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo #{argument1} >$TMP" named || exit 1
+sleep 1 && [ "$(cat $TMP)" = "named" ] || exit 1
+
+# multiple arguments: #1 and #2
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo #1 #2 >$TMP" foo bar || exit 1
+sleep 1 && [ "$(cat $TMP)" = "foo bar" ] || exit 1
+
+# missing argument expands to empty string (not literal '#2')
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo '#2' >$TMP" onlyone || exit 1
+sleep 1 && [ "$(cat $TMP)" = "" ] || exit 1
+
+# no arguments: shell-command still works normally
+$TMUX -f/dev/null new-session -d -s main \; \
+    run-shell "echo noargs >$TMP" || exit 1
+sleep 1 && [ "$(cat $TMP)" = "noargs" ] || exit 1
+
+$TMUX kill-server 2>/dev/null
+
+exit 0

--- a/regress/run-shell-args.sh
+++ b/regress/run-shell-args.sh
@@ -10,38 +10,42 @@ TMUX="$TEST_TMUX -Ltest"
 $TMUX kill-server 2>/dev/null
 
 TMP=$(mktemp)
-trap "rm -f $TMP" 0 1 15
+trap "$TMUX kill-server 2>/dev/null; rm -f $TMP" 0 1 15
 
 # #1 shorthand: first argument
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo #1 >$TMP" hello || exit 1
 sleep 1 && [ "$(cat $TMP)" = "hello" ] || exit 1
+$TMUX kill-server 2>/dev/null
 
 # #{1} format syntax: first argument
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo #{1} >$TMP" world || exit 1
 sleep 1 && [ "$(cat $TMP)" = "world" ] || exit 1
+$TMUX kill-server 2>/dev/null
 
 # #{argument1} named form
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo #{argument1} >$TMP" named || exit 1
 sleep 1 && [ "$(cat $TMP)" = "named" ] || exit 1
+$TMUX kill-server 2>/dev/null
 
 # multiple arguments: #1 and #2
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo #1 #2 >$TMP" foo bar || exit 1
 sleep 1 && [ "$(cat $TMP)" = "foo bar" ] || exit 1
+$TMUX kill-server 2>/dev/null
 
-# missing argument expands to empty string (not literal '#2')
+# missing argument: #2 when only one arg given expands to empty
 $TMUX -f/dev/null new-session -d -s main \; \
-    run-shell "echo '#2' >$TMP" onlyone || exit 1
+    run-shell "echo -n #{2} >$TMP" onlyone || exit 1
 sleep 1 && [ "$(cat $TMP)" = "" ] || exit 1
+$TMUX kill-server 2>/dev/null
 
 # no arguments: shell-command still works normally
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo noargs >$TMP" || exit 1
 sleep 1 && [ "$(cat $TMP)" = "noargs" ] || exit 1
-
 $TMUX kill-server 2>/dev/null
 
 exit 0

--- a/regress/run-shell-args.sh
+++ b/regress/run-shell-args.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# run-shell argument interpolation: #1, #{1}, #{argumentN}
+# run-shell argument interpolation: #1, #{1}
 
 PATH=/bin:/usr/bin
 TERM=screen
@@ -22,12 +22,6 @@ $TMUX kill-server 2>/dev/null
 $TMUX -f/dev/null new-session -d -s main \; \
     run-shell "echo #{1} >$TMP" world || exit 1
 sleep 1 && [ "$(cat $TMP)" = "world" ] || exit 1
-$TMUX kill-server 2>/dev/null
-
-# #{argument1} named form
-$TMUX -f/dev/null new-session -d -s main \; \
-    run-shell "echo #{argument1} >$TMP" named || exit 1
-sleep 1 && [ "$(cat $TMP)" = "named" ] || exit 1
 $TMUX kill-server 2>/dev/null
 
 # multiple arguments: #1 and #2

--- a/tmux.1
+++ b/tmux.1
@@ -7832,7 +7832,7 @@ option.
 .Op Fl c Ar start\-directory
 .Op Fl d Ar delay
 .Op Fl t Ar target\-pane
-.Op Ar shell\-command
+.Op Ar shell\-command Op Ar argument ...
 .Xc
 .D1 Pq alias: Ic run
 Execute
@@ -7849,6 +7849,21 @@ Before being executed,
 is expanded using the rules specified in the
 .Sx FORMATS
 section.
+If
+.Ar argument
+values are given, they are added to the format tree as
+.Ql argument1 ,
+.Ql argument2 ,
+and so on, and may be referenced as
+.Ql #1 ,
+.Ql #2 ,
+or using the standard format syntax
+.Ql #{1} ,
+.Ql #{argument1} .
+For example:
+.Bd -literal -offset indent
+run-shell 'myscript.sh #1 #2' foo bar
+.Ed
 With
 .Fl b ,
 the command is run in the background.

--- a/tmux.1
+++ b/tmux.1
@@ -7852,14 +7852,14 @@ section.
 If
 .Ar argument
 values are given, they are added to the format tree as
-.Ql argument1 ,
-.Ql argument2 ,
+.Ql 1 ,
+.Ql 2 ,
 and so on, and may be referenced as
 .Ql #1 ,
 .Ql #2 ,
 or using the standard format syntax
 .Ql #{1} ,
-.Ql #{argument1} .
+.Ql #{2} .
 For example:
 .Bd -literal -offset indent
 run-shell 'myscript.sh #1 #2' foo bar


### PR DESCRIPTION
Fixes #4784 (from todo list)

# run-shell: add argument interpolation via format tree

I found myself needing to pass an argument to `run-shell` within a
`command-alias`. I decided that a patch was the best way to achieve my
desired behaviour. I initially went with a different design, but after
checking the tmux GitHub page before submitting this PR, I came across
#4784 and #4802. I updated my design to align with the suggested
approach in #4802.

## AI Assisted Description

This patch addresses issue #4784. It follows the approach suggested by
nicm in the review of the prior attempt (#4802, closed Mar 2026):
create a `format_tree`, populate it with the extra arguments, and add
`#1`–`#9` shorthand in `format_expand1`. The issues raised in that
review (declarations not at top of function, overly long lines, use of
`goto`) do not apply here.

Extra arguments passed after the shell command are stored in the format
tree as numbered keys (`1`, `2`, …). They can then be referenced
anywhere in the shell command string using standard tmux format syntax:

- `#1`, `#2`, … — new shorthand (this patch adds `#1`–`#9` to the `#`
  switch in `format_expand1`)
- `#{1}`, `#{2}`, … — existing `#{…}` syntax, works for any number

For example:

```
run-shell 'myscript.sh #1 #2' foo bar
```

Or with `command-alias`:

```
set -g command-alias[0] s='run-shell "~/.config/tmux/new-session.sh #1"'
```

Then `:s myproject` passes `myproject` as the first argument to the
script. All standard format modifiers work: `#{1:s/foo/bar/}` etc.

### Implementation notes

#### cmd-run-shell.c

The maximum argument count is changed from `1` to `-1`, allowing any
number of extra arguments after the shell command.

When a shell command is present, a `format_tree` is created via
`format_create_from_target` and the extra arguments (indices 1…N) are
added in a loop using `format_add`. Each argument is stored under its
numeric string key (`"1"`, `"2"`, …).

`format_expand` is then called on the command string using this tree,
replacing the previous `format_single_from_target` call. The tree is
freed immediately after expansion.

#### format.c

A new block is added in the `default:` case of `format_expand1`'s
`switch(ch)`, before the existing letter-shorthand lookup. If the
character following `#` is a digit `1`–`9`, it constructs a one-character
key and calls `format_replace` — the same code path taken by `#{1}`.
This gives users the terse `#1`–`#9` shorthand, consistent with shell
positional parameter conventions.

This change is purely for convenience. Without it, `#{1}`–`#{N}`
remain fully functional for any N via the existing `#{…}` expansion
path.

#### What is not changed

When no extra arguments are passed, the code path is identical to
before: `cmd` is still expanded via a format tree, it just has no
extra keys populated.

### Tests

`regress/run-shell-args.sh` covers: `#1` shorthand, `#{1}` syntax,
multiple arguments, missing argument expanding to empty, and
no-argument baseline.

Note: `regress/run-shell-output.sh` has a pre-existing timing fragility
— `sleep 1` before querying `#{pane_mode}` is insufficient on some
systems. This reproduces on an unmodified tree and is unrelated to this
patch (`sleep 2` is sufficient to pass). Worth fixing separately.

## AI disclosure

This patch was developed with the assistance of Anthropic Claude via
OpenCode. Per the project's AI contribution policy, Anthropic assigns
ownership of outputs to the user under their terms of service.
