### PR TITLE
refactor(floating_panes): Changing xoff/yoff fields to ox/oy.

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -215,14 +215,14 @@ cmd_display_menu_get_pos(struct client *tc, struct cmdq_item *item,
 
 	/* Position in pane. */
 	tty_window_offset(&tc->tty, &ox, &oy, &sx, &sy);
-	n = top + wp->yoff - oy + h;
+	n = top + wp->oy - oy + h;
 	if (n >= tty->sy)
 		format_add(ft, "popup_pane_top", "%u", tty->sy - h);
 	else
 		format_add(ft, "popup_pane_top", "%ld", n);
-	format_add(ft, "popup_pane_bottom", "%u", top + wp->yoff + wp->sy - oy);
-	format_add(ft, "popup_pane_left", "%u", wp->xoff - ox);
-	n = (long)wp->xoff + wp->sx - ox - w;
+	format_add(ft, "popup_pane_bottom", "%u", top + wp->oy + wp->sy - oy);
+	format_add(ft, "popup_pane_left", "%u", wp->ox - ox);
+	n = (long)wp->ox + wp->sx - ox - w;
 	if (n < 0)
 		format_add(ft, "popup_pane_right", "%u", 0);
 	else

--- a/cmd-display-panes.c
+++ b/cmd-display-panes.c
@@ -65,56 +65,56 @@ cmd_display_panes_draw_pane(struct screen_redraw_ctx *ctx,
 	struct options		*oo = s->options;
 	struct window		*w = wp->window;
 	struct grid_cell	 fgc, bgc;
-	u_int			 pane, idx, px, py, i, j, xoff, yoff, sx, sy;
+	u_int			 pane, idx, px, py, i, j, ox, oy, sx, sy;
 	int			 colour, active_colour;
 	char			 buf[16], lbuf[16], rbuf[16], *ptr;
 	size_t			 len, llen, rlen;
 
-	if (wp->xoff + (int)wp->sx <= ctx->ox ||
-	    wp->xoff >= ctx->ox + (int)ctx->sx ||
-	    wp->yoff + (int)wp->sy <= ctx->oy ||
-	    wp->yoff >= ctx->oy + (int)ctx->sy)
+	if (wp->ox + (int)wp->sx <= ctx->ox ||
+	    wp->ox >= ctx->ox + (int)ctx->sx ||
+	    wp->oy + (int)wp->sy <= ctx->oy ||
+	    wp->oy >= ctx->oy + (int)ctx->sy)
 		return;
 
-	if (wp->xoff >= ctx->ox && wp->xoff + wp->sx <= ctx->ox + ctx->sx) {
+	if (wp->ox >= ctx->ox && wp->ox + wp->sx <= ctx->ox + ctx->sx) {
 		/* All visible. */
-		xoff = wp->xoff - ctx->ox;
+		ox = wp->ox - ctx->ox;
 		sx = wp->sx;
-	} else if (wp->xoff < ctx->ox &&
-	    wp->xoff + wp->sx > ctx->ox + ctx->sx) {
+	} else if (wp->ox < ctx->ox &&
+	    wp->ox + wp->sx > ctx->ox + ctx->sx) {
 		/* Both left and right not visible. */
-		xoff = 0;
+		ox = 0;
 		sx = ctx->sx;
-	} else if (wp->xoff < ctx->ox) {
+	} else if (wp->ox < ctx->ox) {
 		/* Left not visible. */
-		xoff = 0;
-		sx = wp->sx - (ctx->ox - wp->xoff);
+		ox = 0;
+		sx = wp->sx - (ctx->ox - wp->ox);
 	} else {
 		/* Right not visible. */
-		xoff = wp->xoff - ctx->ox;
-		sx = wp->sx - xoff;
+		ox = wp->ox - ctx->ox;
+		sx = wp->sx - ox;
 	}
-	if (wp->yoff >= ctx->oy && wp->yoff + wp->sy <= ctx->oy + ctx->sy) {
+	if (wp->oy >= ctx->oy && wp->oy + wp->sy <= ctx->oy + ctx->sy) {
 		/* All visible. */
-		yoff = wp->yoff - ctx->oy;
+		oy = wp->oy - ctx->oy;
 		sy = wp->sy;
-	} else if (wp->yoff < ctx->oy &&
-	    wp->yoff + wp->sy > ctx->oy + ctx->sy) {
+	} else if (wp->oy < ctx->oy &&
+	    wp->oy + wp->sy > ctx->oy + ctx->sy) {
 		/* Both top and bottom not visible. */
-		yoff = 0;
+		oy = 0;
 		sy = ctx->sy;
-	} else if (wp->yoff < ctx->oy) {
+	} else if (wp->oy < ctx->oy) {
 		/* Top not visible. */
-		yoff = 0;
-		sy = wp->sy - (ctx->oy - wp->yoff);
+		oy = 0;
+		sy = wp->sy - (ctx->oy - wp->oy);
 	} else {
 		/* Bottom not visible. */
-		yoff = wp->yoff - ctx->oy;
-		sy = wp->sy - yoff;
+		oy = wp->oy - ctx->oy;
+		sy = wp->sy - oy;
 	}
 
 	if (ctx->statustop)
-		yoff += ctx->statuslines;
+		oy += ctx->statuslines;
 	px = sx / 2;
 	py = sy / 2;
 
@@ -147,12 +147,12 @@ cmd_display_panes_draw_pane(struct screen_redraw_ctx *ctx,
 		tty_attributes(tty, &fgc, &grid_default_cell, NULL, NULL);
 		if (sx >= len + llen + 1) {
 			len += llen + 1;
-			tty_cursor(tty, xoff + px - len / 2, yoff + py);
+			tty_cursor(tty, ox + px - len / 2, oy + py);
 			tty_putn(tty, buf, len,	 len);
 			tty_putn(tty, " ", 1, 1);
 			tty_putn(tty, lbuf, llen, llen);
 		} else {
-			tty_cursor(tty, xoff + px - len / 2, yoff + py);
+			tty_cursor(tty, ox + px - len / 2, oy + py);
 			tty_putn(tty, buf, len, len);
 		}
 		goto out;
@@ -169,7 +169,7 @@ cmd_display_panes_draw_pane(struct screen_redraw_ctx *ctx,
 
 		for (j = 0; j < 5; j++) {
 			for (i = px; i < px + 5; i++) {
-				tty_cursor(tty, xoff + i, yoff + py + j);
+				tty_cursor(tty, ox + i, oy + py + j);
 				if (window_clock_table[idx][j][i - px])
 					tty_putc(tty, ' ');
 			}
@@ -181,12 +181,12 @@ cmd_display_panes_draw_pane(struct screen_redraw_ctx *ctx,
 		goto out;
 	tty_attributes(tty, &fgc, &grid_default_cell, NULL, NULL);
 	if (rlen != 0 && sx >= rlen) {
-		tty_cursor(tty, xoff + sx - rlen, yoff);
+		tty_cursor(tty, ox + sx - rlen, oy);
 		tty_putn(tty, rbuf, rlen, rlen);
 	}
 	if (llen != 0) {
-		tty_cursor(tty, xoff + sx / 2 + len * 3 - llen - 1,
-		    yoff + py + 5);
+		tty_cursor(tty, ox + sx / 2 + len * 3 - llen - 1,
+		    oy + py + 5);
 		tty_putn(tty, lbuf, llen, llen);
 	}
 

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -118,11 +118,11 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 		status = options_get_number(w->options, "pane-border-status");
 		switch (status) {
 		case PANE_STATUS_TOP:
-			if (y != INT_MAX && wp->yoff == 1)
+			if (y != INT_MAX && wp->oy == 1)
 				y++;
 			break;
 		case PANE_STATUS_BOTTOM:
-			if (y != INT_MAX && wp->yoff + wp->sy == w->sy - 1)
+			if (y != INT_MAX && wp->oy + wp->sy == w->sy - 1)
 				y++;
 			break;
 		}
@@ -181,7 +181,7 @@ cmd_resize_pane_mouse_update_floating(struct client *c, struct mouse_event *m)
 	struct window_pane	*wp;
 	struct layout_cell	*lc;
 	int			 y, ly, x, lx, sx, sy, new_sx, new_sy;
-	int			 new_xoff, new_yoff, resizes = 0;
+	int			 new_ox, new_oy, resizes = 0;
 
 	wp = cmd_mouse_pane(m, NULL, &wl);
 	if (wp == NULL) {
@@ -204,7 +204,7 @@ cmd_resize_pane_mouse_update_floating(struct client *c, struct mouse_event *m)
 	else if (m->statusat > 0 && ly >= m->statusat)
 		ly = m->statusat - 1;
 
-	if ((lx == wp->xoff - 1 || lx == wp->xoff) && ly == wp->yoff - 1) {
+	if ((lx == wp->ox - 1 || lx == wp->ox) && ly == wp->oy - 1) {
 		/* Top left corner. */
 		new_sx = lc->sx + (lx - x);
 		if (new_sx < PANE_MINIMUM)
@@ -212,72 +212,72 @@ cmd_resize_pane_mouse_update_floating(struct client *c, struct mouse_event *m)
 		new_sy = lc->sy + (ly - y);
 		if (new_sy < PANE_MINIMUM)
 			new_sy = PANE_MINIMUM;
-		new_xoff = x + 1; /* because mouse is on border at xoff - 1 */
-		new_yoff = y + 1;
-		layout_set_size(lc, new_sx, new_sy, new_xoff, new_yoff);
+		new_ox = x + 1; /* because mouse is on border at ox - 1 */
+		new_oy = y + 1;
+		layout_set_size(lc, new_sx, new_sy, new_ox, new_oy);
 		resizes++;
-	} else if ((lx == wp->xoff + sx + 1 || lx == wp->xoff + sx) &&
-	    ly == wp->yoff - 1) {
+	} else if ((lx == wp->ox + sx + 1 || lx == wp->ox + sx) &&
+	    ly == wp->oy - 1) {
 		/* Top right corner. */
-		new_sx = x - lc->xoff;
+		new_sx = x - lc->ox;
 		if (new_sx < PANE_MINIMUM)
 			new_sx = PANE_MINIMUM;
 		new_sy = lc->sy + (ly - y);
 		if (new_sy < PANE_MINIMUM)
 			new_sy = PANE_MINIMUM;
-		new_yoff = y + 1;
-		layout_set_size(lc, new_sx, new_sy, lc->xoff, new_yoff);
+		new_oy = y + 1;
+		layout_set_size(lc, new_sx, new_sy, lc->ox, new_oy);
 		resizes++;
-	} else if ((lx == wp->xoff - 1 || lx == wp->xoff) &&
-	    ly == wp->yoff + sy) {
+	} else if ((lx == wp->ox - 1 || lx == wp->ox) &&
+	    ly == wp->oy + sy) {
 		/* Bottom left corner. */
 		new_sx = lc->sx + (lx - x);
 		if (new_sx < PANE_MINIMUM)
 			new_sx = PANE_MINIMUM;
-		new_sy = y - lc->yoff;
+		new_sy = y - lc->oy;
 		if (new_sy < PANE_MINIMUM)
 			return;
-		new_xoff = x + 1;
-		layout_set_size(lc, new_sx, new_sy, new_xoff, lc->yoff);
+		new_ox = x + 1;
+		layout_set_size(lc, new_sx, new_sy, new_ox, lc->oy);
 		resizes++;
-	} else if ((lx == wp->xoff + sx + 1 || lx == wp->xoff + sx) &&
-	    ly == wp->yoff + sy) {
+	} else if ((lx == wp->ox + sx + 1 || lx == wp->ox + sx) &&
+	    ly == wp->oy + sy) {
 		/* Bottom right corner. */
-		new_sx = x - lc->xoff;
+		new_sx = x - lc->ox;
 		if (new_sx < PANE_MINIMUM)
 			new_sx = PANE_MINIMUM;
-		new_sy = y - lc->yoff;
+		new_sy = y - lc->oy;
 		if (new_sy < PANE_MINIMUM)
 			new_sy = PANE_MINIMUM;
-		layout_set_size(lc, new_sx, new_sy, lc->xoff, lc->yoff);
+		layout_set_size(lc, new_sx, new_sy, lc->ox, lc->oy);
 		resizes++;
-	} else if (lx == wp->xoff + sx + 1) {
+	} else if (lx == wp->ox + sx + 1) {
 		/* Right border. */
-		new_sx = x - lc->xoff;
+		new_sx = x - lc->ox;
 		if (new_sx < PANE_MINIMUM)
 			return;
-		layout_set_size(lc, new_sx, lc->sy, lc->xoff, lc->yoff);
+		layout_set_size(lc, new_sx, lc->sy, lc->ox, lc->oy);
 		resizes++;
-	} else if (lx == wp->xoff - 1) {
+	} else if (lx == wp->ox - 1) {
 		/* Left border. */
 		new_sx = lc->sx + (lx - x);
 		if (new_sx < PANE_MINIMUM)
 			return;
-		new_xoff = x + 1;
-		layout_set_size(lc, new_sx, lc->sy, new_xoff, lc->yoff);
+		new_ox = x + 1;
+		layout_set_size(lc, new_sx, lc->sy, new_ox, lc->oy);
 		resizes++;
-	} else if (ly == wp->yoff + sy) {
+	} else if (ly == wp->oy + sy) {
 		/* Bottom border. */
-		new_sy = y - lc->yoff;
+		new_sy = y - lc->oy;
 		if (new_sy < PANE_MINIMUM)
 			return;
-		layout_set_size(lc, lc->sx, new_sy, lc->xoff, lc->yoff);
+		layout_set_size(lc, lc->sx, new_sy, lc->ox, lc->oy);
 		resizes++;
-	} else if (ly == wp->yoff - 1) {
+	} else if (ly == wp->oy - 1) {
 		/* Top border (move instead of resize). */
-		new_xoff = lc->xoff + (x - lx);
-		new_yoff = y + 1;
-		layout_set_size(lc, lc->sx, lc->sy, new_xoff, new_yoff);
+		new_ox = lc->ox + (x - lx);
+		new_oy = y + 1;
+		layout_set_size(lc, lc->sx, lc->sy, new_ox, new_oy);
 		resizes++;
 	}
 	if (resizes != 0) {

--- a/cmd-rotate-window.c
+++ b/cmd-rotate-window.c
@@ -50,7 +50,7 @@ cmd_rotate_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct window		*w = wl->window;
 	struct window_pane	*wp, *wp2;
 	struct layout_cell	*lc;
-	u_int			 sx, sy, xoff, yoff;
+	u_int			 sx, sy, ox, oy;
 
 	window_push_zoom(w, 0, args_has(args, 'Z'));
 
@@ -60,7 +60,7 @@ cmd_rotate_window_exec(struct cmd *self, struct cmdq_item *item)
 		TAILQ_INSERT_HEAD(&w->panes, wp, entry);
 
 		lc = wp->layout_cell;
-		xoff = wp->xoff; yoff = wp->yoff;
+		ox = wp->ox; oy = wp->oy;
 		sx = wp->sx; sy = wp->sy;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
 			if ((wp2 = TAILQ_NEXT(wp, entry)) == NULL)
@@ -68,13 +68,13 @@ cmd_rotate_window_exec(struct cmd *self, struct cmdq_item *item)
 			wp->layout_cell = wp2->layout_cell;
 			if (wp->layout_cell != NULL)
 				wp->layout_cell->wp = wp;
-			wp->xoff = wp2->xoff; wp->yoff = wp2->yoff;
+			wp->ox = wp2->ox; wp->oy = wp2->oy;
 			window_pane_resize(wp, wp2->sx, wp2->sy);
 		}
 		wp->layout_cell = lc;
 		if (wp->layout_cell != NULL)
 			wp->layout_cell->wp = wp;
-		wp->xoff = xoff; wp->yoff = yoff;
+		wp->ox = ox; wp->oy = oy;
 		window_pane_resize(wp, sx, sy);
 
 		if ((wp = TAILQ_PREV(w->active, window_panes, entry)) == NULL)
@@ -85,7 +85,7 @@ cmd_rotate_window_exec(struct cmd *self, struct cmdq_item *item)
 		TAILQ_INSERT_TAIL(&w->panes, wp, entry);
 
 		lc = wp->layout_cell;
-		xoff = wp->xoff; yoff = wp->yoff;
+		ox = wp->ox; oy = wp->oy;
 		sx = wp->sx; sy = wp->sy;
 		TAILQ_FOREACH_REVERSE(wp, &w->panes, window_panes, entry) {
 			if ((wp2 = TAILQ_PREV(wp, window_panes, entry)) == NULL)
@@ -93,13 +93,13 @@ cmd_rotate_window_exec(struct cmd *self, struct cmdq_item *item)
 			wp->layout_cell = wp2->layout_cell;
 			if (wp->layout_cell != NULL)
 				wp->layout_cell->wp = wp;
-			wp->xoff = wp2->xoff; wp->yoff = wp2->yoff;
+			wp->ox = wp2->ox; wp->oy = wp2->oy;
 			window_pane_resize(wp, wp2->sx, wp2->sy);
 		}
 		wp->layout_cell = lc;
 		if (wp->layout_cell != NULL)
 			wp->layout_cell->wp = wp;
-		wp->xoff = xoff; wp->yoff = yoff;
+		wp->ox = ox; wp->oy = oy;
 		window_pane_resize(wp, sx, sy);
 
 		if ((wp = TAILQ_NEXT(w->active, entry)) == NULL)

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -89,8 +89,8 @@ cmd_split_window_get_floating_cell(struct cmdq_item *item, struct args *args,
 	 * tree so we call it with parent == NULL.
 	 */
 	lc = layout_create_cell(NULL);
-	lc->xoff = x;
-	lc->yoff = y;
+	lc->ox = x;
+	lc->oy = y;
 	lc->sx = sx;
 	lc->sy = sy;
 

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -51,7 +51,7 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window		*src_w, *dst_w;
 	struct window_pane	*tmp_wp, *src_wp, *dst_wp;
 	struct layout_cell	*src_lc, *dst_lc;
-	u_int			 sx, sy, xoff, yoff;
+	u_int			 sx, sy, ox, oy;
 
 	dst_w = target->wl->window;
 	dst_wp = target->wp;
@@ -124,10 +124,10 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->flags |= (PANE_STYLECHANGED|PANE_THEMECHANGED);
 
 	sx = src_wp->sx; sy = src_wp->sy;
-	xoff = src_wp->xoff; yoff = src_wp->yoff;
-	src_wp->xoff = dst_wp->xoff; src_wp->yoff = dst_wp->yoff;
+	ox = src_wp->ox; oy = src_wp->oy;
+	src_wp->ox = dst_wp->ox; src_wp->oy = dst_wp->oy;
 	window_pane_resize(src_wp, dst_wp->sx, dst_wp->sy);
-	dst_wp->xoff = xoff; dst_wp->yoff = yoff;
+	dst_wp->ox = ox; dst_wp->oy = oy;
 	window_pane_resize(dst_wp, sx, sy);
 
 	if (!args_has(args, 'd')) {

--- a/cmd-tile-float-pane.c
+++ b/cmd-tile-float-pane.c
@@ -76,7 +76,7 @@ cmd_float_pane_parse_geometry(struct args *args, struct cmdq_item *item,
     int *last_x, int *last_y)
 {
 	char	*cause = NULL;
-	int	 x, y;
+	int	 ox, oy;
 	u_int	 sx, sy;
 
 	/* Default size: half the window. */
@@ -104,7 +104,7 @@ cmd_float_pane_parse_geometry(struct args *args, struct cmdq_item *item,
 
 	/* Default position: cascade from (5,5), step +5, wrap at window edge. */
 	if (args_has(args, 'x')) {
-		x = args_strtonum_and_expand(args, 'x', SHRT_MIN, SHRT_MAX,
+		ox = args_strtonum_and_expand(args, 'x', SHRT_MIN, SHRT_MAX,
 		    item, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "x %s", cause);
@@ -113,15 +113,15 @@ cmd_float_pane_parse_geometry(struct args *args, struct cmdq_item *item,
 		}
 	} else {
 		if (*last_x == 0) {
-			x = 5;
+			ox = 5;
 		} else {
-			x = (*last_x += 5);
+			ox = (*last_x += 5);
 			if (*last_x > (int)w->sx)
-				x = *last_x = 5;
+				ox = *last_x = 5;
 		}
 	}
 	if (args_has(args, 'y')) {
-		y = args_strtonum_and_expand(args, 'y', SHRT_MIN, SHRT_MAX,
+		oy = args_strtonum_and_expand(args, 'y', SHRT_MIN, SHRT_MAX,
 		    item, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "y %s", cause);
@@ -130,18 +130,18 @@ cmd_float_pane_parse_geometry(struct args *args, struct cmdq_item *item,
 		}
 	} else {
 		if (*last_y == 0) {
-			y = 5;
+			oy = 5;
 		} else {
-			y = (*last_y += 5);
+			oy = (*last_y += 5);
 			if (*last_y > (int)w->sy)
-				y = *last_y = 5;
+				oy = *last_y = 5;
 		}
 	}
 
-	*last_x = x;
-	*last_y = y;
-	*out_x = x;
-	*out_y = y;
+	*last_x = ox;
+	*last_y = oy;
+	*out_x = ox;
+	*out_y = oy;
 	*out_sx = sx;
 	*out_sy = sy;
 	return (0);
@@ -155,7 +155,7 @@ cmd_float_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window		*w = target->wl->window;
 	struct window_pane	*wp = target->wp;
 	static int		 last_x = 0, last_y = 0;
-	int			 x, y;
+	int			 ox, oy;
 	u_int			 sx, sy;
 	struct layout_cell	*lc;
 
@@ -179,12 +179,12 @@ cmd_float_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if ((wp->flags & PANE_SAVED_FLOAT) &&
 	    !args_has(args, 'x') && !args_has(args, 'y') &&
 	    !args_has(args, 'w') && !args_has(args, 'h')) {
-		x  = wp->saved_float_xoff;
-		y  = wp->saved_float_yoff;
+		ox  = wp->saved_float_ox;
+		oy  = wp->saved_float_oy;
 		sx = wp->saved_float_sx;
 		sy = wp->saved_float_sy;
 	} else {
-		if (cmd_float_pane_parse_geometry(args, item, w, &x, &y, &sx,
+		if (cmd_float_pane_parse_geometry(args, item, w, &ox, &oy, &sx,
 		    &sy, &last_x, &last_y) != 0)
 			return (CMD_RETURN_ERROR);
 	}
@@ -201,8 +201,8 @@ cmd_float_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	/* Create a detached floating cell with the requested geometry. */
 	lc = layout_create_cell(NULL);
-	lc->xoff = x;
-	lc->yoff = y;
+	lc->ox = ox;
+	lc->oy = oy;
 	lc->sx = sx;
 	lc->sy = sy;
 	layout_make_leaf(lc, wp);	/* sets wp->layout_cell = lc, lc->wp = wp */
@@ -247,8 +247,8 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	 * is floated without an explicit position/size.
 	 */
 	float_lc = wp->layout_cell;
-	wp->saved_float_xoff = float_lc->xoff;
-	wp->saved_float_yoff = float_lc->yoff;
+	wp->saved_float_ox = float_lc->ox;
+	wp->saved_float_oy = float_lc->oy;
 	wp->saved_float_sx   = float_lc->sx;
 	wp->saved_float_sy   = float_lc->sy;
 	wp->flags |= PANE_SAVED_FLOAT;
@@ -331,8 +331,8 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 		lc = layout_create_cell(NULL);
 		lc->sx = w->sx;
 		lc->sy = w->sy;
-		lc->xoff = 0;
-		lc->yoff = 0;
+		lc->ox = 0;
+		lc->oy = 0;
 		w->layout_root = lc;
 		layout_make_leaf(lc, wp);
 	}

--- a/cmd.c
+++ b/cmd.c
@@ -784,15 +784,15 @@ cmd_mouse_at(struct window_pane *wp, struct mouse_event *m, u_int *xp,
 	if (m->statusat == 0 && y >= m->statuslines)
 		y -= m->statuslines;
 
-	if ((int)x < wp->xoff || (int)x >= wp->xoff + (int)wp->sx)
+	if ((int)x < wp->ox || (int)x >= wp->ox + (int)wp->sx)
 		return (-1);
-	if ((int)y < wp->yoff || (int)y >= wp->yoff + (int)wp->sy)
+	if ((int)y < wp->oy || (int)y >= wp->oy + (int)wp->sy)
 		return (-1);
 
 	if (xp != NULL)
-		*xp = x - wp->xoff;
+		*xp = x - wp->ox;
 	if (yp != NULL)
-		*yp = y - wp->yoff;
+		*yp = y - wp->oy;
 	return (0);
 }
 

--- a/format.c
+++ b/format.c
@@ -1162,9 +1162,9 @@ format_cb_pane_at_top(struct format_tree *ft)
 
 	status = options_get_number(w->options, "pane-border-status");
 	if (status == PANE_STATUS_TOP)
-		flag = (wp->yoff == 1);
+		flag = (wp->oy == 1);
 	else
-		flag = (wp->yoff == 0);
+		flag = (wp->oy == 0);
 	xasprintf(&value, "%d", flag);
 	return (value);
 }
@@ -1184,9 +1184,9 @@ format_cb_pane_at_bottom(struct format_tree *ft)
 
 	status = options_get_number(w->options, "pane-border-status");
 	if (status == PANE_STATUS_BOTTOM)
-		flag = (wp->yoff + (int)wp->sy == (int)w->sy - 1);
+		flag = (wp->oy + (int)wp->sy == (int)w->sy - 1);
 	else
-		flag = (wp->yoff + (int)wp->sy == (int)w->sy);
+		flag = (wp->oy + (int)wp->sy == (int)w->sy);
 	xasprintf(&value, "%d", flag);
 	return (value);
 }
@@ -2036,7 +2036,7 @@ static void *
 format_cb_pane_at_left(struct format_tree *ft)
 {
 	if (ft->wp != NULL) {
-		if (ft->wp->xoff == 0)
+		if (ft->wp->ox == 0)
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}
@@ -2048,7 +2048,7 @@ static void *
 format_cb_pane_at_right(struct format_tree *ft)
 {
 	if (ft->wp != NULL) {
-		if (ft->wp->xoff + (int)ft->wp->sx == (int)ft->wp->window->sx)
+		if (ft->wp->ox + (int)ft->wp->sx == (int)ft->wp->window->sx)
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}
@@ -2062,7 +2062,7 @@ format_cb_pane_bottom(struct format_tree *ft)
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL)
-		return (format_printf("%d", wp->yoff + (int)wp->sy - 1));
+		return (format_printf("%d", wp->oy + (int)wp->sy - 1));
 	return (NULL);
 }
 
@@ -2221,7 +2221,7 @@ static void *
 format_cb_pane_left(struct format_tree *ft)
 {
 	if (ft->wp != NULL)
-		return (format_printf("%d", ft->wp->xoff));
+		return (format_printf("%d", ft->wp->ox));
 	return (NULL);
 }
 
@@ -2361,7 +2361,7 @@ format_cb_pane_right(struct format_tree *ft)
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL)
-		return (format_printf("%d", wp->xoff + (int)wp->sx - 1));
+		return (format_printf("%d", wp->ox + (int)wp->sx - 1));
 	return (NULL);
 }
 
@@ -2403,7 +2403,7 @@ static void *
 format_cb_pane_top(struct format_tree *ft)
 {
 	if (ft->wp != NULL)
-		return (format_printf("%d", ft->wp->yoff));
+		return (format_printf("%d", ft->wp->oy));
 	return (NULL);
 }
 

--- a/layout-custom.c
+++ b/layout-custom.c
@@ -102,10 +102,10 @@ layout_append(struct layout_cell *lc, char *buf, size_t len)
 		return (0);
 	if (lc->wp != NULL) {
 		tmplen = xsnprintf(tmp, sizeof tmp, "%ux%u,%d,%d,%u",
-		    lc->sx, lc->sy, lc->xoff, lc->yoff, lc->wp->id);
+		    lc->sx, lc->sy, lc->ox, lc->oy, lc->wp->id);
 	} else {
 		tmplen = xsnprintf(tmp, sizeof tmp, "%ux%u,%d,%d",
-		    lc->sx, lc->sy, lc->xoff, lc->yoff);
+		    lc->sx, lc->sy, lc->ox, lc->oy);
 	}
 	if (tmplen > (sizeof tmp) - 1)
 		return (-1);
@@ -346,12 +346,12 @@ layout_construct_cell(struct layout_cell *lcparent, const char **layout)
 {
 	struct layout_cell     *lc;
 	u_int			sx, sy;
-	int			xoff, yoff;
+	int			ox, oy;
 	const char	       *saved;
 
 	if (!isdigit((u_char) **layout))
 		return (NULL);
-	if (sscanf(*layout, "%ux%u,%d,%d", &sx, &sy, &xoff, &yoff) != 4)
+	if (sscanf(*layout, "%ux%u,%d,%d", &sx, &sy, &ox, &oy) != 4)
 		return (NULL);
 
 	while (isdigit((u_char) **layout))
@@ -383,8 +383,8 @@ layout_construct_cell(struct layout_cell *lcparent, const char **layout)
 	lc = layout_create_cell(lcparent);
 	lc->sx = sx;
 	lc->sy = sy;
-	lc->xoff = xoff;
-	lc->yoff = yoff;
+	lc->ox = ox;
+	lc->oy = oy;
 
 	return (lc);
 }

--- a/layout.c
+++ b/layout.c
@@ -65,8 +65,8 @@ layout_create_cell(struct layout_cell *lcparent)
 	lc->sx = UINT_MAX;
 	lc->sy = UINT_MAX;
 
-	lc->xoff = INT_MAX;
-	lc->yoff = INT_MAX;
+	lc->ox = INT_MAX;
+	lc->oy = INT_MAX;
 
 	lc->wp = NULL;
 
@@ -143,7 +143,7 @@ layout_print_cell(struct layout_cell *lc, const char *hdr, u_int n)
 		break;
 	}
 	log_debug("%s:%*s%p type %s [parent %p] wp=%p [%d,%d %ux%u]", hdr, n,
-	    " ", lc, type, lc->parent, lc->wp, lc->xoff, lc->yoff, lc->sx,
+	    " ", lc, type, lc->parent, lc->wp, lc->ox, lc->oy, lc->sx,
 	    lc->sy);
 	switch (lc->type) {
 	case LAYOUT_LEFTRIGHT:
@@ -164,10 +164,10 @@ layout_search_by_border(struct layout_cell *lc, u_int x, u_int y)
 	struct layout_cell	*lcchild, *last = NULL;
 
 	TAILQ_FOREACH(lcchild, &lc->cells, entry) {
-		if ((int)x >= lcchild->xoff &&
-		    (int)x < lcchild->xoff + (int)lcchild->sx &&
-		    (int)y >= lcchild->yoff &&
-		    (int)y < lcchild->yoff + (int)lcchild->sy) {
+		if ((int)x >= lcchild->ox &&
+		    (int)x < lcchild->ox + (int)lcchild->sx &&
+		    (int)y >= lcchild->oy &&
+		    (int)y < lcchild->oy + (int)lcchild->sy) {
 			/* Inside the cell - recurse. */
 			return (layout_search_by_border(lcchild, x, y));
 		}
@@ -179,13 +179,13 @@ layout_search_by_border(struct layout_cell *lc, u_int x, u_int y)
 
 		switch (lc->type) {
 		case LAYOUT_LEFTRIGHT:
-			if ((int)x < lcchild->xoff &&
-			    (int)x >= last->xoff + (int)last->sx)
+			if ((int)x < lcchild->ox &&
+			    (int)x >= last->ox + (int)last->sx)
 				return (last);
 			break;
 		case LAYOUT_TOPBOTTOM:
-			if ((int)y < lcchild->yoff &&
-			    (int)y >= last->yoff + (int)last->sy)
+			if ((int)y < lcchild->oy &&
+			    (int)y >= last->oy + (int)last->sy)
 				return (last);
 			break;
 		case LAYOUT_WINDOWPANE:
@@ -201,13 +201,13 @@ layout_search_by_border(struct layout_cell *lc, u_int x, u_int y)
 
 /* Set cell size. */
 void
-layout_set_size(struct layout_cell *lc, u_int sx, u_int sy, int xoff, int yoff)
+layout_set_size(struct layout_cell *lc, u_int sx, u_int sy, int ox, int oy)
 {
 	lc->sx = sx;
 	lc->sy = sy;
 
-	lc->xoff = xoff;
-	lc->yoff = yoff;
+	lc->ox = ox;
+	lc->oy = oy;
 }
 
 /* Make a cell a leaf cell. */
@@ -266,33 +266,33 @@ static void
 layout_fix_offsets1(struct layout_cell *lc)
 {
 	struct layout_cell	*lcchild;
-	int			 xoff, yoff;
+	int			 ox, oy;
 
 	if (lc->type == LAYOUT_LEFTRIGHT) {
-		xoff = lc->xoff;
+		ox = lc->ox;
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 			if (lcchild->type == LAYOUT_WINDOWPANE &&
 			    lcchild->wp != NULL &&
 			    lcchild->wp->flags & PANE_HIDDEN)
 				continue;
-			lcchild->xoff = xoff;
-			lcchild->yoff = lc->yoff;
+			lcchild->ox = ox;
+			lcchild->oy = lc->oy;
 			if (lcchild->type != LAYOUT_WINDOWPANE)
 				layout_fix_offsets1(lcchild);
-			xoff += lcchild->sx + 1;
+			ox += lcchild->sx + 1;
 		}
 	} else {
-		yoff = lc->yoff;
+		oy = lc->oy;
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 			if (lcchild->type == LAYOUT_WINDOWPANE &&
 			    lcchild->wp != NULL &&
 			    lcchild->wp->flags & PANE_HIDDEN)
 				continue;
-			lcchild->xoff = lc->xoff;
-			lcchild->yoff = yoff;
+			lcchild->ox = lc->ox;
+			lcchild->oy = oy;
 			if (lcchild->type != LAYOUT_WINDOWPANE)
 				layout_fix_offsets1(lcchild);
-			yoff += lcchild->sy + 1;
+			oy += lcchild->sy + 1;
 		}
 	}
 }
@@ -303,8 +303,8 @@ layout_fix_offsets(struct window *w)
 {
 	struct layout_cell	*lc = w->layout_root;
 
-	lc->xoff = 0;
-	lc->yoff = 0;
+	lc->ox = 0;
+	lc->oy = 0;
 
 	layout_fix_offsets1(lc);
 }
@@ -377,15 +377,15 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 		if ((lc = wp->layout_cell) == NULL || wp == skip)
 			continue;
 
-		wp->xoff = lc->xoff;
-		wp->yoff = lc->yoff;
+		wp->ox = lc->ox;
+		wp->oy = lc->oy;
 		sx = lc->sx;
 		sy = lc->sy;
 
 		if ((~wp->flags & PANE_FLOATING) &&
 		    layout_add_horizontal_border(w, lc, status)) {
 			if (status == PANE_STATUS_TOP)
-				wp->yoff++;
+				wp->oy++;
 			sy--;
 		}
 
@@ -398,12 +398,12 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 				sb_pad = 0;
 			if (sb_pos == PANE_SCROLLBARS_LEFT) {
 				if ((int)sx - sb_w < PANE_MINIMUM) {
-					wp->xoff = wp->xoff +
+					wp->ox = wp->ox +
 					    (int)sx - PANE_MINIMUM;
 					sx = PANE_MINIMUM;
 				} else {
 					sx = sx - sb_w - sb_pad;
-					wp->xoff = wp->xoff + sb_w + sb_pad;
+					wp->ox = wp->ox + sb_w + sb_pad;
 				}
 			} else /* sb_pos == PANE_SCROLLBARS_RIGHT */
 				if ((int)sx - sb_w - sb_pad < PANE_MINIMUM)
@@ -684,8 +684,8 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 
 		lc->parent = lcparent->parent;
 		if (lc->parent == NULL) {
-			lc->xoff = 0;
-			lc->yoff = 0;
+			lc->ox = 0;
+			lc->oy = 0;
 
 			/*
 			 * If the sole remaining child is a hidden
@@ -1143,7 +1143,7 @@ layout_resize_child_cells(struct window *w, struct layout_cell *lc)
 	TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 		if (lc->type == LAYOUT_TOPBOTTOM) {
 			lcchild->sx = lc->sx;
-			lcchild->xoff = lc->xoff;
+			lcchild->ox = lc->ox;
 		} else {
 			lcchild->sx = layout_new_pane_size(w, previous, lcchild,
 			    lc->type, lc->sx, count - idx, available);
@@ -1171,7 +1171,7 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 {
 	struct layout_cell	*lc, *lcparent, *lcnew, *lc1, *lc2;
 	struct style		*sb_style = &wp->scrollbar_style;
-	u_int			 sx, sy, xoff, yoff, size1, size2, minimum;
+	u_int			 sx, sy, ox, oy, size1, size2, minimum;
 	u_int			 new_size, saved_size, resize_first = 0;
 	int			 full_size = (flags & SPAWN_FULLSIZE), status;
 	int			 scrollbars;
@@ -1190,8 +1190,8 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 	/* Copy the old cell size. */
 	sx = lc->sx;
 	sy = lc->sy;
-	xoff = lc->xoff;
-	yoff = lc->yoff;
+	ox = lc->ox;
+	oy = lc->oy;
 
 	/* Check there is enough space for the two new panes. */
 	switch (type) {
@@ -1294,7 +1294,7 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 		/* Create and insert the replacement parent. */
 		lcparent = layout_create_cell(lc->parent);
 		layout_make_node(lcparent, type);
-		layout_set_size(lcparent, sx, sy, xoff, yoff);
+		layout_set_size(lcparent, sx, sy, ox, oy);
 		if (lc->parent == NULL)
 			wp->window->layout_root = lcparent;
 		else
@@ -1324,11 +1324,11 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 	 * bottom/right.
 	 */
 	if (!resize_first && type == LAYOUT_LEFTRIGHT) {
-		layout_set_size(lc1, size1, sy, xoff, yoff);
-		layout_set_size(lc2, size2, sy, xoff + lc1->sx + 1, yoff);
+		layout_set_size(lc1, size1, sy, ox, oy);
+		layout_set_size(lc2, size2, sy, ox + lc1->sx + 1, oy);
 	} else if (!resize_first && type == LAYOUT_TOPBOTTOM) {
-		layout_set_size(lc1, sx, size1, xoff, yoff);
-		layout_set_size(lc2, sx, size2, xoff, yoff + lc1->sy + 1);
+		layout_set_size(lc1, sx, size1, ox, oy);
+		layout_set_size(lc2, sx, size2, ox, oy + lc1->sy + 1);
 	}
 	if (full_size) {
 		if (!resize_first)

--- a/popup.c
+++ b/popup.c
@@ -191,11 +191,11 @@ popup_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	ttyctx->wsy = c->tty.sy;
 
 	if (pd->border_lines == BOX_LINES_NONE) {
-		ttyctx->xoff = ttyctx->rxoff = pd->px;
-		ttyctx->yoff = ttyctx->ryoff = pd->py;
+		ttyctx->ox = ttyctx->rox = pd->px;
+		ttyctx->oy = ttyctx->roy = pd->py;
 	} else {
-		ttyctx->xoff = ttyctx->rxoff = pd->px + 1;
-		ttyctx->yoff = ttyctx->ryoff = pd->py + 1;
+		ttyctx->ox = ttyctx->rox = pd->px + 1;
+		ttyctx->oy = ttyctx->roy = pd->py + 1;
 	}
 
 	return (1);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -124,7 +124,7 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
     int px, int py)
 {
 	struct options	*oo = wp->window->options;
-	int		 ex = wp->xoff + wp->sx, ey = wp->yoff + wp->sy;
+	int		 ex = wp->ox + wp->sx, ey = wp->oy + wp->sy;
 	int		 hsplit = 0, vsplit = 0, pane_status = ctx->pane_status;
 	int		 pane_scrollbars = ctx->pane_scrollbars, sb_w = 0;
 	int		 sb_pos, sx = wp->sx, sy = wp->sy;
@@ -136,7 +136,7 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 		sb_pos = 0;
 
 	/* Inside pane. */
-	if (px >= wp->xoff && px < ex && py >= wp->yoff && py < ey)
+	if (px >= wp->ox && px < ex && py >= wp->oy && py < ey)
 		return (SCREEN_REDRAW_INSIDE);
 
 	/* Are scrollbars enabled? */
@@ -145,23 +145,23 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 
 	/* Floating pane borders. */
 	if (wp->flags & PANE_FLOATING) {
-		if (py >= wp->yoff - 1 && py <= wp->yoff + sy) {
+		if (py >= wp->oy - 1 && py <= wp->oy + sy) {
 			if (sb_pos == PANE_SCROLLBARS_LEFT) {
-				if (px == wp->xoff - 1 - sb_w)
+				if (px == wp->ox - 1 - sb_w)
 					return (SCREEN_REDRAW_BORDER_LEFT);
-				if (px == wp->xoff + sx)
+				if (px == wp->ox + sx)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			} else { /* PANE_SCROLLBARS_RIGHT or none. */
-				if (px == wp->xoff - 1)
+				if (px == wp->ox - 1)
 					return (SCREEN_REDRAW_BORDER_LEFT);
-				if (px == wp->xoff + sx + sb_w)
+				if (px == wp->ox + sx + sb_w)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
 		}
-		if (px >= wp->xoff && px <= wp->xoff + sx) {
-			if (py == wp->yoff - 1)
+		if (px >= wp->ox && px <= wp->ox + sx) {
+			if (py == wp->oy - 1)
 				return (SCREEN_REDRAW_BORDER_TOP);
-			if (py == wp->yoff + sy)
+			if (py == wp->oy + sy)
 				return (SCREEN_REDRAW_BORDER_BOTTOM);
 		}
 		return (SCREEN_REDRAW_OUTSIDE);
@@ -182,29 +182,29 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	 * Left/right borders. The sy / 2 test is to colour only half the
 	 * active window's border when there are two panes.
 	 */
-	if ((wp->yoff == 0 || py >= wp->yoff - 1) && py <= ey) {
+	if ((wp->oy == 0 || py >= wp->oy - 1) && py <= ey) {
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if (wp->xoff - sb_w == 0 && px == sx + sb_w) {
+			if (wp->ox - sb_w == 0 && px == sx + sb_w) {
 				if (!hsplit || (hsplit && py <= sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
-			if (wp->xoff - sb_w != 0) {
-				if (px == wp->xoff - sb_w - 1 &&
+			if (wp->ox - sb_w != 0) {
+				if (px == wp->ox - sb_w - 1 &&
 				    (!hsplit || (hsplit && py > sy / 2)))
 					return (SCREEN_REDRAW_BORDER_LEFT);
-				if (px == wp->xoff + sx + sb_w - 1)
+				if (px == wp->ox + sx + sb_w - 1)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
 		} else { /* sb_pos == PANE_SCROLLBARS_RIGHT or disabled */
-			if (wp->xoff == 0 && px == sx + sb_w) {
+			if (wp->ox == 0 && px == sx + sb_w) {
 				if (!hsplit || (hsplit && py <= sy / 2))
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
-			if (wp->xoff != 0) {
-				if (px == wp->xoff - 1 &&
+			if (wp->ox != 0) {
+				if (px == wp->ox - 1 &&
 				    (!hsplit || (hsplit && py > sy / 2)))
 					return (SCREEN_REDRAW_BORDER_LEFT);
-				if (px == wp->xoff + sx + sb_w)
+				if (px == wp->ox + sx + sb_w)
 					return (SCREEN_REDRAW_BORDER_RIGHT);
 			}
 		}
@@ -212,25 +212,25 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 
 	/* Top/bottom borders. */
 	if (vsplit && pane_status == PANE_STATUS_OFF && sb_w == 0) {
-		if (wp->yoff == 0 && py == sy && px <= sx / 2)
+		if (wp->oy == 0 && py == sy && px <= sx / 2)
 			return (SCREEN_REDRAW_BORDER_BOTTOM);
-		if (wp->yoff != 0 && py == wp->yoff - 1 && px > sx / 2)
+		if (wp->oy != 0 && py == wp->oy - 1 && px > sx / 2)
 			return (SCREEN_REDRAW_BORDER_TOP);
 	} else {
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if ((wp->xoff - sb_w == 0 || px >= wp->xoff - sb_w) &&
+			if ((wp->ox - sb_w == 0 || px >= wp->ox - sb_w) &&
 			    (px <= ex || (sb_w != 0 && px < ex + sb_w))) {
-				if (wp->yoff != 0 && py == wp->yoff - 1)
+				if (wp->oy != 0 && py == wp->oy - 1)
 					return (SCREEN_REDRAW_BORDER_TOP);
 				if (py == ey)
 					return (SCREEN_REDRAW_BORDER_BOTTOM);
 			}
 		} else { /* sb_pos == PANE_SCROLLBARS_RIGHT */
-			if ((wp->xoff == 0 || px >= wp->xoff) &&
+			if ((wp->ox == 0 || px >= wp->ox) &&
 			    (px <= ex || (sb_w != 0 && px < ex + sb_w))) {
 				if (pane_status != PANE_STATUS_BOTTOM &&
-				    wp->yoff != 0 &&
-				    py == wp->yoff - 1)
+				    wp->oy != 0 &&
+				    py == wp->oy - 1)
 					return (SCREEN_REDRAW_BORDER_TOP);
 				if (pane_status != PANE_STATUS_TOP && py == ey)
 					return (SCREEN_REDRAW_BORDER_BOTTOM);
@@ -289,16 +289,16 @@ screen_redraw_cell_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 		    (floating && wp2 != wp))
 			continue;
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if ((px < wp2->xoff - 1 - sb_w ||
-			    px > wp2->xoff + (int)wp2->sx) &&
-			    (py < wp2->yoff - 1 ||
-			    py > wp2->yoff + (int)wp2->sy))
+			if ((px < wp2->ox - 1 - sb_w ||
+			    px > wp2->ox + (int)wp2->sx) &&
+			    (py < wp2->oy - 1 ||
+			    py > wp2->oy + (int)wp2->sy))
 				continue;
 		} else { /* PANE_SCROLLBARS_RIGHT or off. */
-			if ((px < wp2->xoff - 1 ||
-			    px > wp2->xoff + (int)wp2->sx + sb_w) &&
-			    (py < wp2->yoff - 1 ||
-			    py > wp2->yoff + (int)wp2->sy))
+			if ((px < wp2->ox - 1 ||
+			    px > wp2->ox + (int)wp2->sx + sb_w) &&
+			    (py < wp2->oy - 1 ||
+			    py > wp2->oy + (int)wp2->sy))
 				continue;
 		}
 		switch (screen_redraw_pane_border(ctx, wp2, px, py)) {
@@ -448,16 +448,16 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 		}
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if ((px >= wp->xoff - 1 - sb_w &&
-			    px <= wp->xoff + (int)wp->sx) &&
-			    (py >= wp->yoff - 1 &&
-			    py <= wp->yoff + (int)wp->sy))
+			if ((px >= wp->ox - 1 - sb_w &&
+			    px <= wp->ox + (int)wp->sx) &&
+			    (py >= wp->oy - 1 &&
+			    py <= wp->oy + (int)wp->sy))
 				break;
 		} else { /* PANE_SCROLLBARS_RIGHT or none. */
-			if ((px >= wp->xoff - 1 &&
-			    px <= wp->xoff + (int)wp->sx + sb_w) &&
-			    (py >= wp->yoff - 1 &&
-			    py <= wp->yoff + (int)wp->sy))
+			if ((px >= wp->ox - 1 &&
+			    px <= wp->ox + (int)wp->sx + sb_w) &&
+			    (py >= wp->oy - 1 &&
+			    py <= wp->oy + (int)wp->sy))
 				break;
 		}
 	}
@@ -487,16 +487,16 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
-			if ((px < wp->xoff - 1 - sb_w ||
-			     px > wp->xoff + (int)wp->sx) &&
-			    (py < wp->yoff - 1 ||
-			    py > wp->yoff + (int)wp->sy))
+			if ((px < wp->ox - 1 - sb_w ||
+			     px > wp->ox + (int)wp->sx) &&
+			    (py < wp->oy - 1 ||
+			    py > wp->oy + (int)wp->sy))
 				goto next;
 		} else { /* PANE_SCROLLBARS_RIGHT or none. */
-			if ((px < wp->xoff - 1 ||
-			     px > wp->xoff + (int)wp->sx + sb_w) &&
-			    (py < wp->yoff - 1 ||
-			     py > wp->yoff + (int)wp->sy))
+			if ((px < wp->ox - 1 ||
+			     px > wp->ox + (int)wp->sx + sb_w) &&
+			    (py < wp->oy - 1 ||
+			     py > wp->oy + (int)wp->sy))
 				goto next;
 		}
 
@@ -506,11 +506,11 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 		 */
 		if (pane_status != PANE_STATUS_OFF) {
 			if (pane_status == PANE_STATUS_TOP)
-				pane_status_line = wp->yoff - 1;
+				pane_status_line = wp->oy - 1;
 			else
-				pane_status_line = wp->yoff + (int)wp->sy;
-			left = wp->xoff + 2;
-			right = wp->xoff + 2 + (int)wp->status_size - 1;
+				pane_status_line = wp->oy + (int)wp->sy;
+			left = wp->ox + 2;
+			right = wp->ox + 2 + (int)wp->status_size - 1;
 			if (py == pane_status_line + (int)ctx->oy &&
 			    px >= left &&
 			    px <= right)
@@ -522,20 +522,20 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 			/*
 			 * Check if py could lie within a scrollbar. If the
 			 * pane is at the top then py == 0 to sy; if the pane
-			 * is not at the top, then yoff to yoff + sy.
+			 * is not at the top, then oy to oy + sy.
 			 */
 			sb_w = wp->scrollbar_style.width +
 			    wp->scrollbar_style.pad;
-			if ((wp->yoff == 0 && py < (int)wp->sy) ||
-			    (py >= wp->yoff &&
-			     py < wp->yoff + (int)wp->sy)) {
+			if ((wp->oy == 0 && py < (int)wp->sy) ||
+			    (py >= wp->oy &&
+			     py < wp->oy + (int)wp->sy)) {
 				/* Check if px lies within a scrollbar. */
 				if ((sb_pos == PANE_SCROLLBARS_RIGHT &&
-				    (px >= wp->xoff + (int)wp->sx &&
-				    px < wp->xoff + (int)wp->sx + sb_w)) ||
+				    (px >= wp->ox + (int)wp->sx &&
+				    px < wp->ox + (int)wp->sx + sb_w)) ||
 				    (sb_pos == PANE_SCROLLBARS_LEFT &&
-				    (px >= wp->xoff - sb_w &&
-				    px < wp->xoff)))
+				    (px >= wp->ox - sb_w &&
+				    px < wp->ox)))
 					return (CELL_SCROLLBAR);
 			}
 		}
@@ -615,7 +615,7 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 		width = 0;
 	else
 		width = wp->sx + sb_w - 2;
-	max_width = (int)w->sx - (wp->xoff + 2) - sb_w;
+	max_width = (int)w->sx - (wp->ox + 2) - sb_w;
 	if (max_width < 0) max_width = 0;
 	if (width > (u_int)max_width) width = (u_int)max_width;
 	wp->status_size = width;
@@ -627,11 +627,11 @@ screen_redraw_make_pane_status(struct client *c, struct window_pane *wp,
 	screen_write_start(&ctx, &wp->status_screen);
 
 	for (i = 0; i < width; i++) {
-		px = wp->xoff + 2 + i;
+		px = wp->ox + 2 + i;
 		if (pane_status == PANE_STATUS_TOP)
-			py = wp->yoff - 1;
+			py = wp->oy - 1;
 		else
-			py = wp->yoff + wp->sy;
+			py = wp->oy + wp->sy;
 		cell_type = screen_redraw_type_of_cell(rctx, wp, px, py);
 		screen_redraw_border_set(w, wp, pane_lines, cell_type, &gc);
 		screen_write_cell(&ctx, &gc);
@@ -668,7 +668,7 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	u_int			 i, l, x, width, size;
-	int			 xoff, yoff;
+	int			 ox, oy;
 
 	log_debug("%s: %s @%u", __func__, c->name, w->id);
 
@@ -679,49 +679,49 @@ screen_redraw_draw_pane_status(struct screen_redraw_ctx *ctx)
 
 		size = wp->status_size;
 		if (ctx->pane_status == PANE_STATUS_TOP)
-			yoff = wp->yoff - 1;
+			oy = wp->oy - 1;
 		else
-			yoff = wp->yoff + wp->sy;
-		xoff = wp->xoff + 2;
+			oy = wp->oy + wp->sy;
+		ox = wp->ox + 2;
 
-		if (xoff + (int)size <= ctx->ox ||
-		    xoff >= ctx->ox + (int)ctx->sx ||
-		    yoff < ctx->oy ||
-		    yoff >= ctx->oy + (int)ctx->sy)
+		if (ox + (int)size <= ctx->ox ||
+		    ox >= ctx->ox + (int)ctx->sx ||
+		    oy < ctx->oy ||
+		    oy >= ctx->oy + (int)ctx->sy)
 			continue;
 
-		if (xoff >= ctx->ox && xoff + size <= ctx->ox + ctx->sx) {
+		if (ox >= ctx->ox && ox + size <= ctx->ox + ctx->sx) {
 			/* All visible. */
 			l = 0;
-			x = xoff - ctx->ox;
+			x = ox - ctx->ox;
 			width = size;
-		} else if (xoff < ctx->ox && xoff + size > ctx->ox + ctx->sx) {
+		} else if (ox < ctx->ox && ox + size > ctx->ox + ctx->sx) {
 			/* Both left and right not visible. */
 			l = ctx->ox;
 			x = 0;
 			width = ctx->sx;
-		} else if (xoff < ctx->ox) {
+		} else if (ox < ctx->ox) {
 			/* Left not visible. */
-			l = ctx->ox - xoff;
+			l = ctx->ox - ox;
 			x = 0;
 			width = size - i;
 		} else {
 			/* Right not visible. */
 			l = 0;
-			x = xoff - ctx->ox;
+			x = ox - ctx->ox;
 			width = size - x;
 		}
 
-		r = tty_check_overlay_range(tty, x, yoff, width);
-		r = screen_redraw_get_visible_ranges(wp, x, yoff, width, r);
+		r = tty_check_overlay_range(tty, x, oy, width);
+		r = screen_redraw_get_visible_ranges(wp, x, oy, width, r);
 		if (ctx->statustop)
-			yoff += ctx->statuslines;
+			oy += ctx->statuslines;
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 			tty_draw_line(tty, s, l + (ri->px - x), 0, ri->nx,
-			    ri->px, yoff - ctx->oy,
+			    ri->px, oy - ctx->oy,
 			    &grid_default_cell, NULL);
 		}
 	}
@@ -918,7 +918,7 @@ screen_redraw_draw_border_arrows(struct screen_redraw_ctx *ctx, int i,
 
 	if (wp == NULL)
 		return;
-	if (i != wp->xoff + 1 && j != wp->yoff + 1)
+	if (i != wp->ox + 1 && j != wp->oy + 1)
 		return;
 
 	value = options_get_number(oo, "pane-border-indicators");
@@ -929,7 +929,7 @@ screen_redraw_draw_border_arrows(struct screen_redraw_ctx *ctx, int i,
 	if (border == SCREEN_REDRAW_INSIDE)
 		return;
 
-	if (i == wp->xoff + 1) {
+	if (i == wp->ox + 1) {
 		if (border == SCREEN_REDRAW_OUTSIDE) {
 			if (screen_redraw_two_panes(wp->window, &type)) {
 				if (active == TAILQ_FIRST(&w->panes))
@@ -949,7 +949,7 @@ screen_redraw_draw_border_arrows(struct screen_redraw_ctx *ctx, int i,
 				arrows = 1;
 		}
 	}
-	if (j == wp->yoff + 1) {
+	if (j == wp->oy + 1) {
 		if (border == SCREEN_REDRAW_OUTSIDE) {
 			if (screen_redraw_two_panes(wp->window, &type)) {
 				if (active == TAILQ_FIRST(&w->panes))
@@ -1175,8 +1175,8 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, u_int px,
 			continue;
 		}
 
-		tb = wp->yoff > 0 ? wp->yoff - 1 : 0;
-		bb = wp->yoff + wp->sy;
+		tb = wp->oy > 0 ? wp->oy - 1 : 0;
+		bb = wp->oy + wp->sy;
 		if (!found_self ||
 		    !window_pane_visible(wp) ||
 		    py < tb ||
@@ -1192,20 +1192,20 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, u_int px,
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (sb_pos == PANE_SCROLLBARS_LEFT) {
-				if (wp->xoff > sb_w)
-					lb = wp->xoff - 1 - sb_w;
+				if (wp->ox > sb_w)
+					lb = wp->ox - 1 - sb_w;
 				else
 					lb = 0;
 			} else { /* PANE_SCROLLBARS_RIGHT or none. */
-				if (wp->xoff > 0)
-					lb = wp->xoff - 1;
+				if (wp->ox > 0)
+					lb = wp->ox - 1;
 				else
 					lb = 0;
 			}
 			if (sb_pos == PANE_SCROLLBARS_LEFT)
-				rb = wp->xoff + wp->sx;
+				rb = wp->ox + wp->sx;
 			else /* PANE_SCROLLBARS_RIGHT or none. */
-				rb = wp->xoff + wp->sx + sb_w;
+				rb = wp->ox + wp->sx + sb_w;
 			if (rb > w->sx)
 				rb = w->sx - 1;
 
@@ -1285,8 +1285,8 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 
 	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
 
-	if (wp->xoff + (int)wp->sx <= ctx->ox ||
-	    wp->xoff >= (int)ctx->ox + (int)ctx->sx)
+	if (wp->ox + (int)wp->sx <= ctx->ox ||
+	    wp->ox >= (int)ctx->ox + (int)ctx->sx)
 		return;
 
 	if (ctx->statustop)
@@ -1294,36 +1294,36 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	else
 		woy = 0;
 	for (j = 0; j < wp->sy; j++) {
-		if (wp->yoff + (int)j < (int)ctx->oy ||
-		    wp->yoff + (int)j >= (int)ctx->oy + (int)ctx->sy)
+		if (wp->oy + (int)j < (int)ctx->oy ||
+		    wp->oy + (int)j >= (int)ctx->oy + (int)ctx->sy)
 			continue;
-		wy = wp->yoff + j;       /* y line within window w */
+		wy = wp->oy + j;       /* y line within window w */
 		py = woy + wy - ctx->oy; /* y line within tty */
 		if (py > tty->sy) {
 			/* Continue if this line is off of tty. */
 			continue;
 		}
-		if (wp->xoff >= (int)ctx->ox &&
-		    wp->xoff + (int)wp->sx <= (int)ctx->ox + (int)ctx->sx) {
+		if (wp->ox >= (int)ctx->ox &&
+		    wp->ox + (int)wp->sx <= (int)ctx->ox + (int)ctx->sx) {
 			/* All visible. */
 			i = 0;
-			wx = (u_int)(wp->xoff - (int)ctx->ox);
+			wx = (u_int)(wp->ox - (int)ctx->ox);
 			width = wp->sx;
-		} else if (wp->xoff < (int)ctx->ox &&
-		    wp->xoff + (int)wp->sx > (int)ctx->ox + (int)ctx->sx) {
+		} else if (wp->ox < (int)ctx->ox &&
+		    wp->ox + (int)wp->sx > (int)ctx->ox + (int)ctx->sx) {
 			/* Both left and right not visible. */
 			i = ctx->ox;
 			wx = 0;
 			width = ctx->sx;
-		} else if (wp->xoff < (int)ctx->ox) {
+		} else if (wp->ox < (int)ctx->ox) {
 			/* Left not visible. */
-			i = (u_int)((int)ctx->ox - wp->xoff);
+			i = (u_int)((int)ctx->ox - wp->ox);
 			wx = 0;
 			width = wp->sx - i;
 		} else {
 			/* Right not visible. */
 			i = 0;
-			wx = (u_int)(wp->xoff - (int)ctx->ox);
+			wx = (u_int)(wp->ox - (int)ctx->ox);
 			width = ctx->sx - wx;
 		}
 		log_debug("%s: %s %%%u line %u,%u at %u,%u, width %u",
@@ -1337,7 +1337,7 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 			ri = &r->ranges[k];
 			if (ri->nx == 0)
 				continue;
-			tty_draw_line(tty, s, ri->px - wp->xoff, j, ri->nx,
+			tty_draw_line(tty, s, ri->px - wp->ox, j, ri->nx,
 			    ri->px, py, &defaults, palette);
 		}
 	}
@@ -1375,8 +1375,8 @@ screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *ctx,
 	u_int		 sb_pos = ctx->pane_scrollbars_pos, slider_h, slider_y;
 	int		 sb_w = wp->scrollbar_style.width;
 	int		 sb_pad = wp->scrollbar_style.pad;
-	int		 cm_y, cm_size, xoff = wp->xoff;
-	int		 sb_x, sb_y = (int)(wp->yoff); /* sb top */
+	int		 cm_y, cm_size, ox = wp->ox;
+	int		 sb_x, sb_y = (int)(wp->oy); /* sb top */
 
 	if (window_pane_mode(wp) == WINDOW_PANE_NO_MODE) {
 		if (sb == PANE_SCROLLBARS_MODAL)
@@ -1398,9 +1398,9 @@ screen_redraw_draw_pane_scrollbar(struct screen_redraw_ctx *ctx,
 	}
 
 	if (sb_pos == PANE_SCROLLBARS_LEFT)
-		sb_x = xoff - sb_w - sb_pad;
+		sb_x = ox - sb_w - sb_pad;
 	else
-		sb_x = xoff + wp->sx;
+		sb_x = ox + wp->sx;
 
 	if (slider_h < 1)
 		slider_h = 1;
@@ -1428,8 +1428,8 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 	u_int			 i, j, imin = 0, jmin = 0, imax, jmax;
 	u_int			 sb_w = sb_style->width, sb_pad = sb_style->pad;
 	int			 px, py, wx, wy, ox, oy, sx, sy, sb_tty_y;
-	int			 xoff = wp->xoff;
-	int			 yoff = wp->yoff;
+	int			 pox = wp->ox;
+	int			 poy = wp->oy;
 	struct visible_ranges	*r;
 
 	/*
@@ -1505,9 +1505,9 @@ screen_redraw_draw_scrollbar(struct screen_redraw_ctx *ctx,
 		for (i = imin; i < imax; i++) {
 			px = sb_x + ox + i; /* tty x coordinate */
 			wx = sb_x + i; /* window x coordinate */
-			if (wx < xoff - (int)sb_w - (int)sb_pad ||
+			if (wx < pox - (int)sb_w - (int)sb_pad ||
 			    px >= sx || px < 0 ||
-			    wy < yoff - 1 ||
+			    wy < poy - 1 ||
 			    py >= sy || py < 0 ||
 			    !screen_redraw_is_visible(r, wx))
 				continue;

--- a/screen-write.c
+++ b/screen-write.c
@@ -166,11 +166,11 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	else
 		ttyctx->flags &= ~TTY_CTX_WINDOW_BIGGER;
 
-	ttyctx->xoff = ttyctx->rxoff = wp->xoff;
-	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
+	ttyctx->ox = ttyctx->rox = wp->ox;
+	ttyctx->oy = ttyctx->roy = wp->oy;
 
 	if (status_at_line(c) == 0)
-		ttyctx->yoff += status_line_size(c);
+		ttyctx->oy += status_line_size(c);
 
 	return (1);
 }
@@ -193,14 +193,14 @@ screen_write_pane_is_obscured(struct screen_write_ctx *ctx)
 
         while ((wp = TAILQ_PREV(wp, window_panes, zentry)) != NULL) {
                 if ((wp->flags & PANE_FLOATING) &&
-                    ((wp->yoff >= ctx->wp->yoff &&
-                    wp->yoff <= ctx->wp->yoff + (int)ctx->wp->sy) ||
-                    (wp->yoff + (int)wp->sy >= ctx->wp->yoff &&
-                    wp->yoff + wp->sy <= ctx->wp->yoff + ctx->wp->sy)) &&
-                    ((wp->xoff >= ctx->wp->xoff &&
-                    wp->xoff <= ctx->wp->xoff + (int)ctx->wp->sx) ||
-                    (wp->xoff + (int)wp->sx >= ctx->wp->xoff &&
-                    wp->xoff + wp->sx <= ctx->wp->xoff + ctx->wp->sx))) {
+                    ((wp->oy >= ctx->wp->oy &&
+                    wp->oy <= ctx->wp->oy + (int)ctx->wp->sy) ||
+                    (wp->oy + (int)wp->sy >= ctx->wp->oy &&
+                    wp->oy + wp->sy <= ctx->wp->oy + ctx->wp->sy)) &&
+                    ((wp->ox >= ctx->wp->ox &&
+                    wp->ox <= ctx->wp->ox + (int)ctx->wp->sx) ||
+                    (wp->ox + (int)wp->sx >= ctx->wp->ox &&
+                    wp->ox + wp->sx <= ctx->wp->ox + ctx->wp->sx))) {
 			ctx->flags |= SCREEN_WRITE_OBSCURED;
                         return (1);
 		}
@@ -319,7 +319,7 @@ screen_write_start_pane(struct screen_write_ctx *ctx, struct window_pane *wp,
 	if (log_get_level() != 0) {
 		log_debug("%s: size %ux%u, pane %%%u (at %u,%u)",
 		    __func__, screen_size_x(ctx->s), screen_size_y(ctx->s),
-		    wp->id, wp->xoff, wp->yoff);
+		    wp->id, wp->ox, wp->oy);
 	}
 }
 
@@ -618,7 +618,7 @@ screen_write_fast_copy(struct screen_write_ctx *ctx, struct screen *src,
 	struct grid_line	*gl, *sgl;
 	struct grid_cell	 gc;
 	u_int		 	 xx, yy, cx = s->cx, cy = s->cy;
-	int			 yoff = 0;
+	int			 oy = 0;
 	struct visible_ranges	*r;
 
 	if (nx == 0 || ny == 0)
@@ -630,8 +630,8 @@ screen_write_fast_copy(struct screen_write_ctx *ctx, struct screen *src,
 		s->cx = cx;
 		screen_write_initctx(ctx, &ttyctx, 0, 0);
 		if (wp != NULL)
-			yoff = wp->yoff;
-		r = screen_redraw_get_visible_ranges(wp, px, s->cy + yoff, nx,
+			oy = wp->oy;
+		r = screen_redraw_get_visible_ranges(wp, px, s->cy + oy, nx,
 		    NULL);
 		for (xx = px; xx < px + nx; xx++) {
 			gl = grid_get_line(gd, yy);
@@ -1118,7 +1118,7 @@ screen_write_alignmenttest(struct screen_write_ctx *ctx)
 	struct screen		*s = ctx->s;
 	struct tty_ctx	 	 ttyctx;
 	struct grid_cell       	 gc;
-	u_int			 xx, yy, sx, xoff, yoff, cx, i, n;
+	u_int			 xx, yy, sx, ox, oy, cx, i, n;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
@@ -1150,18 +1150,18 @@ screen_write_alignmenttest(struct screen_write_ctx *ctx)
 	}
 
 	sx = screen_size_x(s);
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 
 	for (yy = 0; yy < screen_size_y(s); yy++) {
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + yy, sx, NULL);
+		    ox, oy + yy, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 
-			cx = ri->px - xoff;
+			cx = ri->px - ox;
 			for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 				ttyctx.ocx = cx;
 				ttyctx.ocy = yy;
@@ -1178,7 +1178,7 @@ screen_write_insertcharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 {
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, xoff, yoff, cx, n, i;
+	u_int			 sx, ox, oy, cx, n, i;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1212,19 +1212,19 @@ screen_write_insertcharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 		return;
 	}
 
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 	sx = screen_size_x(s);
 
 	r = screen_redraw_get_visible_ranges(ctx->wp,
-	    xoff + s->cx, yoff + s->cy, sx - s->cx, NULL);
+	    ox + s->cx, oy + s->cy, sx - s->cx, NULL);
 
 	for (i = 0; i < r->used; i++) {
 		ri = &r->ranges[i];
 		if (ri->nx == 0)
 			continue;
 
-		cx = ri->px - xoff;
+		cx = ri->px - ox;
 		for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 			grid_view_get_cell(s->grid, cx, s->cy, &gc);
 			screen_write_set_cursor(ctx, cx, -1);
@@ -1240,7 +1240,7 @@ screen_write_deletecharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 {
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, xoff, yoff, cx, n, i;
+	u_int			 sx, ox, oy, cx, n, i;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1274,19 +1274,19 @@ screen_write_deletecharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 		return;
 	}
 
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 	sx = screen_size_x(s);
 
 	r = screen_redraw_get_visible_ranges(ctx->wp,
-	    xoff + s->cx, yoff + s->cy, sx - s->cx, NULL);
+	    ox + s->cx, oy + s->cy, sx - s->cx, NULL);
 
 	for (i = 0; i < r->used; i++) {
 		ri = &r->ranges[i];
 		if (ri->nx == 0)
 			continue;
 
-		cx = ri->px - xoff;
+		cx = ri->px - ox;
 		for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 			grid_view_get_cell(s->grid, cx, s->cy, &gc);
 			screen_write_set_cursor(ctx, cx, -1);
@@ -1302,7 +1302,7 @@ screen_write_clearcharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 {
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, xoff, yoff, cx, n, i;
+	u_int			 sx, ox, oy, cx, n, i;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1336,19 +1336,19 @@ screen_write_clearcharacter(struct screen_write_ctx *ctx, u_int nx, u_int bg)
 		return;
 	}
 
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 	sx = screen_size_x(s);
 
 	r = screen_redraw_get_visible_ranges(ctx->wp,
-	    xoff + s->cx, yoff + s->cy, sx - s->cx, NULL);
+	    ox + s->cx, oy + s->cy, sx - s->cx, NULL);
 
 	for (i = 0; i < r->used; i++) {
 		ri = &r->ranges[i];
 		if (ri->nx == 0)
 			continue;
 
-		cx = ri->px - xoff;
+		cx = ri->px - ox;
 		for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 			grid_view_get_cell(s->grid, cx, s->cy, &gc);
 			screen_write_set_cursor(ctx, cx, -1);
@@ -1365,7 +1365,7 @@ screen_write_insertline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 	struct screen		*s = ctx->s;
 	struct grid		*gd = s->grid;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, sy, xoff, yoff, y, cx, i, n;
+	u_int			 sx, sy, ox, oy, y, cx, i, n;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1404,19 +1404,19 @@ screen_write_insertline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 		}
 
 		sx = screen_size_x(s);
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 
 		for (y = s->cy; y < sy; y++) {
 			screen_write_set_cursor(ctx, 0, y);
 			r = screen_redraw_get_visible_ranges(ctx->wp,
-			    xoff, yoff + y, sx, NULL);
+			    ox, oy + y, sx, NULL);
 			for (i = 0; i < r->used; i++) {
 				ri = &r->ranges[i];
 				if (ri->nx == 0)
 					continue;
 
-				cx = ri->px - xoff;
+				cx = ri->px - ox;
 				for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 					grid_view_get_cell(gd, cx, y, &gc);
 					screen_write_set_cursor(ctx, cx, -1);
@@ -1451,19 +1451,19 @@ screen_write_insertline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 	}
 
 	sx = screen_size_x(s);
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 
 	for (y = s->cy; y <= s->rlower; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 
-			cx = ri->px - xoff;
+			cx = ri->px - ox;
 			for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 				grid_view_get_cell(gd, cx, y, &gc);
 				screen_write_set_cursor(ctx, cx, -1);
@@ -1481,7 +1481,7 @@ screen_write_deleteline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 	struct screen		*s = ctx->s;
 	struct grid		*gd = s->grid;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, sy, xoff, yoff, y, cx, i, n;
+	u_int			 sx, sy, ox, oy, y, cx, i, n;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1516,19 +1516,19 @@ screen_write_deleteline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 		}
 
 		sx = screen_size_x(s);
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 
 		for (y = s->cy; y < sy; y++) {
 			screen_write_set_cursor(ctx, 0, y);
 			r = screen_redraw_get_visible_ranges(ctx->wp,
-			    xoff, yoff + y, sx, NULL);
+			    ox, oy + y, sx, NULL);
 			for (i = 0; i < r->used; i++) {
 				ri = &r->ranges[i];
 				if (ri->nx == 0)
 					continue;
 
-				cx = ri->px - xoff;
+				cx = ri->px - ox;
 				for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 					grid_view_get_cell(gd, cx, y, &gc);
 					screen_write_set_cursor(ctx, cx, -1);
@@ -1562,19 +1562,19 @@ screen_write_deleteline(struct screen_write_ctx *ctx, u_int ny, u_int bg)
 	}
 
 	sx = screen_size_x(s);
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 
 	for (y = s->cy; y <= s->rlower; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 
-			cx = ri->px - xoff;
+			cx = ri->px - ox;
 			for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 				grid_view_get_cell(gd, cx, y, &gc);
 				screen_write_set_cursor(ctx, cx, -1);
@@ -1722,7 +1722,7 @@ screen_write_reverseindex(struct screen_write_ctx *ctx, u_int bg)
 {
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, xoff, yoff, cx, i, n;
+	u_int			 sx, ox, oy, cx, i, n;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1745,18 +1745,18 @@ screen_write_reverseindex(struct screen_write_ctx *ctx, u_int bg)
 		}
 
 		sx = screen_size_x(s);
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 
 		screen_write_set_cursor(ctx, 0, s->rupper);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + s->rupper, sx, NULL);
+		    ox, oy + s->rupper, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 
-			cx = ri->px - xoff;
+			cx = ri->px - ox;
 			for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 				grid_view_get_cell(s->grid, cx, s->rupper, &gc);
 				screen_write_set_cursor(ctx, cx, -1);
@@ -1868,7 +1868,7 @@ screen_write_scrolldown(struct screen_write_ctx *ctx, u_int lines, u_int bg)
 	struct screen		*s = ctx->s;
 	struct grid		*gd = s->grid;
 	struct tty_ctx		 ttyctx;
-	u_int			 sx, xoff, yoff, y, cx, i, n;
+	u_int			 sx, ox, oy, y, cx, i, n;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 	struct grid_cell	 gc;
@@ -1898,19 +1898,19 @@ screen_write_scrolldown(struct screen_write_ctx *ctx, u_int lines, u_int bg)
 	}
 
 	sx = screen_size_x(s);
-	xoff = ctx->wp->xoff;
-	yoff = ctx->wp->yoff;
+	ox = ctx->wp->ox;
+	oy = ctx->wp->oy;
 
 	for (y = s->rupper; y <= s->rlower; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 
-			cx = ri->px - xoff;
+			cx = ri->px - ox;
 			for (n = 0; n < ri->nx && cx < sx; n++, cx++) {
 				grid_view_get_cell(gd, cx, y, &gc);
 				screen_write_set_cursor(ctx, cx, -1);
@@ -1936,7 +1936,7 @@ screen_write_clearendofscreen(struct screen_write_ctx *ctx, u_int bg)
 	struct grid		*gd = s->grid;
 	struct tty_ctx		 ttyctx;
 	u_int			 sx = screen_size_x(s), sy = screen_size_y(s);
-	u_int			 y, i, xoff, yoff, cx_save, cy_save;
+	u_int			 y, i, ox, oy, cx_save, cy_save;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
@@ -1973,23 +1973,23 @@ screen_write_clearendofscreen(struct screen_write_ctx *ctx, u_int bg)
 	cx_save = s->cx;
 	cy_save = s->cy;
 	if (ctx->wp != NULL) {
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 	} else {
-		xoff = 0;
-		yoff = 0;
+		ox = 0;
+		oy = 0;
 	}
 
 	/* First line: visible ranges from the current cursor to end. */
 	if (s->cx <= sx - 1) {
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff + s->cx, yoff + s->cy, sx - s->cx, NULL);
+		    ox + s->cx, oy + s->cy, sx - s->cx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 			screen_write_clearpartofline(ctx,
-			    ri->px - xoff, ri->nx, bg);
+			    ri->px - ox, ri->nx, bg);
 		}
 	}
 
@@ -1997,13 +1997,13 @@ screen_write_clearendofscreen(struct screen_write_ctx *ctx, u_int bg)
 	for (y = s->cy + 1; y < sy; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 			screen_write_clearpartofline(ctx,
-			    ri->px - xoff, ri->nx, bg);
+			    ri->px - ox, ri->nx, bg);
 		}
 	}
 
@@ -2018,7 +2018,7 @@ screen_write_clearstartofscreen(struct screen_write_ctx *ctx, u_int bg)
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
 	u_int			 sx = screen_size_x(s);
-	u_int			 y, i, xoff, yoff, cx_save, cy_save;
+	u_int			 y, i, ox, oy, cx_save, cy_save;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
@@ -2049,36 +2049,36 @@ screen_write_clearstartofscreen(struct screen_write_ctx *ctx, u_int bg)
 	cx_save = s->cx;
 	cy_save = s->cy;
 	if (ctx->wp != NULL) {
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 	} else {
-		xoff = 0;
-		yoff = 0;
+		ox = 0;
+		oy = 0;
 	}
 
 	/* Lines 0 to cy-1: visible ranges across the full width. */
 	for (y = 0; y < s->cy; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 			screen_write_clearpartofline(ctx,
-			    ri->px - xoff, ri->nx, bg);
+			    ri->px - ox, ri->nx, bg);
 		}
 	}
 
 	/* Last line: visible ranges from 0 to cursor (inclusive). */
 	screen_write_set_cursor(ctx, 0, s->cy);
 	r = screen_redraw_get_visible_ranges(ctx->wp,
-	    xoff, yoff + cy_save, s->cx + 1, NULL);
+	    ox, oy + cy_save, s->cx + 1, NULL);
 	for (i = 0; i < r->used; i++) {
 		ri = &r->ranges[i];
 		if (ri->nx == 0)
 			continue;
-		screen_write_clearpartofline(ctx, ri->px - xoff, ri->nx, bg);
+		screen_write_clearpartofline(ctx, ri->px - ox, ri->nx, bg);
 	}
 
 	screen_write_collect_flush(ctx, 0, __func__);
@@ -2092,7 +2092,7 @@ screen_write_clearscreen(struct screen_write_ctx *ctx, u_int bg)
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
 	u_int			 sx = screen_size_x(s), sy = screen_size_y(s);
-	u_int			 y, i, xoff, yoff, cx_save, cy_save;
+	u_int			 y, i, ox, oy, cx_save, cy_save;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
@@ -2123,23 +2123,23 @@ screen_write_clearscreen(struct screen_write_ctx *ctx, u_int bg)
 	cx_save = s->cx;
 	cy_save = s->cy;
 	if (ctx->wp != NULL) {
-		xoff = ctx->wp->xoff;
-		yoff = ctx->wp->yoff;
+		ox = ctx->wp->ox;
+		oy = ctx->wp->oy;
 	} else {
-		xoff = 0;
-		yoff = 0;
+		ox = 0;
+		oy = 0;
 	}
 
 	for (y = 0; y < sy; y++) {
 		screen_write_set_cursor(ctx, 0, y);
 		r = screen_redraw_get_visible_ranges(ctx->wp,
-		    xoff, yoff + y, sx, NULL);
+		    ox, oy + y, sx, NULL);
 		for (i = 0; i < r->used; i++) {
 			ri = &r->ranges[i];
 			if (ri->nx == 0)
 				continue;
 			screen_write_clearpartofline(ctx,
-			    ri->px - xoff, ri->nx, bg);
+			    ri->px - ox, ri->nx, bg);
 		}
 	}
 
@@ -2311,7 +2311,7 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 	u_int				 wr_start, wr_end, wr_length, wsx, wsy;
 	int				 written;
 	int				 r_start, r_end, ci_start, ci_end;
-	int				 xoff, yoff;
+	int				 ox, oy;
 	struct tty_ctx			 ttyctx;
 	struct visible_ranges		*r;
 	struct visible_range		*ri;
@@ -2335,8 +2335,8 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 			ctx->scrolled = s->rlower - s->rupper + 1;
 
 		screen_write_initctx(ctx, &ttyctx, 1, 1);
-		if (wp != NULL && wp->yoff + wp->sy > wp->window->sy)
-			 ttyctx.orlower -= (wp->yoff + wp->sy - wp->window->sy);
+		if (wp != NULL && wp->oy + wp->sy > wp->window->sy)
+			 ttyctx.orlower -= (wp->oy + wp->sy - wp->window->sy);
 		ttyctx.n = ctx->scrolled;
 		ttyctx.bg = ctx->bg;
 		tty_write(tty_cmd_scrollup, &ttyctx);
@@ -2355,26 +2355,26 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 
 	cx = s->cx; cy = s->cy;
 
-	/* The xoff and width of window pane relative to the window we
+	/* The ox and width of window pane relative to the window we
 	 * are writing to relative to the visible_ranges array. */
 	if (wp != NULL) {
 		wsx = wp->window->sx;
 		wsy = wp->window->sy;
-		xoff = wp->xoff;
-		yoff = wp->yoff;
+		ox = wp->ox;
+		oy = wp->oy;
 	} else {
 		wsx = screen_size_x(s);
 		wsy = screen_size_y(s);
-		xoff = 0;
-		yoff = 0;
+		ox = 0;
+		oy = 0;
 	}
 
 	for (y = 0; y < screen_size_y(s); y++) {
-		if (y + yoff >= wsy)
+		if (y + oy >= wsy)
 			continue;
 		cl = &ctx->s->write_list[y];
 
-		r = screen_redraw_get_visible_ranges(wp, 0, y + yoff, wsx,
+		r = screen_redraw_get_visible_ranges(wp, 0, y + oy, wsx,
 		    NULL);
 
 		last = UINT_MAX;
@@ -2382,10 +2382,10 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 			u_int dbg_cnt = 0;
 			struct screen_write_citem *dbg_ci;
 			TAILQ_FOREACH(dbg_ci, &cl->items, entry) dbg_cnt++;
-			log_debug("%s: row y=%u has %u items (wp_xoff=%d yoff=%d wsx=%u)",
+			log_debug("%s: row y=%u has %u items (wp_ox=%d oy=%d wsx=%u)",
 			    __func__, y, dbg_cnt,
-			    wp ? (int)wp->xoff : -1,
-			    wp ? (int)wp->yoff : -1,
+			    wp ? (int)wp->ox : -1,
+			    wp ? (int)wp->oy : -1,
 			    wsx);
 		}
 		TAILQ_FOREACH_SAFE(ci, &cl->items, entry, tmp) {
@@ -2405,18 +2405,18 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 				ci_start = ci->x;
 				ci_end = ci->x + ci->used;
 
-				if (ci_start + xoff > r_end ||
-				    ci_end + xoff < r_start)
+				if (ci_start + ox > r_end ||
+				    ci_end + ox < r_start)
 					continue;
 
-				if (r_start > ci_start + xoff)
+				if (r_start > ci_start + ox)
 					wr_start = ci_start +
-					    (r_start - (ci_start + xoff));
+					    (r_start - (ci_start + ox));
 				else
 					wr_start = ci_start;
-				if (ci_end + xoff > r_end)
+				if (ci_end + ox > r_end)
 					wr_end = ci_end -
-					    ((ci_end + xoff) - r_end);
+					    ((ci_end + ox) - r_end);
 				else
 					wr_end = ci_end;
 				wr_length = wr_end - wr_start;
@@ -2623,7 +2623,7 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	struct tty_ctx		 ttyctx;
 	u_int			 sx = screen_size_x(s), sy = screen_size_y(s);
 	u_int		 	 width = ud->width, xx, not_wrap, i, n, vis;
-	int			 selected, skip = 1, redraw = 0, yoff = 0;
+	int			 selected, skip = 1, redraw = 0, oy = 0;
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
@@ -2724,8 +2724,8 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 		skip = 0;
 
 	if (wp != NULL)
-		yoff = wp->yoff;
-	r = screen_redraw_get_visible_ranges(wp, s->cx, s->cy + yoff, width,
+		oy = wp->oy;
+	r = screen_redraw_get_visible_ranges(wp, s->cx, s->cy + oy, width,
 	    NULL);
 
 	/*
@@ -2785,7 +2785,7 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	struct window_pane	*wp = ctx->wp;
 	struct grid		*gd = s->grid;
 	const struct utf8_data	*ud = &gc->data;
-	u_int			 i, n, cx = s->cx, cy = s->cy, vis, yoff = 0;
+	u_int			 i, n, cx = s->cx, cy = s->cy, vis, oy = 0;
 	struct grid_cell	 last;
 	struct tty_ctx		 ttyctx;
 	int			 force_wide = 0, zero_width = 0;
@@ -2883,8 +2883,8 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	 * could be an empty range in the visible ranges so we add them all up.
 	 */
 	if (wp != NULL)
-		yoff = wp->yoff;
-	r = screen_redraw_get_visible_ranges(wp, cx - n, cy + yoff, n, NULL);
+		oy = wp->oy;
+	r = screen_redraw_get_visible_ranges(wp, cx - n, cy + oy, n, NULL);
 	for (i=0, vis=0; i < r->used; i++) vis += r->ranges[i].nx;
 	if (vis < n) {
 		/*

--- a/server-client.c
+++ b/server-client.c
@@ -622,43 +622,43 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 	}
 
 	if (pane_status == PANE_STATUS_TOP)
-		pane_status_line = wp->yoff - 1;
+		pane_status_line = wp->oy - 1;
 	else if (pane_status == PANE_STATUS_BOTTOM)
-		pane_status_line = wp->yoff + wp->sy;
+		pane_status_line = wp->oy + wp->sy;
 	else
 		pane_status_line = -1; /* not used */
 
 	/* Check if point is within the pane or scrollbar. */
 	if (((pane_status != PANE_STATUS_OFF &&
-	    py != pane_status_line && py != wp->yoff + (int)wp->sy) ||
-	    (wp->yoff == 0 && py < (int)wp->sy) ||
-	    (py >= wp->yoff && py < wp->yoff + (int)wp->sy)) &&
+	    py != pane_status_line && py != wp->oy + (int)wp->sy) ||
+	    (wp->oy == 0 && py < (int)wp->sy) ||
+	    (py >= wp->oy && py < wp->oy + (int)wp->sy)) &&
 	    ((sb_pos == PANE_SCROLLBARS_RIGHT &&
-	    px < wp->xoff + (int)wp->sx + sb_pad + sb_w) ||
+	    px < wp->ox + (int)wp->sx + sb_pad + sb_w) ||
 	    (sb_pos == PANE_SCROLLBARS_LEFT &&
-	    px < wp->xoff + (int)wp->sx - sb_pad - sb_w))) {
+	    px < wp->ox + (int)wp->sx - sb_pad - sb_w))) {
 		/* Check if in the scrollbar. */
 		if ((sb_pos == PANE_SCROLLBARS_RIGHT &&
-		    (px >= wp->xoff + (int)wp->sx + sb_pad &&
-		    px < wp->xoff + (int)wp->sx + sb_pad + sb_w)) ||
+		    (px >= wp->ox + (int)wp->sx + sb_pad &&
+		    px < wp->ox + (int)wp->sx + sb_pad + sb_w)) ||
 		    (sb_pos == PANE_SCROLLBARS_LEFT &&
-		    (px >= wp->xoff - sb_pad - sb_w &&
-		    px < wp->xoff - sb_pad))) {
+		    (px >= wp->ox - sb_pad - sb_w &&
+		    px < wp->ox - sb_pad))) {
 			/* Check where inside the scrollbar. */
-			sl_top = wp->yoff + wp->sb_slider_y;
-			sl_bottom = (wp->yoff + wp->sb_slider_y +
+			sl_top = wp->oy + wp->sb_slider_y;
+			sl_bottom = (wp->oy + wp->sb_slider_y +
 			    wp->sb_slider_h - 1);
 			if (py < sl_top)
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_UP);
 			else if (py >= sl_top && py <= sl_bottom) {
-				*sl_mpos = (py - wp->sb_slider_y - wp->yoff);
+				*sl_mpos = (py - wp->sb_slider_y - wp->oy);
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_SLIDER);
 			} else /* py > sl_bottom */
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_DOWN);
 		} else if (wp->flags & PANE_FLOATING &&
-		    (px == wp->xoff - 1 ||
-		    py == wp->yoff - 1 ||
-		    py == wp->yoff + (int)wp->sy)) {
+		    (px == wp->ox - 1 ||
+		    py == wp->oy - 1 ||
+		    py == wp->oy + (int)wp->sy)) {
 			/* Floating pane left, bottom or top border. */
 			return (KEYC_MOUSE_LOCATION_BORDER);
 		} else {
@@ -671,33 +671,33 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 			if ((w->flags & WINDOW_ZOOMED) &&
 			    (~fwp->flags & PANE_ZOOMED))
 				continue;
-			bdr_top = fwp->yoff - 1;
-			bdr_bottom = fwp->yoff + fwp->sy;
+			bdr_top = fwp->oy - 1;
+			bdr_bottom = fwp->oy + fwp->sy;
 			if (sb_pos == PANE_SCROLLBARS_LEFT)
-				bdr_right = fwp->xoff + fwp->sx;
+				bdr_right = fwp->ox + fwp->sx;
 			else {
 				/* PANE_SCROLLBARS_RIGHT or none. */
-				bdr_right = fwp->xoff + fwp->sx + sb_pad + sb_w;
+				bdr_right = fwp->ox + fwp->sx + sb_pad + sb_w;
 			}
-			if (py >= fwp->yoff - 1 &&
-			    py <= fwp->yoff + (int)fwp->sy) {
+			if (py >= fwp->oy - 1 &&
+			    py <= fwp->oy + (int)fwp->sy) {
 				if (px == bdr_right)
 					break;
 				if (wp->flags & PANE_FLOATING) {
 					/* Floating pane, check left border. */
-					bdr_left = fwp->xoff - 1;
+					bdr_left = fwp->ox - 1;
 					if (px == bdr_left)
 						break;
 				}
 			}
-			if (px >= fwp->xoff - 1 &&
-			    px <= fwp->xoff + (int)fwp->sx) {
-				bdr_bottom = fwp->yoff + fwp->sy;
+			if (px >= fwp->ox - 1 &&
+			    px <= fwp->ox + (int)fwp->sx) {
+				bdr_bottom = fwp->oy + fwp->sy;
 				if (py == bdr_bottom)
 					break;
 				if (wp->flags & PANE_FLOATING) {
 					/* Floating pane, check top border. */
-					bdr_top = fwp->yoff - 1;
+					bdr_top = fwp->oy - 1;
 					if (py == bdr_top)
 						break;
 				}
@@ -1842,14 +1842,14 @@ server_client_reset_state(struct client *c)
 	} else if (wp != NULL && c->overlay_draw == NULL) {
 		cursor = 0;
 		tty_window_offset(tty, &ox, &oy, &sx, &sy);
-		if (wp->xoff + (int)s->cx >= (int)ox &&
-		    wp->xoff + (int)s->cx <= (int)ox + (int)sx &&
-		    wp->yoff + (int)s->cy >= (int)oy &&
-		    wp->yoff + (int)s->cy <= (int)oy + (int)sy) {
+		if (wp->ox + (int)s->cx >= (int)ox &&
+		    wp->ox + (int)s->cx <= (int)ox + (int)sx &&
+		    wp->oy + (int)s->cy >= (int)oy &&
+		    wp->oy + (int)s->cy <= (int)oy + (int)sy) {
 			cursor = 1;
 
-			cx = wp->xoff + (int)s->cx - (int)ox;
-			cy = wp->yoff + (int)s->cy - (int)oy;
+			cx = wp->ox + (int)s->cx - (int)ox;
+			cy = wp->oy + (int)s->cy - (int)oy;
 
 			if (status_at_line(c) == 0)
 				cy += status_line_size(c);

--- a/tmux.h
+++ b/tmux.h
@@ -1260,8 +1260,8 @@ struct window_pane {
 	u_int		 sx;
 	u_int		 sy;
 
-	int		 xoff;
-	int		 yoff;
+	int		 ox;
+	int		 oy;
 
 	int		 flags;
 	int		 saved_flags;
@@ -1285,8 +1285,8 @@ struct window_pane {
 #define PANE_SAVED_FLOAT 0x80000	/* saved_float_* fields are valid */
 
 	/* Last floating position/size, saved when the pane is tiled. */
-	int		 saved_float_xoff;
-	int		 saved_float_yoff;
+	int		 saved_float_ox;
+	int		 saved_float_oy;
 	u_int		 saved_float_sx;
 	u_int		 saved_float_sy;
 
@@ -1486,8 +1486,8 @@ struct layout_cell {
 	u_int		 sx;
 	u_int		 sy;
 
-	int		 xoff;
-	int		 yoff;
+	int		 ox;
+	int		 oy;
 
 	struct window_pane *wp;
 	struct layout_cells cells;
@@ -1784,10 +1784,10 @@ struct tty_ctx {
 	u_int			 orlower;
 
 	/* Target region (usually pane) offset and size. */
-	int			 xoff;
-	int			 yoff;
-	int			 rxoff;
-	int			 ryoff;
+	int			 ox;
+	int			 oy;
+	int			 rox;
+	int			 roy;
 	u_int			 sx;
 	u_int			 sy;
 

--- a/tty.c
+++ b/tty.c
@@ -75,7 +75,7 @@ static void	tty_write_one(void (*)(struct tty *, const struct tty_ctx *),
 #define tty_use_margin(tty) \
 	(tty->term->flags & TERM_DECSLRM)
 #define tty_full_width(tty, ctx) \
-	((ctx)->xoff == 0 && (ctx)->sx >= (tty)->sx)
+	((ctx)->ox == 0 && (ctx)->sx >= (tty)->sx)
 
 #define TTY_BLOCK_INTERVAL (100000 /* 100 milliseconds */)
 #define TTY_BLOCK_START(tty) (1 + ((tty)->sx * (tty)->sy) * 8)
@@ -989,8 +989,8 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 		*ox = 0;
 		*oy = 0;
 	} else {
-		cx = wp->xoff + wp->screen->cx;
-		cy = wp->yoff + wp->screen->cy;
+		cx = wp->ox + wp->screen->cx;
+		cy = wp->oy + wp->screen->cy;
 
 		if (cx < *sx)
 			*ox = 0;
@@ -1110,13 +1110,13 @@ static int
 tty_is_visible(__unused struct tty *tty, const struct tty_ctx *ctx, u_int px,
     u_int py, u_int nx, u_int ny)
 {
-	u_int	xoff = ctx->rxoff + px, yoff = ctx->ryoff + py;
+	u_int	ox = ctx->rox + px, oy = ctx->roy + py;
 
 	if (~ctx->flags & TTY_CTX_WINDOW_BIGGER)
 		return (1);
 
-	if (xoff + nx <= ctx->wox || xoff >= ctx->wox + ctx->wsx ||
-	    yoff + ny <= ctx->woy || yoff >= ctx->woy + ctx->wsy)
+	if (ox + nx <= ctx->wox || ox >= ctx->wox + ctx->wsx ||
+	    oy + ny <= ctx->woy || oy >= ctx->woy + ctx->wsy)
 		return (0);
 	return (1);
 }
@@ -1126,31 +1126,31 @@ static int
 tty_clamp_line(struct tty *tty, const struct tty_ctx *ctx, u_int px, u_int py,
     u_int nx, u_int *i, u_int *x, u_int *rx, u_int *ry)
 {
-	int	xoff = ctx->rxoff + px;
+	int	ox = ctx->rox + px;
 
 	if (!tty_is_visible(tty, ctx, px, py, nx, 1))
 		return (0);
-	*ry = ctx->yoff + py - ctx->woy;
+	*ry = ctx->oy + py - ctx->woy;
 
-	if (xoff >= (int)ctx->wox && xoff + nx <= ctx->wox + ctx->wsx) {
+	if (ox >= (int)ctx->wox && ox + nx <= ctx->wox + ctx->wsx) {
 		/* All visible. */
 		*i = 0;
-		*x = ctx->xoff + px - ctx->wox;
+		*x = ctx->ox + px - ctx->wox;
 		*rx = nx;
-	} else if (xoff < (int)ctx->wox && xoff + nx > ctx->wox + ctx->wsx) {
+	} else if (ox < (int)ctx->wox && ox + nx > ctx->wox + ctx->wsx) {
 		/* Both left and right not visible. */
 		*i = ctx->wox;
 		*x = 0;
 		*rx = ctx->wsx;
-	} else if (xoff < (int)ctx->wox) {
+	} else if (ox < (int)ctx->wox) {
 		/* Left not visible. */
-		*i = ctx->wox - (ctx->xoff + px);
+		*i = ctx->wox - (ctx->ox + px);
 		*x = 0;
 		*rx = nx - *i;
 	} else {
 		/* Right not visible. */
 		*i = 0;
-		*x = (ctx->xoff + px) - ctx->wox;
+		*x = (ctx->ox + px) - ctx->wox;
 		*rx = ctx->wsx - *x;
 	}
 	if (*rx > nx)
@@ -1243,54 +1243,54 @@ tty_clamp_area(struct tty *tty, const struct tty_ctx *ctx, u_int px, u_int py,
     u_int nx, u_int ny, u_int *i, u_int *j, u_int *x, u_int *y, u_int *rx,
     u_int *ry)
 {
-	u_int	xoff = ctx->rxoff + px, yoff = ctx->ryoff + py;
+	u_int	ox = ctx->rox + px, oy = ctx->roy + py;
 
 	if (!tty_is_visible(tty, ctx, px, py, nx, ny))
 		return (0);
 
-	if (xoff >= ctx->wox && xoff + nx <= ctx->wox + ctx->wsx) {
+	if (ox >= ctx->wox && ox + nx <= ctx->wox + ctx->wsx) {
 		/* All visible. */
 		*i = 0;
-		*x = ctx->xoff + px - ctx->wox;
+		*x = ctx->ox + px - ctx->wox;
 		*rx = nx;
-	} else if (xoff < ctx->wox && xoff + nx > ctx->wox + ctx->wsx) {
+	} else if (ox < ctx->wox && ox + nx > ctx->wox + ctx->wsx) {
 		/* Both left and right not visible. */
 		*i = ctx->wox;
 		*x = 0;
 		*rx = ctx->wsx;
-	} else if (xoff < ctx->wox) {
+	} else if (ox < ctx->wox) {
 		/* Left not visible. */
-		*i = ctx->wox - (ctx->xoff + px);
+		*i = ctx->wox - (ctx->ox + px);
 		*x = 0;
 		*rx = nx - *i;
 	} else {
 		/* Right not visible. */
 		*i = 0;
-		*x = (ctx->xoff + px) - ctx->wox;
+		*x = (ctx->ox + px) - ctx->wox;
 		*rx = ctx->wsx - *x;
 	}
 	if (*rx > nx)
 		fatalx("%s: x too big, %u > %u", __func__, *rx, nx);
 
-	if (yoff >= ctx->woy && yoff + ny <= ctx->woy + ctx->wsy) {
+	if (oy >= ctx->woy && oy + ny <= ctx->woy + ctx->wsy) {
 		/* All visible. */
 		*j = 0;
-		*y = ctx->yoff + py - ctx->woy;
+		*y = ctx->oy + py - ctx->woy;
 		*ry = ny;
-	} else if (yoff < ctx->woy && yoff + ny > ctx->woy + ctx->wsy) {
+	} else if (oy < ctx->woy && oy + ny > ctx->woy + ctx->wsy) {
 		/* Both top and bottom not visible. */
 		*j = ctx->woy;
 		*y = 0;
 		*ry = ctx->wsy;
-	} else if (yoff < ctx->woy) {
+	} else if (oy < ctx->woy) {
 		/* Top not visible. */
-		*j = ctx->woy - (ctx->yoff + py);
+		*j = ctx->woy - (ctx->oy + py);
 		*y = 0;
 		*ry = ny - *j;
 	} else {
 		/* Bottom not visible. */
 		*j = 0;
-		*y = (ctx->yoff + py) - ctx->woy;
+		*y = (ctx->oy + py) - ctx->woy;
 		*ry = ctx->wsy - *y;
 	}
 	if (*ry > ny)
@@ -1408,31 +1408,31 @@ tty_draw_pane(struct tty *tty, const struct tty_ctx *ctx, u_int py)
 				 * coordinates and clip to visible ranges to
 				 * avoid drawing over the floating pane.
 				 */
-				r = tty_check_overlay_range(tty, ctx->xoff,
-				    ctx->yoff + py, nx);
+				r = tty_check_overlay_range(tty, ctx->ox,
+				    ctx->oy + py, nx);
 				for (i = 0; i < r->used; i++) {
 					ri = &r->ranges[i];
 					if (ri->nx == 0) continue;
 					tty_draw_line(tty, s,
-					    ri->px - ctx->xoff, py, ri->nx,
-					    ri->px, ctx->yoff + py,
+					    ri->px - ctx->ox, py, ri->nx,
+					    ri->px, ctx->oy + py,
 					    &ctx->defaults, ctx->palette);
 				}
 			} else {
 				r = tty_check_overlay_range(tty, 0,
-				    ctx->yoff + py, nx);
+				    ctx->oy + py, nx);
 				for (i = 0; i < r->used; i++) {
 					ri = &r->ranges[i];
 					if (ri->nx == 0) continue;
 					tty_draw_line(tty, s, ri->px, py,
-					    ri->nx, ctx->xoff + ri->px,
-					    ctx->yoff + py,
+					    ri->nx, ctx->ox + ri->px,
+					    ctx->oy + py,
 					    &ctx->defaults, ctx->palette);
 				}
 			}
 		} else {
-			tty_draw_line(tty, s, 0, py, nx, ctx->xoff,
-			    ctx->yoff + py, &ctx->defaults, ctx->palette);
+			tty_draw_line(tty, s, 0, py, nx, ctx->ox,
+			    ctx->oy + py, &ctx->defaults, ctx->palette);
 		}
 		return;
 	}
@@ -1535,9 +1535,9 @@ tty_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	else
 		ttyctx->flags &= ~TTY_CTX_WINDOW_BIGGER;
 
-	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
+	ttyctx->oy = ttyctx->roy = wp->oy;
 	if (status_at_line(c) == 0)
-		ttyctx->yoff += status_line_size(c);
+		ttyctx->oy += status_line_size(c);
 
 	return (1);
 }
@@ -1558,7 +1558,7 @@ tty_draw_images(struct client *c, struct window_pane *wp, struct screen *s)
 		ttyctx.orlower = s->rlower;
 		ttyctx.orupper = s->rupper;
 
-		ttyctx.xoff = ttyctx.rxoff = wp->xoff;
+		ttyctx.ox = ttyctx.rox = wp->ox;
 		ttyctx.sx = wp->sx;
 		ttyctx.sy = wp->sy;
 
@@ -1863,11 +1863,11 @@ tty_cmd_linefeed(struct tty *tty, const struct tty_ctx *ctx)
 	 * this and insert extra spaces, so only use the right if margins are
 	 * enabled.
 	 */
-	if (ctx->xoff + ctx->ocx > tty->rright) {
+	if (ctx->ox + ctx->ocx > tty->rright) {
 		if (!tty_use_margin(tty))
-			tty_cursor(tty, 0, ctx->yoff + ctx->ocy);
+			tty_cursor(tty, 0, ctx->oy + ctx->ocy);
 		else
-			tty_cursor(tty, tty->rright, ctx->yoff + ctx->ocy);
+			tty_cursor(tty, tty->rright, ctx->oy + ctx->ocy);
 	} else
 		tty_cursor_pane(tty, ctx, ctx->ocx, ctx->ocy);
 
@@ -2049,15 +2049,15 @@ tty_cmd_cell(struct tty *tty, const struct tty_ctx *ctx)
 	struct visible_ranges	*r = NULL;
 	u_int			 px, py, i, vis = 0;
 
-	px = ctx->xoff + ctx->ocx - ctx->wox;
-	py = ctx->yoff + ctx->ocy - ctx->woy;
+	px = ctx->ox + ctx->ocx - ctx->wox;
+	py = ctx->oy + ctx->ocy - ctx->woy;
 	if (!tty_is_visible(tty, ctx, ctx->ocx, ctx->ocy, 1, 1) ||
 	    (gcp->data.width == 1 && !tty_check_overlay(tty, px, py)))
 		return;
 
 	if (ctx->flags & TTY_CTX_CELL_DRAW_LINE) {
 		tty_draw_line(tty, s, 0, s->cy, screen_size_x(s),
-		    ctx->xoff - ctx->wox, py, &ctx->defaults, ctx->palette);
+		    ctx->ox - ctx->wox, py, &ctx->defaults, ctx->palette);
 		return;
 	}
 
@@ -2073,7 +2073,7 @@ tty_cmd_cell(struct tty *tty, const struct tty_ctx *ctx)
 		}
 	}
 
-	if (ctx->xoff + ctx->ocx - ctx->wox > tty->sx - 1 &&
+	if (ctx->ox + ctx->ocx - ctx->wox > tty->sx - 1 &&
 	    ctx->ocy == ctx->orlower &&
 	    tty_full_width(tty, ctx))
 		tty_region_pane(tty, ctx, ctx->orupper, ctx->orlower);
@@ -2101,13 +2101,13 @@ tty_cmd_cells(struct tty *tty, const struct tty_ctx *ctx)
 		return;
 
 	if ((ctx->flags & TTY_CTX_WINDOW_BIGGER) &&
-	    (ctx->xoff + ctx->ocx < ctx->wox ||
-	    ctx->xoff + ctx->ocx + n > ctx->wox + ctx->wsx)) {
+	    (ctx->ox + ctx->ocx < ctx->wox ||
+	    ctx->ox + ctx->ocx + n > ctx->wox + ctx->wsx)) {
 		if ((~ctx->flags & TTY_CTX_WRAPPED) ||
 		    !tty_full_width(tty, ctx) ||
 		    (tty->term->flags & TERM_NOAM) ||
-		    ctx->xoff + ctx->ocx != 0 ||
-		    ctx->yoff + ctx->ocy != tty->cy + 1 ||
+		    ctx->ox + ctx->ocx != 0 ||
+		    ctx->oy + ctx->ocy != tty->cy + 1 ||
 		    tty->cx < tty->sx ||
 		    tty->cy == tty->rlower)
 			tty_draw_pane(tty, ctx, ctx->ocy);
@@ -2122,14 +2122,14 @@ tty_cmd_cells(struct tty *tty, const struct tty_ctx *ctx)
 	    ctx->s->hyperlinks);
 
 	/* Get tty position from pane position for overlay check. */
-	px = ctx->xoff + ctx->ocx - ctx->wox;
-	py = ctx->yoff + ctx->ocy - ctx->woy;
+	px = ctx->ox + ctx->ocx - ctx->wox;
+	py = ctx->oy + ctx->ocy - ctx->woy;
 
 	r = tty_check_overlay_range(tty, px, py, n);
 	for (i = 0; i < r->used; i++) {
 		ri = &r->ranges[i];
 		if (ri->nx != 0) {
-			cx = ri->px - ctx->xoff + ctx->wox;
+			cx = ri->px - ctx->ox + ctx->wox;
 			tty_cursor_pane_unless_wrap(tty, ctx, cx, ctx->ocy);
 			tty_putn(tty, cp + ri->px - px, ri->nx, ri->nx);
 		}
@@ -2248,8 +2248,8 @@ tty_sixelimage_draw(struct tty *tty, const struct tty_ctx *ctx,
 
 	/*
 	 * sixel_y0 is the window y-coordinate of the first rendered row.
-	 * Derived from tty_clamp_area: y = ctx->yoff + ocy + j - ctx->woy,
-	 * so y + ctx->woy = ctx->yoff + ocy + j.
+	 * Derived from tty_clamp_area: y = ctx->oy + ocy + j - ctx->woy,
+	 * so y + ctx->woy = ctx->oy + ocy + j.
 	 */
 	w = wp->window;
 	sixel_wx0 = x + ctx->wox;
@@ -2263,8 +2263,8 @@ tty_sixelimage_draw(struct tty *tty, const struct tty_ctx *ctx,
 	TAILQ_FOREACH(fp, &w->z_index, zentry) {
 		if (~fp->flags & PANE_FLOATING)
 			continue;
-		fp_tb  = (int)((fp->yoff > 0) ? fp->yoff - 1 : 0);
-		fp_bb1 = (int)fp->yoff + (int)fp->sy + 1;
+		fp_tb  = (int)((fp->oy > 0) ? fp->oy - 1 : 0);
+		fp_bb1 = (int)fp->oy + (int)fp->sy + 1;
 		r_top  = fp_tb  - (int)sixel_y0;
 		r_bot  = fp_bb1 - (int)sixel_y0;
 		if (r_top > 0 && (u_int)r_top < ry && nb < 62)
@@ -2295,7 +2295,7 @@ tty_sixelimage_draw(struct tty *tty, const struct tty_ctx *ctx,
 			continue;
 		strip_h = strip_end - strip_start;
 
-		vr = screen_redraw_get_visible_ranges(wp, ctx->xoff,
+		vr = screen_redraw_get_visible_ranges(wp, ctx->ox,
 		    sixel_y0 + strip_start, wp->sx, NULL);
 
 		for (s = 0; s < vr->used; s++) {
@@ -2475,8 +2475,8 @@ static void
 tty_region_pane(struct tty *tty, const struct tty_ctx *ctx, u_int rupper,
     u_int rlower)
 {
-	tty_region(tty, ctx->yoff + rupper - ctx->woy,
-	    ctx->yoff + rlower - ctx->woy);
+	tty_region(tty, ctx->oy + rupper - ctx->woy,
+	    ctx->oy + rlower - ctx->woy);
 }
 
 /* Set region at absolute position. */
@@ -2521,8 +2521,8 @@ tty_margin_pane(struct tty *tty, const struct tty_ctx *ctx)
 {
 	int l, r;
 
-	l = ctx->xoff - ctx->wox;
-	r = ctx->xoff + ctx->sx - 1 - ctx->wox;
+	l = ctx->ox - ctx->wox;
+	r = ctx->ox + ctx->sx - 1 - ctx->wox;
 
 	if (l < 0) l = 0;
 	if (l > (int)ctx->wsx) l = ctx->wsx;
@@ -2564,8 +2564,8 @@ tty_cursor_pane_unless_wrap(struct tty *tty, const struct tty_ctx *ctx,
 	if ((~ctx->flags & TTY_CTX_WRAPPED) ||
 	    !tty_full_width(tty, ctx) ||
 	    (tty->term->flags & TERM_NOAM) ||
-	    ctx->xoff + cx != 0 ||
-	    ctx->yoff + cy != tty->cy + 1 ||
+	    ctx->ox + cx != 0 ||
+	    ctx->oy + cy != tty->cy + 1 ||
 	    tty->cx < tty->sx ||
 	    tty->cy == tty->rlower)
 		tty_cursor_pane(tty, ctx, cx, cy);
@@ -2577,7 +2577,7 @@ tty_cursor_pane_unless_wrap(struct tty *tty, const struct tty_ctx *ctx,
 static void
 tty_cursor_pane(struct tty *tty, const struct tty_ctx *ctx, u_int cx, u_int cy)
 {
-	tty_cursor(tty, ctx->xoff + cx - ctx->wox, ctx->yoff + cy - ctx->woy);
+	tty_cursor(tty, ctx->ox + cx - ctx->wox, ctx->oy + cy - ctx->woy);
 }
 
 /* Move cursor to absolute position. */

--- a/window-copy.c
+++ b/window-copy.c
@@ -647,7 +647,7 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 	u_int				 ox, oy, px, py, n, offset, size;
 	u_int				 new_offset;
 	u_int				 slider_height = wp->sb_slider_h;
-	u_int				 sb_height = wp->sy, sb_top = wp->yoff;
+	u_int				 sb_height = wp->sy, sb_top = wp->oy;
 	u_int				 sy = screen_size_y(data->backing);
 	u_int				 my_w;
 	int				 new_slider_y, delta;
@@ -656,7 +656,7 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 	 * sl_mpos is where in the slider the user is dragging, mouse is
 	 * dragging this y point relative to top of slider.
 	 *
-	 * my is a raw tty y coordinate; sb_top (= wp->yoff) is a window
+	 * my is a raw tty y coordinate; sb_top (= wp->oy) is a window
 	 * coordinate.  Convert my to window coordinates by adding tty_oy
 	 * (the window pan offset).  sl_mpos already has the statuslines
 	 * adjustment baked in (see server_client_check_mouse), so no further
@@ -665,13 +665,13 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 	my_w = my + tty_oy;
 	if (my_w <= sb_top + (u_int)sl_mpos) {
 		/* Slider banged into top. */
-		new_slider_y = sb_top - wp->yoff;
+		new_slider_y = sb_top - wp->oy;
 	} else if (my_w - sl_mpos > sb_top + sb_height - slider_height) {
 		/* Slider banged into bottom. */
-		new_slider_y = sb_top - wp->yoff + (sb_height - slider_height);
+		new_slider_y = sb_top - wp->oy + (sb_height - slider_height);
 	} else {
 		/* Slider is somewhere in the middle. */
-		new_slider_y = my_w - wp->yoff - sl_mpos;
+		new_slider_y = my_w - wp->oy - sl_mpos;
 	}
 
 	if (TAILQ_FIRST(&wp->modes) == NULL ||

--- a/window.c
+++ b/window.c
@@ -71,7 +71,7 @@ static struct window_pane *window_pane_create(struct window *, u_int, u_int,
 		    u_int);
 static void	window_pane_destroy(struct window_pane *);
 static void	window_pane_full_size_offset(struct window_pane *wp,
-		    int *xoff, int *yoff, u_int *sx, u_int *sy);
+		    int *ox, int *oy, u_int *sx, u_int *sy);
 
 RB_GENERATE(windows, window, entry, window_cmp);
 RB_GENERATE(winlinks, winlink, entry, winlink_cmp);
@@ -625,7 +625,7 @@ struct window_pane *
 window_get_active_at(struct window *w, u_int x, u_int y)
 {
 	struct window_pane	*wp;
-	int			 pane_status, xoff, yoff;
+	int			 pane_status, ox, oy;
 	u_int			 sx, sy;
 
 	pane_status = options_get_number(w->options, "pane-border-status");
@@ -633,27 +633,27 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
 		if (!window_pane_visible(wp))
 			continue;
-		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+		window_pane_full_size_offset(wp, &ox, &oy, &sx, &sy);
 		if (~wp->flags & PANE_FLOATING) {
 			/* Tiled - to and including bottom or right border. */
-			if ((int)x < xoff || x > xoff + sx)
+			if ((int)x < ox || x > ox + sx)
 				continue;
 			if (pane_status == PANE_STATUS_TOP) {
-				if ((int)y < yoff - 1 || y > yoff + sy)
+				if ((int)y < oy - 1 || y > oy + sy)
 					continue;
 			} else {
-				if ((int)y < yoff || y > yoff + sy)
+				if ((int)y < oy || y > oy + sy)
 					continue;
 			}
 		} else {
 			/* Floating - include top or or left border. */
-			if ((int)x < xoff - 1 || x > xoff + sx)
+			if ((int)x < ox - 1 || x > ox + sx)
 				continue;
 			if (pane_status == PANE_STATUS_TOP) {
-				if ((int)y <= yoff - 2 || y > yoff + sy - 1)
+				if ((int)y <= oy - 2 || y > oy + sy - 1)
 					continue;
 			} else {
-				if ((int)y < yoff - 1 || y > yoff + sy)
+				if ((int)y < oy - 1 || y > oy + sy)
 					continue;
 			}
 		}
@@ -1479,7 +1479,7 @@ window_pane_choose_best(struct window_pane **list, u_int size)
  * scrollbars if they were visible but not including the border(s).
  */
 static void
-window_pane_full_size_offset(struct window_pane *wp, int *xoff, int *yoff,
+window_pane_full_size_offset(struct window_pane *wp, int *ox, int *oy,
     u_int *sx, u_int *sy)
 {
 	struct window		*w = wp->window;
@@ -1494,13 +1494,13 @@ window_pane_full_size_offset(struct window_pane *wp, int *xoff, int *yoff,
 	else
 		sb_w = 0;
 	if (sb_pos == PANE_SCROLLBARS_LEFT) {
-		*xoff = wp->xoff - sb_w;
+		*ox = wp->ox - sb_w;
 		*sx = wp->sx + sb_w;
 	} else { /* sb_pos == PANE_SCROLLBARS_RIGHT */
-		*xoff = wp->xoff;
+		*ox = wp->ox;
 		*sx = wp->sx + sb_w;
 	}
-	*yoff = wp->yoff;
+	*oy = wp->oy;
 	*sy = wp->sy;
 }
 
@@ -1514,7 +1514,7 @@ window_pane_find_up(struct window_pane *wp)
 	struct window		*w;
 	struct window_pane	*next, *best, **list;
 	int			 edge, left, right, end, status, found;
-	int			 xoff, yoff;
+	int			 ox, oy;
 	u_int			 size, sx, sy;
 
 	if (wp == NULL)
@@ -1525,9 +1525,9 @@ window_pane_find_up(struct window_pane *wp)
 	list = NULL;
 	size = 0;
 
-	window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+	window_pane_full_size_offset(wp, &ox, &oy, &sx, &sy);
 
-	edge = yoff;
+	edge = oy;
 	if (status == PANE_STATUS_TOP) {
 		if (edge == 1)
 			edge = (int)w->sy + 1;
@@ -1539,21 +1539,21 @@ window_pane_find_up(struct window_pane *wp)
 			edge = (int)w->sy + 1;
 	}
 
-	left = xoff;
-	right = xoff + (int)sx;
+	left = ox;
+	right = ox + (int)sx;
 
 	TAILQ_FOREACH(next, &w->panes, entry) {
-		window_pane_full_size_offset(next, &xoff, &yoff, &sx, &sy);
+		window_pane_full_size_offset(next, &ox, &oy, &sx, &sy);
 		if (next == wp)
 			continue;
-		if (yoff + (int)sy + 1 != edge)
+		if (oy + (int)sy + 1 != edge)
 			continue;
-		end = xoff + (int)sx - 1;
+		end = ox + (int)sx - 1;
 
 		found = 0;
-		if (xoff < left && end > right)
+		if (ox < left && end > right)
 			found = 1;
-		else if (xoff >= left && xoff <= right)
+		else if (ox >= left && ox <= right)
 			found = 1;
 		else if (end >= left && end <= right)
 			found = 1;
@@ -1575,7 +1575,7 @@ window_pane_find_down(struct window_pane *wp)
 	struct window		*w;
 	struct window_pane	*next, *best, **list;
 	int			 edge, left, right, end, status, found;
-	int			 xoff, yoff;
+	int			 ox, oy;
 	u_int			 size, sx, sy;
 
 	if (wp == NULL)
@@ -1586,9 +1586,9 @@ window_pane_find_down(struct window_pane *wp)
 	list = NULL;
 	size = 0;
 
-	window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+	window_pane_full_size_offset(wp, &ox, &oy, &sx, &sy);
 
-	edge = yoff + (int)sy + 1;
+	edge = oy + (int)sy + 1;
 	if (status == PANE_STATUS_TOP) {
 		if (edge >= (int)w->sy)
 			edge = 1;
@@ -1600,21 +1600,21 @@ window_pane_find_down(struct window_pane *wp)
 			edge = 0;
 	}
 
-	left = wp->xoff;
-	right = wp->xoff + (int)wp->sx;
+	left = wp->ox;
+	right = wp->ox + (int)wp->sx;
 
 	TAILQ_FOREACH(next, &w->panes, entry) {
-		window_pane_full_size_offset(next, &xoff, &yoff, &sx, &sy);
+		window_pane_full_size_offset(next, &ox, &oy, &sx, &sy);
 		if (next == wp)
 			continue;
-		if (yoff != edge)
+		if (oy != edge)
 			continue;
-		end = xoff + (int)sx - 1;
+		end = ox + (int)sx - 1;
 
 		found = 0;
-		if (xoff < left && end > right)
+		if (ox < left && end > right)
 			found = 1;
-		else if (xoff >= left && xoff <= right)
+		else if (ox >= left && ox <= right)
 			found = 1;
 		else if (end >= left && end <= right)
 			found = 1;
@@ -1636,7 +1636,7 @@ window_pane_find_left(struct window_pane *wp)
 	struct window		*w;
 	struct window_pane	*next, *best, **list;
 	int			 edge, top, bottom, end, found;
-	int			 xoff, yoff;
+	int			 ox, oy;
 	u_int			 size, sx, sy;
 
 	if (wp == NULL)
@@ -1646,27 +1646,27 @@ window_pane_find_left(struct window_pane *wp)
 	list = NULL;
 	size = 0;
 
-	window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+	window_pane_full_size_offset(wp, &ox, &oy, &sx, &sy);
 
-	edge = xoff;
+	edge = ox;
 	if (edge == 0)
 		edge = (int)w->sx + 1;
 
-	top = yoff;
-	bottom = yoff + (int)sy;
+	top = oy;
+	bottom = oy + (int)sy;
 
 	TAILQ_FOREACH(next, &w->panes, entry) {
-		window_pane_full_size_offset(next, &xoff, &yoff, &sx, &sy);
+		window_pane_full_size_offset(next, &ox, &oy, &sx, &sy);
 		if (next == wp)
 			continue;
-		if (xoff + (int)sx + 1 != edge)
+		if (ox + (int)sx + 1 != edge)
 			continue;
-		end = yoff + (int)sy - 1;
+		end = oy + (int)sy - 1;
 
 		found = 0;
-		if (yoff < top && end > bottom)
+		if (oy < top && end > bottom)
 			found = 1;
-		else if (yoff >= top && yoff <= bottom)
+		else if (oy >= top && oy <= bottom)
 			found = 1;
 		else if (end >= top && end <= bottom)
 			found = 1;
@@ -1688,7 +1688,7 @@ window_pane_find_right(struct window_pane *wp)
 	struct window		*w;
 	struct window_pane	*next, *best, **list;
 	int			 edge, top, bottom, end, found;
-	int			 xoff, yoff;
+	int			 ox, oy;
 	u_int			 size, sx, sy;
 
 	if (wp == NULL)
@@ -1698,27 +1698,27 @@ window_pane_find_right(struct window_pane *wp)
 	list = NULL;
 	size = 0;
 
-	window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+	window_pane_full_size_offset(wp, &ox, &oy, &sx, &sy);
 
-	edge = xoff + (int)sx + 1;
+	edge = ox + (int)sx + 1;
 	if (edge >= (int)w->sx)
 		edge = 0;
 
-	top = wp->yoff;
-	bottom = wp->yoff + (int)wp->sy;
+	top = wp->oy;
+	bottom = wp->oy + (int)wp->sy;
 
 	TAILQ_FOREACH(next, &w->panes, entry) {
-		window_pane_full_size_offset(next, &xoff, &yoff, &sx, &sy);
+		window_pane_full_size_offset(next, &ox, &oy, &sx, &sy);
 		if (next == wp)
 			continue;
-		if (xoff != edge)
+		if (ox != edge)
 			continue;
-		end = yoff + (int)sy - 1;
+		end = oy + (int)sy - 1;
 
 		found = 0;
-		if (yoff < top && end > bottom)
+		if (oy < top && end > bottom)
 			found = 1;
-		else if (yoff >= top && yoff <= bottom)
+		else if (oy >= top && oy <= bottom)
 			found = 1;
 		else if (end >= top && end <= bottom)
 			found = 1;
@@ -2113,9 +2113,9 @@ window_pane_border_status_get_range(struct window_pane *wp, u_int x, u_int y)
 
 	pane_status = options_get_number(wo, "pane-border-status");
 	if (pane_status == PANE_STATUS_TOP)
-		line = wp->yoff - 1;
+		line = wp->oy - 1;
 	else if (pane_status == PANE_STATUS_BOTTOM)
-		line = wp->yoff + wp->sy;
+		line = wp->oy + wp->sy;
 	if (pane_status == PANE_STATUS_OFF || line != y)
 		return (NULL);
 
@@ -2123,7 +2123,7 @@ window_pane_border_status_get_range(struct window_pane *wp, u_int x, u_int y)
 	 * The border formats start 2 off but that isn't reflected in
 	 * the stored bounds of the range.
 	 */
-	return (style_ranges_get_range(srs, x - wp->xoff - 2));
+	return (style_ranges_get_range(srs, x - wp->ox - 2));
 }
 
 /* Work out geometry for tiled panes. */


### PR DESCRIPTION
I would like to change the naming of offset fields to `ox/oy` so that it matches the naming paradigm of the size fields (`sx/sy`). I have a feeling there is a reason it isn't already like this though. Have I missed something? @mgrant0