### PR TITLE
Refresh copy mode from the pane incrementally instead of recloning the whole history.

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -292,7 +292,7 @@ grid_free_line(struct grid *gd, u_int py)
 }
 
 /* Free several lines. */
-static void
+void
 grid_free_lines(struct grid *gd, u_int py, u_int ny)
 {
 	u_int	yy;
@@ -319,6 +319,10 @@ grid_create(u_int sx, u_int sy, u_int hlimit)
 	gd->hscrolled = 0;
 	gd->hsize = 0;
 	gd->hlimit = hlimit;
+
+	gd->scroll_added = 0;
+	gd->scroll_collected = 0;
+	gd->scroll_generation = 0;
 
 	if (gd->sy != 0)
 		gd->linedata = xcalloc(gd->sy, sizeof *gd->linedata);
@@ -405,6 +409,7 @@ grid_collect_history(struct grid *gd, int all)
 	grid_trim_history(gd, ny);
 
 	gd->hsize -= ny;
+	gd->scroll_collected += ny;
 	if (gd->hscrolled > gd->hsize)
 		gd->hscrolled = gd->hsize;
 }
@@ -442,6 +447,7 @@ grid_scroll_history(struct grid *gd, u_int bg)
 	grid_compact_line(&gd->linedata[gd->hsize]);
 	gd->linedata[gd->hsize].time = current_time;
 	gd->hsize++;
+	gd->scroll_added++;
 }
 
 /* Clear the history. */
@@ -452,6 +458,7 @@ grid_clear_history(struct grid *gd)
 
 	gd->hscrolled = 0;
 	gd->hsize = 0;
+	gd->scroll_generation++;
 
 	gd->linedata = xreallocarray(gd->linedata, gd->sy,
 	    sizeof *gd->linedata);
@@ -489,6 +496,7 @@ grid_scroll_history_region(struct grid *gd, u_int upper, u_int lower, u_int bg)
 	/* Move the history offset down over the line. */
 	gd->hscrolled++;
 	gd->hsize++;
+	gd->scroll_added++;
 }
 
 /* Expand line to fit to cell. */
@@ -1510,6 +1518,7 @@ grid_reflow(struct grid *gd, u_int sx)
 	free(gd->linedata);
 	gd->linedata = target->linedata;
 	free(target);
+	gd->scroll_generation++;
 }
 
 /* Convert to position based on wrapped lines. */

--- a/tmux.h
+++ b/tmux.h
@@ -871,6 +871,10 @@ struct grid {
 	u_int			 hsize;
 	u_int			 hlimit;
 
+	u_int			 scroll_added;
+	u_int			 scroll_collected;
+	u_int			 scroll_generation;
+
 	struct grid_line	*linedata;
 };
 
@@ -3208,6 +3212,7 @@ int	 grid_cells_look_equal(const struct grid_cell *,
 	     const struct grid_cell *);
 struct grid *grid_create(u_int, u_int, u_int);
 void	 grid_destroy(struct grid *);
+void	 grid_free_lines(struct grid *, u_int, u_int);
 int	 grid_compare(struct grid *, struct grid *);
 void	 grid_collect_history(struct grid *, int);
 void	 grid_remove_history(struct grid *, u_int );

