### PR TITLE
fix(floating_panes): `swap-pane` can now affect floating panes.

### DIFF
--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -79,12 +79,6 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (src_wp == dst_wp)
 		goto out;
 
-	if (window_pane_is_floating(src_wp) &&
-	    window_pane_is_floating(dst_wp)) {
-		cmdq_error(item, "cannot swap floating panes");
-		return (CMD_RETURN_ERROR);
-	}
-
 	server_client_remove_pane(src_wp);
 	server_client_remove_pane(dst_wp);
 

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -79,7 +79,7 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (src_wp == dst_wp)
 		goto out;
 
-	if (window_pane_is_floating(src_wp) ||
+	if (window_pane_is_floating(src_wp) &&
 	    window_pane_is_floating(dst_wp)) {
 		cmdq_error(item, "cannot swap floating panes");
 		return (CMD_RETURN_ERROR);
@@ -114,10 +114,6 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->layout_cell = src_lc;
 	dst_lc->wp = src_wp;
 	src_wp->layout_cell = dst_lc;
-	if (window_pane_is_floating(src_wp) != window_pane_is_floating(dst_wp)) {
-		src_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
-		dst_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
-	}
 
 	src_wp->window = dst_w;
 	options_set_parent(src_wp->options, dst_w->options);


### PR DESCRIPTION
It seems like the new layout logic works with floating panes in `swap-pane`. I couldn't get it to break.

**EDIT**: as for the second commit message, I noticed that the guard had an `&&` previously. Is there a reason to restrict swapping two floating panes?