### PR TITLE
cmd-list-keys: escape special characters in list-keys output

### DIFF
--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -155,7 +155,7 @@ cmd_list_keys_format_add_key_binding(struct format_tree *ft,
 	format_add(ft, "key_prefix", "%s", prefix);
 	format_add(ft, "key_table", "%s", bd->tablename);
 
-	format_add(ft, "key_string", "%s", key_string_lookup_key(bd->key, 0));
+	format_add(ft, "key_string", "%s", args_escape(key_string_lookup_key(bd->key, 0)));
 
 	s = cmd_list_print(bd->cmdlist, CMD_LIST_PRINT_ESCAPED|
 	    CMD_LIST_PRINT_NO_GROUPS);


### PR DESCRIPTION
## Summary
- Wrap key_string_lookup_key() output with args_escape() in cmd_list_keys_format_add_key_binding()
- This escapes special characters ({, }, #, ;, etc.) so list-keys output can be used directly with source-file

## Changes
| File | Change |
|------|--------|
| cmd-list-keys.c | Added args_escape() wrapper around key_string_lookup_key() |

## Root Cause
The list-keys command outputs key bindings without escaping special characters. This means the output cannot be sourced back into tmux, since characters like { and } are interpreted as tmux syntax.

## Test Plan
- Run tmux, set some bindings with special characters
- Run list-keys and verify output can be piped to source-file
- Example: bind-key M-\{ ... should appear as M-\{ in list-keys output

Fixes tmux/tmux#5153