### PR TITLE
Do not silently change invalid names given to commands.

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -62,6 +62,14 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	int			 idx = target->idx, before;
 	const char		*template;
 
+	if (args_has(args, 'n')) {
+		if (!check_name(args_get(args, 'n'), ":.")) {
+			cmdq_error(item, "invalid window name: %s",
+			    args_get(args, 'n'));
+			return (CMD_RETURN_ERROR);
+		}
+	}
+
 	before = args_has(args, 'b');
 	if (args_has(args, 'a') || before) {
 		if (target->wl != NULL)
@@ -81,7 +89,7 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 			return (CMD_RETURN_ERROR);
 		}
 		if (args_has(args, 'n')) {
-			window_set_name(w, args_get(args, 'n'));
+			window_set_name(w, args_get(args, 'n'), ":.");
 			options_set_number(w->options, "automatic-rename", 0);
 		}
 		server_unlink_window(src_s, wl);
@@ -111,10 +119,10 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (!args_has(args, 'n')) {
 		name = default_window_name(w);
-		window_set_name(w, name);
+		window_set_name(w, name, ":.");
 		free(name);
 	} else {
-		window_set_name(w, args_get(args, 'n'));
+		window_set_name(w, args_get(args, 'n'), ":.");
 		options_set_number(w->options, "automatic-rename", 0);
 	}
 

