### PR TITLE
mode-tree: guard mode_tree_key against an empty tree

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -1224,6 +1224,11 @@ mode_tree_key(struct mode_tree_data *mtd, struct client *c, key_code *key,
 	u_int			 i, x, y;
 	int			 choice, preview;
 
+	if (mtd->line_size == 0) {
+		*key = KEYC_NONE;
+		return (1);
+	}
+
 	if (KEYC_IS_MOUSE(*key) && m != NULL) {
 		if (cmd_mouse_at(mtd->wp, m, &x, &y, 0) != 0) {
 			*key = KEYC_NONE;


### PR DESCRIPTION
mode_tree_key() dereferences mtd->line_list[mtd->current] without checking
line_size, so a key, wheel, or right-click delivered while the tree is empty
(line_list == NULL, line_size == 0) crashes the server.

line_size == 0 only happens when the underlying collection is genuinely empty:
mode_tree_build() rebuilds without the filter when a filter matches nothing
(no_matches), so an empty tree is never a filtered view to recover, and
mode_tree_get_current() returns NULL. So just exit the mode. *key is cleared
first because the callers run their key switch before checking the return value
and some cases dereference the (now NULL) current item.