### PR TITLE
allow rect selection to extend past end of current line

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -5403,8 +5403,10 @@ window_copy_update_cursor(struct window_mode_entry *wme, u_int cx, u_int cy)
 	u_int				 maxx;
 	int				 allow_onemore;
 
-	allow_onemore = (data->screen.sel != NULL && data->rectflag);
-	if (cy < screen_size_y(s)) {
+	// allow rect selection to extend past end of current line
+	// to behave the same as vi with virtualedit=block set
+	if ( (!data->rectflag) && (cy < screen_size_y(s)) ) {
+		allow_onemore = (data->screen.sel != NULL && data->rectflag);
 		py = screen_hsize(data->backing) + cy - data->oy;
 		maxx = window_copy_cursor_limit(wme, py, allow_onemore);
 		if (cx > maxx)


### PR DESCRIPTION
This change allows rectangular selection to extend past the end of the current line.
It behaves the same as vi with virtualedit=block set.
Without this change tmux no longer has the ability to select all chars of a right most column if the last line of a selection is not as long as other lines in the selection.
This PR also restores functionality that was present prior to the original change.
The original change was in https://github.com/tmux/tmux/pull/5070
Specifically commit: f12d7b4e67b6b62a14a584137db5e7a9d5614f77

I understand not wanting to add tmux options for vi options (there are too many!), but I think losing the feature to select a column like we can in vi and could in tmux before is not as desirable as making this the default.

thx