### PR TITLE
refactor(floating_panes): Moved the functionality of `float-pane` and `tile-pane` into `break-pane` and `join-pane`

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -36,8 +36,8 @@ const struct cmd_entry cmd_break_pane_entry = {
 
 	.args = { "abdPF:n:s:t:Wx:X:y:Y:", 0, 0, NULL },
 	.usage = "[-abdPW] [-F format] [-n window-name] [-s src-pane] "
-		 "[-t dst-window] [x width] [y height] [X x-position] "
-		 "[Y y-position]",
+		 "[-t dst-window] [-x width] [-y height] [-X x-position] "
+		 "[-Y y-position]",
 
 	.source = { 's', CMD_FIND_PANE, 0 },
 	.target = { 't', CMD_FIND_WINDOW, CMD_FIND_WINDOW_INDEX },

--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -34,9 +34,10 @@ const struct cmd_entry cmd_break_pane_entry = {
 	.name = "break-pane",
 	.alias = "breakp",
 
-	.args = { "abdPF:n:s:t:", 0, 0, NULL },
-	.usage = "[-abdP] [-F format] [-n window-name] [-s src-pane] "
-		 "[-t dst-window]",
+	.args = { "abdPF:n:s:t:Wx:X:y:Y:", 0, 0, NULL },
+	.usage = "[-abdPW] [-F format] [-n window-name] [-s src-pane] "
+		 "[-t dst-window] [x width] [y height] [X x-position] "
+		 "[Y y-position]",
 
 	.source = { 's', CMD_FIND_PANE, 0 },
 	.target = { 't', CMD_FIND_WINDOW, CMD_FIND_WINDOW_INDEX },
@@ -44,6 +45,51 @@ const struct cmd_entry cmd_break_pane_entry = {
 	.flags = 0,
 	.exec = cmd_break_pane_exec
 };
+
+static enum cmd_retval
+cmd_break_pane_float(struct cmdq_item *item, struct args *args,
+    struct window *w, struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+	u_int			 sx = lc->saved_sx, sy = lc->saved_sy;
+	int			 ox = lc->saved_xoff, oy = lc->saved_yoff;
+	char			*cause = NULL;
+
+	if (window_pane_is_floating(wp)) {
+		cmdq_error(item, "pane is already floating");
+		return (CMD_RETURN_ERROR);
+	}
+	if (window_pane_is_hidden(wp)) {
+		cmdq_error(item, "can't float a hidden pane");
+		return (CMD_RETURN_ERROR);
+	}
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't float a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+
+	layout_remove_tile(w, lc);
+	layout_cell_floating_args_parse(item, args, w, &sx, &sy, &ox, &oy, &cause);
+	if (cause != NULL) {
+		cmdq_error(item, "failed to float pane: %s", cause);
+		free(cause);
+		return (CMD_RETURN_ERROR);
+	}
+	layout_set_size(lc, sx, sy, ox, oy);
+
+	lc->flags |= LAYOUT_CELL_FLOATING;
+	TAILQ_REMOVE(&w->z_index, wp, zentry);
+	TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
+
+	if (!args_has(args, 'd'))
+		window_set_active_pane(w, wp, 1);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
+
+	return (CMD_RETURN_NORMAL);
+}
 
 static enum cmd_retval
 cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
@@ -61,6 +107,9 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	char			*newname, *cause, *cp;
 	int			 idx = target->idx, before;
 	const char		*template, *name = args_get(args, 'n');
+
+	if (args_has(args, 'W'))
+		return (cmd_break_pane_float(item, args, w, wp));
 
 	if (name != NULL && !check_name(name, WINDOW_NAME_FORBID)) {
 		cmdq_error(item, "invalid window name: %s", name);

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -359,6 +359,45 @@ cmd_join_pane_zindex(struct cmdq_item *item, struct winlink *wl,
 }
 
 static enum cmd_retval
+cmd_join_pane_tile(struct cmdq_item *item, struct args *args, struct window *w,
+    struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (!window_pane_is_floating(wp)) {
+		cmdq_error(item, "pane is not floating");
+		return (CMD_RETURN_ERROR);
+	}
+	if (window_pane_is_hidden(wp)) {
+		cmdq_error(item, "can't tile a hidden pane");
+		return (CMD_RETURN_ERROR);
+	}
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't tile a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+
+	layout_save_size(lc);
+	lc->flags &= ~LAYOUT_CELL_FLOATING;
+	if (layout_insert_tile(w, lc) == 0) {
+		cmdq_error(item, "can't tile a pane that is already tiled");
+		return (CMD_RETURN_ERROR);
+	}
+
+	TAILQ_REMOVE(&w->z_index, wp, zentry);
+	TAILQ_INSERT_TAIL(&w->z_index, wp, zentry);
+
+	if (!args_has(args, 'd'))
+		window_set_active_pane(w, wp, 1);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
+
+	return (CMD_RETURN_NORMAL);
+}
+
+static enum cmd_retval
 cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 {
 	struct args		*args = cmd_get_args(self);
@@ -372,7 +411,7 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 	const char		*s;
 	char			*cause = NULL;
 	int			 flags = 0, dst_idx;
-	struct layout_cell	*lc;
+	struct layout_cell	*lc, *src_lc;
 
 	dst_s = target->s;
 	dst_wl = target->wl;
@@ -403,12 +442,16 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	src_wl = source->wl;
 	src_wp = source->wp;
+	src_lc = src_wp->layout_cell;
 	src_w = src_wl->window;
 	server_unzoom_window(src_w);
 
+	if (!args_has(args, 't') && window_pane_is_floating(src_wp))
+		return (cmd_join_pane_tile(item, args, src_w, src_wp));
+
 	if (src_wp == dst_wp) {
 		cmdq_error(item, "source and target panes must be different");
-		return (CMD_RETURN_ERROR);
+		return (CMD_RETURN_ERROR);                                    
 	}
 
 	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, flags, &cause);
@@ -416,6 +459,12 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "size or position %s", cause);
 		free(cause);
 		return (CMD_RETURN_ERROR);
+	}
+	if (window_pane_is_floating(src_wp)) {
+		lc->saved_sx = src_lc->sx;
+		lc->saved_sy = src_lc->sy;
+		lc->saved_xoff = src_lc->xoff;
+		lc->saved_yoff = src_lc->yoff;
 	}
 
 	layout_close_pane(src_wp);

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -451,7 +451,7 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 
 	if (src_wp == dst_wp) {
 		cmdq_error(item, "source and target panes must be different");
-		return (CMD_RETURN_ERROR);                                    
+		return (CMD_RETURN_ERROR);
 	}
 
 	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, flags, &cause);

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -380,7 +380,7 @@ cmd_join_pane_tile(struct cmdq_item *item, struct args *args, struct window *w,
 	layout_save_size(lc);
 	lc->flags &= ~LAYOUT_CELL_FLOATING;
 	if (layout_insert_tile(w, lc) == 0) {
-		cmdq_error(item, "can't tile a pane that is already tiled");
+		cmdq_error(item, "no space for a new pane");
 		return (CMD_RETURN_ERROR);
 	}
 

--- a/cmd-tile-float-pane.c
+++ b/cmd-tile-float-pane.c
@@ -136,7 +136,7 @@ cmd_tile_pane_exec(struct cmd *self, struct cmdq_item *item)
 	layout_save_size(lc);
 	lc->flags &= ~LAYOUT_CELL_FLOATING;
 	if (layout_insert_tile(w, lc) == 0) {
-		cmdq_error(item, "can't tile a pane that is already tiled");
+		cmdq_error(item, "no space for a new pane");
 		return (CMD_RETURN_ERROR);
 	}
 

--- a/tmux.1
+++ b/tmux.1
@@ -2690,11 +2690,15 @@ Commands related to windows and panes are as follows:
 .Bl -tag -width Ds
 .Tg breakp
 .It Xo Ic break\-pane
-.Op Fl abdP
+.Op Fl abdPW
 .Op Fl F Ar format
 .Op Fl n Ar window\-name
 .Op Fl s Ar src\-pane
 .Op Fl t Ar dst\-window
+.Op Fl x Ar width
+.Op Fl y Ar height
+.Op Fl X Ar x-position
+.Op Fl Y Ar y-position
 .Xc
 .D1 Pq alias: Ic breakp
 Break
@@ -2717,6 +2721,40 @@ By default, it uses the format
 .Ql #{session_name}:#{window_index}.#{pane_index}
 but a different format may be specified with
 .Fl F .
+.Pp
+If the
+.Fl W
+option is given,
+.Ar src\-pane
+is lifted out of the tiled layout and made floating.
+The
+.Fl x
+and
+.Fl y
+options set the width and height of the floating pane in columns and lines
+respectively.
+The default is half the window width and a quarter the window height.
+The
+.Fl X
+and
+.Fl Y
+options set the position of the upper-left corner of the pane.
+If omitted, new floating panes are cascaded from the top-left of the window.
+.Pp
+If the pane had previously been floating, the position and sizes are restored
+from the saved values not specified by the
+.Fl x ,
+.Fl y ,
+.Fl X ,
+and
+.Fl Y
+options.
+.Pp
+If
+.Fl d
+is given, the active pane is not changed.
+The pane must not already be floating or hidden, and the window must not
+be zoomed.
 .Tg capturep
 .It Xo Ic capture\-pane
 .Op Fl aeFHLpPqCJMN
@@ -3188,6 +3226,21 @@ is omitted and a marked pane is present (see
 .Ic select\-pane
 .Fl m ) ,
 the marked pane is used rather than the current pane.
+.Pp
+If
+.Ar dst\-pane
+is not specified and
+.Ar src\-pane
+is floating, return the pane back to the tiled layout.
+Half the space from the nearest tiled pane in the layout tree is given to
+.Ar src\-pane .
+The floating position and sizes are saved so they can be restored if
+.Ar src\-pane
+is floated again.
+If
+.Fl d
+is given, the active pane is not changed.
+The pane must be floating, not hidden, and the window must not be zoomed.
 .Tg killp
 .It Xo Ic kill\-pane
 .Op Fl a


### PR DESCRIPTION
This is the PR for #5205.

There is once minor annoyance; since `break-pane` and `join-pane` have the "source/target" find mechanics "targeting" a pane for the float/tile action, `-s` is used and not `-t` like all other commands that behave similarly on panes.

Once this PR is accepted, `cmd-tile-float-pane.c` will be removed and the documentation for `float-pane` and `tile-pane` cleaned up.