### PR TITLE
feat(master): `break-pane` now has `W/x/y/X/Y` to float a tiled pane.

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -34,9 +34,10 @@ const struct cmd_entry cmd_break_pane_entry = {
 	.name = "break-pane",
 	.alias = "breakp",
 
-	.args = { "abdPF:n:s:t:", 0, 0, NULL },
-	.usage = "[-abdP] [-F format] [-n window-name] [-s src-pane] "
-		 "[-t dst-window]",
+	.args = { "abdPF:n:s:t:Wx:X:y:Y:", 0, 0, NULL },
+	.usage = "[-abdPW] [-F format] [-n window-name] [-s src-pane] "
+		 "[-t dst-window] [-x width] [-y height] [-X x-position] "
+		 "[-Y y-position]",
 
 	.source = { 's', CMD_FIND_PANE, 0 },
 	.target = { 't', CMD_FIND_WINDOW, CMD_FIND_WINDOW_INDEX },
@@ -44,6 +45,47 @@ const struct cmd_entry cmd_break_pane_entry = {
 	.flags = 0,
 	.exec = cmd_break_pane_exec
 };
+
+static enum cmd_retval
+cmd_break_pane_float(struct cmdq_item *item, struct args *args,
+    struct window *w, struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+	u_int			 sx = lc->saved_sx, sy = lc->saved_sy;
+	int			 ox = lc->saved_xoff, oy = lc->saved_yoff;
+	char			*cause = NULL;
+
+	if (window_pane_is_floating(wp)) {
+		cmdq_error(item, "pane is already floating");
+		return (CMD_RETURN_ERROR);
+	}
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't float a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+
+	layout_remove_tile(w, lc);
+	layout_floating_args_parse(item, args, w, &sx, &sy, &ox, &oy, &cause);
+	if (cause != NULL) {
+		cmdq_error(item, "failed to float pane: %s", cause);
+		free(cause);
+		return (CMD_RETURN_ERROR);
+	}
+	layout_set_size(lc, sx, sy, ox, oy);
+
+	lc->flags |= LAYOUT_CELL_FLOATING;
+	TAILQ_REMOVE(&w->z_index, wp, zentry);
+	TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
+
+	if (!args_has(args, 'd'))
+		window_set_active_pane(w, wp, 1);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
+
+	return (CMD_RETURN_NORMAL);
+}
 
 static enum cmd_retval
 cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
@@ -61,6 +103,9 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	char			*newname, *cause, *cp;
 	int			 idx = target->idx, before;
 	const char		*template, *name = args_get(args, 'n');
+
+	if (args_has(args, 'W'))
+		return (cmd_break_pane_float(item, args, w, wp));
 
 	if (name != NULL && !check_name(name, WINDOW_NAME_FORBID)) {
 		cmdq_error(item, "invalid window name: %s", name);

--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -54,6 +54,7 @@ cmd_break_pane_float(struct cmdq_item *item, struct args *args,
 	u_int			 sx = lc->saved_sx, sy = lc->saved_sy;
 	int			 ox = lc->saved_xoff, oy = lc->saved_yoff;
 	char			*cause = NULL;
+	enum pane_lines		 lines = window_get_pane_lines(w);
 
 	if (window_pane_is_floating(wp)) {
 		cmdq_error(item, "pane is already floating");
@@ -64,13 +65,14 @@ cmd_break_pane_float(struct cmdq_item *item, struct args *args,
 		return (CMD_RETURN_ERROR);
 	}
 
-	layout_remove_tile(w, lc);
-	layout_floating_args_parse(item, args, w, &sx, &sy, &ox, &oy, &cause);
+	layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
+	    &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "failed to float pane: %s", cause);
 		free(cause);
 		return (CMD_RETURN_ERROR);
 	}
+	layout_remove_tile(w, lc);
 	layout_set_size(lc, sx, sy, ox, oy);
 
 	lc->flags |= LAYOUT_CELL_FLOATING;

--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -65,9 +65,8 @@ cmd_break_pane_float(struct cmdq_item *item, struct args *args,
 		return (CMD_RETURN_ERROR);
 	}
 
-	layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
-	    &cause);
-	if (cause != NULL) {
+	if (layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
+	    &cause) != 0) {
 		cmdq_error(item, "failed to float pane: %s", cause);
 		free(cause);
 		return (CMD_RETURN_ERROR);

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -101,9 +101,8 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			return (CMD_RETURN_ERROR);
 		}
 		if (window_pane_is_floating(wp)) {
-			layout_resize_floating_pane_to(wp, LAYOUT_LEFTRIGHT, x,
-			    &cause);
-			if (cause != NULL) {
+			if (layout_resize_floating_pane_to(wp, LAYOUT_LEFTRIGHT,
+			    x, &cause) != 0) {
 				cmdq_error(item, "size %s", cause);
 				free(cause);
 				return (CMD_RETURN_ERROR);
@@ -130,9 +129,8 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			break;
 		}
 		if (window_pane_is_floating(wp)) {
-			layout_resize_floating_pane_to(wp, LAYOUT_TOPBOTTOM, y,
-			    &cause);
-			if (cause != NULL) {
+			if (layout_resize_floating_pane_to(wp, LAYOUT_TOPBOTTOM,
+			    y, &cause) != 0) {
 				cmdq_error(item, "size %s", cause);
 				free(cause);
 				return (CMD_RETURN_ERROR);
@@ -164,9 +162,8 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			if (flag == 'L' || flag == 'U')
 				opposite = 1;
 
-			layout_resize_floating_pane(wp, type, adjust, opposite,
-			    &cause);
-			if (cause != NULL) {
+			if (layout_resize_floating_pane(wp, type, adjust,
+			    opposite, &cause) != 0) {
 				cmdq_error(item, "adjustment %s", cause);
 				free(cause);
 				return (CMD_RETURN_ERROR);

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -70,25 +70,6 @@ const struct cmd_entry cmd_split_window_entry = {
 	.exec = cmd_split_window_exec
 };
 
-static struct layout_cell *
-layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    enum pane_lines lines, struct window *w, struct window_pane *wp,
-    char **cause)
-{
-	struct layout_cell	*lcnew;
-	u_int			 sx = UINT_MAX, sy = UINT_MAX;
-	int			 ox = INT_MAX, oy = INT_MAX;
-
-	layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
-	    cause);
-	if (*cause != NULL) {
-		return (NULL);
-	}
-
-	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
-	return (lcnew);
-}
-
 static enum cmd_retval
 cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 {

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -70,6 +70,25 @@ const struct cmd_entry cmd_split_window_entry = {
 	.exec = cmd_split_window_exec
 };
 
+static struct layout_cell *
+layout_get_floating_cell(struct cmdq_item *item, struct args *args,
+    enum pane_lines lines, struct window *w, struct window_pane *wp,
+    char **cause)
+{
+	struct layout_cell	*lcnew;
+	u_int			 sx = UINT_MAX, sy = UINT_MAX;
+	int			 ox = INT_MAX, oy = INT_MAX;
+
+	layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
+	    cause);
+	if (*cause != NULL) {
+		return (NULL);
+	}
+
+	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
+	return (lcnew);
+}
+
 static enum cmd_retval
 cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 {

--- a/layout.c
+++ b/layout.c
@@ -74,6 +74,12 @@ layout_create_cell(struct layout_cell *lcparent)
 	lc->xoff = INT_MAX;
 	lc->yoff = INT_MAX;
 
+	lc->saved_sx = UINT_MAX;
+	lc->saved_sy = UINT_MAX;
+
+	lc->saved_xoff = INT_MAX;
+	lc->saved_yoff = INT_MAX;
+
 	lc->wp = NULL;
 
 	return (lc);
@@ -1568,9 +1574,37 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
     char **cause)
 {
 	struct layout_cell	*lcnew;
-	int			 sx = w->sx / 2, sy = w->sy / 4;
+	u_int			 sx = UINT_MAX, sy = UINT_MAX;
 	int			 ox = INT_MAX, oy = INT_MAX;
-	char			*error;
+
+	layout_floating_args_parse(item, args, w, &sx, &sy, &ox, &oy, cause);
+	if (*cause != NULL) {
+		return (NULL);
+	}
+
+	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
+		*cause = xstrdup("invalid width");
+		return (NULL);
+	}
+	if (sy < PANE_MINIMUM || sy > PANE_MAXIMUM) {
+		*cause = xstrdup("invalid height");
+		return (NULL);
+	}
+
+	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
+	return (lcnew);
+}
+
+void
+layout_floating_args_parse(struct cmdq_item *item, struct args *args,
+    struct window *w, u_int *sxp, u_int *syp, int *oxp, int *oyp, char **cause)
+{
+	int	sx, sy, ox, oy;
+
+	sx = *sxp == UINT_MAX ? w->sx / 2 : *sxp;
+	sy = *syp == UINT_MAX ? w->sy / 4 : *syp;
+	ox = *oxp == INT_MAX ? INT_MAX : *oxp;
+	oy = *oyp == INT_MAX ? INT_MAX : *oyp;
 
 	if (args_has(args, 'x')) {
 		sx = args_percentage_and_expand(args, 'x', 0, PANE_MAXIMUM,
@@ -1595,22 +1629,16 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 			sy -= 2;
 	}
 	if (args_has(args, 'X')) {
-		ox = args_percentage_and_expand(args, 'X', -sx, w->sx,
-		    w->sx, item, &error);
-		if (error != NULL) {
-			xasprintf(cause, "size %s", error);
-			free(error);
-			return (NULL);
-		}
+		ox = args_percentage_and_expand(args, 'X', -(int)w->sx, w->sx,
+		    w->sx, item, cause);
+		if (*cause != NULL)
+			return;
 	}
 	if (args_has(args, 'Y')) {
-		oy = args_percentage_and_expand(args, 'Y', -sy, w->sy,
-		    w->sy, item, &error);
-		if (error != NULL) {
-			xasprintf(cause, "size %s", error);
-			free(error);
-			return (NULL);
-		}
+		oy = args_percentage_and_expand(args, 'Y', -(int)w->sy, w->sy,
+		    w->sy, item, cause);
+		if (*cause != NULL)
+			return;
 	}
 
 	if (ox == INT_MAX) {
@@ -1647,8 +1675,10 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
-	return (lcnew);
+	*sxp = sx;
+	*syp = sy;
+	*oxp = ox;
+	*oyp = oy;
 }
 
 /*

--- a/layout.c
+++ b/layout.c
@@ -1623,7 +1623,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 			sy -= 2;
 	}
 	if (args_has(args, 'X')) {
-		ox = args_percentage_and_expand(args, 'X', -(int)w->sx, w->sx,
+		ox = args_percentage_and_expand(args, 'X', -sx, w->sx,
 		    w->sx, item, &error);
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
@@ -1632,7 +1632,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		}
 	}
 	if (args_has(args, 'Y')) {
-		oy = args_percentage_and_expand(args, 'Y', -(int)w->sy, w->sy,
+		oy = args_percentage_and_expand(args, 'Y', -sy, w->sy,
 		    w->sy, item, &error);
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);

--- a/layout.c
+++ b/layout.c
@@ -1567,39 +1567,13 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 	return (lc);
 }
 
-/* Get a new floating cell. */
-struct layout_cell *
-layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    enum pane_lines lines, struct window *w, struct window_pane *wp,
-    char **cause)
-{
-	struct layout_cell	*lcnew;
-	u_int			 sx = UINT_MAX, sy = UINT_MAX;
-	int			 ox = INT_MAX, oy = INT_MAX;
-
-	layout_floating_args_parse(item, args, w, &sx, &sy, &ox, &oy, cause);
-	if (*cause != NULL) {
-		return (NULL);
-	}
-
-	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
-		*cause = xstrdup("invalid width");
-		return (NULL);
-	}
-	if (sy < PANE_MINIMUM || sy > PANE_MAXIMUM) {
-		*cause = xstrdup("invalid height");
-		return (NULL);
-	}
-
-	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
-	return (lcnew);
-}
-
 void
 layout_floating_args_parse(struct cmdq_item *item, struct args *args,
-    struct window *w, u_int *sxp, u_int *syp, int *oxp, int *oyp, char **cause)
+    enum pane_lines lines, struct window *w, u_int *sxp, u_int *syp, int *oxp,
+    int *oyp, char **cause)
 {
-	int	sx, sy, ox, oy;
+	int	 sx, sy, ox, oy;
+	char	*error = NULL;
 
 	sx = *sxp == UINT_MAX ? w->sx / 2 : *sxp;
 	sy = *syp == UINT_MAX ? w->sy / 4 : *syp;
@@ -1612,7 +1586,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return (NULL);
+			return;
 		}
 		if (lines != PANE_LINES_NONE)
 			sx -= 2;
@@ -1623,22 +1597,28 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return (NULL);
+			return;
 		}
 		if (lines != PANE_LINES_NONE)
 			sy -= 2;
 	}
 	if (args_has(args, 'X')) {
 		ox = args_percentage_and_expand(args, 'X', -(int)w->sx, w->sx,
-		    w->sx, item, cause);
-		if (*cause != NULL)
+		    w->sx, item, &error);
+		if (error != NULL) {
+			xasprintf(cause, "position %s", error);
+			free(error);
 			return;
+		}
 	}
 	if (args_has(args, 'Y')) {
 		oy = args_percentage_and_expand(args, 'Y', -(int)w->sy, w->sy,
-		    w->sy, item, cause);
-		if (*cause != NULL)
+		    w->sy, item, &error);
+		if (error != NULL) {
+			xasprintf(cause, "position %s", error);
+			free(error);
 			return;
+		}
 	}
 
 	if (ox == INT_MAX) {
@@ -1668,11 +1648,11 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 
 	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
 		*cause = xstrdup("invalid width");
-		return (NULL);
+		return;
 	}
 	if (sy < PANE_MINIMUM || sy > PANE_MAXIMUM) {
 		*cause = xstrdup("invalid height");
-		return (NULL);
+		return;
 	}
 
 	*sxp = sx;

