### PR TITLE
fix(master): `split-window` can be used to create a new tiled pane when there is no tiled layout.

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -70,6 +70,38 @@ const struct cmd_entry cmd_split_window_entry = {
 	.exec = cmd_split_window_exec
 };
 
+static struct layout_cell *
+cmd_split_window_new_tiled(struct cmdq_item *item, struct args *args,
+    struct window *w, struct window_pane *wp, int flags, int new_pane,
+    char **cause)
+{
+	struct layout_cell	*lcnew, *lc = wp->layout_cell;
+	struct layout_cell	*lcroot = w->layout_root;
+
+	/*
+	 * When no panes are tiled and `new-pane` was used, a new cell is
+	 * created and inserted at the top of the root node. A new root node is
+	 * created if necessary.
+	 */
+	if (new_pane && !layout_cell_has_tiled_child(lcroot)) {
+		lcnew = layout_create_cell(NULL);
+		layout_set_size(lcnew, w->sx, w->sy, 0, 0);
+		if (lcroot->type == LAYOUT_WINDOWPANE) {
+			lcroot = layout_replace_with_node(w, lcnew,
+			    LAYOUT_TOPBOTTOM);
+			TAILQ_INSERT_TAIL(&lcroot->cells, lc, entry);
+			lc->parent = lcroot;
+			w->layout_root = lcroot;
+		} else {
+			lcnew->parent = lcroot;
+			TAILQ_INSERT_HEAD(&lcroot->cells, lcnew, entry);
+		}
+		return (lcnew);
+	}
+
+	return layout_get_tiled_cell(item, args, w, wp, flags, cause);
+}
+
 static enum cmd_retval
 cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 {
@@ -84,7 +116,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp, *new_wp;
 	struct layout_cell	*lc = NULL;
 	struct cmd_find_state	 fs;
-	int			 input, empty, is_floating, flags = 0;
+	int			 input, empty, is_floating, new_pane, flags = 0;
 	const char		*template, *style, *value;
 	char			*cause = NULL, *cp, *title;
 	const struct options_table_entry *oe;
@@ -92,7 +124,8 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	enum pane_lines		 lines;
 	u_int			 count = args_count(args);
 
-	if (cmd_get_entry(self) == &cmd_new_pane_entry)
+	new_pane = cmd_get_entry(self) == &cmd_new_pane_entry;
+	if (new_pane)
 		is_floating = !args_has(args, 'L');
 	else
 		is_floating = 0;
@@ -132,7 +165,8 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	if (is_floating)
 		lc = layout_get_floating_cell(item, args, lines, w, wp, &cause);
 	else
-		lc = layout_get_tiled_cell(item, args, w, wp, flags, &cause);
+		lc = cmd_split_window_new_tiled(item, args, w, wp, flags,
+		    new_pane, &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "%s", cause);
 		free(cause);

--- a/layout.c
+++ b/layout.c
@@ -1401,8 +1401,7 @@ layout_floating_pane(struct window *w, struct window_pane *wp, u_int sx,
 		* insert a new root.
 		*/
 		lcparent = layout_replace_with_node(w, lc, LAYOUT_TOPBOTTOM);
-	} else
-		lcparent = w->layout_root;
+	}
 
 	lcnew = layout_create_cell(lcparent);
 	TAILQ_INSERT_AFTER(&lcparent->cells, lc, lcnew, entry);

--- a/layout.c
+++ b/layout.c
@@ -263,7 +263,7 @@ layout_cell_is_tiled(struct layout_cell *lc)
 	return is_leaf && !is_floating;
 }
 