--- a/window-copy.c
+++ b/window-copy.c
@@ -255,6 +255,10 @@ struct window_copy_mode_data {
 	int		 backing_written; /* backing display started */
 	struct input_ctx *ictx;
 
+	u_int		 sync_added;	/* snapshot of backing grid counters */
+	u_int		 sync_collected;
+	u_int		 sync_generation;
+
 	int		 viewmode;	/* view mode entered */
 
 	u_int		 oy;		/* number of lines scrolled up */
@@ -424,6 +428,116 @@ window_copy_clone_screen(struct screen *src, struct screen *hint, u_int *cx,
 	return (dst);
 }
 
+/*
+ * Snapshot the source grid's monotonic scroll counters so the next incremental
+ * sync can tell how much history was added or collected since this point.
+ */
+static void
+window_copy_sync_snapshot(struct window_copy_mode_data *data, struct grid *src)
+{
+	data->sync_added = src->scroll_added;
+	data->sync_collected = src->scroll_collected;
+	data->sync_generation = src->scroll_generation;
+}
+
+/*
+ * Reconcile the backing screen with the live pane grid in place, copying only
+ * the history that scrolled in or was collected since the last snapshot rather
+ * than cloning the whole scrollback. The result is identical to a fresh
+ * window_copy_clone_screen, so the caller repositions and redraws the same way
+ * for both paths. Returns 1 on success, or 0 if the caller must fall back to a
+ * full clone (different source pane, geometry or generation change, or counter
+ * deltas that do not add up).
+ */
+static int
+window_copy_sync_backing(struct window_mode_entry *wme)
+{
+	struct window_copy_mode_data	*data = wme->data;
+	struct window_pane		*wp = wme->swp;
+	struct screen			*src = &wp->base;
+	struct screen			*dst = data->backing;
+	struct grid			*sg = src->grid;
+	struct grid			*dg = dst->grid;
+	u_int				 sy = sg->sy;
+	u_int				 old_hsize = dg->hsize;
+	u_int				 new_hsize = sg->hsize;
+	u_int				 added, collected, kept;
+
+	/*
+	 * Only a pane's own live grid is tracked incrementally. A different
+	 * source pane (copy-mode -s) goes through clone_screen, which also
+	 * trims trailing blank lines that this path does not.
+	 */
+	if (data->viewmode || wme->swp != wme->wp)
+		return (0);
+
+	/* Indices only line up at the same size and generation. */
+	if (sg->sx != dg->sx || sg->sy != dg->sy ||
+	    sg->scroll_generation != data->sync_generation)
+		return (0);
+
+	added = sg->scroll_added - data->sync_added;
+	collected = sg->scroll_collected - data->sync_collected;
+
+	/*
+	 * Reject anything that does not balance: counter wrap, a history-limit
+	 * change that collected past the snapshot, or arithmetic that does not
+	 * reproduce the new history size.
+	 */
+	if (added > (u_int)INT_MAX || collected > (u_int)INT_MAX ||
+	    collected > old_hsize || old_hsize + added < collected ||
+	    old_hsize + added - collected != new_hsize)
+		return (0);
+
+	kept = old_hsize - collected;
+
+	if (added == 0 && collected == 0) {
+		/* History is unchanged; only the viewport can have mutated. */
+		grid_duplicate_lines(dg, dg->hsize, sg, sg->hsize, sy);
+	} else {
+		/* Drop the oldest lines and shift the rest down. */
+		if (collected > 0) {
+			grid_free_lines(dg, 0, collected);
+			memmove(&dg->linedata[0], &dg->linedata[collected],
+			    (old_hsize + sy - collected) * sizeof *dg->linedata);
+			memset(&dg->linedata[old_hsize + sy - collected], 0,
+			    collected * sizeof *dg->linedata);
+		}
+
+		/* Resize linedata to the new history plus viewport. */
+		if (new_hsize + sy != old_hsize + sy - collected) {
+			dg->linedata = xreallocarray(dg->linedata,
+			    new_hsize + sy, sizeof *dg->linedata);
+			memset(&dg->linedata[old_hsize + sy - collected], 0,
+			    (new_hsize - kept) * sizeof *dg->linedata);
+		}
+
+		/*
+		 * Set hsize before copying so grid_duplicate_lines does not
+		 * clamp the count to the old, smaller grid size.
+		 */
+		dg->hsize = new_hsize;
+
+		/* Copy the newly scrolled history, then refresh the viewport. */
+		if (added > 0)
+			grid_duplicate_lines(dg, kept, sg, kept, added);
+		grid_duplicate_lines(dg, new_hsize, sg, new_hsize, sy);
+	}
+
+	dg->hscrolled = sg->hscrolled;
+
+	/* Match clone_screen's backing cursor placement. */
+	if (src->cy > dg->sy - 1) {
+		dst->cx = 0;
+		dst->cy = dg->sy - 1;
+	} else {
+		dst->cx = src->cx;
+		dst->cy = src->cy;
+	}
+
+	return (1);
+}
+
 static struct window_copy_mode_data *
 window_copy_common_init(struct window_mode_entry *wme)
 {
@@ -475,6 +589,7 @@ window_copy_init(struct window_mode_entry *wme,
 	data = window_copy_common_init(wme);
 	data->backing = window_copy_clone_screen(base, &data->screen, &cx, &cy,
 	    wme->swp != wme->wp);
+	window_copy_sync_snapshot(data, base->grid);
 
 	data->cx = cx;
 	if (cy < screen_hsize(data->backing)) {
@@ -2800,10 +2915,12 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 		data->oy = screen_hsize(data->backing);
 	oy_from_top = screen_hsize(data->backing) - data->oy;
 
-	screen_free(data->backing);
-	free(data->backing);
-	data->backing = window_copy_clone_screen(&wp->base, &data->screen, NULL,
-	    NULL, wme->swp != wme->wp);
+	if (!window_copy_sync_backing(wme)) {
+		screen_free(data->backing);
+		free(data->backing);
+		data->backing = window_copy_clone_screen(&wp->base,
+		    &data->screen, NULL, NULL, wme->swp != wme->wp);
+	}
 
 	if (oy_from_top <= screen_hsize(data->backing))
 		data->oy = screen_hsize(data->backing) - oy_from_top;
@@ -2812,6 +2929,7 @@ window_copy_cmd_refresh_from_pane(struct window_copy_cmd_state *cs)
 		data->oy = screen_hsize(data->backing);
 	}
 
+	window_copy_sync_snapshot(data, wp->base.grid);
 	window_copy_size_changed(wme);
 	return (WINDOW_COPY_CMD_REDRAW);
 }


### PR DESCRIPTION
Superseded by #5165, which folds this incremental backing-grid sync together with the copy-mode auto-refresh feature.