### PR TITLE
CONTRIBUTING: fix shell code block language

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,7 +63,7 @@ tmux -vv -Ltest -f/dev/null new
 
 Or if you need your configuration:
 
-~~~base
+~~~bash
 tmux kill-server
 tmux -vv new
 ~~~


### PR DESCRIPTION
Fix a Markdown code fence language tag from `base` to `bash` for a shell command example.