--- a/cmd-new-session.c
+++ b/cmd-new-session.c
@@ -99,15 +99,26 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-	tmp = args_get(args, 's');
+	tmp = args_get(args, 'n');
 	if (tmp != NULL) {
 		name = format_single(item, tmp, c, NULL, NULL, NULL);
-		newname = clean_name(name, "#:.");
-		if (newname == NULL) {
-			cmdq_error(item, "invalid session: %s", name);
+		if (!check_name(name, ":.")) {
+			cmdq_error(item, "invalid window name: %s", name);
 			free(name);
 			return (CMD_RETURN_ERROR);
 		}
+		free(name);
+	}
+
+	tmp = args_get(args, 's');
+	if (tmp != NULL) {
+		name = format_single(item, tmp, c, NULL, NULL, NULL);
+		if (!check_name(name, ":.")) {
+			cmdq_error(item, "invalid session name: %s", name);
+			free(name);
+			return (CMD_RETURN_ERROR);
+		}
+		newname = clean_name(name, ":.");
 		free(name);
 	}
 	if (args_has(args, 'A')) {
@@ -142,12 +153,12 @@ cmd_new_session_exec(struct cmd *self, struct cmdq_item *item)
 		else if (groupwith != NULL)
 			prefix = xstrdup(groupwith->name);
 		else {
-			prefix = clean_name(group, "#:.");
-			if (prefix == NULL) {
-				cmdq_error(item, "invalid session group: %s",
-				    group);
+			if (!check_name(group, ":.")) {
+				cmdq_error(item,
+				    "invalid session group name: %s", group);
 				goto fail;
 			}
+			prefix = clean_name(group, ":.");
 		}
 	}
 

--- a/cmd-new-window.c
+++ b/cmd-new-window.c
@@ -71,6 +71,15 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 	 * name already exists, select it.
 	 */
 	name = args_get(args, 'n');
+	if (name != NULL) {
+		expanded = format_single(item, name, c, s, NULL, NULL);
+		if (!check_name(expanded, ":.")) {
+			cmdq_error(item, "invalid window name: %s", expanded);
+			free(expanded);
+			return (CMD_RETURN_ERROR);
+		}
+		free(expanded);
+	}
 	if (args_has(args, 'S') && name != NULL && target->idx == -1) {
 		expanded = format_single(item, name, c, s, NULL, NULL);
 		RB_FOREACH(wl, winlinks, &s->windows) {

--- a/cmd-rename-session.c
+++ b/cmd-rename-session.c
@@ -52,12 +52,12 @@ cmd_rename_session_exec(struct cmd *self, struct cmdq_item *item)
 	char			*newname, *tmp;
 
 	tmp = format_single_from_target(item, args_string(args, 0));
-	newname = clean_name(tmp, "#:.");
-	if (newname == NULL) {
-		cmdq_error(item, "invalid session: %s", tmp);
+	if (!check_name(tmp, ":.")) {
+		cmdq_error(item, "invalid session name: %s", tmp);
 		free(tmp);
 		return (CMD_RETURN_ERROR);
 	}
+	newname = clean_name(tmp, ":.");
 	free(tmp);
 	if (strcmp(newname, s->name) == 0) {
 		free(newname);

--- a/cmd-rename-window.c
+++ b/cmd-rename-window.c
@@ -48,15 +48,21 @@ cmd_rename_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct args		*args = cmd_get_args(self);
 	struct cmd_find_state	*target = cmdq_get_target(item);
 	struct winlink		*wl = target->wl;
-	char			*newname;
+	char			*tmp;
 
-	newname = format_single_from_target(item, args_string(args, 0));
-	window_set_name(wl->window, newname);
+	tmp = format_single_from_target(item, args_string(args, 0));
+	if (!check_name(tmp, ":.")) {
+		cmdq_error(item, "invalid window name: %s", tmp);
+		free(tmp);
+		return (CMD_RETURN_ERROR);
+	}
+
+	window_set_name(wl->window, tmp, ":.");
 	options_set_number(wl->window->options, "automatic-rename", 0);
 
 	server_redraw_window_borders(wl->window);
 	server_status_window(wl->window);
-	free(newname);
+	free(tmp);
 
 	return (CMD_RETURN_NORMAL);
 }

--- a/cmd-select-pane.c
+++ b/cmd-select-pane.c
@@ -217,7 +217,7 @@ cmd_select_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (args_has(args, 'T')) {
 		title = format_single_from_target(item, args_get(args, 'T'));
-		if (screen_set_title(&wp->base, title)) {
+		if (screen_set_title(&wp->base, title, "")) {
 			notify_pane("pane-title-changed", wp);
 			server_redraw_window_borders(wp->window);
 			server_status_window(wp->window);

--- a/input.c
+++ b/input.c
@@ -2701,7 +2701,7 @@ input_exit_osc(struct input_ctx *ictx)
 	case 2:
 		if (wp != NULL &&
 		    options_get_number(wp->options, "allow-set-title") &&
-		    screen_set_title(sctx->s, p)) {
+		    screen_set_title(sctx->s, p, "#")) {
 			notify_pane("pane-title-changed", wp);
 			server_redraw_window_borders(wp->window);
 			server_status_window(wp->window);
@@ -2779,7 +2779,7 @@ input_exit_apc(struct input_ctx *ictx)
 
 	if (wp != NULL &&
 	    options_get_number(wp->options, "allow-set-title") &&
-	    screen_set_title(sctx->s, ictx->input_buf)) {
+	    screen_set_title(sctx->s, ictx->input_buf, "#")) {
 		notify_pane("pane-title-changed", wp);
 		server_redraw_window_borders(wp->window);
 		server_status_window(wp->window);
@@ -2822,10 +2822,10 @@ input_exit_rename(struct input_ctx *ictx)
 		if (o != NULL)
 			options_remove_or_default(o, -1, NULL);
 		if (!options_get_number(w->options, "automatic-rename"))
-			window_set_name(w, "");
+			window_set_name(w, "", ":.#");
 	} else {
 		options_set_number(w->options, "automatic-rename", 0);
-		window_set_name(w, ictx->input_buf);
+		window_set_name(w, ictx->input_buf, ":.#");
 	}
 	server_redraw_window_borders(w);
 	server_status_window(w);

--- a/names.c
+++ b/names.c
@@ -95,7 +95,7 @@ check_window_name(struct window *w)
 	name = format_window_name(w);
 	if (strcmp(name, w->name) != 0) {
 		log_debug("@%u new name %s (was %s)", w->id, name, w->name);
-		window_set_name(w, name);
+		window_set_name(w, name, ":.");
 		server_redraw_window_borders(w);
 		server_status_window(w);
 	} else
@@ -166,7 +166,7 @@ parse_window_name(const char *in)
 
 	if (*name == '/')
 		name = basename(name);
-	name = clean_name(name, "#");
+	name = clean_name(name, ":.");
 	free(copy);
 	if (name == NULL)
 		return (xstrdup(""));

--- a/popup.c
+++ b/popup.c
@@ -435,7 +435,7 @@ popup_make_pane(struct popup_data *pd, enum layout_type type)
 		pd->job = NULL;
 	}
 
-	screen_set_title(&pd->s, new_wp->base.title);
+	screen_set_title(&pd->s, new_wp->base.title, "");
 	screen_free(&new_wp->base);
 	memcpy(&new_wp->base, &pd->s, sizeof wp->base);
 	screen_resize(&new_wp->base, new_wp->sx, new_wp->sy, 1);

--- a/screen.c
+++ b/screen.c
@@ -245,11 +245,11 @@ screen_set_cursor_colour(struct screen *s, int colour)
 
 /* Set screen title. */
 int
-screen_set_title(struct screen *s, const char *title)
+screen_set_title(struct screen *s, const char *title, const char *forbid)
 {
 	char	*new_title;
 
-	new_title = clean_name(title, "#");
+	new_title = clean_name(title, forbid);
 	if (new_title == NULL)
 		return (0);
 	free(s->title);

--- a/spawn.c
+++ b/spawn.c
@@ -182,7 +182,7 @@ spawn_window(struct spawn_context *sc, char **cause)
 		free(w->name);
 		if (sc->name != NULL) {
 			name = format_single(item, sc->name, c, s, NULL, NULL);
-			w->name = clean_name(name, "#");
+			w->name = clean_name(name, ":.");
 			free(name);
 			if (w->name == NULL)
 				w->name = xstrdup("");

--- a/tmux.c
+++ b/tmux.c
@@ -298,6 +298,25 @@ clean_name(const char *name, const char* forbid)
 	return (new_name);
 }
 
+/*
+ * Check a name given by a command: reject it if it is empty, not valid UTF-8,
+ * or contains a forbidden character. Other characters that clean_name would
+ * change (for example with utf8_stravis) are allowed and fixed silently.
+ */
+int
+check_name(const char *name, const char *forbid)
+{
+	const char	*cp;
+
+	if (*name == '\0' || !utf8_isvalid(name))
+		return (0);
+	for (cp = name; *cp != '\0'; cp++) {
+		if (strchr(forbid, *cp) != NULL)
+			return (0);
+	}
+	return (1);
+}
+
 const char *
 sig2name(int signo)
 {

--- a/tmux.h
+++ b/tmux.h
@@ -2404,6 +2404,7 @@ void		 setblocking(int, int);
 char 		*shell_argv0(const char *, int);
 uint64_t	 get_timer(void);
 char		*clean_name(const char *, const char *);
+int		 check_name(const char *, const char *);
 const char	*sig2name(int);
 const char	*find_cwd(void);
 const char	*find_home(void);
@@ -3374,7 +3375,7 @@ void	 screen_reset_hyperlinks(struct screen *);
 void	 screen_set_default_cursor(struct screen *, struct options *);
 void	 screen_set_cursor_style(u_int, enum screen_cursor_style *, int *);
 void	 screen_set_cursor_colour(struct screen *, int);
-int	 screen_set_title(struct screen *, const char *);
+int	 screen_set_title(struct screen *, const char *, const char *);
 int	 screen_set_path(struct screen *, const char *);
 void	 screen_push_title(struct screen *);
 void	 screen_pop_title(struct screen *);
@@ -3479,7 +3480,7 @@ void		 window_pane_stack_push(struct window_panes *,
 		     struct window_pane *);
 void		 window_pane_stack_remove(struct window_panes *,
 		     struct window_pane *);
-void		 window_set_name(struct window *, const char *);
+void		 window_set_name(struct window *, const char *, const char *);
 void		 window_add_ref(struct window *, const char *);
 void		 window_remove_ref(struct window *, const char *);
 void		 winlink_clear_flags(struct winlink *);

--- a/window.c
+++ b/window.c
@@ -401,11 +401,11 @@ window_remove_ref(struct window *w, const char *from)
 }
 
 void
-window_set_name(struct window *w, const char *new_name)
+window_set_name(struct window *w, const char *new_name, const char *forbid)
 {
 	char	*name;
 
-	name = clean_name(new_name, "#");
+	name = clean_name(new_name, forbid);
 	if (name != NULL) {
 		free(w->name);
 		w->name = name;
@@ -1059,7 +1059,7 @@ window_pane_create(struct window *w, u_int sx, u_int sy, u_int hlimit)
 	style_ranges_init(&wp->border_status_line.ranges);
 
 	if (gethostname(host, sizeof host) == 0)
-		screen_set_title(&wp->base, host);
+		screen_set_title(&wp->base, host, "");
 
 	return (wp);
 }


### PR DESCRIPTION
closes #5173

use nicholas's solution: reject invalid session, window names instead of rewrite: add `check_name` and use it _everywhere_ a command takes a name (session, window, pane title, buffer).

there's no way to reject escape sequences and automatic renames so those still modify silently,

2 open questions here:

1. buffer names keep `forbid=""` (from 746dd91e), so `{#,:,.}` are still allowed in them and only control chars get rejected. in other words, buffers end up reject-consistent but not character-level consistent with sessions/windows. **lmk if you want to rather forbid `#` in buffers too**
2. i normalized error messages as follows - this alright with you?
```
invalid session name: %s
invalid session group name: %s
invalid window name: %s
invalid pane title: %s
invalid buffer name: %s
```