### PR TITLE
regress: add command-alias test

### DIFF
--- a/regress/command-alias.sh
+++ b/regress/command-alias.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# command-alias expansion
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+$TMUX new-session -d -sfoo || exit 1
+$TMUX split-window -d -tfoo:0.0 || exit 1
+$TMUX set -s command-alias[100] zoom='resize-pane -Z' || exit 1
+$TMUX zoom -tfoo:0.0 || exit 1
+[ "$($TMUX display-message -p -tfoo:0.0 '#{window_zoomed_flag}')" = 1 ] || exit 1
+
+$TMUX kill-server 2>/dev/null
+
+exit 0


### PR DESCRIPTION
Add a regression test for command-alias expansion.

The test defines a zoom alias for resize-pane -Z, invokes it, and checks #{window_zoomed_flag} to verify that the alias had the expected effect.