### PR TITLE
feat(master): resize floating panes

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -41,8 +41,8 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.alias = "resizep",
 
 	.args = { "D::L::MR::Tt:U::x:y:Z", 0, 1, NULL },
-	.usage = "[-DLMRTUZ] [-x width] [-y height] " CMD_TARGET_PANE_USAGE " "
-		 "[adjustment]",
+	.usage = "[-MTZ] [-U up] [-D down] [-L left] [-R right] "
+		 "[-x width] [-y height] " CMD_TARGET_PANE_USAGE,
 
 	.target = { 't', CMD_FIND_PANE, 0 },
 

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -41,7 +41,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.alias = "resizep",
 
 	.args = { "D::L::MR::Tt:U::x:y:Z", 0, 1, NULL },
-	.usage = "[-MTZ] [-U up] [-D down] [-L left] [-R right] "
+	.usage = "[-MTZ] [-U lines] [-D lines] [-L columns] [-R columns] "
 		 "[-x width] [-y height] " CMD_TARGET_PANE_USAGE,
 
 	.target = { 't', CMD_FIND_PANE, 0 },
@@ -61,10 +61,10 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct layout_cell	*lc = wp->layout_cell;
 	enum layout_type	 type;
 	const char		*errstr, *argval;
-	char			*cause;
-	char			 flag, flags[4] = { 'U', 'D', 'L', 'R' };
-	u_int			 adjust, shift = 0;
-	int			 x, y, status;
+	const char		 flags[4] = { 'U', 'D', 'L', 'R' };
+	char			*cause = NULL, flag;
+	u_int			 opposite = 0;
+	int			 adjust, x, y, status;
 	long unsigned		 i;
 	struct grid		*gd = wp->base.grid;
 
@@ -72,7 +72,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 		if (!TAILQ_EMPTY(&wp->modes))
 			return (CMD_RETURN_NORMAL);
 		adjust = screen_size_y(&wp->base) - 1 - wp->base.cy;
-		if (adjust > gd->hsize)
+		if (adjust > (int)gd->hsize)
 			adjust = gd->hsize;
 		grid_remove_history(gd, adjust);
 		wp->base.cy += adjust;
@@ -100,9 +100,15 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
-		if (window_pane_is_floating(wp))
-			lc->sx = x;
-		else
+		if (window_pane_is_floating(wp)) {
+			layout_resize_floating_pane_to(wp, LAYOUT_LEFTRIGHT, x,
+			    &cause);
+			if (cause != NULL) {
+				cmdq_error(item, "size %s", cause);
+				free(cause);
+				return (CMD_RETURN_ERROR);
+			}
+		} else
 			layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
 	}
 	if (args_has(args, 'y')) {
@@ -123,9 +129,15 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 				y++;
 			break;
 		}
-		if (window_pane_is_floating(wp))
-			lc->sy = y;
-		else
+		if (window_pane_is_floating(wp)) {
+			layout_resize_floating_pane_to(wp, LAYOUT_TOPBOTTOM, y,
+			    &cause);
+			if (cause != NULL) {
+				cmdq_error(item, "size %s", cause);
+				free(cause);
+				return (CMD_RETURN_ERROR);
+			}
+		} else
 			layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
 	}
 