-static int
+int
 layout_cell_has_tiled_child(struct layout_cell *lc)
 {
 	struct layout_cell      *lcchild;
@@ -1189,7 +1189,7 @@ layout_resize_child_cells(struct window *w, struct layout_cell *lc)
  * inserts the cell into it. Used when creating new cells requires a different
  * layout type, or when the root layout is a window pane.
  */
-static struct layout_cell *
+struct layout_cell *
 layout_replace_with_node(struct window *w, struct layout_cell *lc,
     enum layout_type type)
 {
@@ -1521,36 +1521,15 @@ struct layout_cell *
 layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
     struct window *w, struct window_pane *wp, int flags, char **cause)
 {
-	struct layout_cell	*lcnew, *lc = wp->layout_cell;
-	struct layout_cell	*lcroot = w->layout_root;
+	struct layout_cell	*lcnew;
 	enum layout_type	 type;
 	u_int			 curval;
 	int			 size = -1;
 	char			*error = NULL;
 
 	if (window_pane_is_floating(wp)) {
-		if (layout_cell_has_tiled_child(lcroot)) {
-			*cause = xstrdup("can't split a floating pane");
-			return (NULL);
-		}
-		/*
-		 * When no panes are tiled, a new cell is created and inserted
-		 * at the top of the root node. A new root node is created if
-		 * necessary.
-		 */
-		lcnew = layout_create_cell(NULL);
-		layout_set_size(lcnew, w->sx, w->sy, 0, 0);
-		if (lcroot->type == LAYOUT_WINDOWPANE) {
-			lcroot = layout_replace_with_node(w, lcnew,
-			    LAYOUT_TOPBOTTOM);
-			TAILQ_INSERT_TAIL(&lcroot->cells, lc, entry);
-			lc->parent = lcroot;
-			w->layout_root = lcroot;
-		} else {
-			lcnew->parent = lcroot;
-			TAILQ_INSERT_HEAD(&lcroot->cells, lcnew, entry);
-		}
-		return (lcnew);
+		*cause = xstrdup("can't split a floating pane");
+		return (NULL);
 	}
 
 	type = LAYOUT_TOPBOTTOM;

--- a/layout.c
+++ b/layout.c
@@ -1542,9 +1542,11 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		lcnew = layout_create_cell(NULL);
 		layout_set_size(lcnew, w->sx, w->sy, 0, 0);
 		if (lcroot->type == LAYOUT_WINDOWPANE) {
-			layout_replace_with_node(w, lcnew, LAYOUT_TOPBOTTOM);
+			lcroot = layout_replace_with_node(w, lcnew,
+			    LAYOUT_TOPBOTTOM);
 			TAILQ_INSERT_TAIL(&lcroot->cells, lc, entry);
 			lc->parent = lcroot;
+			w->layout_root = lcroot;
 		} else {
 			lcnew->parent = lcroot;
 			TAILQ_INSERT_HEAD(&lcroot->cells, lcnew, entry);

--- a/layout.c
+++ b/layout.c
@@ -1185,6 +1185,32 @@ layout_resize_child_cells(struct window *w, struct layout_cell *lc)
 }
 
 /*
+ * Replaces the provided layout cell with a new node of the specified type and
+ * inserts the cell into it. Used when creating new cells requires a different
+ * layout type, or when the root layout is a window pane.
+ */
+static struct layout_cell *
+layout_replace_with_node(struct window *w, struct layout_cell *lc,
+    enum layout_type type)
+{
+	struct layout_cell	*lcparent;
+
+	lcparent = layout_create_cell(lc->parent);
+	layout_make_node(lcparent, type);
+	layout_set_size(lcparent, lc->sx, lc->sy, lc->xoff, lc->yoff);
+	if (lc->parent == NULL)
+		w->layout_root = lcparent;
+	else
+		TAILQ_REPLACE(&lc->parent->cells, lc, lcparent, entry);
+
+	/* Insert the old cell. */
+	lc->parent = lcparent;
+	TAILQ_INSERT_HEAD(&lcparent->cells, lc, entry);
+
+	return (lcparent);
+}
+
+/*
  * Split a pane into two. size is a hint, or -1 for default half/half
  * split. This must be followed by layout_assign_pane before much else happens!
  */
@@ -1315,17 +1341,7 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 		 */
 
 		/* Create and insert the replacement parent. */
-		lcparent = layout_create_cell(lc->parent);
-		layout_make_node(lcparent, type);
-		layout_set_size(lcparent, sx, sy, xoff, yoff);
-		if (lc->parent == NULL)
-			wp->window->layout_root = lcparent;
-		else
-			TAILQ_REPLACE(&lc->parent->cells, lc, lcparent, entry);
-
-		/* Insert the old cell. */
-		lc->parent = lcparent;
-		TAILQ_INSERT_HEAD(&lcparent->cells, lc, entry);
+		lcparent = layout_replace_with_node(wp->window, lc, type);
 
 		/* Create the new child cell. */
 		lcnew = layout_create_cell(lcparent);
@@ -1384,15 +1400,9 @@ layout_floating_pane(struct window *w, struct window_pane *wp, u_int sx,
 		* Adding a pane to a root that isn't node. Must create and
 		* insert a new root.
 		*/
-		lcparent = layout_create_cell(NULL);
-		layout_make_node(lcparent, LAYOUT_TOPBOTTOM);
-		layout_set_size(lcparent, w->sx, w->sy, 0, 0);
-		w->layout_root = lcparent;
-
-		/* Insert the old cell. */
-		lc->parent = lcparent;
-		TAILQ_INSERT_HEAD(&lcparent->cells, lc, entry);
-	}
+		lcparent = layout_replace_with_node(w, lc, LAYOUT_TOPBOTTOM);
+	} else
+		lcparent = w->layout_root;
 
 	lcnew = layout_create_cell(lcparent);
 	TAILQ_INSERT_AFTER(&lcparent->cells, lc, lcnew, entry);
@@ -1512,15 +1522,34 @@ struct layout_cell *
 layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
     struct window *w, struct window_pane *wp, int flags, char **cause)
 {
-	struct layout_cell	*lc;
+	struct layout_cell	*lcnew, *lc = wp->layout_cell;
+	struct layout_cell	*lcroot = w->layout_root;
 	enum layout_type	 type;
 	u_int			 curval;
 	int			 size = -1;
 	char			*error = NULL;
 
 	if (window_pane_is_floating(wp)) {
-		*cause = xstrdup("can't split a floating pane");
-		return (NULL);
+		if (layout_cell_has_tiled_child(lcroot)) {
+			*cause = xstrdup("can't split a floating pane");
+			return (NULL);
+		}
+		/*
+		 * When no panes are tiled, a new cell is created and inserted
+		 * at the top of the root node. A new root node is created if
+		 * necessary.
+		 */
+		lcnew = layout_create_cell(NULL);
+		layout_set_size(lcnew, w->sx, w->sy, 0, 0);
+		if (lcroot->type == LAYOUT_WINDOWPANE) {
+			layout_replace_with_node(w, lcnew, LAYOUT_TOPBOTTOM);
+			TAILQ_INSERT_TAIL(&lcroot->cells, lc, entry);
+			lc->parent = lcroot;
+		} else {
+			lcnew->parent = lcroot;
+			TAILQ_INSERT_HEAD(&lcroot->cells, lcnew, entry);
+		}
+		return (lcnew);
 	}
 
 	type = LAYOUT_TOPBOTTOM;
@@ -1562,11 +1591,11 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		flags |= SPAWN_FULLSIZE;
 
 	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
-	lc = layout_split_pane(wp, type, size, flags);
-	if (lc == NULL)
+	lcnew = layout_split_pane(wp, type, size, flags);
+	if (lcnew == NULL)
 		*cause = xstrdup("no space for a new pane");
 
-	return (lc);
+	return (lcnew);
 }
 
 struct layout_cell *
