### PR TITLE
fix offset subtraction in sixel_scale raster attributes

### DIFF
--- a/image-sixel.c
+++ b/image-sixel.c
@@ -450,11 +450,11 @@ sixel_scale(struct sixel_image *si, u_int xpixel, u_int ypixel, u_int ox,
 
 	new->set_ra = si->set_ra;
 	/* subtract offset */
-	new->ra_x = new->ra_x > pox ? new->ra_x - pox : 0;
-	new->ra_y = new->ra_y > poy ? new->ra_y - poy : 0;
+	new->ra_x = si->ra_x > pox ? si->ra_x - pox : 0;
+	new->ra_y = si->ra_y > poy ? si->ra_y - poy : 0;
 	/* clamp to size */
-	new->ra_x = si->ra_x < psx ? si->ra_x : psx;
-	new->ra_y = si->ra_y < psy ? si->ra_y : psy;
+	new->ra_x = new->ra_x < psx ? new->ra_x : psx;
+	new->ra_y = new->ra_y < psy ? new->ra_y : psy;
 	/* resize */
 	new->ra_x = new->ra_x * xpixel / si->xpixel;
 	new->ra_y = new->ra_y * ypixel / si->ypixel;


### PR DESCRIPTION
Traced this while reading sixel_scale. The offset subtraction reads new->ra_x, but new has just come back from xcalloc so it is always 0:

        new->ra_x = new->ra_x > pox ? new->ra_x - pox : 0;   /* new->ra_x == 0 */
        ...
        new->ra_x = si->ra_x < psx ? si->ra_x : psx;         /* overwrites it */

So the first two lines are dead and the ox/oy offset never reaches the scaled raster attributes. The clamp then re-reads si->ra_x rather than the subtracted value, so both steps are wrong.

The clamp usually hides this because for a normal image ra_x equals the width, so I forced them apart: an image whose pixels run wider than its declared raster size, scaled at a non-zero offset. Reading back the raster attributes from sixel_print:

        offset 5,5   before:  "1;1;10;10   (offset ignored)
                     after:   "1;1;5;5

Chained the three steps so each works on the previous result: subtract the offset from si->ra_x/ra_y, clamp that, then resize.