### PR TITLE
window-tree: fix squash-groups skipping every session

### DIFF
--- a/window-tree.c
+++ b/window-tree.c
@@ -367,8 +367,8 @@ window_tree_build(void *modedata, struct sort_criteria *sort_crit,
 	l = sort_get_sessions(&n, sort_crit);
 	if (n == 0)
 		return;
-	s = l[n - 1];
 	for (i = 0; i < n; i++) {
+		s = l[i];
 		if (data->squash_groups &&
 		    (sg = session_group_contains(s)) != NULL) {
 			if ((sg == current && s != data->fs.s) ||


### PR DESCRIPTION
window_tree_build() sets `s = l[n - 1]` once before the loop and then tests
session_group_contains(s) on every iteration instead of the current session
l[i]:

    s = l[n - 1];
    for (i = 0; i < n; i++) {
        if (data->squash_groups &&
            (sg = session_group_contains(s)) != NULL) {
            if ((sg == current && s != data->fs.s) ||
                (sg != current && s != TAILQ_FIRST(&sg->sessions)))
                continue;
        }
        window_tree_build_session(l[i], modedata, sort_crit, filter);
    }

When the last session (l[n-1]) is a grouped, non-representative member, the
squash check is true on every iteration, so `continue` skips building every
session and choose-tree shows an empty (blank) tree. (no_matches rebuilds via
the same path, so it stays empty.)

Reproduces with grouped sessions and no config:

    tmux -f /dev/null new-session -d -s main
    tmux -f /dev/null new-session -d -s g1 -t main
    tmux -f /dev/null new-session -d -s g2 -t main
    tmux -f /dev/null attach -t main   # then prefix + s -> blank
    # choose-tree -sG (squash disabled) renders fine; so does 3.6b.

Fix: assign s = l[i] inside the loop.