### PR TITLE
Update copy mode vi test result

### DIFF
--- a/regress/copy-mode-test-vi.sh
+++ b/regress/copy-mode-test-vi.sh
@@ -34,14 +34,17 @@ $TMUX send-keys -X previous-word
 $TMUX send-keys -X copy-selection
 [ "$($TMUX show-buffer)" = "line" ] || exit 1
 
-# Test that `next-word-end` wraps around indented line breaks.
+# Test that `next-word-end` stops at the end of the line.
 $TMUX send-keys -X next-word
 $TMUX send-keys -X next-word
 $TMUX send-keys -X begin-selection
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X next-word-end
 $TMUX send-keys -X copy-selection
-[ "$($TMUX show-buffer)" = "$(printf "words\n\tIndented")" ] || exit 1
+[ "$($TMUX show-buffer)" = "words" ] || exit 1
+
+# Move to the next word for the following tests.
+$TMUX send-keys -X next-word
 
 # Test that `next-word` wraps around un-indented line breaks.
 $TMUX send-keys -X next-word


### PR DESCRIPTION
## Summary

- update the vi copy-mode regression for the new `next-word-end` end-of-line behavior
- add an explicit `next-word` step so later stateful checks keep their intended starting position

## Testing

- `TEST_TMUX=../tmux sh copy-mode-test-vi.sh` against a locally built tmux in nix shell