### PR TITLE
Do not write to the tty while a pane synchronized update is in progress

### DIFF
--- a/input.c
+++ b/input.c
@@ -1959,9 +1959,7 @@ input_csi_dispatch_rm_private(struct input_ctx *ictx)
 				ictx->wp->flags &= ~PANE_THEMECHANGED;
 			break;
 		case 2026:	/* synchronized output */
-			screen_write_stop_sync(ictx->wp);
-			if (ictx->wp != NULL)
-				ictx->wp->flags |= PANE_REDRAW;
+			screen_write_end_sync(sctx);
 			break;
 		default:
 			log_debug("%s: unknown '%c'", __func__, ictx->ch);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1330,8 +1330,17 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 	 *   pane_y = window_y - wp->yoff
 	 */
 
-	if (wp->base.mode & MODE_SYNC)
-		screen_write_stop_sync(wp);
+	/*
+	 * If the pane is in the middle of a synchronized update, do not
+	 * draw it now: the screen may be partially updated (for example
+	 * just cleared), so drawing it would show a partial update. ESU
+	 * (or the sync timeout) sets PANE_REDRAW, so the pane will be
+	 * drawn when the update ends.
+	 */
+	if (wp->base.mode & MODE_SYNC) {
+		wp->flags |= PANE_REDRAW;
+		return;
+	}
 
 	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -1009,6 +1009,29 @@ screen_write_stop_sync(struct window_pane *wp)
 	log_debug("%s: %%%u stopped sync mode", __func__, wp->id);
 }
 
+/*
+ * Stop sync mode in response to ESU from the application. Any collected
+ * items are discarded first (the flush takes the discard path while
+ * MODE_SYNC is still set): they have already been applied to the screen
+ * and the full redraw scheduled below will draw them. If they were left
+ * queued, they would be flushed to the tty at the end of input
+ * processing, outside the redraw's synchronized update block, so the
+ * terminal would still paint a partial update.
+ */
+void
+screen_write_end_sync(struct screen_write_ctx *ctx)
+{
+	struct window_pane	*wp = ctx->wp;
+
+	if (wp == NULL)
+		return;
+
+	if (wp->base.mode & MODE_SYNC)
+		screen_write_collect_flush(ctx, 0, __func__);
+	screen_write_stop_sync(wp);
+	wp->flags |= PANE_REDRAW;
+}
+
 /* Cursor up by ny. */
 void
 screen_write_cursorup(struct screen_write_ctx *ctx, u_int ny)

--- a/server-client.c
+++ b/server-client.c
@@ -1779,6 +1779,19 @@ server_client_reset_state(struct client *c)
 		    screen_mode_to_string(mode));
 	}
 
+	/*
+	 * If the pane is in the middle of a synchronized update, do not
+	 * touch the tty: the redraw scheduled when the update ends will
+	 * reset everything. Resetting now would write cursor movement and
+	 * mode changes to the tty outside any synchronized update block,
+	 * so the terminal would show the cursor walking around the screen
+	 * while the application is still drawing.
+	 */
+	if (mode & MODE_SYNC) {
+		tty->flags |= flags;
+		return;
+	}
+
 	/* Reset region and margin. */
 	tty_region_off(tty);
 	tty_margin_off(tty);

--- a/tmux.h
+++ b/tmux.h
@@ -3327,6 +3327,7 @@ void	 screen_write_mode_set(struct screen_write_ctx *, int);
 void	 screen_write_mode_clear(struct screen_write_ctx *, int);
 void	 screen_write_start_sync(struct window_pane *);
 void	 screen_write_stop_sync(struct window_pane *);
+void	 screen_write_end_sync(struct screen_write_ctx *);
 void	 screen_write_cursorup(struct screen_write_ctx *, u_int);
 void	 screen_write_cursordown(struct screen_write_ctx *, u_int);
 void	 screen_write_cursorright(struct screen_write_ctx *, u_int);


### PR DESCRIPTION
### Problem

The recent pane-side synchronized output support (DECSET 2026, #4744) suppresses most pane output between BSU and ESU, but some output still reaches the client tty while the update is in progress. On terminals that honour synchronized updates this shows up as the very tearing/flicker the feature is meant to prevent: the cursor visibly walks around the screen during each frame, and occasionally a partially-updated (e.g. just-cleared) screen is committed atomically.

Measured on the attached client tty with `script(1)`: with a pane application emitting 12 synchronized frames per second, about **72%** of the bytes written to the client arrive **outside** any synchronized update block.

### Causes (three separate leaks)

1. **ESU clears `MODE_SYNC` before pending collected items are discarded.** The items collected during the frame are still queued when the mode is cleared, so the flush at the end of input processing writes them to the tty, outside the synchronized update block of the redraw that ESU schedules. (`input.c` / `screen-write.c`: added `screen_write_end_sync` which discards them first, while `MODE_SYNC` is still set.)

2. **`server_client_reset_state` runs after every input batch and follows the pane cursor/modes.** While the application is mid-update this writes cursor movement, region and mode changes to the tty outside any synchronized update block — this is the "cursor walking" part. Skipped while `MODE_SYNC` is set; the redraw at ESU resets everything anyway.

3. **`screen_redraw_draw_pane` force-stopped sync mode and drew the pane mid-update.** For example when a deferred redraw timer fired just after the next frame had cleared the screen, a mostly-empty screen was committed atomically. Now the draw is skipped instead; ESU (or the 1-second sync timeout) sets `PANE_REDRAW` so the pane is drawn when the update ends.

### Reproduction / measurement

```sh
cat > /tmp/producer.sh <<'EOS'
#!/bin/sh
while :; do
  printf '\033[?2026h\033[?25l\033[2J\033[H'
  i=1
  while [ $i -le 20 ]; do
    printf '\033[%d;1HRow %02d ====================================================' $i $i
    i=$((i+1))
  done
  printf '\033[5;10H\033[?25h\033[?2026l'
  sleep 0.08
done
EOS
chmod +x /tmp/producer.sh
tmux -Ltest -f/dev/null new-session -d -s s -x 80 -y 24 /tmp/producer.sh
tmux -Ltest set-option -g terminal-features ',xterm*:sync'
script -q /tmp/outer.raw tmux -Ltest attach -t s     # detach after ~5s
```

Then compute how many of the captured bytes are inside `ESC[?2026h ... ESC[?2026l`:

| | inside sync blocks | outside (naked) |
|---|---|---|
| before | ~28% | **~72%** (repeating per frame: small wrapped scroll block, then the row content, cursor walk, region/mode resets, all unwrapped) |
| after | ~99.7% | ~0.3% (attach-time one-shots only) |

Also reproduced with a real application (a TUI redrawing its screen in 2026 frames): unwrapped multi-CUP bursts such as `[4;59H[12;68H[19;20H[22;68H` between wrapped blocks — visible cursor scatter — disappear with this change.

### Notes

- In `server_client_reset_state` the early return also defers the `tty_sync_end` at the tail; it is sent on the next pass once the pane leaves `MODE_SYNC` (ESU or the 1-second timeout), so a sync block is never left open for longer than that.
- Skipping the draw in `screen_redraw_draw_pane` means a full redraw that happens mid-update leaves the pane content undrawn until ESU; for a healthy application that is a few milliseconds, and the 1-second timeout bounds the stalled-application case (same bound as the existing sync timer).

`uname -sp`: Darwin arm; `tmux -V`: next-3.7 (master); `$TERM` inside: tmux-256color, outside: xterm-256color.
