### PR TITLE
Guard cmd_find_from_nothing fallback

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -821,17 +821,25 @@ cmd_find_from_nothing(struct cmd_find_state *fs, int flags)
 	cmd_find_clear_state(fs, flags);
 
 	fs->s = cmd_find_best_session(NULL, 0, flags);
-	if (fs->s == NULL) {
-		cmd_find_clear_state(fs, flags);
-		return (-1);
-	}
+	if (fs->s == NULL)
+		goto fail;
 	fs->wl = fs->s->curw;
-	fs->idx = fs->wl->idx;
+	if (fs->wl == NULL)
+		goto fail;
 	fs->w = fs->wl->window;
+	if (fs->w == NULL)
+		goto fail;
+	fs->idx = fs->wl->idx;
 	fs->wp = fs->w->active;
+	if (fs->wp == NULL)
+		goto fail;
 
 	cmd_find_log_state(__func__, fs);
 	return (0);
+
+fail:
+	cmd_find_clear_state(fs, flags);
+	return (-1);
 }
 
 /* Find state from mouse. */


### PR DESCRIPTION
## Summary

Guard each pointer step in `cmd_find_from_nothing()` before constructing the fallback target state.

This prevents the server from dereferencing a NULL `curw`, `window`, or active pane when the fallback path is used during session teardown. On any incomplete state, the helper now clears the partially-filled find state and returns `-1`, matching the existing no-session failure behavior.

Fixes #5163.

## Notes

This is a defensive crash fix rather than a broader change to session teardown ordering. It leaves the `session_destroy()` notification ordering alone and makes the fallback lookup robust to the NULL state shown by the crash reports, regardless of the exact race that exposes it.

Related find-state helpers still assume validated input in their narrower call paths; this PR only hardens the global fallback path used by `notify_session()` when the destroyed session is no longer alive.

## Checks

- `make`
- `make check`