### PR TITLE
fix(master): Possible fix to mouse events not being correctly identified for pane border buttons.

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -695,12 +695,8 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 				bdr_bottom = fwp->yoff + fwp->sy;
 				if (py == bdr_bottom)
 					break;
-				if (window_pane_is_floating(wp)) {
-					/* Floating pane, check top border. */
-					bdr_top = fwp->yoff - 1;
-					if (py == bdr_top)
-						break;
-				}
+				if (py == bdr_top)
+					break;
 			}
 		}
 		if (fwp != NULL)

--- a/window.c
+++ b/window.c
@@ -628,6 +628,23 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 
 	pane_status = options_get_number(w->options, "pane-border-status");
 
+	if (pane_status == PANE_STATUS_TOP) {
+		/*
+		 * Prefer a pane's top border status line over the pane above's
+		 * bottom border.
+		 */
+		TAILQ_FOREACH(wp, &w->z_index, zentry) {
+			if (!window_pane_visible(wp) || window_pane_is_floating(wp))
+				continue;
+
+			window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
+			if ((int)x < xoff || x > xoff + sx)
+				continue;
+			if ((int)y == yoff - 1)
+				return (wp);
+		}
+	}
+
 	TAILQ_FOREACH(wp, &w->z_index, zentry) {
 		if (!window_pane_visible(wp))
 			continue;
@@ -640,10 +657,10 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 			if ((int)x < xoff || x > xoff + sx)
 				continue;
 			if (pane_status == PANE_STATUS_TOP) {
-				if ((int)y < yoff - 1 || y > yoff + sy - 1)
+				if ((int)y < yoff - 1 || y > yoff + sy)
 					continue;
 			} else {
-				if ((int)y < yoff || y > yoff + sy - 1)
+				if ((int)y < yoff || y > yoff + sy)
 					continue;
 			}
 		} else {

--- a/window.c
+++ b/window.c
@@ -633,14 +633,17 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 			continue;
 		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
 		if (!window_pane_is_floating(wp)) {
-			/* Tiled - to and including bottom or right border. */
+			/*
+			 * Tiled - to and including the right border, excluding
+			 * the bottom border.
+			 */
 			if ((int)x < xoff || x > xoff + sx)
 				continue;
 			if (pane_status == PANE_STATUS_TOP) {
-				if ((int)y < yoff - 1 || y > yoff + sy)
+				if ((int)y < yoff - 1 || y > yoff + sy - 1)
 					continue;
 			} else {
-				if ((int)y < yoff || y > yoff + sy)
+				if ((int)y < yoff || y > yoff + sy - 1)
 					continue;
 			}
 		} else {


### PR DESCRIPTION
There was a regression with the mouse event detection for pane borders. The change in `server-client.c` i believe should happen regardless. 

I am less sure about the change in `window.c`. I believe that the bottom border of a pane should be identified as the top border of the lower pane for pane border buttons to be correctly detected. I am unsure if this change will have unintended side effects. Is there a better way to approach this?