--- a/layout.c
+++ b/layout.c
@@ -820,7 +820,7 @@ layout_resize_pane_to(struct window_pane *wp, enum layout_type type,
 }
 
 /* Resize a floating pane to an absolute size. */
-void
+int
 layout_resize_floating_pane_to(struct window_pane *wp, enum layout_type type,
     u_int size, char **cause)
 {
@@ -828,7 +828,7 @@ layout_resize_floating_pane_to(struct window_pane *wp, enum layout_type type,
 
 	if (~lc->flags & LAYOUT_CELL_FLOATING) {
 		*cause = xstrdup("pane is not floating");
-		return;
+		return (-1);
 	}
 
 	if (window_pane_get_pane_lines(wp) != PANE_LINES_NONE &&
@@ -836,23 +836,24 @@ layout_resize_floating_pane_to(struct window_pane *wp, enum layout_type type,
 		size -= 2;
 	if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
 		*cause = xstrdup("size is too big or too small");
-		return;
+		return (-1);
 	}
 
 	if (type == LAYOUT_TOPBOTTOM) {
 		if (lc->sy == size)
-			return;
+			return (0);
 		lc->sy = size;
 	} else {
 		if (lc->sx == size)
-			return;
+			return (0);
 		lc->sx = size;
 	}
 	redraw_invalidate_scene(wp->window);
+	return (0);
 }
 
 /* Resize a floating pane relative to its current size. */
-void
+int
 layout_resize_floating_pane(struct window_pane *wp, enum layout_type type,
     int change, int opposite, char **cause)
 {
@@ -861,16 +862,16 @@ layout_resize_floating_pane(struct window_pane *wp, enum layout_type type,
 
 	if (~lc->flags & LAYOUT_CELL_FLOATING) {
 		*cause = xstrdup("pane is not floating");
-		return;
+		return (-1);
 	}
 	if (change == 0)
-		return;
+		return (0);
 
 	if (type == LAYOUT_TOPBOTTOM) {
 		size = lc->sy + change;
 		if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
 			*cause = xstrdup("change is too big or too small");
-			return;
+			return (-1);
 		}
 		lc->sy = size;
 		if (opposite)
@@ -879,13 +880,14 @@ layout_resize_floating_pane(struct window_pane *wp, enum layout_type type,
 		size = lc->sx + change;
 		if (size < PANE_MINIMUM || size > PANE_MAXIMUM) {
 			*cause = xstrdup("change is too big or too small");
-			return;
+			return (-1);
 		}
 		lc->sx = size;
 		if (opposite)
 			lc->xoff -= change;
 	}
 	redraw_invalidate_scene(wp->window);
+	return (0);
 }
 
 /* Resize a layout cell. */
@@ -1567,7 +1569,25 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 	return (lc);
 }
 
-void
+struct layout_cell *
+layout_get_floating_cell(struct cmdq_item *item, struct args *args,
+    enum pane_lines lines, struct window *w, struct window_pane *wp,
+    char **cause)
+{
+	struct layout_cell	*lcnew;
+	u_int			 sx = UINT_MAX, sy = UINT_MAX;
+	int			 ox = INT_MAX, oy = INT_MAX;
+
+	if (layout_floating_args_parse(item, args, lines, w, &sx, &sy, &ox, &oy,
+	    cause) != 0) {
+		return (NULL);
+	}
+
+	lcnew = layout_floating_pane(w, wp, sx, sy, ox, oy);
+	return (lcnew);
+}
+
+int
 layout_floating_args_parse(struct cmdq_item *item, struct args *args,
     enum pane_lines lines, struct window *w, u_int *sxp, u_int *syp, int *oxp,
     int *oyp, char **cause)
@@ -1586,7 +1606,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return;
+			return (-1);
 		}
 		if (lines != PANE_LINES_NONE)
 			sx -= 2;
@@ -1597,7 +1617,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return;
+			return (-1);
 		}
 		if (lines != PANE_LINES_NONE)
 			sy -= 2;