@@ -149,18 +161,16 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			type = LAYOUT_LEFTRIGHT;
 
 		if (window_pane_is_floating(wp)) {
-			shift = 0;
 			if (flag == 'L' || flag == 'U')
-				shift = 1;
+				opposite = 1;
 
-			if (type == LAYOUT_LEFTRIGHT) {
-				lc->sx += adjust;
-				if (shift)
-					lc->xoff -= adjust;
-			} else {
-				lc->sy += adjust;
-				if (shift)
-					lc->yoff -= adjust;
+			layout_resize_floating_pane(wp, type, adjust, opposite,
+			    &cause);
+			if (cause != NULL) {
+				cmdq_error(item, "floating adjust %s", adjust,
+				    cause);
+				free(cause);
+				return (CMD_RETURN_ERROR);
 			}
 		} else {
 			if (flag == 'L' || flag == 'U')

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -40,7 +40,7 @@ const struct cmd_entry cmd_resize_pane_entry = {
 	.name = "resize-pane",
 	.alias = "resizep",
 
-	.args = { "DLMRTt:Ux:y:Z", 0, 1, NULL },
+	.args = { "D::L::MR::Tt:U::x:y:Z", 0, 1, NULL },
 	.usage = "[-DLMRTUZ] [-x width] [-y height] " CMD_TARGET_PANE_USAGE " "
 		 "[adjustment]",
 
@@ -58,10 +58,14 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp;
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
-	const char		*errstr;
+	struct layout_cell	*lc = wp->layout_cell;
+	enum layout_type	 type;
+	const char		*errstr, *argval;
 	char			*cause;
-	u_int			 adjust;
+	char			 flag, flags[4] = { 'U', 'D', 'L', 'R' };
+	u_int			 adjust, shift = 0;
 	int			 x, y, status;
+	long unsigned		 i;
 	struct grid		*gd = wp->base.grid;
 
 	if (args_has(args, 'T')) {
@@ -89,16 +93,6 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	server_unzoom_window(w);
 
-	if (args_count(args) == 0)
-		adjust = 1;
-	else {
-		adjust = strtonum(args_string(args, 0), 1, INT_MAX, &errstr);
-		if (errstr != NULL) {
-			cmdq_error(item, "adjustment %s", errstr);
-			return (CMD_RETURN_ERROR);
-		}
-	}
-
 	if (args_has(args, 'x')) {
 		x = args_percentage(args, 'x', 0, INT_MAX, w->sx, &cause);
 		if (cause != NULL) {
@@ -106,7 +100,10 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
-		layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
+		if (window_pane_is_floating(wp))
+			lc->sx = x;
+		else
+			layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
 	}
 	if (args_has(args, 'y')) {
 		y = args_percentage(args, 'y', 0, INT_MAX, w->sy, &cause);
@@ -126,18 +123,57 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 				y++;
 			break;
 		}
-		layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
+		if (window_pane_is_floating(wp))
+			lc->sy = y;
+		else
+			layout_resize_pane_to(wp, LAYOUT_TOPBOTTOM, y);
 	}
 
-	if (args_has(args, 'L'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, -adjust, 1);
-	else if (args_has(args, 'R'))
-		layout_resize_pane(wp, LAYOUT_LEFTRIGHT, adjust, 1);
-	else if (args_has(args, 'U'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, -adjust, 1);
-	else if (args_has(args, 'D'))
-		layout_resize_pane(wp, LAYOUT_TOPBOTTOM, adjust, 1);
-	server_redraw_window(wl->window);
+	for (i = 0; i < nitems(flags); i++) {
+		flag = flags[i];
+		if (!args_has(args, flag))
+			continue;
+
+		argval = args_get(args, flag);
+		if (argval == NULL)
+			argval = "1";
+
+		adjust = strtonum(argval, INT_MIN, INT_MAX, &errstr);
+		if (errstr != NULL) {
+			cmdq_error(item, "adjustment %s", errstr);
+			return (CMD_RETURN_ERROR);
+		}
+
+		type = LAYOUT_TOPBOTTOM;
+		if (flag == 'L' || flag == 'R')
+			type = LAYOUT_LEFTRIGHT;
+
+		if (window_pane_is_floating(wp)) {
+			shift = 0;
+			if (flag == 'L' || flag == 'U')
+				shift = 1;
+
+			if (type == LAYOUT_LEFTRIGHT) {
+				lc->sx += adjust;
+				if (shift)
+					lc->xoff -= adjust;
+			} else {
+				lc->sy += adjust;
+				if (shift)
+					lc->yoff -= adjust;
+			}
+		} else {
+			if (flag == 'L' || flag == 'U')
+				adjust = -adjust;
+			layout_resize_pane(wp, type, adjust, 1);
+		}
+	}
+
+	if (lc->parent != NULL)
+		layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
 
 	return (CMD_RETURN_NORMAL);
 }

--- a/layout.c
+++ b/layout.c
@@ -687,6 +687,61 @@ layout_resize_pane_to(struct window_pane *wp, enum layout_type type,
 }
 
 void
+layout_resize_floating_pane_to(struct window_pane *wp, enum layout_type type,
+    int size, char **cause)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (~lc->flags & LAYOUT_CELL_FLOATING) {
+		*cause = xstrdup("pane is not floating");
+		return;
+	}
+
+	if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
+		*cause = xstrdup("invalid size");
+		return;
+	}
+
+	if (type == LAYOUT_TOPBOTTOM)
+		lc->sy = size;
+	else
+		lc->sx = size;
+}
+
+void
+layout_resize_floating_pane(struct window_pane *wp, enum layout_type type,
+    int change, int opposite, char **cause)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+	int			 size;
+
+	if (~lc->flags & LAYOUT_CELL_FLOATING) {
+		*cause = xstrdup("pane is not floating");
+		return;
+	}
+
+	if (type == LAYOUT_TOPBOTTOM) {
+		size = lc->sy + change;
+		if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
+			*cause = xstrdup("invalid change");
+			return;
+		}
+		lc->sy = size;
+		if (opposite)
+			lc->yoff -= change;
+	} else {
+		size = lc->sx + change;
+		if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
+			*cause = xstrdup("invalid change");
+			return;
+		}
+		lc->sx = size;
+		if (opposite)
+			lc->xoff -= change;
+	}
+}
+
+void
 layout_resize_layout(struct window *w, struct layout_cell *lc,
     enum layout_type type, int change, int opposite)
 {
@@ -1406,6 +1461,15 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 				oy = 2;
 		}
 		w->last_new_pane_y = oy;
