### PR TITLE
refactor(master): floating layout cells are placed meaningfully in the layout.

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -1344,7 +1344,7 @@ layout_floating_pane(struct window *w, struct window_pane *wp, u_int sx,
 	if (wp == NULL)
 		lc = w->layout_root;
 	else
-		lc = w->layout_root;
+		lc = wp->layout_cell;
 	lcparent = lc->parent;
 
 	if (lcparent == NULL) {

--- a/layout.c
+++ b/layout.c
@@ -1339,9 +1339,11 @@ struct layout_cell *
 layout_floating_pane(struct window *w, struct window_pane *wp, u_int sx,
     u_int sy, int ox, int oy)
 {
-	struct layout_cell	*lc = wp->layout_cell, *lcnew, *lcparent;
+	struct layout_cell	*lc, *lcnew, *lcparent;
 
-	if (lc == NULL)
+	if (wp == NULL)
+		lc = w->layout_root;
+	else
 		lc = w->layout_root;
 	lcparent = lc->parent;
 

--- a/layout.c
+++ b/layout.c
@@ -1336,14 +1336,19 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
  * layout_assign_pane before much else happens!
  */
 struct layout_cell *
-layout_floating_pane(struct window *w, u_int sx, u_int sy, int ox, int oy)
+layout_floating_pane(struct window *w, struct window_pane *wp, u_int sx,
+    u_int sy, int ox, int oy)
 {
-	struct layout_cell	*lc = w->layout_root, *lcnew, *lcparent;
+	struct layout_cell	*lc = wp->layout_cell, *lcnew, *lcparent;
 
-	if (lc->type == LAYOUT_WINDOWPANE) {
+	if (lc == NULL)
+		lc = w->layout_root;
+	lcparent = lc->parent;
+
+	if (lcparent == NULL) {
 		/*
-		* Adding a pane to a root that doesn't have a container. Must
-		* create and insert a new root.
+		* Adding a pane to a root that isn't node. Must create and
+		* insert a new root.
 		*/
 		lcparent = layout_create_cell(NULL);
 		layout_make_node(lcparent, LAYOUT_TOPBOTTOM);
@@ -1353,11 +1358,10 @@ layout_floating_pane(struct window *w, u_int sx, u_int sy, int ox, int oy)
 		/* Insert the old cell. */
 		lc->parent = lcparent;
 		TAILQ_INSERT_HEAD(&lcparent->cells, lc, entry);
-	} else
-		lcparent = w->layout_root;
+	}
 
 	lcnew = layout_create_cell(lcparent);
-	TAILQ_INSERT_TAIL(&lcparent->cells, lcnew, entry);
+	TAILQ_INSERT_AFTER(&lcparent->cells, lc, lcnew, entry);
 	lcnew->flags |= LAYOUT_CELL_FLOATING;
 	layout_set_size(lcnew, sx, sy, ox, oy);
 
@@ -1532,7 +1536,7 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 /* Get a new floating cell. */
 struct layout_cell *
 layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    struct window *w, __unused struct window_pane *wp, char **cause)
+    struct window *w, struct window_pane *wp, char **cause)
 {
 	struct layout_cell	*lcnew;
 	int			 sx = w->sx / 2, sy = w->sy / 4;
@@ -1606,7 +1610,7 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	lcnew = layout_floating_pane(w, sx, sy, ox, oy);
+	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
 	return (lcnew);
 }
 

--- a/spawn.c
+++ b/spawn.c
@@ -660,7 +660,7 @@ spawn_editor(struct client *c, const char *buf, size_t len,
 	px = w->sx / 2 - sx / 2;
 	py = w->sy / 2 - sy / 2;
 	window_push_zoom(w, 1, 0);
-	lc = layout_floating_pane(w, sx, sy, px, py);
+	lc = layout_floating_pane(w, NULL, sx, sy, px, py);
 	if (lc == NULL) {
 		spawn_editor_free(es);
 		return (NULL);

--- a/tmux.h
+++ b/tmux.h
@@ -3575,8 +3575,8 @@ void		 layout_assign_pane(struct layout_cell *, struct window_pane *,
 		     int);
 struct layout_cell *layout_split_pane(struct window_pane *, enum layout_type,
 		     int, int);
-struct layout_cell *layout_floating_pane(struct window *, u_int, u_int, int,
-		     int);
+struct layout_cell *layout_floating_pane(struct window *, struct window_pane *,
+		     u_int, u_int, int, int);
 void		 layout_close_pane(struct window_pane *);
 int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);


### PR DESCRIPTION
Up until this point, floating layout cells were stuffed at the end of the top node of the layout tree. The changes prior to this have enabled this PR to function. Layout cells are now created after the target window panes cell of the `new-pane` command. This has no real affect as of now. However, this will allow for floating and tiling operations to maintain the cell's layout position.