### PR TITLE
Crash fix: do not redraw line when there is no pane in screen_write_cell.

### DIFF
--- a/regress/copy-mode-wide-overwrite.sh
+++ b/regress/copy-mode-wide-overwrite.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -f/dev/null -Ltest-wide-overwrite"
+$TMUX kill-server 2>/dev/null
+trap "$TMUX kill-server 2>/dev/null" 0 1 15
+
+$TMUX new -d -x40 -y10 \
+      "printf '\350\241\250'; sleep 1; printf '\033[2G\347\225\214'; sleep 5" \
+      || exit 1
+
+$TMUX copy-mode || exit 1
+sleep 2
+
+$TMUX has-session || exit 1
+exit 0

--- a/screen-write.c
+++ b/screen-write.c
@@ -2575,7 +2575,8 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 
 	/* Do a full line redraw if needed. */
 	if (redraw) {
-		screen_write_redraw_line(ctx, &ttyctx, s->cy);
+		if (wp != NULL)
+			screen_write_redraw_line(ctx, &ttyctx, s->cy);
 		return;
 	}
 


### PR DESCRIPTION
When input is parsed while a pane has an active mode (e.g. copy mode), input_parse_buffer() calls screen_write_start() instead of screen_write_start_pane() so ctx->wp is NULL. If an overwrite of a wide or padding cell sets redraw = 1, screen_write_redraw_line() crashes dereferencing wp->xoff. Skip the redraw when wp is NULL, matching the other call sites of screen_write_redraw_line in this file.

Includes a regress test that reproduces the crash by entering copy mode while a pane writes a wide UTF-8 character over the padding cell of an existing wide character.