### PR TITLE
fix(master): remove old floating logic from `swap-pane`.

### DIFF
--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -114,10 +114,6 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->layout_cell = src_lc;
 	dst_lc->wp = src_wp;
 	src_wp->layout_cell = dst_lc;
-	if (window_pane_is_floating(src_wp) != window_pane_is_floating(dst_wp)) {
-		src_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
-		dst_wp->layout_cell->flags ^= LAYOUT_CELL_FLOATING;
-	}
 
 	src_wp->window = dst_w;
 	options_set_parent(src_wp->options, dst_w->options);


### PR DESCRIPTION
Even though swapping is disabled with floating panes, leaving this old code in there will only add noise when the time comes to enable it.