@@ -1608,7 +1628,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return;
+			return (-1);
 		}
 	}
 	if (args_has(args, 'Y')) {
@@ -1617,7 +1637,7 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 		if (error != NULL) {
 			xasprintf(cause, "position %s", error);
 			free(error);
-			return;
+			return (-1);
 		}
 	}
 
@@ -1648,17 +1668,18 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 
 	if (sx < PANE_MINIMUM || sx > PANE_MAXIMUM) {
 		*cause = xstrdup("invalid width");
-		return;
+		return (-1);
 	}
 	if (sy < PANE_MINIMUM || sy > PANE_MAXIMUM) {
 		*cause = xstrdup("invalid height");
-		return;
+		return (-1);
 	}
 
 	*sxp = sx;
 	*syp = sy;
 	*oxp = ox;
 	*oyp = oy;
+	return (0);
 }
 
 /*

--- a/tmux.1
+++ b/tmux.1
@@ -2692,11 +2692,15 @@ Commands related to windows and panes are as follows:
 .Bl -tag -width Ds
 .Tg breakp
 .It Xo Ic break\-pane
-.Op Fl abdP
+.Op Fl abdPW
 .Op Fl F Ar format
 .Op Fl n Ar window\-name
 .Op Fl s Ar src\-pane
 .Op Fl t Ar dst\-window
+.Op Fl x Ar width
+.Op Fl y Ar height
+.Op Fl X Ar x-position
+.Op Fl Y Ar y-position
 .Xc
 .D1 Pq alias: Ic breakp
 Break
@@ -2719,6 +2723,40 @@ By default, it uses the format
 .Ql #{session_name}:#{window_index}.#{pane_index}
 but a different format may be specified with
 .Fl F .
+.Pp
+If the
+.Fl W
+option is given,
+.Ar src\-pane
+is lifted out of the tiled layout and made floating.
+The
+.Fl x
+and
+.Fl y
+options set the width and height of the floating pane in columns and lines
+respectively.
+The default is half the window width and a quarter the window height.
+The
+.Fl X
+and
+.Fl Y
+options set the position of the upper-left corner of the pane.
+If omitted, new floating panes are cascaded from the top-left of the window.
+.Pp
+If the pane had previously been floating, the position and sizes are restored
+from the saved values not specified by the
+.Fl x ,
+.Fl y ,
+.Fl X ,
+and
+.Fl Y
+options.
+.Pp
+If
+.Fl d
+is given, the active pane is not changed.
+The pane must not already be floating or hidden, and the window must not
+be zoomed.
 .Tg capturep
 .It Xo Ic capture\-pane
 .Op Fl aeFHLpPqCJMN

--- a/tmux.h
+++ b/tmux.h
@@ -3594,7 +3594,8 @@ void		 layout_spread_out(struct window_pane *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
 		     struct window *, struct window_pane *, int, char **);
 void		 layout_floating_args_parse(struct cmdq_item *, struct args *,
-		     struct window *, u_int *, u_int *, int *, int *, char **);
+		     enum pane_lines, struct window *, u_int *, u_int *, int *,
+		     int *, char **);
 int		 layout_remove_tile(struct window *, struct layout_cell *);
 
 /* layout-custom.c */

