### PR TITLE
fix(master): floating panes now accomodate for border size.

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -998,7 +998,7 @@ args_string_percentage(const char *value, long long minval, long long maxval,
 		copy = xstrdup(value);
 		copy[valuelen - 1] = '\0';
 
-		ll = strtonum(copy, 0, 100, &errstr);
+		ll = strtonum(copy, 0, 1000, &errstr);
 		free(copy);
 		if (errstr != NULL) {
 			*cause = xstrdup(errstr);
@@ -1066,7 +1066,7 @@ args_string_percentage_and_expand(const char *value, long long minval,
 		copy[valuelen - 1] = '\0';
 
 		f = format_single_from_target(item, copy);
-		ll = strtonum(f, 0, 100, &errstr);
+		ll = strtonum(f, 0, 1000, &errstr);
 		free(f);
 		free(copy);
 		if (errstr != NULL) {

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -94,7 +94,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	server_unzoom_window(w);
 
 	if (args_has(args, 'x')) {
-		x = args_percentage(args, 'x', 0, INT_MAX, w->sx, &cause);
+		x = args_percentage(args, 'x', 0, PANE_MAXIMUM, w->sx, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "width %s", cause);
 			free(cause);
@@ -112,7 +112,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			layout_resize_pane_to(wp, LAYOUT_LEFTRIGHT, x);
 	}
 	if (args_has(args, 'y')) {
-		y = args_percentage(args, 'y', 0, INT_MAX, w->sy, &cause);
+		y = args_percentage(args, 'y', 0, PANE_MAXIMUM, w->sy, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "height %s", cause);
 			free(cause);

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -155,10 +155,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	if ((new_wp = spawn_pane(&sc, &cause)) == NULL) {
 		cmdq_error(item, "create pane failed: %s", cause);
 		free(cause);
-		if (sc.argv != NULL)
-			cmd_free_argv(sc.argc, sc.argv);
-		environ_free(sc.environ);
-		return (CMD_RETURN_ERROR);
+		goto fail;
 	}
 
 	style = args_get(args, 's');
@@ -166,7 +163,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		if (options_set_string(new_wp->options, "window-style", 0,
 		    "%s", style) == NULL) {
 			cmdq_error(item, "bad style: %s", style);
-			return (CMD_RETURN_ERROR);
+			goto fail;
 		}
 		options_set_string(new_wp->options, "window-active-style", 0,
 		    "%s", style);
@@ -178,7 +175,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		if (options_set_string(new_wp->options,
 		    "pane-active-border-style", 0, "%s", style) == NULL) {
 			cmdq_error(item, "bad active border style: %s", style);
-			return (CMD_RETURN_ERROR);
+			goto fail;
 		}
 	}
 	style = args_get(args, 'R');
@@ -187,7 +184,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		    "%s", style) == NULL) {
 			cmdq_error(item, "bad inactive border style: %s",
 			    style);
-			return (CMD_RETURN_ERROR);
+			goto fail;
 		}
 	}
 	value = args_get(args, 'B');
@@ -198,7 +195,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		if (cause != NULL) {
 			cmdq_error(item, "pane-border-lines %s", cause);
 			free(cause);
-			return (CMD_RETURN_ERROR);
+			goto fail;
 		}
 		options_set_number(new_wp->options, "pane-border-lines",
 		    lines);
@@ -227,10 +224,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 			window_remove_pane(wp->window, new_wp);
 			cmdq_error(item, "%s", cause);
 			free(cause);
-			if (sc.argv != NULL)
-				cmd_free_argv(sc.argc, sc.argv);
-			environ_free(sc.environ);
-			return (CMD_RETURN_ERROR);
+			goto fail;
 		case 1:
 			input = 0;
 			break;
@@ -272,4 +266,13 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_WAIT);
 	}
 	return (CMD_RETURN_NORMAL);
+
+fail:
+	if (sc.argv != NULL)
+		cmd_free_argv(sc.argc, sc.argv);
+	environ_free(sc.environ);
+	layout_destroy_cell(w, lc, &w->layout_root);
+
+	return (CMD_RETURN_ERROR);
+
 }

--- a/layout.c
+++ b/layout.c
@@ -1544,12 +1544,30 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 	struct layout_cell	*lcnew;
 	int			 sx = w->sx / 2, sy = w->sy / 4;
 	int			 ox = INT_MAX, oy = INT_MAX;
+	int			 borders;
 	char			*error;
-	const char		*barg = args_get(args, 'B');
-	enum pane_lines		 lines = window_pane_get_pane_lines(wp);
-	int			 borders = lines != PANE_LINES_NONE;
+	const char		*value = args_get(args, 'B');
+	enum pane_lines		 arglines, lines = window_get_pane_lines(w);
+	struct options_entry	*oe;
 
