### PR TITLE
Add -g flag to kill-session to kill all sessions in a group

### DIFF
--- a/cmd-kill-session.c
+++ b/cmd-kill-session.c
@@ -33,8 +33,8 @@ const struct cmd_entry cmd_kill_session_entry = {
 	.name = "kill-session",
 	.alias = NULL,
 
-	.args = { "aCt:", 0, 0, NULL },
-	.usage = "[-aC] " CMD_TARGET_SESSION_USAGE,
+	.args = { "aCgt:", 0, 0, NULL },
+	.usage = "[-aCg] " CMD_TARGET_SESSION_USAGE,
 
 	.target = { 't', CMD_FIND_SESSION, 0 },
 
@@ -48,6 +48,7 @@ cmd_kill_session_exec(struct cmd *self, struct cmdq_item *item)
 	struct args		*args = cmd_get_args(self);
 	struct cmd_find_state	*target = cmdq_get_target(item);
 	struct session		*s = target->s, *sloop, *stmp;
+	struct session_group	*sg;
 	struct winlink		*wl;
 
 	if (args_has(args, 'C')) {
@@ -62,6 +63,12 @@ cmd_kill_session_exec(struct cmd *self, struct cmdq_item *item)
 				server_destroy_session(sloop);
 				session_destroy(sloop, 1, __func__);
 			}
+		}
+	} else if (args_has(args, 'g') &&
+	    (sg = session_group_contains(s)) != NULL) {
+		TAILQ_FOREACH_SAFE(sloop, &sg->sessions, gentry, stmp) {
+			server_destroy_session(sloop);
+			session_destroy(sloop, 1, __func__);
 		}
 	} else {
 		server_destroy_session(s);

--- a/tmux.1
+++ b/tmux.1
@@ -1202,7 +1202,7 @@ Kill the
 .Nm
 server and clients and destroy all sessions.
 .It Xo Ic kill\-session
-.Op Fl aC
+.Op Fl aCg
 .Op Fl t Ar target\-session
 .Xc
 Destroy the given session, closing any windows linked to it and no other
@@ -1210,6 +1210,10 @@ sessions, and detaching all clients attached to it.
 If
 .Fl a
 is given, all sessions but the specified one is killed.
+If
+.Fl g
+is given and the session is in a session group, all sessions in the group are
+killed.
 The
 .Fl C
 flag clears alerts (bell, activity, or silence) in all windows linked to the


### PR DESCRIPTION
This implements the request in #2346 (also on the wiki todo list): a `-g` flag for `kill-session` to kill all sessions in the target session's group.

If the target session is not in a group, only that session is killed as before. The man page is updated.