### PR TITLE
Add new -h arg to choose-tree and choose-client to hide current pane in preview

### DIFF
--- a/cmd-choose-tree.c
+++ b/cmd-choose-tree.c
@@ -33,8 +33,8 @@ const struct cmd_entry cmd_choose_tree_entry = {
 	.name = "choose-tree",
 	.alias = NULL,
 
-	.args = { "F:f:GK:NO:rst:wyZ", 0, 1, cmd_choose_tree_args_parse },
-	.usage = "[-GNrswZ] [-F format] [-f filter] [-K key-format] "
+	.args = { "F:f:GhK:NO:rst:wyZ", 0, 1, cmd_choose_tree_args_parse },
+	.usage = "[-GhNrswZ] [-F format] [-f filter] [-K key-format] "
 		 "[-O sort-order] " CMD_TARGET_PANE_USAGE " [template]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -47,8 +47,8 @@ const struct cmd_entry cmd_choose_client_entry = {
 	.name = "choose-client",
 	.alias = NULL,
 
-	.args = { "F:f:K:NO:rt:yZ", 0, 1, cmd_choose_tree_args_parse },
-	.usage = "[-NrZ] [-F format] [-f filter] [-K key-format] "
+	.args = { "F:f:hK:NO:rt:yZ", 0, 1, cmd_choose_tree_args_parse },
+	.usage = "[-hNrZ] [-F format] [-f filter] [-K key-format] "
 		 "[-O sort-order] " CMD_TARGET_PANE_USAGE " [template]",
 
 	.target = { 't', CMD_FIND_PANE, 0 },

--- a/tmux.1
+++ b/tmux.1
@@ -2816,10 +2816,18 @@ specifies the format for each item in the list and
 a format for each shortcut key; both are evaluated once for each line.
 .Fl N
 starts without the preview or if given twice with the larger preview.
+.Fl h
+hides the pane that is in choose\-client mode.  Useful if opening
+choose\-client in a new\-pane (floating pane) to avoid showing an empty
+preview for the empty floating pane. For example:
+.Bd -literal -offset indent
+bind D 'new-pane -x50% -y50% -E; choose-client -h'
+.Ed
+.Pp
 This command works only if at least one client is attached.
 .It Xo
 .Ic choose\-tree
-.Op Fl GNrswyZ
+.Op Fl GhNrswyZ
 .Op Fl F Ar format
 .Op Fl f Ar filter
 .Op Fl K Ar key\-format
@@ -2909,6 +2917,14 @@ starts without the preview or if given twice with the larger preview.
 .Fl G
 includes all sessions in any session groups in the tree rather than only the
 first.
+.Fl h
+hides the pane that is in choose\-tree mode.  Useful if opening
+choose\-tree in a new\-pane (floating pane) to avoid showing an empty
+preview for the empty floating pane. For example:
+.Bd -literal -offset indent
+bind s 'new-pane -x50% -y50% -E; choose-tree -h'
+.Ed
+.Pp
 This command works only if at least one client is attached.
 .It Xo
 .Ic customize\-mode

--- a/window-client.c
+++ b/window-client.c
@@ -77,6 +77,7 @@ struct window_client_itemdata {
 
 struct window_client_modedata {
 	struct window_pane		 *wp;
+	int				  hide_preview_this_pane;
 
 	struct mode_tree_data		 *data;
 	char				 *format;
@@ -162,9 +163,10 @@ window_client_build(void *modedata, struct sort_criteria *sort_crit,
 }
 
 static void
-window_client_draw(__unused void *modedata, void *itemdata,
+window_client_draw(void *modedata, void *itemdata,
     struct screen_write_ctx *ctx, u_int sx, u_int sy)
 {
+	struct window_client_modedata	*data = modedata;
 	struct window_client_itemdata	*item = itemdata;
 	struct client			*c = item->c;
 	struct screen			*s = ctx->s;
@@ -174,6 +176,12 @@ window_client_draw(__unused void *modedata, void *itemdata,
 	if (c->session == NULL || (c->flags & CLIENT_UNATTACHEDFLAGS))
 		return;
 	wp = c->session->curw->window->active;
+	if (data->hide_preview_this_pane && wp == data->wp) {
+		if (!TAILQ_EMPTY(&c->session->curw->window->last_panes))
+			wp = TAILQ_FIRST(&c->session->curw->window->last_panes);
+		else
+			wp = NULL;
+	}
 
 	lines = status_line_size(c);
 	if (lines >= sy)
@@ -184,7 +192,8 @@ window_client_draw(__unused void *modedata, void *itemdata,
 		at = 0;
 
 	screen_write_cursormove(ctx, cx, cy + at, 0);
-	screen_write_preview(ctx, &wp->base, sx, sy - 2 - lines);
+	if (wp != NULL)
+		screen_write_preview(ctx, &wp->base, sx, sy - 2 - lines);
 
 	if (at != 0)
 		screen_write_cursormove(ctx, cx, cy + 2, 0);
@@ -270,6 +279,7 @@ window_client_init(struct window_mode_entry *wme,
 
 	wme->data = data = xcalloc(1, sizeof *data);
 	data->wp = wp;
+	data->hide_preview_this_pane = args != NULL && args_has(args, 'h');
 
 	if (args == NULL || !args_has(args, 'F'))
 		data->format = xstrdup(WINDOW_CLIENT_DEFAULT_FORMAT);

--- a/window-tree.c
+++ b/window-tree.c
@@ -107,6 +107,7 @@ struct window_tree_modedata {
 	struct window_pane		 *wp;
 	int				  dead;
 	int				  references;
+	int				  hide_preview_this_pane;
 
 	struct mode_tree_data		 *data;
 	char				 *format;
@@ -289,6 +290,8 @@ window_tree_build_window(struct session *s, struct winlink *wl,
 	if (n == 0)
 		goto empty;
 	for (i = 0; i < n; i++) {
+		if (data->hide_preview_this_pane && l[i] == data->wp)
+			continue;
 		if (window_tree_filter_pane(s, wl, l[i], filter))
 			window_tree_build_pane(s, wl, l[i], modedata, mti);
 	}
@@ -580,6 +583,10 @@ window_tree_draw_window(struct window_tree_modedata *data, struct session *s,
 	struct options		*oo;
 
 	total = window_count_panes(w, 1);
+	if (data->hide_preview_this_pane && data->wp->window == w)
+		total--;
+	if (total == 0)
+		return;
 
 	if (sx / total < 24) {
 		visible = sx / 24;
@@ -590,6 +597,8 @@ window_tree_draw_window(struct window_tree_modedata *data, struct session *s,
 
 	current = 0;
 	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (data->hide_preview_this_pane && wp == data->wp)
+			continue;
 		if (wp == w->active)
 			break;
 		current++;
@@ -653,6 +662,8 @@ window_tree_draw_window(struct window_tree_modedata *data, struct session *s,
 
 	i = loop = 0;
 	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (data->hide_preview_this_pane && wp == data->wp)
+			continue;
 		if (loop == end)
 			break;
 		if (loop < start) {
@@ -704,6 +715,7 @@ static void
 window_tree_draw(void *modedata, void *itemdata, struct screen_write_ctx *ctx,
     u_int sx, u_int sy)
 {
+	struct window_tree_modedata	*data = modedata;
 	struct window_tree_itemdata	*item = itemdata;
 	struct session			*sp;
 	struct winlink			*wl;
@@ -723,7 +735,8 @@ window_tree_draw(void *modedata, void *itemdata, struct screen_write_ctx *ctx,
 		window_tree_draw_window(modedata, sp, wl, ctx, sx, sy);
 		break;
 	case WINDOW_TREE_PANE:
-		screen_write_preview(ctx, &wp->base, sx, sy);
+		if (!data->hide_preview_this_pane || wp != data->wp)
+			screen_write_preview(ctx, &wp->base, sx, sy);
 		break;
 	}
 }
@@ -932,6 +945,7 @@ window_tree_init(struct window_mode_entry *wme, struct cmd_find_state *fs,
 	else
 		data->command = xstrdup(args_string(args, 0));
 	data->squash_groups = !args_has(args, 'G');
+	data->hide_preview_this_pane = args_has(args, 'h');
 	if (args_has(args, 'y'))
 		data->prompt_flags = PROMPT_ACCEPT;
 


### PR DESCRIPTION
In `choose-tree` and `choose-client`, add new -h arg to omit the current pane from being in this list.  This is useful if you bind it to something like this:

```
tmux bind S 'new-pane  -x50% -y50% -E; choose-tree -h'
```
or
```
tmux bind S 'new-pane  -x50% -y50% -E; choose-client -h'
```

