### PR TITLE
Add option to pass keypresses through while status message is displayed

### DIFF
--- a/alerts.c
+++ b/alerts.c
@@ -315,10 +315,10 @@ alerts_set_message(struct winlink *wl, const char *type, const char *option)
 		if (visual == VISUAL_OFF)
 			continue;
 		if (c->session->curw == wl) {
-			status_message_set(c, -1, 1, 0, 0,
+			status_message_set(c, -1, 1, 0, 0, 0,
 			    "%s in current window", type);
 		} else {
-			status_message_set(c, -1, 1, 0, 0,
+			status_message_set(c, -1, 1, 0, 0, 0,
 			    "%s in window %d", type, wl->idx);
 		}
 	}

--- a/cmd-display-message.c
+++ b/cmd-display-message.c
@@ -39,8 +39,8 @@ const struct cmd_entry cmd_display_message_entry = {
 	.name = "display-message",
 	.alias = "display",
 
-	.args = { "aCc:d:lINpt:F:v", 0, 1, NULL },
-	.usage = "[-aCIlNpv] [-c target-client] [-d delay] [-F format] "
+	.args = { "aCc:d:lINPpt:F:v", 0, 1, NULL },
+	.usage = "[-aCIlNPpv] [-c target-client] [-d delay] [-F format] "
 		 CMD_TARGET_PANE_USAGE " [message]",
 
 	.target = { 't', CMD_FIND_PANE, CMD_FIND_CANFAIL },
@@ -68,8 +68,10 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	const char		*template;
 	char			*msg, *cause;
-	int			 delay = -1, flags, Nflag = args_has(args, 'N');
-	int			 Cflag = args_has(args, 'C');
+	int				delay = -1, flags;
+	int				Pflag = args_has(args, 'P');
+	int				Nflag = args_has(args, 'N') || Pflag;
+	int				Cflag = args_has(args, 'C') || Pflag;
 	struct format_tree	*ft;
 	u_int			 count = args_count(args);
 	struct evbuffer		*evb;
@@ -152,7 +154,7 @@ cmd_display_message_exec(struct cmd *self, struct cmdq_item *item)
 		server_client_print(tc, 0, evb);
 		evbuffer_free(evb);
 	} else if (tc != NULL)
-		status_message_set(tc, delay, 0, Nflag, Cflag, "%s", msg);
+		status_message_set(tc, delay, 0, Nflag, Cflag, Pflag, "%s", msg);
 	free(msg);
 
 	format_free(ft);

--- a/cmd-if-shell.c
+++ b/cmd-if-shell.c
@@ -157,7 +157,7 @@ cmd_if_shell_callback(struct job *job)
 	if (cmdlist == NULL) {
 		if (cdata->item == NULL) {
 			*error = toupper((u_char)*error);
-			status_message_set(c, -1, 1, 0, 0, "%s", error);
+			status_message_set(c, -1, 1, 0, 0, 0, "%s", error);
 		} else
 			cmdq_error(cdata->item, "%s", error);
 		free(error);

--- a/cmd-list-keys.c
+++ b/cmd-list-keys.c
@@ -238,7 +238,7 @@ cmd_list_keys_exec(struct cmd *self, struct cmdq_item *item)
 
 		line = format_expand(ft, template);
 		if ((single && tc != NULL) || n == 1)
-			status_message_set(tc, -1, 1, 0, 0, "%s", line);
+			status_message_set(tc, -1, 1, 0, 0, 0, "%s", line);
 		else if (*line != '\0')
 			cmdq_print(item, "%s", line);
 		free(line);

--- a/cmd-queue.c
+++ b/cmd-queue.c
@@ -892,7 +892,7 @@ cmdq_error(struct cmdq_item *item, const char *fmt, ...)
 		c->retval = 1;
 	} else {
 		*msg = toupper((u_char) *msg);
-		status_message_set(c, -1, 1, 0, 0, "%s", msg);
+		status_message_set(c, -1, 1, 0, 0, 0, "%s", msg);
 	}
 
 	free(msg);

--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -209,7 +209,7 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 		    cmd_run_shell_callback, cmd_run_shell_free, cdata,
 		    cdata->flags, -1, -1) == NULL) {
 			if (cdata->item == NULL)
-				status_message_set(c, -1, 1, 0, 0,
+				status_message_set(c, -1, 1, 0, 0, 0,
 				    "failed to run command: %s", cmd);
 			else {
 				cmdq_error(cdata->item,
@@ -225,7 +225,7 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 	if (cmdlist == NULL) {
 		if (cdata->item == NULL) {
 			*error = toupper((u_char)*error);
-			status_message_set(c, -1, 1, 0, 0, "%s", error);
+			status_message_set(c, -1, 1, 0, 0, 0, "%s", error);
 		} else
 			cmdq_error(cdata->item, "%s", error);
 		free(error);

--- a/mode-tree.c
+++ b/mode-tree.c
@@ -1474,7 +1474,7 @@ mode_tree_run_command(struct client *c, struct cmd_find_state *fs,
 		if (status == CMD_PARSE_ERROR) {
 			if (c != NULL) {
 				*error = toupper((u_char)*error);
-				status_message_set(c, -1, 1, 0, 0, "%s", error);
+				status_message_set(c, -1, 1, 0, 0, 0, "%s", error);
 			}
 			free(error);
 		}

--- a/server-client.c
+++ b/server-client.c
@@ -1465,7 +1465,7 @@ server_client_handle_key(struct client *c, struct key_event *event)
 	 * immediately rather than queued.
 	 */
 	if (~c->flags & CLIENT_READONLY) {
-		if (c->message_string != NULL) {
+		if (c->message_string != NULL && !c->message_passthru_keys) {
 			if (c->message_ignore_keys)
 				return (0);
 			status_message_clear(c);

--- a/status.c
+++ b/status.c
@@ -458,7 +458,7 @@ status_redraw(struct client *c)
 /* Set a status line message. */
 void
 status_message_set(struct client *c, int delay, int ignore_styles,
-    int ignore_keys, int no_freeze, const char *fmt, ...)
+    int ignore_keys, int no_freeze, int passthu_keys, const char *fmt, ...)
 {
 	struct timeval	 tv;
 	va_list		 ap;
@@ -498,13 +498,16 @@ status_message_set(struct client *c, int delay, int ignore_styles,
 		evtimer_add(&c->message_timer, &tv);
 	}
 
-	if (delay != 0)
+	if (delay != 0) {
 		c->message_ignore_keys = ignore_keys;
+		c->message_passthru_keys = passthu_keys;
+	}
 	c->message_ignore_styles = ignore_styles;
 
 	if (!no_freeze)
 		c->tty.flags |= TTY_FREEZE;
-	c->tty.flags |= TTY_NOCURSOR;
+	if (!passthu_keys)
+		c->tty.flags |= TTY_NOCURSOR;
 	c->flags |= CLIENT_REDRAWSTATUS;
 }
 

--- a/tmux.1
+++ b/tmux.1
@@ -7369,7 +7369,7 @@ The following keys are available in menus:
 .El
 .Tg display
 .It Xo Ic display\-message
-.Op Fl aCIlNpv
+.Op Fl aCIlNPpv
 .Op Fl c Ar target\-client
 .Op Fl d Ar delay
 .Op Fl t Ar target\-pane
@@ -7394,6 +7394,13 @@ ignores key presses and closes only after the delay expires.
 If
 .Fl C
 is given, the pane will continue to be updated while the message is displayed.
+If
+.Fl P
+is given,
+.Fl N
+and
+.Fl C
+are implied, and keystrokes are passed through to the active pane.
 If
 .Fl l
 is given,

--- a/tmux.h
+++ b/tmux.h
@@ -2161,6 +2161,7 @@ struct client {
 	uint64_t		 redraw_scrollbars;
 
 	int			 message_ignore_keys;
+	int			 message_passthru_keys;
 	int			 message_ignore_styles;
 	char			*message_string;
 	struct event		 message_timer;
@@ -3128,7 +3129,7 @@ struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);
 int	 status_redraw(struct client *);
-void printflike(6, 7) status_message_set(struct client *, int, int, int, int,
+void printflike(7, 8) status_message_set(struct client *, int, int, int, int, int,
 	     const char *, ...);
 void	 status_message_clear(struct client *);
 int	 status_message_redraw(struct client *);

--- a/window-copy.c
+++ b/window-copy.c
@@ -3479,7 +3479,7 @@ window_copy_command(struct window_mode_entry *wme, struct client *c,
 			if (c != NULL &&
 			    c->flags & CLIENT_READONLY &&
 			    (~flags & WINDOW_COPY_CMD_FLAG_READONLY)) {
-				status_message_set(c, -1, 1, 0, 0,
+				status_message_set(c, -1, 1, 0, 0, 0,
 				    "client is read-only");
 				return;
 			}

--- a/window-customize.c
+++ b/window-customize.c
@@ -1021,7 +1021,7 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 
 fail:
 	*cause = toupper((u_char)*cause);
-	status_message_set(c, -1, 1, 0, 0, "%s", cause);
+	status_message_set(c, -1, 1, 0, 0, 0, "%s", cause);
 	free(cause);
 	return (0);
 }
@@ -1224,7 +1224,7 @@ window_customize_set_command_callback(struct client *c, void *itemdata,
 
 fail:
 	*error = toupper((u_char)*error);
-	status_message_set(c, -1, 1, 0, 0, "%s", error);
+	status_message_set(c, -1, 1, 0, 0, 0, "%s", error);
 	free(error);
 	return (0);
 }


### PR DESCRIPTION
I like to use status messages as a notification system. I find it annoying that status messages always eat a keypress or totally ignore keypresses with no option to simply pass keypresses through to the active pane as if the status message wasn't even there. I implemented this functionality in `display-message` with the option `-P`, which implies `-NC`. I updated the man page as well.

I read the style guide and tried to stick to it. Please let me know if there is anything that I need to change, add, or remove.