--- a/tmux.h
+++ b/tmux.h
@@ -3578,9 +3578,9 @@ void		 layout_resize_pane(struct window_pane *, enum layout_type,
 		     int, int);
 void		 layout_resize_pane_to(struct window_pane *, enum layout_type,
 		     u_int);
-void		 layout_resize_floating_pane(struct window_pane *,
+int		 layout_resize_floating_pane(struct window_pane *,
 		     enum layout_type, int, int, char **);
-void		 layout_resize_floating_pane_to(struct window_pane *,
+int		 layout_resize_floating_pane_to(struct window_pane *,
 		     enum layout_type, u_int, char **);
 void		 layout_assign_pane(struct layout_cell *, struct window_pane *,
 		     int);
@@ -3593,7 +3593,10 @@ int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
 		     struct window *, struct window_pane *, int, char **);
-void		 layout_floating_args_parse(struct cmdq_item *, struct args *,
+struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
+		     enum pane_lines, struct window *, struct window_pane *,
+		     char **cause);
+int		 layout_floating_args_parse(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, u_int *, u_int *, int *,
 		     int *, char **);
 int		 layout_remove_tile(struct window *, struct layout_cell *);

--- a/tmux.h
+++ b/tmux.h
@@ -1490,6 +1490,12 @@ struct layout_cell {
 	int		 xoff;
 	int		 yoff;
 
+	u_int		 saved_sx;
+	u_int		 saved_sy;
+
+	int		 saved_xoff;
+	int		 saved_yoff;
+
 	struct window_pane *wp;
 	struct layout_cells cells;
 
@@ -3587,9 +3593,8 @@ int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
 		     struct window *, struct window_pane *, int, char **);
-struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
-		     enum pane_lines, struct window *, struct window_pane *,
-		     char **);
+void		 layout_floating_args_parse(struct cmdq_item *, struct args *,
+		     struct window *, u_int *, u_int *, int *, int *, char **);
 int		 layout_remove_tile(struct window *, struct layout_cell *);
 
 /* layout-custom.c */


### PR DESCRIPTION
This PR is the next step in #5229. Window panes can now be floated out of their tiled positions. There is also some cleanup with error handling and the float args api. I have left in the new `saved` fields of `struct layout_cell`. They will be used in the coming PRs to restore geometry.