### PR TITLE
control: avoid NULL deref in session-window-changed control notification

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -224,6 +224,15 @@ control_notify_session_window_changed(struct session *s)
 {
 	struct client	*c;
 
+	/*
+	 * A deferred session-window-changed notification can fire after the
+	 * session has been destroyed (which sets curw to NULL) but is kept
+	 * alive by the notification's reference. There is no current window to
+	 * report, so skip the notification.
+	 */
+	if (s->curw == NULL)
+		return;
+
 	TAILQ_FOREACH(c, &clients, entry) {
 		if (!CONTROL_SHOULD_NOTIFY_CLIENT(c))
 			continue;


### PR DESCRIPTION
Fixes #5243.

`control_notify_session_window_changed()` dereferences `s->curw->window->id` without checking that `s->curw` is non-NULL. The `session-window-changed` notification is deferred through the command queue (`notify_add()` → `cmdq_append()`) and holds a reference to the session, so it can run after `session_destroy()` has set `s->curw = NULL` — the held reference keeps the `struct session` alive. The deferred notification then dereferences NULL and crashes the whole server.

It is reachable with a control client (`tmux -CC`) attached by, for example, selecting a different window and then killing that session in a single command list, so the deferred notify fires after `curw` was cleared.

This skips the notification when there is no current window, matching how the other window-touching notify functions in this file guard their access (e.g. `control_notify_window_pane_changed` checks `w->active`).

Full analysis, backtrace, and a deterministic reproduction are in #5243.
