### PR TITLE
fix(master): Added border offset calculation to `move-pane`

### DIFF
--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -202,6 +202,7 @@ cmd_join_pane_move(struct cmdq_item *item, struct args *args,
 	char			*cause = NULL, flag;
 	int			 xoff = lc->xoff, yoff = lc->yoff, adjust;
 	u_int			 i;
+	enum pane_lines		 lines = window_pane_get_pane_lines(wp);
 
 	if (args_has(args, 'X')) {
 		xoff = args_percentage_and_expand(args, 'X', -(int)lc->sx,
@@ -211,6 +212,8 @@ cmd_join_pane_move(struct cmdq_item *item, struct args *args,
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
+		if (lines != PANE_LINES_NONE)
+			xoff += 1;
 	}
 	if (args_has(args, 'Y')) {
 		yoff = args_percentage_and_expand(args, 'Y', -(int)lc->sy,
@@ -220,6 +223,8 @@ cmd_join_pane_move(struct cmdq_item *item, struct args *args,
 			free(cause);
 			return (CMD_RETURN_ERROR);
 		}
+		if (lines != PANE_LINES_NONE)
+			yoff += 1;
 	}
 
 	for (i = 0; i < nitems(flags); i++) {

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -205,7 +205,7 @@ cmd_join_pane_move(struct cmdq_item *item, struct args *args,
 	enum pane_lines		 lines = window_pane_get_pane_lines(wp);
 
 	if (args_has(args, 'X')) {
-		xoff = args_percentage_and_expand(args, 'X', -(int)lc->sx,
+		xoff = args_percentage_and_expand(args, 'X', -(int)w->sx,
 		    w->sx, w->sx, item, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "position %s", cause);
@@ -216,7 +216,7 @@ cmd_join_pane_move(struct cmdq_item *item, struct args *args,
 			xoff += 1;
 	}
 	if (args_has(args, 'Y')) {
-		yoff = args_percentage_and_expand(args, 'Y', -(int)lc->sy,
+		yoff = args_percentage_and_expand(args, 'Y', -(int)w->sy,
 		    w->sy, w->sy, item, &cause);
 		if (cause != NULL) {
 			cmdq_error(item, "position %s", cause);


### PR DESCRIPTION
`move-pane` was overlooked when the floating geometry made to accommodate differing border styles. I have also corrected a strange lower bound when calculating the positions.