+	}
+
+	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
+		*cause = xstrdup("invalid width");
+		return (NULL);
+	}
+	if (sy < PANE_MINIMUM || sy > PANE_MAXIMUM) {
+		*cause = xstrdup("invalid height");
+		return (NULL);
 	}
 
 	lcnew = layout_floating_pane(w, sx, sy, ox, oy);

--- a/tmux.1
+++ b/tmux.1
@@ -3620,7 +3620,7 @@ if specified, to
 .Op Fl y Ar height
 .Xc
 .D1 Pq alias: Ic resizep
-Resize a pane, up, down, left or right by specified adjustment with
+Resize a pane, up, down, left or right by a specified adjustment with
 .Fl U ,
 .Fl D ,
 .Fl L

--- a/tmux.1
+++ b/tmux.1
@@ -3612,10 +3612,10 @@ if specified, to
 .It Xo Ic resize\-pane
 .Op Fl MTZ
 .Op Fl t Ar target\-pane
-.Op Fl U Ar up
-.Op Fl D Ar down
-.Op Fl L Ar left
-.Op Fl R Ar right
+.Op Fl U Ar lines
+.Op Fl D Ar lines
+.Op Fl L Ar columns
+.Op Fl R Ar columns
 .Op Fl x Ar width
 .Op Fl y Ar height
 .Xc
@@ -3632,11 +3632,19 @@ with
 .Fl x
 or
 .Fl y .
-The adjustment is given in lines or columns (the default is 1);
+The adjustment is given in
+.Ar lines
+or
+.Ar columns
+(the default is 1);
 .Fl x
 and
 .Fl y
-may be a given as a number of lines or columns or followed by
+may be a given as a number of
+.Ar lines
+or
+.Ar columns
+or followed by
 .Ql %
 for a percentage of the window size (for example
 .Ql \-x 10% ) .

--- a/tmux.1
+++ b/tmux.1
@@ -3610,16 +3610,17 @@ if specified, to
 .Ar new\-name .
 .Tg resizep
 .It Xo Ic resize\-pane
-.Op Fl DLMRTUZ
+.Op Fl MTZ
 .Op Fl t Ar target\-pane
+.Op Fl U Ar up
+.Op Fl D Ar down
+.Op Fl L Ar left
+.Op Fl R Ar right
 .Op Fl x Ar width
 .Op Fl y Ar height
-.Op Ar adjustment
 .Xc
 .D1 Pq alias: Ic resizep
-Resize a pane, up, down, left or right by
-.Ar adjustment
-with
+Resize a pane, up, down, left or right by specified adjustment with
 .Fl U ,
 .Fl D ,
 .Fl L
@@ -3631,9 +3632,7 @@ with
 .Fl x
 or
 .Fl y .
-The
-.Ar adjustment
-is given in lines or columns (the default is 1);
+The adjustment is given in lines or columns (the default is 1);
 .Fl x
 and
 .Fl y
@@ -3641,6 +3640,15 @@ may be a given as a number of lines or columns or followed by
 .Ql %
 for a percentage of the window size (for example
 .Ql \-x 10% ) .
+If
+.Ar target\-pane
+is floating,
+.Fl U ,
+.Fl D ,
+.Fl L ,
+and
+.Fl R
+target their respective borders, and negative values may be given.
 With
 .Fl Z ,
 the active pane is toggled between zoomed (occupying the whole of the window)

--- a/tmux.h
+++ b/tmux.h
@@ -96,8 +96,9 @@ struct winlink;
 #define TMUX_LOCK_CMD "lock -np"
 #endif
 
-/* Minimum layout cell size, NOT including border lines. */
+/* Minimum and Maximum layout cell size, NOT including border lines. */
 #define PANE_MINIMUM 1
+#define PANE_MAXIMUM 10000
 
 /* Minimum and maximum window size. */
 #define WINDOW_MINIMUM PANE_MINIMUM
@@ -3541,6 +3542,10 @@ void		 layout_resize_pane(struct window_pane *, enum layout_type,
 		     int, int);
 void		 layout_resize_pane_to(struct window_pane *, enum layout_type,
 		     u_int);
+void		 layout_resize_floating_pane(struct window_pane *,
+		     enum layout_type, int, int, char **);
+void		 layout_resize_floating_pane_to(struct window_pane *,
+		     enum layout_type, int, char **);
 void		 layout_assign_pane(struct layout_cell *, struct window_pane *,
 		     int);
 struct layout_cell *layout_split_pane(struct window_pane *, enum layout_type,


### PR DESCRIPTION
`resize-pane` can not affect floating panes. The boundaries are specified with `U/D/L/R` and negative values may be given.