### PR TITLE
feat(floating_panes): `resize-pane` can now resize floating panes.

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -40,7 +40,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.name = "resize-pane",
 	.alias = "resizep",
 
-	.args = { "DLMRTt:Ux:y:Z", 0, 1, NULL },
+	.args = { "D::L::MR::Tt:U::x:y:Z", 0, 1, NULL },
 	.usage = "[-DLMRTUZ] [-x width] [-y height] " CMD_TARGET_PANE_USAGE " "
 		 "[adjustment]",
 
@@ -58,10 +58,14 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
-	const char		*errstr;
+	struct layout_cell	*lc = wp->layout_cell;
+	enum layout_type	 type;
+	const char		*errstr, *argval;
 	char			*cause;
-	u_int			 adjust;
-	int			 x, y, status;
+	char			 flag, flags[4] = { 'U', 'D', 'L', 'R' };
+	u_int			 adjust, shift = 0;
+	int			 x, y, status, neg;
+	long unsigned		 i;
 	struct grid		*gd = wp->base.grid;
 
 	if (args_has(args, 'T')) {
@@ -89,16 +93,6 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	server_unzoom_window(w);
 
-	if (args_count(args) == 0)
-		adjust = 1;
-	else {
-		adjust = strtonum(args_string(args, 0), 1, INT_MAX, &errstr);
-		if (errstr != NULL) {
-			cmdq_error(item, "adjustment %s", errstr);
-			return (CMD_RETURN_ERROR);
-		}
-	}
-
 	if (args_has(args, 'x')) {
 		x = args_percentage(args, 'x', 0, INT_MAX, w->sx, &cause);
 		if (cause != NULL) {
@@ -106,7 +100,10 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
-		layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
+		if (window_pane_is_floating(wp))
+			lc->sx = x;
+		else
+			layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
 	}
 	if (args_has(args, 'y')) {
 		y = args_percentage(args, 'y', 0, INT_MAX, w->sy, &cause);
@@ -126,18 +123,66 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 				y++;
 			break;
 		}
-		layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
+		if (window_pane_is_floating(wp))
+			lc->sy = y;
+		else
+			layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
 	}
 
-	if (args_has(args, 'L'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, -adjust, 1);
-	else if (args_has(args, 'R'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, adjust, 1);
-	else if (args_has(args, 'U'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, -adjust, 1);
-	else if (args_has(args, 'D'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, adjust, 1);
-	server_redraw_window(wl->window);
+	for (i = 0; i < nitems(flags); i++) {
+		flag = flags[i];
+		if (!args_has(args, flag))
+			continue;
+
+		argval = args_get(args, flag);
+		if (argval == NULL)
+			argval = "1";
+
+		neg = 0;
+		if (argval[0] == '-') {
+			argval++;
+			neg = 1;
+		}
+
+		adjust = strtonum(argval, 1, INT_MAX, &errstr);
+		if (errstr != NULL) {
+			cmdq_error(item, "adjustment %s", errstr);
+			return (CMD_RETURN_ERROR);
+		}
+
+		if (neg)
+			adjust = -adjust;
+
+		type = LAYOUT_TOPBOTTOM;
+		if (flag == 'L' || flag == 'R')
+			type = LAYOUT_LEFTRIGHT;
+
+		if (window_pane_is_floating(wp)) {
+			shift = 0;
+			if (flag == 'L' || flag == 'U')
+				shift = 1;
+
+			if (type == LAYOUT_LEFTRIGHT) {
+				lc->sx += adjust;
+				if (shift)
+					lc->xoff -= adjust;
+			} else {
+				lc->sy += adjust;
+				if (shift)
+					lc->yoff -= adjust;
+			}
+		} else {
+			if (flag == 'L' || flag == 'U')
+				adjust = -adjust;
+			layout_resize_pane(wp, type, adjust, 1);
+		}
+	}
+
+	if (lc->parent != NULL)
+		layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
 
 	return (CMD_RETURN_NORMAL);
 }


### PR DESCRIPTION
See title.

This is part of the way to being to supporting middle split resizing.