@@ -1712,7 +1741,11 @@ layout_remove_tile(struct window *w, struct layout_cell *lc)
 		layout_resize_adjust(w, lcneighbour, type, change);
 	}
 
-	/* Zeroing out the cell geometry until the cell is retiled. */
-	layout_set_size(lc, 0, 0, 0, 0);
+	/*
+	 * Zeroing out the cell geometry until the cell is retiled unless this
+	 * is the top level node.
+	 */
+	if (lc->parent != NULL)
+		layout_set_size(lc, 0, 0, 0, 0);
 	return (1);
 }

--- a/tmux.1
+++ b/tmux.1
@@ -2744,6 +2744,15 @@ and
 .Fl Y
 options set the position of the upper-left corner of the pane.
 If omitted, new floating panes are cascaded from the top-left of the window.
+The
+.Fl x ,
+.Fl y ,
+.Fl X ,
+and
+.Fl Y
+options may be followed by
+.Ql %
+to specify a percentage of the window size.
 .Pp
 If the pane had previously been floating, the position and sizes are restored
 from the saved values not specified by the
@@ -3588,7 +3597,7 @@ but a different format may be specified with
 .Fl F .
 .Tg newp
 .It Xo Ic new\-pane
-.Op Fl bdefhIkPvWZ
+.Op Fl bdefhIkLPvWZ
 .Op Fl B Ar border\-lines
 .Op Fl c Ar start\-directory
 .Op Fl e Ar environment
