### PR TITLE
Add regression test for respawn-pane with zoom

### DIFF
--- a/regress/respawn-zoom-uaf.sh
+++ b/regress/respawn-zoom-uaf.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Regression test for respawning the active pane in a zoomed window.
+#
+# window_zoom() saves each pane's original unzoomed layout in saved_layout_cell
+# and gives the active pane a temporary one-pane zoom layout. On the respawn
+# path, spawn_pane() reuses the active pane; the buggy zoom handling is:
+#
+#     if (w->flags & WINDOW_ZOOMED)
+#             new_wp->saved_layout_cell = new_wp->layout_cell;
+#
+# This clobbers the saved_layout_cell already there with the temporary cell.
+# On the next unzoom, window_unzoom() frees the temporary layout, restores
+# the now-dangling saved_layout_cell, and layout_fix_panes() reads freed
+# memory. With ASan, this is reported as a heap use-after-free.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+sleep 1
+
+# Two panes so the window can be zoomed; zoom the active pane.
+$TMUX -f/dev/null new -d 'sleep 1000' || exit 1
+$TMUX split-window -d 'sleep 1000' || exit 1
+$TMUX resize-pane -Z || exit 1
+
+# Respawn the active (zoomed) pane in place, then unzoom.
+$TMUX respawn-pane -k 'sleep 1000' || exit 1
+$TMUX resize-pane -Z 2>/dev/null
+sleep 1
+
+# With the bug, unzooming crashes the server; with the fix, it survives and
+# has-session succeeds.
+$TMUX has-session 2>/dev/null || exit 1
+
+$TMUX kill-server 2>/dev/null
+
+exit 0


### PR DESCRIPTION
## Summary

Add a regression test for a heap use-after-free when `respawn-pane` is used on
the active pane in a zoomed window.

This PR intentionally adds the failing regression before the fix. Against the
current buggy code, ASan builds are expected to abort during this test; once the
`spawn_pane()` fix lands, the same test should pass.

When a window is zoomed, `window_zoom()` saves each pane's original unzoomed
layout in `saved_layout_cell` and gives the active pane a temporary one-pane
zoom layout. On the respawn path, `spawn_pane()` reuses the active pane and the
buggy zoom handling is:

```c
if (w->flags & WINDOW_ZOOMED)
        new_wp->saved_layout_cell = new_wp->layout_cell;
```

That clobbers the `saved_layout_cell` already there with the temporary zoom
cell. On the next unzoom, `window_unzoom()` frees the temporary layout,
restores the now-dangling `saved_layout_cell`, and `layout_fix_panes()` reads
freed memory.

The new regression creates a split window, zooms the active pane, respawns it
in place, unzooms, and then checks `has-session`. With the bug, the server
crashes during unzoom; with the fix, the server survives.


## ASan Output

Here is the ASan log when running this test on commit 74b91d6d.

<details>
<summary>AddressSanitizer report</summary>

