### PR TITLE
configure.ac: Prefer wide ncurses libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -297,24 +297,24 @@ fi
 # Look for ncurses or curses. Try pkg-config first then directly for the
 # library.
 PKG_CHECK_MODULES(
-	LIBTINFO,
-	tinfo,
+	LIBTINFOW,
+	tinfow,
 	[
-		AM_CPPFLAGS="$LIBTINFO_CFLAGS $AM_CPPFLAGS"
-		CPPFLAGS="$LIBTINFO_CFLAGS $SAVED_CPPFLAGS"
-		LIBS="$LIBTINFO_LIBS $LIBS"
+		AM_CPPFLAGS="$LIBTINFOW_CFLAGS $AM_CPPFLAGS"
+		CPPFLAGS="$LIBTINFOW_CFLAGS $SAVED_CPPFLAGS"
+		LIBS="$LIBTINFOW_LIBS $LIBS"
 		found_ncurses=yes
 	],
 	found_ncurses=no
 )
 if test "x$found_ncurses" = xno; then
 	PKG_CHECK_MODULES(
-		LIBNCURSES,
-		ncurses,
+		LIBTINFO,
+		tinfo,
 		[
-			AM_CPPFLAGS="$LIBNCURSES_CFLAGS $AM_CPPFLAGS"
-			CPPFLAGS="$LIBNCURSES_CFLAGS $SAVED_CPPFLAGS"
-			LIBS="$LIBNCURSES_LIBS $LIBS"
+			AM_CPPFLAGS="$LIBTINFO_CFLAGS $AM_CPPFLAGS"
+			CPPFLAGS="$LIBTINFO_CFLAGS $SAVED_CPPFLAGS"
+			LIBS="$LIBTINFO_LIBS $LIBS"
 			found_ncurses=yes
 		],
 		found_ncurses=no
@@ -334,9 +334,22 @@ if test "x$found_ncurses" = xno; then
 	)
 fi
 if test "x$found_ncurses" = xno; then
+	PKG_CHECK_MODULES(
+		LIBNCURSES,
+		ncurses,
+		[
+			AM_CPPFLAGS="$LIBNCURSES_CFLAGS $AM_CPPFLAGS"
+			CPPFLAGS="$LIBNCURSES_CFLAGS $SAVED_CPPFLAGS"
+			LIBS="$LIBNCURSES_LIBS $LIBS"
+			found_ncurses=yes
+		],
+		found_ncurses=no
+	)
+fi
+if test "x$found_ncurses" = xno; then
 	AC_SEARCH_LIBS(
 		setupterm,
-		[tinfo terminfo ncurses ncursesw],
+		[tinfow tinfo terminfo ncursesw ncurses],
 		found_ncurses=yes,
 		found_ncurses=no
 	)


### PR DESCRIPTION
otherwise startup of tmux may fail with very recent ncurses:

  `missing or unsuitable terminal: xterm-256color`

Fixes: #4844