### PR TITLE
fix(floating_panes_staging): Added plumbing for 'placeholder' layout cells to fix `NULL` root layouts.

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -159,7 +159,7 @@ cmd_resize_pane_mouse_update(__unused struct cmd *self, struct cmdq_item *item)
 	if (wp == NULL || c == NULL || c->session != s)
 		return (CMD_RETURN_NORMAL);
 
-	if (~wp->flags & PANE_FLOATING) {
+	if (window_pane_is_floating(wp)) {
 		c->tty.mouse_drag_update = cmd_resize_pane_mouse_update_tiled;
 		cmd_resize_pane_mouse_update_tiled(c, &event->m);
 		return (CMD_RETURN_NORMAL);

--- a/cmd-select-pane.c
+++ b/cmd-select-pane.c
@@ -160,7 +160,7 @@ cmd_select_pane_exec(struct cmd *self, struct cmdq_item *item)
 			server_redraw_window_borders(markedwp->window);
 			server_status_window(markedwp->window);
 		}
-		if (wp->flags & PANE_FLOATING) {
+		if (window_pane_is_floating(wp)) {
 			window_redraw_active_switch(w, wp);
 			window_set_active_pane(w, wp, 1);
 		}

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -69,63 +69,6 @@ const struct cmd_entry cmd_split_window_entry = {
 	.exec = cmd_split_window_exec
 };
 
-static struct layout_cell *
-cmd_split_window_get_floating_cell(struct cmdq_item *item, struct args *args,
-    struct window *w, struct window_pane *wp)
-{
-	struct layout_cell	*lc = NULL;
-	char			*cause = NULL;
-	u_int			 x, y, sx, sy;
-
-	if (window_pane_floating_geometry(w, wp, &x, &y, &sx, &sy, item, args,
-	    &cause) != 0) {
-		cmdq_error(item, "invalid floating pane geometry %s", cause);
-		free(cause);
-		return (NULL);
-	}
-
-	/*
-	 * Floating panes sit in layout cells which are not in the layout_root
-	 * tree so we call it with parent == NULL.
-	 */
-	lc = layout_create_cell(NULL);
-	lc->xoff = x;
-	lc->yoff = y;
-	lc->sx = sx;
-	lc->sy = sy;
-
-	return (lc);
-}
-
-static struct layout_cell *
-cmd_split_window_get_tiled_cell(struct cmdq_item *item, struct args *args,
-    struct window *w, struct window_pane *wp, int flags)
-{
-	enum layout_type	 type;
-	struct layout_cell	*lc = NULL;
-	char			*cause = NULL;
-	int			 size;
-
-	if (wp->flags & PANE_FLOATING) {
-		cmdq_error(item, "can't split a floating pane");
-		return (NULL);
-	}
-
-	if (window_pane_tiled_geometry(w, wp, &size, &flags, &type, item, args,
-	    &cause) != 0) {
-		cmdq_error(item, "invalid tiled geometry %s", cause);
-		free(cause);
-		return (NULL);
-	}
-
-	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
-	lc = layout_split_pane(wp, type, size, flags);
-	if (lc == NULL)
-		cmdq_error(item, "no space for new pane");
-
-	return (lc);
-}
-
 static enum cmd_retval
 cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 {
@@ -161,11 +104,14 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		flags |= SPAWN_EMPTY;
 
 	if (is_floating)
-		lc = cmd_split_window_get_floating_cell(item, args, w, wp);
+		lc = layout_get_floating_cell(item, args, w, wp, NULL, &cause);
 	else
-		lc = cmd_split_window_get_tiled_cell(item, args, w, wp, flags);
-	if (lc == NULL)
+		lc = layout_get_tiled_cell(item, args, w, wp, flags, &cause);
+	if (lc == NULL) {
+		cmdq_error(item, "create cell failed: %s", cause);
+		free(cause);
 		return (CMD_RETURN_ERROR);
+	}
 
 	sc.item = item;
 	sc.s = s;

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -79,8 +79,7 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (src_wp == dst_wp)
 		goto out;
 
-	if ((src_wp->flags & PANE_FLOATING) &&
-	    (dst_wp->flags & PANE_FLOATING)) {
+	if (window_pane_is_floating(src_wp) && window_pane_is_floating(dst_wp)) {
 		cmdq_error(item, "cannot swap floating panes");
 		return (CMD_RETURN_ERROR);
 	}
@@ -114,9 +113,9 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->layout_cell = src_lc;
 	dst_lc->wp = src_wp;
 	src_wp->layout_cell = dst_lc;
-	if ((src_wp->flags ^ dst_wp->flags) & PANE_FLOATING) {
-		src_wp->flags ^= PANE_FLOATING;
-		dst_wp->flags ^= PANE_FLOATING;
+	if (window_pane_is_floating(src_wp) != window_pane_is_floating(dst_wp)) {
+		src_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
+		dst_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
 	}
 
 	src_wp->window = dst_w;

--- a/format.c
+++ b/format.c
@@ -1035,7 +1035,7 @@ format_cb_pane_floating_flag(struct format_tree *ft)
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}
@@ -2418,7 +2418,7 @@ format_cb_pane_zoomed_flag(struct format_tree *ft)
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL) {
-		if (wp->flags & PANE_ZOOMED)
+		if (window_pane_is_zoomed(wp))
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}

--- a/layout-custom.c
+++ b/layout-custom.c
@@ -70,7 +70,7 @@ layout_dump(struct window *w, struct layout_cell *root)
 		return (NULL);
 
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
-		if (~wp->flags & PANE_FLOATING)
+		if (!window_pane_is_floating(wp))
 			break;
 		if (!bracket) {
 			strlcat(layout, "<", sizeof layout);
@@ -127,7 +127,6 @@ layout_append(struct layout_cell *lc, char *buf, size_t len)
 		}
 		buf[strlen(buf) - 1] = brackets[0];
 		break;
-	case LAYOUT_FLOATING:
 	case LAYOUT_WINDOWPANE:
 		break;
 	}
@@ -143,7 +142,6 @@ layout_check(struct layout_cell *lc)
 	u_int			 n = 0;
 
 	switch (lc->type) {
-	case LAYOUT_FLOATING:
 	case LAYOUT_WINDOWPANE:
 		break;
 	case LAYOUT_LEFTRIGHT:
@@ -257,9 +255,6 @@ layout_parse(struct window *w, const char *layout, char **cause)
 			sy += lcchild->sy + 1;
 		}
 		break;
-	case LAYOUT_FLOATING:
-		*cause = xstrdup("invalid layout");
-		goto fail;
 	}
 	if (tiled_lc->type != LAYOUT_WINDOWPANE &&
 	    (tiled_lc->sx != sx || tiled_lc->sy != sy)) {
@@ -286,7 +281,7 @@ layout_parse(struct window *w, const char *layout, char **cause)
 	if (tiled_lc != NULL)
 		layout_assign(&wp, tiled_lc, 0);
 	if (floating_lc != NULL)
-		layout_assign(&wp, floating_lc, PANE_FLOATING);
+		layout_assign(&wp, floating_lc, LAYOUT_CELL_FLOATING);
 
         /* Fix pane z-indexes. */
         while (!TAILQ_EMPTY(&w->z_index)) {
@@ -328,12 +323,11 @@ layout_assign(struct window_pane **wp, struct layout_cell *lc, int flags)
 	switch (lc->type) {
 	case LAYOUT_WINDOWPANE:
 		layout_make_leaf(lc, *wp);
-		(*wp)->flags |= flags;
+		lc->flags |= flags;
 		*wp = TAILQ_NEXT(*wp, entry);
 		return;
 	case LAYOUT_LEFTRIGHT:
 	case LAYOUT_TOPBOTTOM:
-	case LAYOUT_FLOATING:
 		TAILQ_FOREACH(lcchild, &lc->cells, entry)
 			layout_assign(wp, lcchild, flags);
 		return;
@@ -399,7 +393,7 @@ static int
 layout_construct(struct layout_cell *lcparent, const char **layout,
     struct layout_cell **lc, struct layout_cell **floating_lc)
 {
-	struct layout_cell	*lcchild, *saved_lc;
+	struct layout_cell	*lcchild;
 
 	*lc = layout_construct_cell(lcparent, layout);
 
@@ -415,11 +409,6 @@ layout_construct(struct layout_cell *lcparent, const char **layout,
 		break;
 	case '[':
 		(*lc)->type = LAYOUT_TOPBOTTOM;
-		break;
-	case '<':
-		saved_lc = *lc;
-		*lc = layout_create_cell(lcparent);
-		(*lc)->type = LAYOUT_FLOATING;
 		break;
 	default:
 		goto fail;
@@ -440,12 +429,6 @@ layout_construct(struct layout_cell *lcparent, const char **layout,
 	case LAYOUT_TOPBOTTOM:
 		if (**layout != ']')
 			goto fail;
-		break;
-	case LAYOUT_FLOATING:
-		if (**layout != '>')
-			goto fail;
-		*floating_lc = *lc;
-		*lc = saved_lc;
 		break;
 	default:
 		goto fail;

--- a/layout-set.c
+++ b/layout-set.c
@@ -129,7 +129,7 @@ layout_first_tiled(struct window *w)
 	struct window_pane	*wp;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (~wp->flags & PANE_FLOATING)
+		if (!window_pane_is_floating(wp))
 			return (wp);
 	}
 	return (NULL);
@@ -168,7 +168,7 @@ layout_set_even(struct window *w, enum layout_type type)
 
 	/* Build new leaf cells. */
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			continue;
 		lcnew = layout_create_cell(lc);
 		layout_make_leaf(lcnew, wp);
@@ -272,7 +272,7 @@ layout_set_main_h(struct window *w)
 	layout_set_size(lcother, sx, otherh, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && (window_pane_is_floating(wp)))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -282,7 +282,7 @@ layout_set_main_h(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -368,7 +368,7 @@ layout_set_main_h_mirrored(struct window *w)
 	layout_set_size(lcother, sx, otherh, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && (window_pane_is_floating(wp)))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -378,7 +378,7 @@ layout_set_main_h_mirrored(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -476,7 +476,7 @@ layout_set_main_v(struct window *w)
 	layout_set_size(lcother, otherw, sy, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && (window_pane_is_floating(wp)))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -486,7 +486,7 @@ layout_set_main_v(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -572,7 +572,7 @@ layout_set_main_v_mirrored(struct window *w)
 	layout_set_size(lcother, otherw, sy, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && (window_pane_is_floating(wp)))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -582,7 +582,7 @@ layout_set_main_v_mirrored(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -661,7 +661,7 @@ layout_set_tiled(struct window *w)
 
 	/* Create a grid of the cells, skipping any floating panes. */
 	wp = TAILQ_FIRST(&w->panes);
-	while (wp != NULL && (wp->flags & PANE_FLOATING))
+	while (wp != NULL && (window_pane_is_floating(wp)))
 		wp = TAILQ_NEXT(wp, entry);
 	for (j = 0; j < rows; j++) {
 		/* If this is the last cell, all done. */
@@ -677,7 +677,7 @@ layout_set_tiled(struct window *w)
 		if (n - (j * columns) == 1 || columns == 1) {
 			layout_make_leaf(lcrow, wp);
 			wp = TAILQ_NEXT(wp, entry);
-			while (wp != NULL && (wp->flags & PANE_FLOATING))
+			while (wp != NULL && (window_pane_is_floating(wp)))
 				wp = TAILQ_NEXT(wp, entry);
 			continue;
 		}
@@ -693,7 +693,7 @@ layout_set_tiled(struct window *w)
 
 			/* Move to the next non-floating cell. */
 			wp = TAILQ_NEXT(wp, entry);
-			while (wp != NULL && (wp->flags & PANE_FLOATING))
+			while (wp != NULL && (window_pane_is_floating(wp)))
 				wp = TAILQ_NEXT(wp, entry);
 			if (wp == NULL)
 				break;

--- a/layout.c
+++ b/layout.c
@@ -46,8 +46,12 @@ static int	layout_set_size_check(struct window *, struct layout_cell *,
 		    enum layout_type, int);
 static void	layout_resize_child_cells(struct window *,
 		    struct layout_cell *);
-void		layout_redistribute_cells(struct window *, struct layout_cell *,
-		    enum layout_type);
+
+/* Layout cells positional relationship. */
+enum {
+	POSITION_BEFORE,
+	POSITION_AFTER,
+};
 
 /* Create a new layout cell. */
 struct layout_cell *
@@ -57,6 +61,7 @@ layout_create_cell(struct layout_cell *lcparent)
 
 	lc = xmalloc(sizeof *lc);
 	lc->type = LAYOUT_WINDOWPANE;
+	lc->flags = 0;
 	lc->parent = lcparent;
 
 	TAILQ_INIT(&lc->cells);
@@ -90,19 +95,6 @@ layout_free_cell(struct layout_cell *lc)
 			layout_free_cell(lcchild);
 		}
 		break;
-	case LAYOUT_FLOATING:
-		/*
-		 * A floating layout cell is only used temporarily while
-		 * select-layout constructs a layout. Remove the children from
-		 * the temporary layout, then free temporary floating layout
-		 * cell. Each floating pane has stub layout.
-		 */
-		while (!TAILQ_EMPTY(&lc->cells)) {
-			lcchild = TAILQ_FIRST(&lc->cells);
-			TAILQ_REMOVE(&lc->cells, lcchild, entry);
-			lcchild->parent = NULL;
-		}
-		break;
 	case LAYOUT_WINDOWPANE:
 		if (lc->wp != NULL) {
 			lc->wp->layout_cell->parent = NULL;
@@ -131,9 +123,6 @@ layout_print_cell(struct layout_cell *lc, const char *hdr, u_int n)
 	case LAYOUT_TOPBOTTOM:
 		type = "TOPBOTTOM";
 		break;
-	case LAYOUT_FLOATING:
-		type = "FLOATING";
-		break;
 	case LAYOUT_WINDOWPANE:
 		type = "WINDOWPANE";
 		break;
@@ -147,7 +136,6 @@ layout_print_cell(struct layout_cell *lc, const char *hdr, u_int n)
 	switch (lc->type) {
 	case LAYOUT_LEFTRIGHT:
 	case LAYOUT_TOPBOTTOM:
-	case LAYOUT_FLOATING:
 		TAILQ_FOREACH(lcchild, &lc->cells, entry)
 			layout_print_cell(lcchild, hdr, n + 1);
 		break;
@@ -188,7 +176,6 @@ layout_search_by_border(struct layout_cell *lc, u_int x, u_int y)
 				return (last);
 			break;
 		case LAYOUT_WINDOWPANE:
-		case LAYOUT_FLOATING:
 			break;
 		}
 
@@ -236,12 +223,100 @@ layout_make_node(struct layout_cell *lc, enum layout_type type)
 	lc->wp = NULL;
 }
 
+/*
+ * Determines where the placeholder cell is put in the root layout when creating
+ * a new floating window.
+ */
+static struct layout_cell *
+layout_placeholder_after(struct window *w, struct window_pane *wp)
+{
+	struct window_pane	*active, *wpp;
+
+	active = w->active;
+	if (active != NULL && active != wp)
+		wpp = active;
+	else { /* fallback */
+		TAILQ_FOREACH_REVERSE(wpp, &w->panes, window_panes, entry) {
+			if (wpp != wp)
+				break;
+		}
+	}
+	if (wpp == NULL)
+		return (NULL);
+	if (wpp->layout_cell->flags & LAYOUT_CELL_FLOATING)
+		return (wpp->placeholder_layout_cell);
+	return (wpp->layout_cell);
+}
+
+/*
+ * Puts a placeholder cell into the root layout when creating a new
+ * floating pane
+ */
+static struct layout_cell *
+layout_placeholder_for_floating(struct window *w, struct window_pane *wp)
+{
+	struct layout_cell	*lc, *lcafter, *lcparent = NULL;
+
+	lcafter = layout_placeholder_after(w, wp);
+	if (lcafter != NULL && lcafter->parent == NULL) {
+		/*
+		* The layout root is a single window pane. A container
+		* needs to be created and wired in.
+		*/
+		lcparent = layout_create_cell(NULL);
+		layout_make_node(lcparent, LAYOUT_TOPBOTTOM);
+		layout_set_size(lcparent, w->sx, w->sy, 0, 0);
+		w->layout_root = lcparent;
+		lcafter->parent = lcparent;
+		TAILQ_INSERT_HEAD(&lcparent->cells, lcafter, entry);
+	} else if (lcafter != NULL)
+		lcparent = lcafter->parent;
+
+	lc = layout_create_cell(lcparent);
+	if (lcafter == NULL)
+		w->layout_root = lc;
+	else
+		TAILQ_INSERT_AFTER(&lcparent->cells, lcafter, lc, entry);
+
+	return (lc);
+}
+
+/* Make a cell a placeholder cell. Returns the old placeholder cell. Does not
+ * clean up existing placeholder cells. If NULL is given as the layout cell, a
+ * tiled placeholder will be created for a floating pane.
+ */
+struct layout_cell *
+layout_make_placeholder(struct window *w, struct window_pane *wp,
+    struct layout_cell *lc)
+{
+	struct layout_cell	*lcret = NULL;
+
+	if (lc == NULL) {
+		if (!window_pane_is_floating(wp))
+			return (NULL);
+		/* Always makes tiled placeholder for a floating pane */
+		lc = layout_placeholder_for_floating(w, wp);
+	}
+
+	if (lc->type != LAYOUT_WINDOWPANE)
+		fatalx("bad placeholder layout type");
+
+	lcret = wp->placeholder_layout_cell;
+	if (lcret != NULL)
+		lcret->flags &= ~LAYOUT_CELL_CONCEALED;
+	layout_conceal_cell(w, lc);
+
+	lc->wp = wp;
+	wp->placeholder_layout_cell = lc;
+
+	return (lcret);
+}
+
 /* Fix z-indexes. */
 void
 layout_fix_zindexes(struct window *w, struct layout_cell *lc)
 {
 	struct layout_cell	*lcchild;
-
 	if (lc == NULL)
 		return;
 
@@ -251,7 +326,6 @@ layout_fix_zindexes(struct window *w, struct layout_cell *lc)
 		break;
 	case LAYOUT_LEFTRIGHT:
 	case LAYOUT_TOPBOTTOM:
-	case LAYOUT_FLOATING:
 		TAILQ_FOREACH(lcchild, &lc->cells, entry)
 			layout_fix_zindexes(w, lcchild);
 		return;
@@ -270,6 +344,8 @@ layout_fix_offsets1(struct layout_cell *lc)
 	if (lc->type == LAYOUT_LEFTRIGHT) {
 		xoff = lc->xoff;
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
+			if (lcchild->flags & LAYOUT_CELL_CONCEALED)
+				continue;
 			lcchild->xoff = xoff;
 			lcchild->yoff = lc->yoff;
 			if (lcchild->type != LAYOUT_WINDOWPANE)
@@ -279,6 +355,8 @@ layout_fix_offsets1(struct layout_cell *lc)
 	} else {
 		yoff = lc->yoff;
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
+			if (lcchild->flags & LAYOUT_CELL_CONCEALED)
+				continue;
 			lcchild->xoff = lc->xoff;
 			lcchild->yoff = yoff;
 			if (lcchild->type != LAYOUT_WINDOWPANE)
@@ -373,7 +451,7 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 		sx = lc->sx;
 		sy = lc->sy;
 
-		if ((~wp->flags & PANE_FLOATING) &&
+		if (!window_pane_is_floating(wp) &&
 		    layout_add_horizontal_border(w, lc, status)) {
 			if (status == PANE_STATUS_TOP)
 				wp->yoff++;
@@ -420,7 +498,6 @@ layout_count_cells(struct layout_cell *lc)
 		return (1);
 	case LAYOUT_LEFTRIGHT:
 	case LAYOUT_TOPBOTTOM:
-	case LAYOUT_FLOATING:
 		TAILQ_FOREACH(lcchild, &lc->cells, entry)
 			count += layout_count_cells(lcchild);
 		return (count);
@@ -491,6 +568,10 @@ layout_resize_adjust(struct window *w, struct layout_cell *lc,
 {
 	struct layout_cell	*lcchild;
 
+	/* Nothing to do for a concealed cell. */
+	if (lc->flags & LAYOUT_CELL_CONCEALED)
+		return;
+
 	/* Adjust the cell size. */
 	if (type == LAYOUT_LEFTRIGHT)
 		lc->sx += change;
@@ -516,6 +597,8 @@ layout_resize_adjust(struct window *w, struct layout_cell *lc,
 		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
 			if (change == 0)
 				break;
+			if (lcchild->flags & LAYOUT_CELL_CONCEALED)
+				continue;
 			if (change > 0) {
 				layout_resize_adjust(w, lcchild, type, 1);
 				change--;
@@ -529,12 +612,73 @@ layout_resize_adjust(struct window *w, struct layout_cell *lc,
 	}
 }
 
-/* Destroy a cell and redistribute the space. */
 void
+layout_resize_set(struct window *w, struct layout_cell *lc,
+    enum layout_type type, u_int val)
+{
+	int	change;
+
+	if (type == LAYOUT_LEFTRIGHT)
+		change = val - lc->sx;
+	else
+		change = val - lc->sy;
+
+	layout_resize_adjust(w, lc, type, change);
+}
+
+/* Helper function for layout_cell_visible_neighbour. */
+static struct layout_cell *
+layout_cell_visible_neighbour_helper(struct layout_cell *lc, int direction)
+{
+	struct layout_cell	*lcother = lc;
+
+	while (1) {
+		if (direction == POSITION_AFTER)
+			lcother = TAILQ_NEXT(lcother, entry);
+		else
+			lcother = TAILQ_PREV(lcother, layout_cells, entry);
+
+		if (lcother == NULL || !(lcother->flags & LAYOUT_CELL_CONCEALED))
+			return (lcother);
+	}
+}
+
+/*
+ * Finds the nearest visible neighbour. Prefers scanning POSITION_BEFORE.
+ * This behavior defines how cell dimensions are redistributed when a cell is
+ * concealed or revealed.
+ */
+struct layout_cell *
+layout_cell_visible_neighbour(struct layout_cell *lc)
+{
+	struct layout_cell	*lcother, *lcparent = lc->parent;
+	int			 dir, rid;
+
+	if (lcparent == NULL)
+		return (NULL);
+
+	if (lc == TAILQ_FIRST(&lcparent->cells)) {
+		dir = POSITION_AFTER;
+		rid = POSITION_BEFORE;
+	} else {
+		dir = POSITION_BEFORE;
+		rid = POSITION_AFTER;
+	}
+
+	lcother = layout_cell_visible_neighbour_helper(lc, dir);
+	if (lcother == NULL)
+		lcother = layout_cell_visible_neighbour_helper(lc, rid);
+
+	return lcother;
+}
+
+/* Destroy a cell and redistribute the space if the cell was tiled. */
+struct layout_cell *
 layout_destroy_cell(struct window *w, struct layout_cell *lc,
     struct layout_cell **lcroot)
 {
 	struct layout_cell     *lcother, *lcparent;
+	int			val;
 
 	/*
 	 * If no parent, this is either a floating pane or the last
@@ -543,33 +687,33 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 	 */
 	lcparent = lc->parent;
 	if (lcparent == NULL) {
-		if (lc->wp != NULL && ~lc->wp->flags & PANE_FLOATING)
+		if (lc->wp != NULL && (~lc->flags & LAYOUT_CELL_FLOATING))
 			*lcroot = NULL;
 		layout_free_cell(lc);
-		return;
+		return NULL;
 	}
 
-	/* A floating cell need only be removed from the parent. */
-	if (lcparent->type == LAYOUT_FLOATING) {
+	if (lc->flags & LAYOUT_CELL_CONCEALED) {
 		TAILQ_REMOVE(&lcparent->cells, lc, entry);
 		layout_free_cell(lc);
-		return;
+		goto out;
 	}
 
-	/* Merge the space into the previous or next cell. */
-	if (lc == TAILQ_FIRST(&lcparent->cells))
-		lcother = TAILQ_NEXT(lc, entry);
-	else
-		lcother = TAILQ_PREV(lc, layout_cells, entry);
-	if (lcother != NULL && lcparent->type == LAYOUT_LEFTRIGHT)
-		layout_resize_adjust(w, lcother, lcparent->type, lc->sx + 1);
-	else if (lcother != NULL)
-		layout_resize_adjust(w, lcother, lcparent->type, lc->sy + 1);
+	lcother = layout_cell_visible_neighbour(lc);
+	if (lcother != NULL) {
+		if (lcparent->type == LAYOUT_LEFTRIGHT)
+			val = lc->sx + 1;
+		else
+			val = lc->sy + 1;
+		layout_resize_adjust(w, lcother, lcparent->type, val);
+	} else
+		layout_conceal_cell(w, lcparent);
 
 	/* Remove this from the parent's list. */
 	TAILQ_REMOVE(&lcparent->cells, lc, entry);
 	layout_free_cell(lc);
 
+out:
 	/*
 	 * If the parent now has one cell, remove the parent from the tree and
 	 * replace it by that cell.
@@ -580,13 +724,59 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 
 		lc->parent = lcparent->parent;
 		if (lc->parent == NULL) {
-			lc->xoff = 0;
-			lc->yoff = 0;
+			if (!(lc->flags & LAYOUT_CELL_CONCEALED))
+				layout_set_size(lc, w->sx, w->sy, 0, 0);
 			*lcroot = lc;
 		} else
 			TAILQ_REPLACE(&lc->parent->cells, lcparent, lc, entry);
 
 		layout_free_cell(lcparent);
+		lcparent = lc->parent;
+	}
+
+	return (lcparent);
+}
+
+/* Conceal a cell. Space is redistributed to the active neighbour when cell is
+ * tiled.
+ */
+void
+layout_conceal_cell(struct window *w, struct layout_cell *lc)
+{
+	struct layout_cell	*lcother, *lcparent, *lcchild;
+	u_int			 shown_children = 0;
+	int			 val;
+
+	if (lc == NULL)
+		return;
+
+	lcparent = lc->parent;
+	lc->flags |= LAYOUT_CELL_CONCEALED;
+
+	/* Merge the space into the nearest neighbour. */
+	lcother = layout_cell_visible_neighbour(lc);
+
+	if (lcother != NULL) {
+		if (lcparent->type == LAYOUT_LEFTRIGHT)
+			val = lc->sx + 1;
+		else
+			val = lc->sy + 1;
+		layout_resize_adjust(w, lcother, lcparent->type, val);
+	}
+
+	if (~lc->flags & LAYOUT_CELL_FLOATING)
+		layout_set_size(lc, 0, 0, 0, 0);
+
+	/* If all children are concealed, conceal the parent. */
+	if (lcparent != NULL) {
+		TAILQ_FOREACH(lcchild, &lcparent->cells, entry) {
+			if (!(lcchild->flags & LAYOUT_CELL_CONCEALED)) {
+				shown_children = 1;
+				break;
+			}
+		}
+		if (shown_children == 0)
+			layout_conceal_cell(w, lcparent);
 	}
 }
 
@@ -967,9 +1157,10 @@ layout_resize_child_cells(struct window *w, struct layout_cell *lc)
 			    lc->type, lc->sx, count - idx, available);
 			available -= (lcchild->sx + 1);
 		}
-		if (lc->type == LAYOUT_LEFTRIGHT)
+		if (lc->type == LAYOUT_LEFTRIGHT) {
 			lcchild->sy = lc->sy;
-		else {
+			lcchild->yoff = lc->yoff;
+		} else {
 			lcchild->sy = layout_new_pane_size(w, previous, lcchild,
 			    lc->type, lc->sy, count - idx, available);
 			available -= (lcchild->sy + 1);
@@ -1162,19 +1353,38 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 void
 layout_close_pane(struct window_pane *wp)
 {
-	struct window	*w = wp->window;
+	struct window		*w = wp->window;
+	struct layout_cell	*lcparent, *lc = wp->layout_cell;
+	struct layout_cell	*lcph = wp->placeholder_layout_cell;
+	int			 conceal = 0;
 
-	if (wp->layout_cell == NULL)
+	if (lc == NULL)
 		return;
+
+	lcparent = lc->parent;
+	if (lcparent != NULL && layout_cell_visible_neighbour(lc) == NULL)
+		conceal = 1;
 
 	/* Remove the cell. */
 	layout_destroy_cell(w, wp->layout_cell, &w->layout_root);
+	if (lcph != NULL) { /* Also remove the placeholder */
+		wp->layout_cell = lcph;
+		wp->layout_cell->wp = wp;
+		layout_destroy_cell(w, wp->layout_cell, &w->layout_root);
+	}
+	wp->layout_cell = NULL;
+
+	if (lcparent != NULL &&
+	    lcparent->type != LAYOUT_WINDOWPANE &&
+	    !(lcparent->flags & LAYOUT_CELL_CONCEALED) &&
+	    conceal)
+		layout_conceal_cell(w, lcparent);
 
 	/* Fix pane offsets and sizes. */
 	if (w->layout_root != NULL) {
 		layout_fix_offsets(w);
-		layout_fix_panes(w, NULL);
 	}
+	layout_fix_panes(w, NULL);
 	notify_window("window-layout-changed", w);
 }
 
@@ -1257,4 +1467,144 @@ layout_spread_out(struct window_pane *wp)
 			break;
 		}
 	} while ((parent = parent->parent) != NULL);
+}
+
+struct layout_cell *
+layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
+    struct window *w, struct window_pane *wp, int flags, char **cause)
+{
+	struct layout_cell	*lc;
+	enum layout_type	 type;
+	u_int			 curval;
+	int			 size = -1;
+
+
+	if (window_pane_is_floating(wp)) {
+		*cause = xstrdup("can't split a floating pane");
+		return (NULL);
+	}
+	if (window_pane_is_hidden(wp)) {
+		*cause = xstrdup("can't split a hidden pane");
+		return (NULL);
+	}
+
+	type = LAYOUT_TOPBOTTOM;
+	if (args_has(args, 'h'))
+		type = LAYOUT_LEFTRIGHT;
+
+	if (args_has(args, 'l') || args_has(args, 'p')) {
+		if (args_has(args, 'f')) {
+			if (type == LAYOUT_TOPBOTTOM)
+				curval = w->sy;
+			else
+				curval = w->sx;
+		} else {
+			if (type == LAYOUT_TOPBOTTOM)
+				curval = wp->sy;
+			else
+				curval = wp->sx;
+		}
+	}
+
+	if (args_has(args, 'l')) {
+		size = args_percentage_and_expand(args, 'l', 0, INT_MAX, curval,
+		    item, cause);
+	} else if (args_has(args, 'p')) {
+		size = args_strtonum_and_expand(args, 'p', 0, 100, item,
+		    cause);
+		if (*cause == NULL)
+			size = curval * size / 100;
+	}
+	if (*cause != NULL) {
+		*cause = xstrdup("invalid tiled geometry");
+		return (NULL);
+	}
+
+	if (args_has(args, 'b'))
+		flags |= SPAWN_BEFORE;
+	if (args_has(args, 'f'))
+		flags |= SPAWN_FULLSIZE;
+
+	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
+	lc = layout_split_pane(wp, type, size, flags);
+	if (lc == NULL)
+		*cause = xstrdup("no space for a new pane");
+
+	return (lc);
+}
+
+struct layout_cell *
+layout_get_floating_cell(struct cmdq_item *item, struct args *args,
+    struct window *w, __unused struct window_pane *wp, struct layout_cell *lc,
+    char **cause)
+{
+	u_int			 sx, sy, ox, oy;
+	int			 new = 0;
+
+	if (lc == NULL) {
+		lc = layout_create_cell(NULL);
+		new = 1;
+	}
+
+	sx = lc->sx; sy = lc->sy;
+	ox = lc->xoff; oy = lc->yoff;
+
+	if (args_has(args, 'x')) {
+		sx = args_percentage_and_expand(args, 'x', 0, USHRT_MAX, w->sx,
+		    item, cause);
+		if (*cause != NULL)
+			goto error;
+	}
+	if (args_has(args, 'y')) {
+		sy = args_percentage_and_expand(args, 'y', 0, USHRT_MAX, w->sy,
+		    item, cause);
+		if (*cause != NULL)
+			goto error;
+	}
+	if (args_has(args, 'X')) {
+		ox = args_percentage_and_expand(args, 'X', 0, USHRT_MAX, w->sx,
+		    item, cause);
+		if (*cause != NULL)
+			goto error;
+	}
+	if (args_has(args, 'Y')) {
+		oy = args_percentage_and_expand(args, 'Y', 0, USHRT_MAX, w->sy,
+		    item, cause);
+		if (*cause != NULL)
+			goto error;
+	}
+
+	if (sx == UINT_MAX)
+		sx = w->sx / 2;
+	if (sy == UINT_MAX)
+		sy = w->sy / 2;
+	if (ox == INT_MAX) {
+		if (w->last_new_pane_x == 0)
+			ox = 4;
+		else {
+			ox = w->last_new_pane_x + 4;
+			if (w->last_new_pane_x > w->sx)
+				ox = 4;
+		}
+		w->last_new_pane_x = ox;
+	}
+	if (oy == INT_MAX) {
+		if (w->last_new_pane_y == 0)
+			oy = 2;
+		else {
+			oy = w->last_new_pane_y + 2;
+			if (w->last_new_pane_y > w->sy)
+				oy = 2;
+		}
+		w->last_new_pane_y = oy;
+	}
+	layout_set_size(lc, sx, sy, ox, oy);
+	lc->flags |= LAYOUT_CELL_FLOATING;
+
+	return (lc);
+
+error:
+	if (new)
+		layout_destroy_cell(w, lc, &w->layout_root);
+	return (NULL);
 }

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -106,7 +106,7 @@ screen_redraw_two_panes(struct window *w, enum layout_type *type)
 	u_int			 count = 0;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING || wp->layout_cell == NULL)
+		if (window_pane_is_floating(wp) || wp->layout_cell == NULL)
 			continue;
 		count++;
 		if (count > 2 || wp->layout_cell->parent == NULL)
@@ -144,7 +144,7 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 
 	/* Floating pane borders. */
-	if (wp->flags & PANE_FLOATING) {
+	if (window_pane_is_floating(wp)) {
 		if (py >= wp->yoff - 1 && py <= wp->yoff + sy) {
 			if (sb_pos == PANE_SCROLLBARS_LEFT) {
 				if (px == wp->xoff - 1 - sb_w)
@@ -261,7 +261,7 @@ screen_redraw_cell_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	if (ctx->pane_status == PANE_STATUS_BOTTOM)
 		sy--;
 
-	floating = (wp->flags & PANE_FLOATING);
+	floating = (window_pane_is_floating(wp));
 	if (!floating) {
 		/* Outside the window? */
 		if (px > sx || py > sy)
@@ -285,7 +285,7 @@ screen_redraw_cell_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	/* Check all the panes. */
 	TAILQ_FOREACH(wp2, &w->z_index, zentry) {
 		if (!window_pane_visible(wp2) ||
-		    (!floating && (wp2->flags & PANE_FLOATING)) ||
+		    (!floating && window_pane_is_floating(wp2)) ||
 		    (floating && wp2 != wp))
 			continue;
 		if (sb_pos == PANE_SCROLLBARS_LEFT) {
@@ -338,7 +338,7 @@ screen_redraw_type_of_cell(struct screen_redraw_ctx *ctx,
 	 *		   8 + 4
 	 *		     1
 	 */
-	if (~wp->flags & PANE_FLOATING) {
+	if (!window_pane_is_floating(wp)) {
 		if (px == 0 || screen_redraw_cell_border(ctx, wp, px - 1, py))
 			borders |= 8;
 		if (px <= sx && screen_redraw_cell_border(ctx, wp, px + 1, py))
@@ -442,7 +442,7 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 
 	/* Find pane higest in z-index at this point. */
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
-		if (wp->flags & PANE_FLOATING && (px >= sx || py >= sy)) {
+		if (window_pane_is_floating(wp) && (px >= sx || py >= sy)) {
 			/* Clip floating panes to window. */
 			continue;
 		}
@@ -477,11 +477,11 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 	 * necessary if there are two side-by-side or top-bottom panes with a
 	 * shared border and half the shared border is the active border.
 	 */
-	if (~wp->flags & PANE_FLOATING)
+	if (!window_pane_is_floating(wp))
 		tiled_only = 1;
 	do { /* Loop until back to wp == start.*/
 		if (!window_pane_visible(wp) ||
-		    (tiled_only && (wp->flags & PANE_FLOATING)))
+		    (tiled_only && window_pane_is_floating(wp)))
 			goto next;
 		*wpp = wp;
 
@@ -1189,7 +1189,7 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, int px,
 		    (u_int)py < tb ||
 		    (u_int)py > bb)
 			continue;
-		if (~wp->flags & PANE_FLOATING && (u_int)py == bb)
+		if (!window_pane_is_floating(wp) && (u_int)py == bb)
 			continue;
 
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;

--- a/screen-write.c
+++ b/screen-write.c
@@ -198,7 +198,7 @@ screen_write_pane_is_obscured(struct screen_write_ctx *ctx)
 	}
 
 	while ((wp = TAILQ_PREV(wp, window_panes, zentry)) != NULL) {
-		if ((wp->flags & PANE_FLOATING) &&
+		if (window_pane_is_floating(wp) &&
 		    ((wp->yoff >= ctx->wp->yoff &&
 		    wp->yoff <= ctx->wp->yoff + (int)ctx->wp->sy) ||
 		    (wp->yoff + (int)wp->sy >= ctx->wp->yoff &&

--- a/server-client.c
+++ b/server-client.c
@@ -655,7 +655,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_SLIDER);
 			} else /* py > sl_bottom */
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_DOWN);
-		} else if (wp->flags & PANE_FLOATING &&
+		} else if (window_pane_is_floating(wp) &&
 		    (px == wp->xoff - 1 ||
 		    py == wp->yoff - 1 ||
 		    py == wp->yoff + (int)wp->sy)) {
@@ -669,7 +669,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 		/* Try the pane borders. */
 		TAILQ_FOREACH(fwp, &w->panes, entry) {
 			if ((w->flags & WINDOW_ZOOMED) &&
-			    (~fwp->flags & PANE_ZOOMED))
+			    !window_pane_is_zoomed(fwp))
 				continue;
 			bdr_top = fwp->yoff - 1;
 			bdr_bottom = fwp->yoff + fwp->sy;
@@ -683,7 +683,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 			    py <= fwp->yoff + (int)fwp->sy) {
 				if (px == bdr_right)
 					break;
-				if (wp->flags & PANE_FLOATING) {
+				if (window_pane_is_floating(wp)) {
 					/* Floating pane, check left border. */
 					bdr_left = fwp->xoff - 1;
 					if (px == bdr_left)
@@ -695,7 +695,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 				bdr_bottom = fwp->yoff + fwp->sy;
 				if (py == bdr_bottom)
 					break;
-				if (wp->flags & PANE_FLOATING) {
+				if (window_pane_is_floating(wp)) {
 					/* Floating pane, check top border. */
 					bdr_top = fwp->yoff - 1;
 					if (py == bdr_top)

--- a/spawn.c
+++ b/spawn.c
@@ -278,6 +278,11 @@ spawn_pane(struct spawn_context *sc, char **cause)
 			layout_assign_pane(sc->lc, new_wp, 1);
 		else
 			layout_assign_pane(sc->lc, new_wp, 0);
+
+		if (sc->flags & SPAWN_FLOATING) {
+			new_wp->layout_cell->flags |= LAYOUT_CELL_FLOATING;
+			layout_make_placeholder(w, new_wp, NULL);
+		}
 	}
 
 	/*

--- a/tmux.h
+++ b/tmux.h
@@ -1256,6 +1256,7 @@ struct window_pane {
 
 	struct layout_cell *layout_cell;
 	struct layout_cell *saved_layout_cell;
+	struct layout_cell *placeholder_layout_cell;
 
 	u_int		 sx;
 	u_int		 sy;
@@ -1268,8 +1269,8 @@ struct window_pane {
 #define PANE_DROP 0x2
 #define PANE_FOCUSED 0x4
 #define PANE_VISITED 0x8
-#define PANE_ZOOMED 0x10
-#define PANE_FLOATING 0x20
+/* unused 0x10 */
+/* unused 0x20 */
 #define PANE_INPUTOFF 0x40
 #define PANE_CHANGED 0x80
 #define PANE_EXITED 0x100
@@ -1463,7 +1464,6 @@ TAILQ_HEAD(winlink_stack, winlink);
 enum layout_type {
 	LAYOUT_LEFTRIGHT,
 	LAYOUT_TOPBOTTOM,
-	LAYOUT_FLOATING,
 	LAYOUT_WINDOWPANE
 };
 
@@ -1473,6 +1473,11 @@ TAILQ_HEAD(layout_cells, layout_cell);
 /* Layout cell. */
 struct layout_cell {
 	enum layout_type type;
+
+#define LAYOUT_CELL_CONCEALED	0x1
+#define LAYOUT_CELL_FLOATING	0x2
+#define LAYOUT_CELL_ZOOMED	0x4
+	int		 flags;
 
 	struct layout_cell *parent;
 
@@ -3498,31 +3503,34 @@ enum client_theme window_pane_get_theme(struct window_pane *);
 void		 window_pane_send_theme_update(struct window_pane *);
 struct style_range *window_pane_border_status_get_range(struct window_pane *,
 			u_int, u_int);
-int              window_pane_tiled_geometry(struct window *,
-		     struct window_pane *, int *, int *, enum layout_type *,
-		     struct cmdq_item *, struct args *, char **);
-int              window_pane_floating_geometry(struct window *,
-		     struct window_pane *, u_int *, u_int *, u_int *, u_int *,
-		     struct cmdq_item *, struct args *, char **);
+int		 window_pane_is_floating(struct window_pane *);
+int		 window_pane_is_hidden(struct window_pane *);
+int		 window_pane_is_zoomed(struct window_pane *);
 
 /* layout.c */
 u_int		 layout_count_cells(struct layout_cell *);
 struct layout_cell *layout_create_cell(struct layout_cell *);
 void		 layout_free_cell(struct layout_cell *);
 void		 layout_print_cell(struct layout_cell *, const char *, u_int);
-void		 layout_destroy_cell(struct window *, struct layout_cell *,
+struct layout_cell *layout_destroy_cell(struct window *, struct layout_cell *,
 		     struct layout_cell **);
+void		 layout_conceal_cell(struct window *, struct layout_cell *);
 void		 layout_resize_layout(struct window *, struct layout_cell *,
 		     enum layout_type, int, int);
 struct layout_cell *layout_search_by_border(struct layout_cell *, u_int, u_int);
 void             layout_set_size(struct layout_cell *, u_int, u_int, int, int);
 void		 layout_make_leaf(struct layout_cell *, struct window_pane *);
 void		 layout_make_node(struct layout_cell *, enum layout_type);
+struct layout_cell *layout_make_placeholder(struct window *,
+		     struct window_pane *, struct layout_cell *);
 void		 layout_fix_zindexes(struct window *, struct layout_cell *);
 void		 layout_fix_offsets(struct window *);
 void		 layout_fix_panes(struct window *, struct window_pane *);
 void		 layout_resize_adjust(struct window *, struct layout_cell *,
 		     enum layout_type, int);
+void		 layout_resize_set(struct window *, struct layout_cell *,
+		     enum layout_type, u_int);
+struct layout_cell *layout_cell_visible_neighbour(struct layout_cell *);
 void		 layout_init(struct window *, struct window_pane *);
 void		 layout_free(struct window *);
 void		 layout_resize(struct window *, u_int, u_int);
@@ -3532,11 +3540,20 @@ void		 layout_resize_pane_to(struct window_pane *, enum layout_type,
 		     u_int);
 void		 layout_assign_pane(struct layout_cell *, struct window_pane *,
 		     int);
+int		 layout_split_check_space(struct window_pane *,
+		     struct layout_cell *, enum layout_type);
+void		 layout_split_sizes(struct layout_cell *, int, int,
+		     enum layout_type, u_int *, u_int *);
 struct layout_cell *layout_split_pane(struct window_pane *, enum layout_type,
 		     int, int);
 void		 layout_close_pane(struct window_pane *);
 int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
+struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
+		     struct window *, struct window_pane *, int, char **);
+struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
+		     struct window *, struct window_pane *, struct layout_cell *,
+		     char **);
 
 /* layout-custom.c */
 char		*layout_dump(struct window *, struct layout_cell *);

--- a/window.c
+++ b/window.c
@@ -467,7 +467,7 @@ window_has_floating_panes(struct window *w)
 	struct window_pane	*wp;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return (1);
 	}
 	return (0);
@@ -607,7 +607,7 @@ window_redraw_active_switch(struct window *w, struct window_pane *wp)
 			break;
 
 		/* If the pane is floating, move to the front. */
-		if (wp->flags & PANE_FLOATING) {
+		if (window_pane_is_floating(wp)) {
 			TAILQ_REMOVE(&w->z_index, wp, zentry);
 			TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 			wp->flags |= PANE_REDRAW;
@@ -632,7 +632,7 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 		if (!window_pane_visible(wp))
 			continue;
 		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
-		if (~wp->flags & PANE_FLOATING) {
+		if (!window_pane_is_floating(wp)) {
 			/* Tiled - to and including bottom or right border. */
 			if ((int)x < xoff || x > xoff + sx)
 				continue;
@@ -705,25 +705,23 @@ int
 window_zoom(struct window_pane *wp)
 {
 	struct window		*w = wp->window;
-	struct window_pane	*wp1;
+	struct window_pane	*wpp;
 
 	if (w->flags & WINDOW_ZOOMED)
 		return (-1);
 	if (window_count_panes(w, 1) == 1)
 		return (-1);
 
-	if (w->active != wp)
-		window_set_active_pane(w, wp, 1);
-	wp->flags |= PANE_ZOOMED;
-
-	TAILQ_FOREACH(wp1, &w->panes, entry) {
-		wp1->saved_layout_cell = wp1->layout_cell;
-		wp1->layout_cell = NULL;
+	TAILQ_FOREACH(wpp, &w->panes, entry) {
+		wpp->saved_layout_cell = wpp->layout_cell;
+		wpp->layout_cell = NULL;
 	}
 
 	w->saved_layout_root = w->layout_root;
 	layout_init(w, wp);
 	w->flags |= WINDOW_ZOOMED;
+	wp->layout_cell->flags |= LAYOUT_CELL_ZOOMED;
+	window_set_active_pane(w, wp, 1);
 	notify_window("window-layout-changed", w);
 
 	return (0);
@@ -732,7 +730,7 @@ window_zoom(struct window_pane *wp)
 int
 window_unzoom(struct window *w, int notify)
 {
-	struct window_pane	*wp;
+	struct window_pane	*wpp;
 
 	if (!(w->flags & WINDOW_ZOOMED))
 		return (-1);
@@ -742,10 +740,9 @@ window_unzoom(struct window *w, int notify)
 	w->layout_root = w->saved_layout_root;
 	w->saved_layout_root = NULL;
 
-	TAILQ_FOREACH(wp, &w->panes, entry) {
-		wp->layout_cell = wp->saved_layout_cell;
-		wp->saved_layout_cell = NULL;
-		wp->flags &= ~PANE_ZOOMED;
+	TAILQ_FOREACH(wpp, &w->panes, entry) {
+		wpp->layout_cell = wpp->saved_layout_cell;
+		wpp->saved_layout_cell = NULL;
 	}
 	layout_fix_panes(w, NULL);
 
@@ -806,7 +803,6 @@ window_add_pane(struct window *w, struct window_pane *other, u_int hlimit,
 	if (~flags & SPAWN_FLOATING)
 		TAILQ_INSERT_TAIL(&w->z_index, wp, zentry);
 	else {
-		wp->flags |= PANE_FLOATING;
 		TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 	}
 	return (wp);
@@ -908,7 +904,7 @@ window_count_panes(struct window *w, int with_floating)
 	u_int			 n = 0;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (with_floating || ~wp->flags & PANE_FLOATING)
+		if (with_floating || !window_pane_is_floating(wp))
 			n++;
 	}
 	return (n);
@@ -971,9 +967,9 @@ window_pane_printable_flags(struct window_pane *wp)
 		flags[pos++] = '*';
 	if (wp == TAILQ_FIRST(&w->last_panes))
 		flags[pos++] = '-';
-	if (wp->flags & PANE_ZOOMED)
+	if (window_pane_is_zoomed(wp))
 		flags[pos++] = 'Z';
-	if (wp->flags & PANE_FLOATING)
+	if (window_pane_is_floating(wp))
 		flags[pos++] = 'F';
 	flags[pos] = '\0';
 	return (flags);
@@ -1136,8 +1132,9 @@ window_pane_error_callback(__unused struct bufferevent *bufev,
 	log_debug("%%%u error", wp->id);
 	wp->flags |= PANE_EXITED;
 
-	if (window_pane_destroy_ready(wp))
+	if (window_pane_destroy_ready(wp)) {
 		server_destroy_pane(wp, 1);
+	}
 }
 
 void
@@ -1350,7 +1347,8 @@ window_pane_key(struct window_pane *wp, struct client *c, struct session *s,
 int
 window_pane_visible(struct window_pane *wp)
 {
-	if (~wp->window->flags & WINDOW_ZOOMED)
+	if (~wp->window->flags & WINDOW_ZOOMED &&
+	    !window_pane_is_hidden(wp))
 		return (1);
 	return (wp == wp->window->active);
 }
@@ -2080,112 +2078,29 @@ window_pane_border_status_get_range(struct window_pane *wp, u_int x, u_int y)
 	return (style_ranges_get_range(srs, x - wp->xoff - 2));
 }
 
-/* Work out geometry for tiled panes. */
-int
-window_pane_tiled_geometry(struct window *w, struct window_pane *wp,
-    int *out_size, int *out_flags, enum layout_type *out_type,
-    struct cmdq_item *item, struct args *args, char **cause)
+static int
+window_pane_has_lcflag(struct window_pane *wp, int lcflag)
 {
-	int			size = -1, flags = *out_flags;
-	enum layout_type	type;
-	u_int			curval = 0;
-
-	type = LAYOUT_TOPBOTTOM;
-	if (args_has(args, 'h'))
-		type = LAYOUT_LEFTRIGHT;
-
-	if (args_has(args, 'l') || args_has(args, 'p')) {
-		if (args_has(args, 'f')) {
-			if (type == LAYOUT_TOPBOTTOM)
-				curval = w->sy;
-			else
-				curval = w->sx;
-		} else {
-			if (type == LAYOUT_TOPBOTTOM)
-				curval = wp->sy;
-			else
-				curval = wp->sx;
-		}
-	}
-
-	if (args_has(args, 'l')) {
-		size = args_percentage_and_expand(args, 'l', 0, INT_MAX, curval,
-		    item, cause);
-	} else if (args_has(args, 'p')) {
-		size = args_strtonum_and_expand(args, 'p', 0, 100, item,
-		    cause);
-		if (*cause == NULL)
-			size = curval * size / 100;
-	}
-	if (*cause != NULL)
-		return (-1);
-
-	if (args_has(args, 'b'))
-		flags |= SPAWN_BEFORE;
-	if (args_has(args, 'f'))
-		flags |= SPAWN_FULLSIZE;
-
-	*out_size = size;
-	*out_flags = flags;
-	*out_type = type;
-	return (0);
+	if (wp == NULL)
+		return 0;
+	return (wp->layout_cell != NULL &&
+		(wp->layout_cell->flags & lcflag) > 0);
 }
 
-/* Work out geometry for floating panes. */
 int
-window_pane_floating_geometry(struct window *w, __unused struct window_pane *wp,
-    u_int *out_x, u_int *out_y, u_int *out_sx, u_int *out_sy,
-    struct cmdq_item *item, struct args *args, char **cause)
+window_pane_is_floating(struct window_pane *wp)
 {
-	u_int	x, y, sx = w->sx / 2, sy = w->sy / 2;
+	return window_pane_has_lcflag(wp, LAYOUT_CELL_FLOATING);
+}
 
-	if (args_has(args, 'x')) {
-		sx = args_percentage_and_expand(args, 'x', 0, USHRT_MAX, w->sx,
-		    item, cause);
-		if (*cause != NULL)
-			return (-1);
-	}
-	if (args_has(args, 'y')) {
-		sy = args_percentage_and_expand(args, 'y', 0, USHRT_MAX, w->sy,
-		    item, cause);
-		if (*cause != NULL)
-			return (-1);
-	}
+int
+window_pane_is_hidden(struct window_pane *wp)
+{
+	return window_pane_has_lcflag(wp, LAYOUT_CELL_CONCEALED);
+}
 
-	if (args_has(args, 'X')) {
-		x = args_percentage_and_expand(args, 'X', 0, USHRT_MAX, w->sx,
-		    item, cause);
-		if (*cause != NULL)
-			return (-1);
-	} else {
-		if (w->last_new_pane_x == 0)
-			x = 4;
-		else {
-			x = w->last_new_pane_x + 4;
-			if (w->last_new_pane_x > w->sx)
-				x = 4;
-		}
-		w->last_new_pane_x = x;
-	}
-	if (args_has(args, 'Y')) {
-		y = args_percentage_and_expand(args, 'Y', 0, USHRT_MAX, w->sy,
-		    item, cause);
-		if (*cause != NULL)
-			return (-1);
-	} else {
-		if (w->last_new_pane_y == 0)
-			y = 2;
-		else {
-			y = w->last_new_pane_y + 2;
-			if (w->last_new_pane_y > w->sy)
-				y = 2;
-		}
-		w->last_new_pane_y = y;
-	}
-
-	*out_x = x;
-	*out_y = y;
-	*out_sx = sx;
-	*out_sy = sy;
-	return (0);
+int
+window_pane_is_zoomed(struct window_pane *wp)
+{
+	return window_pane_has_lcflag(wp, LAYOUT_CELL_ZOOMED);
 }


### PR DESCRIPTION
This is a fix to the [first known issue](https://github.com/tmux/tmux/issues/4800#issuecomment-4543971922) in #5135. The implementation is also forward looking, laying the tracks for future layout operations like hiding panes and toggling floating state.

Some state has been moved away from `struct window_pane` and into `struct layout_cell`s' new `flags` field when that state concerns aspects of the layout.

Layout cells can now have the state `LAYOUT_CELL_CONCEALED` (previously `PANE_HIDDEN`) which is used for the "placeholder" cells. Whenever a pane is created as a floater, an additional cell is created and inserted into the root layout as the placeholder for the float. This ensures that there will always be a root layout when a window has a pane. I am using the "conceal/reveal" semantics for layout cells over "hide/show" because a layout cell can be concealed, but not be related to a hidden pane. This divide in semantics is meant to keep related but distinct states clear.

With the movement of state to layout cells, some helper functions have been added to `window.c` which retrieve the state of a window pane; mainly convenience functions to avoid having to write out long dereference chains. This abstraction of pane state will give room for future changes in layout implementation.

I believe I have torn out everything related to hiding panes and commands. Let me know what y'all think!

@mgrant0 @nicm

**EDIT1**: I have a feeling that this is too untested of a change to add to staging. Would a PR against `floating_panes` be more appropriate?