### PR TITLE
add flag to dismiss popup when click outside

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -54,8 +54,8 @@ const struct cmd_entry cmd_display_popup_entry = {
 	.name = "display-popup",
 	.alias = "popup",
 
-	.args = { "Bb:Cc:d:e:Eh:kNs:S:t:T:w:x:y:", 0, -1, NULL },
-	.usage = "[-BCEkN] [-b border-lines] [-c target-client] "
+	.args = { "Bb:Cc:d:e:Eh:kNOs:S:t:T:w:x:y:", 0, -1, NULL },
+	.usage = "[-BCEkNO] [-b border-lines] [-c target-client] "
 		 "[-d start-directory] [-e environment] [-h height] "
 		 "[-s style] [-S border-style] " CMD_TARGET_PANE_USAGE
 		 " [-T title] [-w width] [-x position] [-y position] "
@@ -502,6 +502,11 @@ cmd_display_popup_exec(struct cmd *self, struct cmdq_item *item)
 		if (flags == -1)
 			flags = 0;
 		flags |= POPUP_CLOSEANYKEY;
+	}
+	if (args_has(args, 'O')) {
+		if (flags == -1)
+			flags = 0;
+		flags |= POPUP_CLOSEOUTSIDE;
 	}
 
 	if (modify) {

--- a/popup.c
+++ b/popup.c
@@ -578,6 +578,10 @@ popup_key_cb(struct client *c, void *data, struct key_event *event)
 		    m->y > pd->py + pd->sy - 1) {
 			if (MOUSE_BUTTONS(m->b) == MOUSE_BUTTON_3)
 				goto menu;
+			if ((pd->flags & POPUP_CLOSEOUTSIDE) &&
+			    !MOUSE_DRAG(m->b) && !MOUSE_WHEEL(m->b) &&
+			    !MOUSE_RELEASE(m->b))
+				return (1);
 			return (0);
 		}
 		if (pd->border_lines != BOX_LINES_NONE) {

--- a/tmux.1
+++ b/tmux.1
@@ -7689,7 +7689,7 @@ forwards any input read from stdin to the empty pane given by
 .Ar target\-pane .
 .Tg popup
 .It Xo Ic display\-popup
-.Op Fl BCEkN
+.Op Fl BCEkNO
 .Op Fl b Ar border\-lines
 .Op Fl c Ar target\-client
 .Op Fl d Ar start\-directory
@@ -7721,6 +7721,7 @@ Only the
 .Fl EE ,
 .Fl K ,
 .Fl N ,
+.Fl O ,
 .Fl s ,
 and
 .Fl S
@@ -7741,6 +7742,8 @@ allows any key to dismiss the popup instead of only
 .Ql Escape
 or
 .Ql C\-c .
+.Fl O
+dismisses the popup when the mouse is clicked outside of it.
 .Pp
 .Fl x
 and

--- a/tmux.h
+++ b/tmux.h
@@ -3842,6 +3842,7 @@ int		 menu_key_cb(struct client *, void *, struct key_event *);
 #define POPUP_CLOSEEXIT 0x1
 #define POPUP_CLOSEEXITZERO 0x2
 #define POPUP_CLOSEANYKEY 0x4
+#define POPUP_CLOSEOUTSIDE 0x8
 typedef void (*popup_close_cb)(int, void *);
 int		 popup_display(int, enum box_lines, struct cmdq_item *, u_int,
                     u_int, u_int, u_int, struct environ *, const char *, int,


### PR DESCRIPTION
This PR adds `-O` to `display-popup` to opt into dismissing when the user clicks outside of the popup.

I would find this useful because I sometimes spawn popups by clicking on the statusline and closing them requires either clicking the popup or using the keyboard. For some popups there is not much room to allow closing on click so I have to use the keyboard which is a mode switch.