-	borders = borders && (!barg || strcmp(barg, "none") != 0);
+	/*
+	 * The position and sizes of floating panes need to be adjusted
+	 * depending upon the border type. A floating pane with PANE_LINES_NONE
+	 * can be grown and offset to occupy the border space.
+	 */
+	if (value) {
+		oe = options_get(w->options, "pane-border-lines");
+		arglines = options_find_choice(options_table_entry(oe), value,
+		    &error);
+		if (*cause != NULL) {
+			xasprintf(cause, "pane-border-lines %s", error);
+			free(error);
+			return (NULL);
+		}
+	} else
+		arglines = lines;
+
+	borders = arglines != PANE_LINES_NONE && lines != PANE_LINES_NONE;
 	if (args_has(args, 'x')) {
 		sx = args_percentage_and_expand(args, 'x', 0, PANE_MAXIMUM,
 		    w->sx, item, &error);

--- a/layout.c
+++ b/layout.c
@@ -1544,11 +1544,12 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 	struct layout_cell	*lcnew;
 	int			 sx = w->sx / 2, sy = w->sy / 4;
 	int			 ox = INT_MAX, oy = INT_MAX;
-	int			 borders;
 	char			*error;
 	const char		*barg = args_get(args, 'B');
+	enum pane_lines		 lines = window_pane_get_pane_lines(wp);
+	int			 borders = lines != PANE_LINES_NONE;
 
-	borders = !barg || strcmp(barg, "none") != 0;
+	borders = borders && (!barg || strcmp(barg, "none") != 0);
 	if (args_has(args, 'x')) {
 		sx = args_percentage_and_expand(args, 'x', 0, PANE_MAXIMUM,
 		    w->sx, item, &error);

--- a/layout.c
+++ b/layout.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "tmux.h"
 
@@ -1543,25 +1544,32 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 	struct layout_cell	*lcnew;
 	int			 sx = w->sx / 2, sy = w->sy / 4;
 	int			 ox = INT_MAX, oy = INT_MAX;
+	int			 borders;
 	char			*error;
+	const char		*barg = args_get(args, 'B');
 
+	borders = !barg || strcmp(barg, "none") != 0;
 	if (args_has(args, 'x')) {
-		sx = args_percentage_and_expand(args, 'x', 0, w->sx - 1, w->sx,
-		    item, &error);
+		sx = args_percentage_and_expand(args, 'x', 0, PANE_MAXIMUM,
+		    w->sx, item, &error);
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
 			return (NULL);
 		}
+		if (borders)
+			sx -= 2;
 	}
 	if (args_has(args, 'y')) {
-		sy = args_percentage_and_expand(args, 'y', 0, w->sy - 1, w->sy,
-		    item, &error);
+		sy = args_percentage_and_expand(args, 'y', 0, PANE_MAXIMUM,
+		    w->sy, item, &error);
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
 			return (NULL);
 		}
+		if (borders)
+			sy -= 2;
 	}
 	if (args_has(args, 'X')) {
 		ox = args_percentage_and_expand(args, 'X', -sx, w->sx,
@@ -1591,7 +1599,9 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 				ox = 4;
 		}
 		w->last_new_pane_x = ox;
-	}
+	} else
+		if (borders)
+			ox += 1;
 	if (oy == INT_MAX) {
 		if (w->last_new_pane_y == 0)
 			oy = 2;
@@ -1601,7 +1611,9 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 				oy = 2;
 		}
 		w->last_new_pane_y = oy;
-	}
+	} else
+		if (borders)
+			oy += 1;
 
 	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
 		*cause = xstrdup("invalid width");

--- a/tmux.h
+++ b/tmux.h
@@ -3530,6 +3530,7 @@ int		 window_get_bg_client(struct window_pane *);
 enum client_theme window_pane_get_theme(struct window_pane *);
 void		 window_pane_send_theme_update(struct window_pane *);
 enum pane_lines	 window_pane_get_pane_lines(struct window_pane *);
+enum pane_lines	 window_get_pane_lines(struct window *);
 int		 window_get_pane_status(struct window *);
 int		 window_pane_get_pane_status(struct window_pane *);
 struct style_range *window_pane_status_get_range(struct window_pane *, u_int,

--- a/window.c
+++ b/window.c
@@ -2183,6 +2183,15 @@ window_pane_get_pane_lines(struct window_pane *wp)
 	return (options_get_number(oo, "pane-border-lines"));
 }
 
+enum pane_lines
+window_get_pane_lines(struct window *w)
+{
+	struct options	*oo;
+
+	oo = w->options;
+	return (options_get_number(oo, "pane-border-lines"));
+}
+
 int
 window_get_pane_status(struct window *w)
 {


### PR DESCRIPTION
Possible fix for #5251.

A few notes:
- This feels kind of hacky. I'm adjusting the size and positions based on border state.
- There was a maximum of window size for pane sizes which didn't make much sense to me. We already dont enforce a floating pane's spawn offsets to be in the window, so why enforce the size? I set it to PANE_MAXIMUM which feels more appropriate to me.
- This doesn't account for the pane border option that is already set. This PR intersects slightly with #5247 and would like that one to be finished before fully fixing up this one.