### PR TITLE
Fix status bar wide char crash

### DIFF
--- a/regress/status-redraw-wide-char-crash.sh
+++ b/regress/status-redraw-wide-char-crash.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Regression test: crash in screen_write_redraw_line when status bar
+# contains a wide character (emoji).
+#
+# When the status line is redrawn, it is first filled with spaces
+# (width 1). If the previous content had a wide character (width 2),
+# writing a space over it triggers screen_write_overwrite() which sets
+# redraw = 1. Then screen_write_redraw_line() dereferences ctx->wp,
+# but wp is NULL for status-bar screens, causing a SIGSEGV.
+#
+# A real PTY client is required because control-mode clients skip
+# status bar rendering entirely (CLIENT_CONTROL flag causes
+# server_client_check_redraw to return early).
+
+PATH=/bin:/usr/bin
+TERM=xterm-256color
+export TERM
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -f/dev/null -Ltest"
+$TMUX kill-server 2>/dev/null
+
+$TMUX new -d -x 40 -y 10 || exit 1
+SERVER_PID=$($TMUX display-message -p '#{pid}')
+
+# Put a wide character in the status bar.
+$TMUX set -g status-right '🤖' || exit 1
+
+# Attach a PTY client via script(1).  Pipe from sleep to keep stdin
+# open; redirect stdout/stderr to prevent escape sequence leakage.
+sleep 10 | script -qfc "$TMUX attach" /dev/null >/dev/null 2>&1 &
+SCRIPT_PID=$!
+
+# Wait for the client to connect.
+n=0
+while [ "$n" -lt 50 ]; do
+    CLIENT=$($TMUX list-clients -F '#{client_tty}' 2>/dev/null | head -1)
+    [ -n "$CLIENT" ] && break
+    sleep 0.1
+    n=$((n + 1))
+done
+[ -z "$CLIENT" ] && exit 1
+
+# Resize the PTY with stty to trigger a status bar redraw.  This sends
+# SIGWINCH to the tmux client, unlike refresh-client -C which only
+# works for control-mode clients.
+stty -F "$CLIENT" rows 10 cols 40 2>/dev/null
+sleep 0.5
+n=0
+while [ "$n" -lt 10 ]; do
+    [ ! -e "/proc/$SERVER_PID" ] && break
+    grep -q '^State:.*Z' "/proc/$SERVER_PID/status" 2>/dev/null && break
+    stty -F "$CLIENT" cols $((41 + n % 2)) 2>/dev/null
+    sleep 0.3
+    stty -F "$CLIENT" cols 40 2>/dev/null
+    sleep 0.3
+    n=$((n + 1))
+done
+
+# Check if the server survived.
+if [ -e "/proc/$SERVER_PID/status" ] &&    ! grep -q '^State:.*Z' "/proc/$SERVER_PID/status" 2>/dev/null; then
+    $TMUX kill-server 2>/dev/null
+    wait "$SCRIPT_PID" 2>/dev/null
+    exit 0
+fi
+
+wait "$SCRIPT_PID" 2>/dev/null
+exit 1

--- a/screen-write.c
+++ b/screen-write.c
@@ -2574,7 +2574,7 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 		return;
 
 	/* Do a full line redraw if needed. */
-	if (redraw) {
+	if (redraw && ctx->wp != NULL) {
 		screen_write_redraw_line(ctx, &ttyctx, s->cy);
 		return;
 	}


### PR DESCRIPTION
#### Description

Segfault in `screen_write_redraw_line` when the status bar contains a wide character (emoji) and the terminal is resized. The server crashes, killing all active sessions. I've included a regression test.

### Required information

**Version**: mainline commit (e778f7f8)
**OS**: Linux (kernel 5.19.0-45-generic, x86_64)
**Trigger**: Resize terminal with an emoji in `status-right`.

**Backtrace (from core dump)**:

```gdb
#0  screen_write_redraw_line (ctx=..., yy=0) at screen-write.c:1136
        wp = <optimized out>
#1  screen_write_cell (ctx=..., gc=...) at screen-write.c:2578
        wp = 0x0
        now_gc = {data = "🤖", width = 2}
        tmp_gc = {data = " ", width = 1}
        sx = 40
#2  screen_write_putc (ch=32 ' ') at screen-write.c:398
#3  status_redraw (c=...) at status.c:437
        ctx = {wp = 0x0, s = 0x155555518bc0}
        n = 38, width = 40
#4  screen_redraw_update () at screen-redraw.c:744
#5  screen_redraw_screen () at screen-redraw.c:811
#6  server_client_check_redraw () at server-client.c:2117
#7  server_client_loop () at server-client.c:1528
```

`ctx->wp` seems to be unconditionally dereferenced