### PR TITLE
avoid out-of-bounds read in menu_key_cb when all items are dimmed

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -438,7 +438,7 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 					break;
 			}
 		}
-		while (name == NULL || *name == '-') {
+		while ((name == NULL || *name == '-') && md->choice != 0) {
 			md->choice--;
 			name = menu->items[md->choice].name;
 		}
@@ -448,7 +448,7 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 	case KEYC_HOME:
 		md->choice = 0;
 		name = menu->items[md->choice].name;
-		while (name == NULL || *name == '-') {
+		while ((name == NULL || *name == '-') && md->choice != count - 1) {
 			md->choice++;
 			name = menu->items[md->choice].name;
 		}
@@ -458,7 +458,7 @@ menu_key_cb(struct client *c, void *data, struct key_event *event)
 	case KEYC_END:
 		md->choice = count - 1;
 		name = menu->items[md->choice].name;
-		while (name == NULL || *name == '-') {
+		while ((name == NULL || *name == '-') && md->choice != 0) {
 			md->choice--;
 			name = menu->items[md->choice].name;
 		}


### PR DESCRIPTION
Built with -fsanitize=address and opened a menu whose entries are all dimmed (every item name starts with `-`, which display-menu allows for section headers). Pressing End or Home:

    AddressSanitizer: global-buffer-overflow
    READ of size 8 ... 0 bytes after the menu items array
        in menu_key_cb menu.c

The Home, End and Page Down handlers look for a selectable entry with

    while (name == NULL || *name == '-')

and never check the array edge. When no entry is selectable the index runs off the array: End and the Page Down tail step below 0 and read items[-1], Home steps past the last item and reads items[count]. Both then chase the stray name pointer.

The Up/Down loops and the prepare loops in this file already keep the index in range. These three did not, so I bounded each scan the same way.