### PR TITLE
Use correct X position for visible range checks in screen_write_fast_copy.

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -624,21 +624,23 @@ screen_write_fast_copy(struct screen_write_ctx *ctx, struct screen *src,
 	struct grid_line	*gl, *sgl;
 	struct grid_cell	 gc;
 	u_int			 xx, yy, cx = s->cx, cy = s->cy;
-	int			 yoff = 0;
+	int			 xoff = 0, yoff = 0;
 	struct visible_ranges	*r;
 
 	if (nx == 0 || ny == 0)
 		return;
-	if (wp != NULL)
+	if (wp != NULL) {
+		xoff = wp->xoff;
 		yoff = wp->yoff;
+	}
 
 	for (yy = py; yy < py + ny; yy++) {
 		if (yy >= gd->hsize + gd->sy)
 			break;
 		s->cx = cx;
 		screen_write_initctx(ctx, &ttyctx, 0, 0);
-		r = screen_redraw_get_visible_ranges(wp, px, s->cy + yoff, nx,
-		    NULL);
+		r = screen_redraw_get_visible_ranges(wp, xoff + s->cx,
+		    s->cy + yoff, nx, NULL);
 		for (xx = px; xx < px + nx; xx++) {
 			gl = grid_get_line(gd, yy);
 			sgl = grid_get_line(s->grid, s->cy);
@@ -650,7 +652,7 @@ screen_write_fast_copy(struct screen_write_ctx *ctx, struct screen *src,
 				break;
 			grid_view_set_cell(s->grid, s->cx, s->cy, &gc);
 
-			if (!screen_redraw_is_visible(r, px))
+			if (!screen_redraw_is_visible(r, xoff + s->cx))
 				break;
 			ttyctx.cell = &gc;
 			ttyctx.flags &= (TTY_CTX_OVERLAY_SYNC|TTY_CTX_SYNC);


### PR DESCRIPTION
## context

found while testing a copy-mode live-refresh experiment for #5017.

reproduces on current `master` without any refresh changes; does not reproduce on 3.6a.

## problem

1. with a horizontally split window, put the right pane into copy-mode with line
2. move the cursor
3. the position indicator in the top-right of the right pane is:

```text
[
```

not:

```text
[X/Y]
```

## solution

this only happens when the pane has a non-zero `xoff`. the same pane looks fine
when it is the only pane/full-width.

use `xoff + s->cx` for the visible range lookup/checks, matching the coordinate
space used by the rest of the screen-write visibility paths.

## repro

the following script makes a new window in the current session to reproduce the issue:

```sh
left='i=0; while :; do printf "left %06d abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz\n" "$i"; i=$((i + 1)); sleep 0.02; done'
right='i=0; while :; do printf "right %06d ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ\n" "$i"; i=$((i + 1)); sleep 0.02; done'

set -- $(tmux new-window -d -P -F '#{window_id} #{pane_id}' -n repro-5164 "$left")
win=$1
right_pane=$(tmux split-window -d -P -F '#{pane_id}' -h -t "$win" "$right")

tmux set-option -w -t "$win" mode-keys vi
tmux set-option -w -t "$win" copy-mode-line-numbers off
tmux select-layout -t "$win" even-horizontal
tmux resize-pane -t "$right_pane" -x 62

sleep 2

tmux copy-mode -t "$right_pane"
tmux send-keys -t "$right_pane" -X history-bottom
tmux select-pane -t "$right_pane"
tmux select-window -t "$win"

tmux display-message 'press k in the right pane and watch the top-right copy-mode indicator'
```