@@ -3601,101 +3610,50 @@ but a different format may be specified with
 .Op Fl S Ar active\-border\-style
 .Op Fl t Ar target\-pane
 .Op Fl T Ar title
+.Op Fl x Ar width
+.Op Fl y Ar height
+.Op Fl X Ar x-position
+.Op Fl Y Ar y-position
 .Op Ar shell\-command Op Ar argument ...
 .Xc
 .D1 Pq alias: Ic newp
-Create a new pane.
-The new pane is created by splitting
-.Ar target\-pane .
-If
-.Fl d
-is given, the session does not make the new pane the current pane.
-.Fl Z
-zooms if the window is not zoomed, or keeps it zoomed if already zoomed.
-.Fl s
-sets the style for the pane content.
-.Fl S
-sets the border style when the pane is active and
-.Fl R
-sets the border style when the pane is inactive (see
-.Sx STYLES ) .
-.Fl T
-sets the pane title.
+Creates a new floating pane.
+The
+.Fl x
+and
+.Fl y
+options set the width and height of the floating pane in columns and lines
+respectively.
+The default is half the window width and a quarter the window height.
+The
+.Fl X
+and
+.Fl Y
+options set the position of the upper-left corner of the pane.
+If omitted, new floating panes are cascaded from the top-left of the window.
+The
+.Fl x ,
+.Fl y ,
+.Fl X ,
+and
+.Fl Y
+options may be followed by
+.Ql %
+to specify a percentage of the window size.
 .Fl B
 sets the pane border lines for floating panes; see
 .Ic pane\-border\-lines .
 .Pp
-.Fl h
-does a horizontal split and
-.Fl v
-a vertical split; if neither is specified,
-.Fl v
-is assumed.
 The
-.Fl l
-option specifies the size of the new pane in lines (for vertical split) or in
-columns (for horizontal split);
-.Ar size
-may be followed by
-.Ql %
-to specify a percentage of the available space.
-.Fl p
-is a shorthand option for this.
-The
-.Fl b
-option causes the new pane to be created to the left of or above
-.Ar target\-pane .
-The
-.Fl f
-option creates a new pane spanning the full window height (with
-.Fl h )
-or full window width (with
-.Fl v ) ,
-instead of splitting the active pane.
-.Pp
-.Fl k
-keeps the pane open after the optional
-.Ar shell\-command
-exits and waits for a key to be pressed before closing it.
-The message shown is controlled by the
-.Ic remain\-on\-exit\-format
-option.
-.Fl m Ar message
-is equivalent to
-.Fl k
-but also sets the
-.Ic remain\-on\-exit\-format
-option for this pane to
-.Ar message .
-.Pp
-.Fl W
-Waits until
-.Ar shell\-command
-exits, then returns its exit status.
-For example:
-.Bd -literal -offset indent
-$ tmux new-pane -W 'vi afile'
-$ echo $?
-0
-.Ed
-.Pp
-.Fl E ,
-or an empty
-.Ar shell\-command ,
-(\[aq]\[aq]) will create an empty pane with no command running in it;
-.Ic display-message
-.Fl I
-can write to an empty pane.
-The
-.Fl I
-flag will create an empty pane and forward any output from stdin to it.
-For example:
-.Bd -literal -offset indent
-$ make 2>&1|tmux new\-pane \-dI &
-.Ed
+.Fl L
+option makes
+.Ic new\-pane
+behave like
+.Ic split\-window ,
+unless there is no tiled layout, then a new tiled pane is created.
 .Pp
 All other options have the same meaning as for the
