### PR TITLE
feat(floating_panes_staging): `resize-pane` can now affect floating panes.

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -60,10 +60,10 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window		*w = wl->window;
 	struct layout_cell	*lc = wp->layout_cell;
 	enum layout_type	 type;
-	const char		*errstr;
+	const char		*errstr, *argval;
 	char			*cause;
 	u_int			 adjust, shift = 0;
-	int			 x, y, status;
+	int			 x, y, status, neg = 0;
 	struct grid		*gd = wp->base.grid;
 
 	if (args_has(args, 'T')) {
@@ -94,11 +94,18 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_count(args) == 0)
 		adjust = 1;
 	else {
-		adjust = strtonum(args_string(args, 0), 1, INT_MAX, &errstr);
+		argval = args_string(args, 0);
+		if (argval[0] == 'n') {
+			neg = 1;
+			argval = argval + 1;
+		}
+		adjust = strtonum(argval, 1, INT_MAX, &errstr);
 		if (errstr != NULL) {
 			cmdq_error(item, "adjustment %s", errstr);
 			return (CMD_RETURN_ERROR);
 		}
+		if (neg)
+			adjust = -adjust;
 	}
 
 	if (args_has(args, 'x')) {

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -40,7 +40,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.name = "resize-pane",
 	.alias = "resizep",
 
-	.args = { "D:L:MR:Tt:U:x:y:Z", 0, 1, NULL },
+	.args = { "D::L::MR::Tt:U::x:y:Z", 0, 1, NULL },
 	.usage = "[-DLMRTUZ] [-x width] [-y height] " CMD_TARGET_PANE_USAGE " "
 		 "[adjustment]",
 
@@ -135,6 +135,8 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			continue;
 
 		argval = args_get(args, flag);
+		if (argval == NULL)
+			argval = "1";
 
 		neg = 0;
 		if (argval[0] == '-') {

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -40,7 +40,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.name = "resize-pane",
 	.alias = "resizep",
 
-	.args = { "DLMRTt:Ux:y:Z", 0, 1, NULL },
+	.args = { "D:L:MR:Tt:U:x:y:Z", 0, 1, NULL },
 	.usage = "[-DLMRTUZ] [-x width] [-y height] " CMD_TARGET_PANE_USAGE " "
 		 "[adjustment]",
 
@@ -59,11 +59,13 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
 	struct layout_cell	*lc = wp->layout_cell;
-	enum layout_type	 type = LAYOUT_TOPBOTTOM;
+	enum layout_type	 type;
 	const char		*errstr, *argval;
 	char			*cause;
+	char			 flag, flags[4] = { 'U', 'D', 'L', 'R' };
 	u_int			 adjust, shift = 0;
-	int			 x, y, status, neg = 0;
+	int			 x, y, status, neg;
+	long unsigned		 i;
 	struct grid		*gd = wp->base.grid;
 
 	if (args_has(args, 'T')) {
@@ -90,23 +92,6 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_NORMAL);
 	}
 	server_unzoom_window(w);
-
-	if (args_count(args) == 0)
-		adjust = 1;
-	else {
-		argval = args_string(args, 0);
-		if (argval[0] == 'n') {
-			neg = 1;
-			argval = argval + 1;
-		}
-		adjust = strtonum(argval, 1, INT_MAX, &errstr);
-		if (errstr != NULL) {
-			cmdq_error(item, "adjustment %s", errstr);
-			return (CMD_RETURN_ERROR);
-		}
-		if (neg)
-			adjust = -adjust;
-	}
 
 	if (args_has(args, 'x')) {
 		x = args_percentage(args, 'x', 0, INT_MAX, w->sx, &cause);
@@ -144,26 +129,51 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
 	}
 
-	if (args_has(args, 'L') || args_has(args, 'R'))
-		type = LAYOUT_LEFTRIGHT;
+	for (i = 0; i < nitems(flags); i++) {
+		flag = flags[i];
+		if (!args_has(args, flag))
+			continue;
 
-	if (window_pane_is_floating(wp)) {
-		if (args_has(args, 'L') || args_has(args, 'U'))
-			shift = 1;
+		argval = args_get(args, flag);
 
-		if (type == LAYOUT_LEFTRIGHT) {
-			lc->sx += adjust;
-			if (shift)
-				lc->xoff -= adjust;
-		} else {
-			lc->sy += adjust;
-			if (shift)
-				lc->yoff -= adjust;
+		neg = 0;
+		if (argval[0] == '-') {
+			argval++;
+			neg = 1;
 		}
-	} else {
-		if (args_has(args, 'L') || args_has(args, 'U'))
+
+		adjust = strtonum(argval, 1, INT_MAX, &errstr);
+		if (errstr != NULL) {
+			cmdq_error(item, "adjustment %s", errstr);
+			return (CMD_RETURN_ERROR);
+		}
+
+		if (neg)
 			adjust = -adjust;
-		layout_resize_pane(wp, type, adjust, 1);
+
+		type = LAYOUT_TOPBOTTOM;
+		if (flag == 'L' || flag == 'R')
+			type = LAYOUT_LEFTRIGHT;
+
+		if (window_pane_is_floating(wp)) {
+			shift = 0;
+			if (flag == 'L' || flag == 'U')
+				shift = 1;
+
+			if (type == LAYOUT_LEFTRIGHT) {
+				lc->sx += adjust;
+				if (shift)
+					lc->xoff -= adjust;
+			} else {
+				lc->sy += adjust;
+				if (shift)
+					lc->yoff -= adjust;
+			}
+		} else {
+			if (flag == 'L' || flag == 'U')
+				adjust = -adjust;
+			layout_resize_pane(wp, type, adjust, 1);
+		}
 	}
 
 	if (lc->parent != NULL)

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -59,7 +59,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
 	struct layout_cell	*lc = wp->layout_cell;
-	enum layout_type	 type;
+	enum layout_type	 type = LAYOUT_TOPBOTTOM;
 	const char		*errstr, *argval;
 	char			*cause;
 	u_int			 adjust, shift = 0;

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -58,9 +58,11 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
+	struct layout_cell	*lc = wp->layout_cell;
+	enum layout_type	 type;
 	const char		*errstr;
 	char			*cause;
-	u_int			 adjust;
+	u_int			 adjust, shift = 0;
 	int			 x, y, status;
 	struct grid		*gd = wp->base.grid;
 
@@ -106,7 +108,10 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
-		layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
+		if (window_pane_is_floating(wp))
+			lc->sx = x;
+		else
+			layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
 	}
 	if (args_has(args, 'y')) {
 		y = args_percentage(args, 'y', 0, INT_MAX, w->sy, &cause);
@@ -126,18 +131,39 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 				y++;
 			break;
 		}
-		layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
+		if (window_pane_is_floating(wp))
+			lc->sy = y;
+		else
+			layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
 	}
 
-	if (args_has(args, 'L'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, -adjust, 1);
-	else if (args_has(args, 'R'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, adjust, 1);
-	else if (args_has(args, 'U'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, -adjust, 1);
-	else if (args_has(args, 'D'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, adjust, 1);
-	server_redraw_window(wl->window);
+	if (args_has(args, 'L') || args_has(args, 'R'))
+		type = LAYOUT_LEFTRIGHT;
+
+	if (window_pane_is_floating(wp)) {
+		if (args_has(args, 'L') || args_has(args, 'U'))
+			shift = 1;
+
+		if (type == LAYOUT_LEFTRIGHT) {
+			lc->sx += adjust;
+			if (shift)
+				lc->xoff -= adjust;
+		} else {
+			lc->sy += adjust;
+			if (shift)
+				lc->yoff -= adjust;
+		}
+	} else {
+		if (args_has(args, 'L') || args_has(args, 'U'))
+			adjust = -adjust;
+		layout_resize_pane(wp, type, adjust, 1);
+	}
+
+	if (lc->parent != NULL)
+		layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
 
 	return (CMD_RETURN_NORMAL);
 }

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -433,10 +433,10 @@ key_bindings_init(void)
 		"bind -N 'Resize the pane down by 5' -r M-Down { resize-pane -D 5 }",
 		"bind -N 'Resize the pane left by 5' -r M-Left { resize-pane -L 5 }",
 		"bind -N 'Resize the pane right by 5' -r M-Right { resize-pane -R 5 }",
-		"bind -N 'Resize the pane up' -r C-Up { resize-pane -U 1 }",
-		"bind -N 'Resize the pane down' -r C-Down { resize-pane -D 1 }",
-		"bind -N 'Resize the pane left' -r C-Left { resize-pane -L 1 }",
-		"bind -N 'Resize the pane right' -r C-Right { resize-pane -R 1 }",
+		"bind -N 'Resize the pane up' -r C-Up { resize-pane -U }",
+		"bind -N 'Resize the pane down' -r C-Down { resize-pane -D }",
+		"bind -N 'Resize the pane left' -r C-Left { resize-pane -L }",
+		"bind -N 'Resize the pane right' -r C-Right { resize-pane -R }",
 
 		/* Menu keys */
 		"bind -N 'Display window menu' < { display-menu -xW -yW -T '#[align=centre]#{window_index}:#{window_name}' " DEFAULT_WINDOW_MENU " }",

--- a/key-bindings.c
+++ b/key-bindings.c
@@ -433,10 +433,10 @@ key_bindings_init(void)
 		"bind -N 'Resize the pane down by 5' -r M-Down { resize-pane -D 5 }",
 		"bind -N 'Resize the pane left by 5' -r M-Left { resize-pane -L 5 }",
 		"bind -N 'Resize the pane right by 5' -r M-Right { resize-pane -R 5 }",
-		"bind -N 'Resize the pane up' -r C-Up { resize-pane -U }",
-		"bind -N 'Resize the pane down' -r C-Down { resize-pane -D }",
-		"bind -N 'Resize the pane left' -r C-Left { resize-pane -L }",
-		"bind -N 'Resize the pane right' -r C-Right { resize-pane -R }",
+		"bind -N 'Resize the pane up' -r C-Up { resize-pane -U 1 }",
+		"bind -N 'Resize the pane down' -r C-Down { resize-pane -D 1 }",
+		"bind -N 'Resize the pane left' -r C-Left { resize-pane -L 1 }",
+		"bind -N 'Resize the pane right' -r C-Right { resize-pane -R 1 }",
 
 		/* Menu keys */
 		"bind -N 'Display window menu' < { display-menu -xW -yW -T '#[align=centre]#{window_index}:#{window_name}' " DEFAULT_WINDOW_MENU " }",


### PR DESCRIPTION
I added some additional logic for `resize-pane` to handle negative numbers as that is a common use case for resizing a floating pane, and floating panes have all four borders that `U/D/L/R` handle. I have chosen 'n' as a prefix to the number argument to signify that it should be negative. I am not thrilled about this solution, but am unsure about what would be better. Negative numbers currently also affect tiled targets, so `-D 10` is the same as `-U n10`. I have a feeling this behavior isn't weird enough to implement restriction to the flags.