### PR TITLE
refactor(floating_panes_staging): Moving floating state to `struct layout_cell`

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -159,7 +159,7 @@ cmd_resize_pane_mouse_update(__unused struct cmd *self, struct cmdq_item *item)
 	if (wp == NULL || c == NULL || c->session != s)
 		return (CMD_RETURN_NORMAL);
 
-	if (~wp->flags & PANE_FLOATING) {
+	if (!window_pane_is_floating(wp)) {
 		c->tty.mouse_drag_update = cmd_resize_pane_mouse_update_tiled;
 		cmd_resize_pane_mouse_update_tiled(c, &event->m);
 		return (CMD_RETURN_NORMAL);

--- a/cmd-select-pane.c
+++ b/cmd-select-pane.c
@@ -160,7 +160,7 @@ cmd_select_pane_exec(struct cmd *self, struct cmdq_item *item)
 			server_redraw_window_borders(markedwp->window);
 			server_status_window(markedwp->window);
 		}
-		if (wp->flags & PANE_FLOATING) {
+		if (window_pane_is_floating(wp)) {
 			window_redraw_active_switch(w, wp);
 			window_set_active_pane(w, wp, 1);
 		}

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -106,7 +106,7 @@ cmd_split_window_get_tiled_cell(struct cmdq_item *item, struct args *args,
 	char			*cause = NULL;
 	int			 size;
 
-	if (wp->flags & PANE_FLOATING) {
+	if (window_pane_is_floating(wp)) {
 		cmdq_error(item, "can't split a floating pane");
 		return (NULL);
 	}

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -79,8 +79,8 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (src_wp == dst_wp)
 		goto out;
 
-	if ((src_wp->flags & PANE_FLOATING) &&
-	    (dst_wp->flags & PANE_FLOATING)) {
+	if (window_pane_is_floating(src_wp) &&
+	    window_pane_is_floating(dst_wp)) {
 		cmdq_error(item, "cannot swap floating panes");
 		return (CMD_RETURN_ERROR);
 	}
@@ -114,9 +114,9 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->layout_cell = src_lc;
 	dst_lc->wp = src_wp;
 	src_wp->layout_cell = dst_lc;
-	if ((src_wp->flags ^ dst_wp->flags) & PANE_FLOATING) {
-		src_wp->flags ^= PANE_FLOATING;
-		dst_wp->flags ^= PANE_FLOATING;
+	if (window_pane_is_floating(src_wp) != window_pane_is_floating(dst_wp)) {
+		src_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
+		dst_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
 	}
 
 	src_wp->window = dst_w;

--- a/format.c
+++ b/format.c
@@ -1035,7 +1035,7 @@ format_cb_pane_floating_flag(struct format_tree *ft)
 	struct window_pane	*wp = ft->wp;
 
 	if (wp != NULL) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}

--- a/layout-custom.c
+++ b/layout-custom.c
@@ -69,7 +69,7 @@ layout_dump(struct window *w, struct layout_cell *root)
 		return (NULL);
 
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
-		if (~wp->flags & PANE_FLOATING)
+		if (!window_pane_is_floating(wp))
 			break;
 		if (!bracket) {
 			strlcat(layout, "<", sizeof layout);
@@ -307,7 +307,7 @@ layout_assign(struct window_pane **wp, struct layout_cell *lc, int flags)
 	switch (lc->type) {
 	case LAYOUT_WINDOWPANE:
 		layout_make_leaf(lc, *wp);
-		(*wp)->flags |= flags;
+		lc->flags |= flags;
 		*wp = TAILQ_NEXT(*wp, entry);
 		return;
 	case LAYOUT_LEFTRIGHT:

--- a/layout-set.c
+++ b/layout-set.c
@@ -129,7 +129,7 @@ layout_first_tiled(struct window *w)
 	struct window_pane	*wp;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (~wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return (wp);
 	}
 	return (NULL);
@@ -168,7 +168,7 @@ layout_set_even(struct window *w, enum layout_type type)
 
 	/* Build new leaf cells. */
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			continue;
 		lcnew = layout_create_cell(lc);
 		layout_make_leaf(lcnew, wp);
@@ -272,7 +272,7 @@ layout_set_main_h(struct window *w)
 	layout_set_size(lcother, sx, otherh, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && window_pane_is_floating(wp))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -282,7 +282,7 @@ layout_set_main_h(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -368,7 +368,7 @@ layout_set_main_h_mirrored(struct window *w)
 	layout_set_size(lcother, sx, otherh, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && window_pane_is_floating(wp))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -378,7 +378,7 @@ layout_set_main_h_mirrored(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -476,7 +476,7 @@ layout_set_main_v(struct window *w)
 	layout_set_size(lcother, otherw, sy, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && window_pane_is_floating(wp))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -486,7 +486,7 @@ layout_set_main_v(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -572,7 +572,7 @@ layout_set_main_v_mirrored(struct window *w)
 	layout_set_size(lcother, otherw, sy, 0, 0);
 	if (n == 1) {
 		wp = TAILQ_NEXT(layout_first_tiled(w), entry);
-		while (wp != NULL && (wp->flags & PANE_FLOATING))
+		while (wp != NULL && window_pane_is_floating(wp))
 			wp = TAILQ_NEXT(wp, entry);
 		layout_make_leaf(lcother, wp);
 		TAILQ_INSERT_TAIL(&lc->cells, lcother, entry);
@@ -582,7 +582,7 @@ layout_set_main_v_mirrored(struct window *w)
 
 		/* Add the remaining panes as children. */
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->flags & PANE_FLOATING)
+			if (window_pane_is_floating(wp))
 				continue;
 			if (wp == layout_first_tiled(w))
 				continue;
@@ -661,7 +661,7 @@ layout_set_tiled(struct window *w)
 
 	/* Create a grid of the cells, skipping any floating panes. */
 	wp = TAILQ_FIRST(&w->panes);
-	while (wp != NULL && (wp->flags & PANE_FLOATING))
+	while (wp != NULL && window_pane_is_floating(wp))
 		wp = TAILQ_NEXT(wp, entry);
 	for (j = 0; j < rows; j++) {
 		/* If this is the last cell, all done. */
@@ -677,7 +677,7 @@ layout_set_tiled(struct window *w)
 		if (n - (j * columns) == 1 || columns == 1) {
 			layout_make_leaf(lcrow, wp);
 			wp = TAILQ_NEXT(wp, entry);
-			while (wp != NULL && (wp->flags & PANE_FLOATING))
+			while (wp != NULL && window_pane_is_floating(wp))
 				wp = TAILQ_NEXT(wp, entry);
 			continue;
 		}
@@ -693,7 +693,7 @@ layout_set_tiled(struct window *w)
 
 			/* Move to the next non-floating cell. */
 			wp = TAILQ_NEXT(wp, entry);
-			while (wp != NULL && (wp->flags & PANE_FLOATING))
+			while (wp != NULL && window_pane_is_floating(wp))
 				wp = TAILQ_NEXT(wp, entry);
 			if (wp == NULL)
 				break;

--- a/layout-set.c
+++ b/layout-set.c
@@ -129,7 +129,7 @@ layout_first_tiled(struct window *w)
 	struct window_pane	*wp;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (window_pane_is_floating(wp))
+		if (!window_pane_is_floating(wp))
 			return (wp);
 	}
 	return (NULL);

--- a/layout.c
+++ b/layout.c
@@ -57,6 +57,7 @@ layout_create_cell(struct layout_cell *lcparent)
 
 	lc = xmalloc(sizeof *lc);
 	lc->type = LAYOUT_WINDOWPANE;
+	lc->flags = 0;
 	lc->parent = lcparent;
 
 	TAILQ_INIT(&lc->cells);
@@ -354,7 +355,7 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 		sx = lc->sx;
 		sy = lc->sy;
 
-		if ((~wp->flags & PANE_FLOATING) &&
+		if (!window_pane_is_floating(wp) &&
 		    layout_add_horizontal_border(w, lc, status)) {
 			if (status == PANE_STATUS_TOP)
 				wp->yoff++;
@@ -523,7 +524,7 @@ layout_destroy_cell(struct window *w, struct layout_cell *lc,
 	 */
 	lcparent = lc->parent;
 	if (lcparent == NULL) {
-		if (lc->wp != NULL && ~lc->wp->flags & PANE_FLOATING)
+		if (lc->wp != NULL && !window_pane_is_floating(lc->wp))
 			*lcroot = NULL;
 		layout_free_cell(lc);
 		return;

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -106,7 +106,7 @@ screen_redraw_two_panes(struct window *w, enum layout_type *type)
 	u_int			 count = 0;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING || wp->layout_cell == NULL)
+		if (window_pane_is_floating(wp) || wp->layout_cell == NULL)
 			continue;
 		count++;
 		if (count > 2 || wp->layout_cell->parent == NULL)
@@ -144,7 +144,7 @@ screen_redraw_pane_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 
 	/* Floating pane borders. */
-	if (wp->flags & PANE_FLOATING) {
+	if (window_pane_is_floating(wp)) {
 		if (py >= wp->yoff - 1 && py <= wp->yoff + sy) {
 			if (sb_pos == PANE_SCROLLBARS_LEFT) {
 				if (px == wp->xoff - 1 - sb_w)
@@ -287,7 +287,7 @@ screen_redraw_cell_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;
 
 	/* For floating panes, only check the pane itself. */
-	if (wp->flags & PANE_FLOATING) {
+	if (window_pane_is_floating(wp)) {
 		n = screen_redraw_cell_border1(ctx, sb_pos, sb_w, wp, px, py);
 		if (n == -1)
 			return (0);
@@ -309,7 +309,7 @@ screen_redraw_cell_border(struct screen_redraw_ctx *ctx, struct window_pane *wp,
 	 * single z-index.
 	 */
 	TAILQ_FOREACH(wp2, &w->z_index, zentry) {
-		if (!window_pane_visible(wp2) || wp2->flags & PANE_FLOATING)
+		if (!window_pane_visible(wp2) || window_pane_is_floating(wp2))
 			continue;
 		n = screen_redraw_cell_border1(ctx, sb_pos, sb_w, wp2, px, py);
 		if (n != -1)
@@ -343,7 +343,7 @@ screen_redraw_type_of_cell(struct screen_redraw_ctx *ctx,
 	 *		   8 + 4
 	 *		     1
 	 */
-	if (~wp->flags & PANE_FLOATING) {
+	if (!window_pane_is_floating(wp)) {
 		if (px == 0 || screen_redraw_cell_border(ctx, wp, px - 1, py))
 			borders |= 8;
 		if (px <= sx && screen_redraw_cell_border(ctx, wp, px + 1, py))
@@ -447,7 +447,7 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 
 	/* Find pane highest in z-index at this point. */
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
-		if (wp->flags & PANE_FLOATING && (px >= sx || py >= sy)) {
+		if (window_pane_is_floating(wp) && (px >= sx || py >= sy)) {
 			/* Clip floating panes to window. */
 			continue;
 		}
@@ -482,12 +482,12 @@ screen_redraw_check_cell(struct screen_redraw_ctx *ctx, int px, int py,
 	 * necessary if there are two side-by-side or top-bottom panes with a
 	 * shared border and half the shared border is the active border.
 	 */
-	if (~wp->flags & PANE_FLOATING)
+	if (!window_pane_is_floating(wp))
 		tiled_only = 1;
 	do { /* loop until back to wp == start */
 		if (!window_pane_visible(wp))
 			goto next;
-		if (tiled_only && (wp->flags & PANE_FLOATING))
+		if (tiled_only && window_pane_is_floating(wp))
 			goto next;
 		*wpp = wp;
 
@@ -882,8 +882,8 @@ screen_redraw_draw_borders_style(struct screen_redraw_ctx *ctx, u_int x,
 	struct format_tree	*ft;
 	int			*flag;
 
-	if ((wp->flags & PANE_FLOATING && wp == active) ||
-	    (!(wp->flags & PANE_FLOATING) && screen_redraw_check_is(ctx, x, y,
+	if ((window_pane_is_floating(wp) && wp == active) ||
+	    (!window_pane_is_floating(wp) && screen_redraw_check_is(ctx, x, y,
 	    active))) {
 		flag = &wp->active_border_gc_set;
 		gc = &wp->active_border_gc;
@@ -923,9 +923,9 @@ screen_redraw_draw_border_arrows(struct screen_redraw_ctx *ctx, int i,
 		return;
 
 	if (wp != active) {
-		if (active->flags & PANE_FLOATING)
+		if (window_pane_is_floating(active))
 			return;
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return;
 	}
 
@@ -1197,7 +1197,7 @@ screen_redraw_get_visible_ranges(struct window_pane *base_wp, int px,
 		    (u_int)py < tb ||
 		    (u_int)py > bb)
 			continue;
-		if (~wp->flags & PANE_FLOATING && (u_int)py == bb)
+		if (!window_pane_is_floating(wp) && (u_int)py == bb)
 			continue;
 
 		sb_w = wp->scrollbar_style.width + wp->scrollbar_style.pad;

--- a/screen-write.c
+++ b/screen-write.c
@@ -198,7 +198,7 @@ screen_write_pane_is_obscured(struct screen_write_ctx *ctx)
 	}
 
 	while ((wp = TAILQ_PREV(wp, window_panes, zentry)) != NULL) {
-		if ((wp->flags & PANE_FLOATING) &&
+		if (window_pane_is_floating(wp) &&
 		    ((wp->yoff >= ctx->wp->yoff &&
 		    wp->yoff <= ctx->wp->yoff + (int)ctx->wp->sy) ||
 		    (wp->yoff + (int)wp->sy >= ctx->wp->yoff &&

--- a/server-client.c
+++ b/server-client.c
@@ -655,7 +655,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_SLIDER);
 			} else /* py > sl_bottom */
 				return (KEYC_MOUSE_LOCATION_SCROLLBAR_DOWN);
-		} else if (wp->flags & PANE_FLOATING &&
+		} else if (window_pane_is_floating(wp) &&
 		    (px == wp->xoff - 1 ||
 		    py == wp->yoff - 1 ||
 		    py == wp->yoff + (int)wp->sy)) {
@@ -683,7 +683,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 			    py <= fwp->yoff + (int)fwp->sy) {
 				if (px == bdr_right)
 					break;
-				if (wp->flags & PANE_FLOATING) {
+				if (window_pane_is_floating(wp)) {
 					/* Floating pane, check left border. */
 					bdr_left = fwp->xoff - 1;
 					if (px == bdr_left)
@@ -695,7 +695,7 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 				bdr_bottom = fwp->yoff + fwp->sy;
 				if (py == bdr_bottom)
 					break;
-				if (wp->flags & PANE_FLOATING) {
+				if (window_pane_is_floating(wp)) {
 					/* Floating pane, check top border. */
 					bdr_top = fwp->yoff - 1;
 					if (py == bdr_top)

--- a/spawn.c
+++ b/spawn.c
@@ -280,6 +280,8 @@ spawn_pane(struct spawn_context *sc, char **cause)
 			else
 				layout_assign_pane(sc->lc, new_wp, 0);
 		}
+		if (sc->flags & SPAWN_FLOATING)
+			new_wp->layout_cell->flags |= LAYOUT_CELL_FLOATING;
 
 		/*
 		 * If window currently zoomed, window_set_active_pane calls

--- a/tmux.h
+++ b/tmux.h
@@ -1269,7 +1269,7 @@ struct window_pane {
 #define PANE_FOCUSED 0x4
 #define PANE_VISITED 0x8
 #define PANE_ZOOMED 0x10
-#define PANE_FLOATING 0x20
+/* unused 0x20 */
 #define PANE_INPUTOFF 0x40
 #define PANE_CHANGED 0x80
 #define PANE_EXITED 0x100
@@ -1472,6 +1472,10 @@ TAILQ_HEAD(layout_cells, layout_cell);
 /* Layout cell. */
 struct layout_cell {
 	enum layout_type type;
+
+/* unused 0x1 */
+#define LAYOUT_CELL_FLOATING 0x2
+	int		 flags;
 
 	struct layout_cell *parent;
 
@@ -3499,6 +3503,7 @@ enum client_theme window_pane_get_theme(struct window_pane *);
 void		 window_pane_send_theme_update(struct window_pane *);
 struct style_range *window_pane_border_status_get_range(struct window_pane *,
 			u_int, u_int);
+int		 window_pane_is_floating(struct window_pane *);
 int              window_pane_tiled_geometry(struct window *,
 		     struct window_pane *, int *, int *, enum layout_type *,
 		     struct cmdq_item *, struct args *, char **);

--- a/window.c
+++ b/window.c
@@ -467,7 +467,7 @@ window_has_floating_panes(struct window *w)
 	struct window_pane	*wp;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (wp->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			return (1);
 	}
 	return (0);
@@ -607,7 +607,7 @@ window_redraw_active_switch(struct window *w, struct window_pane *wp)
 			break;
 
 		/* If the pane is floating, move to the front. */
-		if (wp->flags & PANE_FLOATING) {
+		if (window_pane_is_floating(wp)) {
 			TAILQ_REMOVE(&w->z_index, wp, zentry);
 			TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 			wp->flags |= PANE_REDRAW;
@@ -632,7 +632,7 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 		if (!window_pane_visible(wp))
 			continue;
 		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
-		if (~wp->flags & PANE_FLOATING) {
+		if (!window_pane_is_floating(wp)) {
 			/* Tiled - to and including bottom or right border. */
 			if ((int)x < xoff || x > xoff + sx)
 				continue;
@@ -801,7 +801,6 @@ window_add_pane(struct window *w, struct window_pane *other, u_int hlimit,
 	if (~flags & SPAWN_FLOATING)
 		TAILQ_INSERT_TAIL(&w->z_index, wp, zentry);
 	else {
-		wp->flags |= PANE_FLOATING;
 		TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 	}
 	return (wp);
@@ -905,11 +904,11 @@ window_pane_zindex(struct window_pane *wp, u_int *i)
 	*i = 0;
 	TAILQ_FOREACH(wq, &w->z_index, zentry) {
 		if (wq == wp) {
-			if (~wp->flags & PANE_FLOATING)
+			if (!window_pane_is_floating(wp))
 				(*i)++;
 			return (0);
 		}
-		if (wq->flags & PANE_FLOATING)
+		if (window_pane_is_floating(wp))
 			(*i)++;
 	}
 
@@ -923,7 +922,7 @@ window_count_panes(struct window *w, int with_floating)
 	u_int			 n = 0;
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
-		if (with_floating || ~wp->flags & PANE_FLOATING)
+		if (with_floating || !window_pane_is_floating(wp))
 			n++;
 	}
 	return (n);
@@ -988,7 +987,7 @@ window_pane_printable_flags(struct window_pane *wp)
 		flags[pos++] = '-';
 	if (wp->flags & PANE_ZOOMED)
 		flags[pos++] = 'Z';
-	if (wp->flags & PANE_FLOATING)
+	if (window_pane_is_floating(wp))
 		flags[pos++] = 'F';
 	flags[pos] = '\0';
 	return (flags);
@@ -2211,4 +2210,14 @@ window_pane_floating_geometry(struct window *w, __unused struct window_pane *wp,
 	*out_sx = sx;
 	*out_sy = sy;
 	return (0);
+}
+
+int
+window_pane_is_floating(struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (lc == NULL || (lc->flags & LAYOUT_CELL_FLOATING) == 0)
+		return (0);
+	return (1);
 }

--- a/window.c
+++ b/window.c
@@ -908,7 +908,7 @@ window_pane_zindex(struct window_pane *wp, u_int *i)
 				(*i)++;
 			return (0);
 		}
-		if (window_pane_is_floating(wp))
+		if (window_pane_is_floating(wq))
 			(*i)++;
 	}
 


### PR DESCRIPTION
Part of the layout refactor. I have moved the floating state away from `struct window_pane` into `struct layout_cell`.