### PR TITLE
Add XDG session variables to update-environment

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -97,6 +97,8 @@ CHANGES FROM 3.6b TO 3.7
 * Add WAYLAND_DISPLAY to default update-environment, issue 4965 from wgh at
   torlan dot ru.
 
+* Add XDG session variables to default update-environment, issue 5169.
+
 * Add -C flag to command-prompt to match display-message -C (do not freeze
   panes) (from Barrett Ruth in issue 4978).
 

--- a/options-table.c
+++ b/options-table.c
@@ -1028,7 +1028,8 @@ const struct options_table_entry options_table[] = {
 	  .flags = OPTIONS_TABLE_IS_ARRAY,
 	  .default_str = "DISPLAY KRB5CCNAME MSYSTEM SSH_ASKPASS SSH_AUTH_SOCK "
 			 "SSH_AGENT_PID SSH_CONNECTION WAYLAND_DISPLAY "
-			 "WINDOWID XAUTHORITY",
+			 "WINDOWID XAUTHORITY XDG_CURRENT_DESKTOP "
+			 "XDG_SESSION_DESKTOP XDG_SESSION_TYPE",
 	  .text = "List of environment variables to update in the session "
 		  "environment when a client is attached."
 	},


### PR DESCRIPTION
Adds XDG_CURRENT_DESKTOP, XDG_SESSION_DESKTOP, and XDG_SESSION_TYPE to the default update-environment list so tmux refreshes Wayland/XDG session identity along with display variables.\n\nCloses #5169.\n\nTested with:\n- make\n- git diff --check\n- throwaway tmux server with controlled XDG values\n- control-mode attach refresh from stale XDG values to fresh values