```text
=================================================================
==1494196==ERROR: AddressSanitizer: heap-use-after-free on address 0x507000044c88 at pc 0x5f0ae1050a98 bp 0x7ffc0a503d60 sp 0x7ffc0a503d50
READ of size 4 at 0x507000044c88 thread T0 (tmux: server)
    #0 0x5f0ae1050a97 in layout_fix_panes <tmux-src>/layout.c:371
    #1 0x5f0ae1133159 in window_unzoom <tmux-src>/window.c:750
    #2 0x5f0ae0fd2b45 in cmd_resize_pane_exec <tmux-src>/cmd-resize-pane.c:84
    #3 0x5f0ae0fcea41 in cmdq_fire_command <tmux-src>/cmd-queue.c:649
    #4 0x5f0ae0fcea41 in cmdq_next <tmux-src>/cmd-queue.c:774
    #5 0x5f0ae10ae54d in server_loop <tmux-src>/server.c:275
    #6 0x5f0ae1076887 in proc_loop <tmux-src>/proc.c:214
    #7 0x5f0ae10af577 in server_start <tmux-src>/server.c:254
    #8 0x5f0ae0faa6d5 in client_connect <tmux-src>/client.c:164
    #9 0x5f0ae0faa6d5 in client_main <tmux-src>/client.c:290
    #10 0x5f0ae10cd1dd in main <tmux-src>/tmux.c:556
    #11 0x7baf9162a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #12 0x7baf9162a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #13 0x5f0ae0f9eee4 in _start (<tmux-src>/tmux+0xafee4) (BuildId: 5d39bd9792429eba172724bf15c77ed9ea8a19da)

0x507000044c88 is located 24 bytes inside of 72-byte region [0x507000044c70,0x507000044cb8)
freed by thread T0 (tmux: server) here:
    #0 0x7baf91afc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x5f0ae104fd95 in layout_free_cell <tmux-src>/layout.c:114
    #2 0x5f0ae10518b5 in layout_free <tmux-src>/layout.c:609
    #3 0x5f0ae11330e2 in window_unzoom <tmux-src>/window.c:741
    #4 0x5f0ae0fd2b45 in cmd_resize_pane_exec <tmux-src>/cmd-resize-pane.c:84
    #5 0x5f0ae0fcea41 in cmdq_fire_command <tmux-src>/cmd-queue.c:649
    #6 0x5f0ae0fcea41 in cmdq_next <tmux-src>/cmd-queue.c:774
    #7 0x5f0ae10ae54d in server_loop <tmux-src>/server.c:275
    #8 0x5f0ae1076887 in proc_loop <tmux-src>/proc.c:214
    #9 0x5f0ae10af577 in server_start <tmux-src>/server.c:254
    #10 0x5f0ae0faa6d5 in client_connect <tmux-src>/client.c:164
    #11 0x5f0ae0faa6d5 in client_main <tmux-src>/client.c:290
    #12 0x5f0ae10cd1dd in main <tmux-src>/tmux.c:556
    #13 0x7baf9162a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #14 0x7baf9162a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #15 0x5f0ae0f9eee4 in _start (<tmux-src>/tmux+0xafee4) (BuildId: 5d39bd9792429eba172724bf15c77ed9ea8a19da)

previously allocated by thread T0 (tmux: server) here:
    #0 0x7baf91afd9c7 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5f0ae113c5e2 in xmalloc <tmux-src>/xmalloc.c:33
    #2 0x5f0ae104fb4d in layout_create_cell <tmux-src>/layout.c:58
    #3 0x5f0ae1051673 in layout_init <tmux-src>/layout.c:599
    #4 0x5f0ae1137400 in window_zoom <tmux-src>/window.c:725
    #5 0x5f0ae0fd2db9 in cmd_resize_pane_exec <tmux-src>/cmd-resize-pane.c:86
    #6 0x5f0ae0fcea41 in cmdq_fire_command <tmux-src>/cmd-queue.c:649
    #7 0x5f0ae0fcea41 in cmdq_next <tmux-src>/cmd-queue.c:774
    #8 0x5f0ae10ae54d in server_loop <tmux-src>/server.c:275
    #9 0x5f0ae1076887 in proc_loop <tmux-src>/proc.c:214
    #10 0x5f0ae10af577 in server_start <tmux-src>/server.c:254
    #11 0x5f0ae0faa6d5 in client_connect <tmux-src>/client.c:164
    #12 0x5f0ae0faa6d5 in client_main <tmux-src>/client.c:290
    #13 0x5f0ae10cd1dd in main <tmux-src>/tmux.c:556
    #14 0x7baf9162a1c9 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #15 0x7baf9162a28a in __libc_start_main_impl ../csu/libc-start.c:360
    #16 0x5f0ae0f9eee4 in _start (<tmux-src>/tmux+0xafee4) (BuildId: 5d39bd9792429eba172724bf15c77ed9ea8a19da)

SUMMARY: AddressSanitizer: heap-use-after-free <tmux-src>/layout.c:371 in layout_fix_panes
Shadow bytes around the buggy address:
  0x507000044a00: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x507000044a80: fd fa fa fa fa fa fd fd fd fd fd fd fd fd fd fd
  0x507000044b00: fa fa fa fa fd fd fd fd fd fd fd fd fd fa fa fa
  0x507000044b80: fa fa fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x507000044c00: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fd fd
=>0x507000044c80: fd[fd]fd fd fd fd fd fa fa fa fa fa fd fd fd fd
  0x507000044d00: fd fd fd fd fd fa fa fa fa fa fd fd fd fd fd fd
  0x507000044d80: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x507000044e00: fd fd fa fa fa fa fd fd fd fd fd fd fd fd fd fa
  0x507000044e80: fa fa fa fa fd fd fd fd fd fd fd fd fd fa fa fa
  0x507000044f00: fa fa fd fd fd fd fd fd fd fd fd fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1494196==ABORTING
```

</details>