-.Ic new\-window
+.Ic split\-window
 command.
 .Tg nextl
 .It Ic next\-layout Op Fl t Ar target\-window
@@ -4050,14 +4008,92 @@ the command behaves like
 .Op Ar shell\-command Op Ar argument ...
 .Xc
 .D1 Pq alias: Ic splitw
-Creates a new pane by splitting
+Create a new pane by splitting
 .Ar target\-pane .
-Shares behavior with
-.Ic new\-pane .
+If
+.Fl d
+is given, the session does not make the new pane the current pane.
+.Fl Z
+zooms if the window is not zoomed, or keeps it zoomed if already zoomed.
+.Fl s
+sets the style for the pane content.
+.Fl S
+sets the border style when the pane is active and
+.Fl R
+sets the border style when the pane is inactive (see
+.Sx STYLES ) .
+.Fl T
+sets the pane title.
 .Pp
-See
-.Ic new\-pane
-for more details.
+.Fl h
+does a horizontal split and
+.Fl v
+a vertical split; if neither is specified,
+.Fl v
+is assumed.
+The
+.Fl l
+option specifies the size of the new pane in lines (for vertical split) or in
+columns (for horizontal split);
+.Ar size
+may be followed by
+.Ql %
+to specify a percentage of the available space.
+.Fl p
+is a shorthand option for this.
+The
+.Fl b
+option causes the new pane to be created to the left of or above
+.Ar target\-pane .
+The
+.Fl f
+option creates a new pane spanning the full window height (with
+.Fl h )
+or full window width (with
+.Fl v ) ,
+instead of splitting the active pane.
+.Pp
+.Fl k
+keeps the pane open after the optional
+.Ar shell\-command
+exits and waits for a key to be pressed before closing it.
+The message shown is controlled by the
+.Ic remain\-on\-exit\-format
+option.
+.Fl m Ar message
+is equivalent to
+.Fl k
+but also sets the
+.Ic remain\-on\-exit\-format
+option for this pane to
+.Ar message .
+.Pp
+.Fl W
+Waits until
+.Ar shell\-command
+exits, then returns its exit status.
+For example:
+.Bd -literal -offset indent
+$ tmux new-pane -W 'vi afile'
+$ echo $?
+0
+.Ed
+.Pp
+.Fl E ,
+or an empty
+.Ar shell\-command ,
+(\[aq]\[aq]) will create an empty pane with no command running in it;
+.Ic display-message
+.Fl I
+can write to an empty pane.
+The
+.Fl I
+flag will create an empty pane and forward any output from stdin to it.
+For example:
+.Bd -literal -offset indent
+$ make 2>&1|tmux new\-pane \-dI &
+.Ed
+.Pp
 .Tg swapp
 .It Xo Ic swap\-pane
 .Op Fl dDUZ

--- a/tmux.h
+++ b/tmux.h
@@ -3692,6 +3692,8 @@ int		 layout_resize_floating_pane_to(struct window_pane *,
 		     enum layout_type, u_int, char **);
 void		 layout_assign_pane(struct layout_cell *, struct window_pane *,
 		     int);
+struct layout_cell *layout_replace_with_node(struct window *,
+		     struct layout_cell *, enum layout_type);
 struct layout_cell *layout_split_pane(struct window_pane *, enum layout_type,
 		     int, int);
 struct layout_cell *layout_floating_pane(struct window *, struct window_pane *,
@@ -3699,6 +3701,7 @@ struct layout_cell *layout_floating_pane(struct window *, struct window_pane *,
 void		 layout_close_pane(struct window_pane *);
 int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
+int		 layout_cell_has_tiled_child(struct layout_cell *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
 		     struct window *, struct window_pane *, int, char **);
 struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,


### PR DESCRIPTION
This fixes #5213. The logic to create and swap in a new parent node has been pulled into its own function. This logic is used in many places.