### PR TITLE
kitty images: render via unicode placeholders (grid-resident)

### DIFF
--- a/image-kitty.c
+++ b/image-kitty.c
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 
+#include <resolv.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -45,6 +46,11 @@ struct kitty_image {
 	int		 z_index;     /* z=: z-index */
 	char		 compression; /* o=: 'z'=zlib, 0=none */
 	char		 delete_what; /* d=: delete target (used with a=d) */
+
+	/* Set after this image has been transmitted to a kitty terminal so
+	 * we transmit the payload only once and let the terminal retain the
+	 * placement, rather than re-transmitting on every redraw. */
+	int			transmitted;
 
 	/* Cell size at the time of parsing (from the owning window). */
 	u_int		 xpixel;
@@ -229,9 +235,67 @@ kitty_free(struct kitty_image *ki)
  * Get the size in cells of a kitty image. If cols/rows are 0 (auto),
  * calculate from pixel dimensions. Returns size via sx/sy pointers.
  */
+/*
+ * For PNG images (f=100) the application often omits the pixel dimensions
+ * (s=, v=) because they are embedded in the PNG itself. Without them the
+ * cell-size computation below cannot work, so decode the IHDR from the
+ * accumulated base64 payload to recover the real width and height. This is
+ * only done once and only when the dimensions are missing.
+ */
+static void
+kitty_ensure_png_size(struct kitty_image *ki)
+{
+	char		head[33];
+	u_char		buf[24];
+	u_int		 w, h, n, take;
+	int		 decoded;
+
+	if (ki->format != 100)
+		return;
+	if (ki->pixel_w != 0 && ki->pixel_h != 0)
+		return;
+	if (ki->encoded == NULL || ki->encodedlen < 32)
+		return;
+
+	/*
+	 * The IHDR (width/height) is within the first 24 decoded bytes, i.e.
+	 * the first 32 base64 characters. b64_pton() decodes its entire input, so
+	 * feed it only that prefix - decoding the full payload into a tiny buffer
+	 * fails with -1.
+	 */
+	take = sizeof(head) - 1;
+	if (take > ki->encodedlen)
+		take = ki->encodedlen;
+	memcpy(head, ki->encoded, take);
+	head[take] = '\0';
+
+	/* b64_pton needs an input length that is a multiple of 4; trim back. */
+	n = take - (take % 4);
+	head[n] = '\0';
+	decoded = b64_pton(head, buf, sizeof buf);
+	if (decoded < 24)
+		return;
+
+	/* PNG: 8-byte signature, then IHDR chunk with 4-byte BE width/height. */
+	if (memcmp(buf, "\x89PNG\r\n\x1a\n", 8) != 0)
+		return;
+	if (memcmp(buf + 12, "IHDR", 4) != 0)
+		return;
+	w = (buf[16] << 24) | (buf[17] << 16) | (buf[18] << 8) | buf[19];
+	h = (buf[20] << 24) | (buf[21] << 16) | (buf[22] << 8) | buf[23];
+	if (w == 0 || h == 0)
+		return;
+	if (ki->pixel_w == 0)
+		ki->pixel_w = w;
+	if (ki->pixel_h == 0)
+		ki->pixel_h = h;
+}
+
 void
 kitty_size_in_cells(struct kitty_image *ki, u_int *sx, u_int *sy)
 {
+	kitty_ensure_png_size(ki);
+
 	*sx = ki->cols;
 	*sy = ki->rows;
 
@@ -265,48 +329,144 @@ kitty_get_image_id(struct kitty_image *ki)
 	return (ki->image_id);
 }
 
+void
+kitty_set_image_id(struct kitty_image *ki, u_int image_id)
+{
+	ki->image_id = image_id;
+}
+
+/*
+ * Override the image's display cell size. Used once the placeholder rectangle
+ * has been fitted to the pane (aspect preserved) so that every consumer of
+ * kitty_size_in_cells() - the grid cell loop and the per-client transmit -
+ * agrees on the same dimensions.
+ */
+void
+kitty_set_cells(struct kitty_image *ki, u_int cols, u_int rows)
+{
+	ki->cols = cols;
+	ki->rows = rows;
+}
+
 u_int
 kitty_get_rows(struct kitty_image *ki)
 {
 	return (ki->rows);
 }
 
+int
+kitty_get_transmitted(struct kitty_image *ki)
+{
+	return (ki->transmitted);
+}
+
+u_int
+kitty_get_more(struct kitty_image *ki)
+{
+	return (ki->more);
+}
+
+/* Append the base64 payload of "src" onto the accumulating "dst". */
+void
+kitty_append(struct kitty_image *dst, struct kitty_image *src)
+{
+	char	*new;
+	size_t	 newlen;
+
+	if (src->encoded == NULL || src->encodedlen == 0)
+		return;
+	newlen = dst->encodedlen + src->encodedlen;
+	new = xmalloc(newlen + 1);
+	if (dst->encoded != NULL && dst->encodedlen != 0)
+		memcpy(new, dst->encoded, dst->encodedlen);
+	memcpy(new + dst->encodedlen, src->encoded, src->encodedlen);
+	new[newlen] = '\0';
+	free(dst->encoded);
+	dst->encoded = new;
+	dst->encodedlen = newlen;
+}
+
+void
+kitty_set_transmitted(struct kitty_image *ki, int transmitted)
+{
+	ki->transmitted = transmitted;
+}
+
 /*
- * Serialize a kitty_image back into an APC escape sequence for transmission
- * to the terminal. This recreates the original command that was parsed.
+ * Allocate a unique, terminal-wide image id for a captured image, so that
+ * coexisting images (which applications frequently send with a recycled id
+ * such as i=1) get distinct ids and thus distinct placeholder colours. ids
+ * are kept below 256 so they fit in a 256-colour foreground escape, which is
+ * how the terminal recovers the image id from each placeholder cell.
+ */
+u_int
+kitty_alloc_id(void)
+{
+	static u_int	current = 0;
+
+	if (current == 0)
+		current = 1;
+	return (current++ % 255 + 1);
+}
+
+/*
+ * Serialize a kitty_image into a single complete APC for (re-)transmission
+ * to a kitty terminal. The control string is rebuilt from the parsed fields
+ * rather than echoed verbatim so that multi-chunk images (which arrived as
+ * several a=T,m=1 fragments and were accumulated) are re-emitted as one
+ * complete single-chunk transmit.
  */
 char *
 kitty_print(struct kitty_image *ki, size_t *outlen)
 {
+	char	ctrl[128];
+	size_t	 ctrllen, total, pos;
 	char	*out;
-	size_t	 total, pos;
 
-	if (ki == NULL || ki->ctrl == NULL)
+	if (ki == NULL)
 		return (NULL);
 
-	/* Calculate total length: ESC _ G + ctrl + ; + encoded + ESC \ */
-	total = 3 + ki->ctrllen;  /* \033_G + ctrl */
-	if (ki->encoded != NULL && ki->encodedlen > 0) {
-		total += 1 + ki->encodedlen;  /* ; + encoded */
-	}
-	total += 2;  /* \033\\ */
+	/* Rebuild a clean single-chunk control string from the fields. */
+	ctrllen = xsnprintf(ctrl, sizeof ctrl, "a=%c", ki->action);
+	if (ki->image_id != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",i=%u", ki->image_id);
+	if (ki->format != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",f=%u", ki->format);
+	if (ki->pixel_w != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",s=%u", ki->pixel_w);
+	if (ki->pixel_h != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",v=%u", ki->pixel_h);
+	if (ki->cols != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",c=%u", ki->cols);
+	if (ki->rows != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",r=%u", ki->rows);
+	if (ki->compression != 0)
+		ctrllen += xsnprintf(ctrl + ctrllen, sizeof ctrl - ctrllen,
+		    ",o=%c", ki->compression);
+
+	total = 3 + ctrllen + 2;
+	if (ki->encoded != NULL && ki->encodedlen > 0)
+		total += 1 + ki->encodedlen;
 
 	out = xmalloc(total + 1);
 	*outlen = total;
 
-	/* Build the sequence */
 	pos = 0;
 	memcpy(out + pos, "\033_G", 3);
 	pos += 3;
-	memcpy(out + pos, ki->ctrl, ki->ctrllen);
-	pos += ki->ctrllen;
-
+	memcpy(out + pos, ctrl, ctrllen);
+	pos += ctrllen;
 	if (ki->encoded != NULL && ki->encodedlen > 0) {
 		out[pos++] = ';';
 		memcpy(out + pos, ki->encoded, ki->encodedlen);
 		pos += ki->encodedlen;
 	}
-
 	memcpy(out + pos, "\033\\", 2);
 	pos += 2;
 	out[pos] = '\0';
@@ -322,4 +482,149 @@ kitty_delete_all(size_t *outlen)
 	out = xstrdup("\033_Ga=d,d=a\033\\");
 	*outlen = strlen(out);
 	return (out);
+}
+
+/*
+ * Unicode placeholder support. Instead of re-emitting the image as a terminal
+ * overlay (which tmux's grid-based, per-pane redraw model cannot clip or scroll),
+ * the image is transmitted once with a=T,U=1,q=2 (transmit + create a virtual
+ * placement, quiet) and then displayed by writing U+10EEEE placeholder cells
+ * into tmux's own grid. Because those cells are ordinary text, tmux's existing
+ * redraw/scroll/per-pane machinery handles clipping, scrolling and coexistence
+ * for free -- the image becomes grid-resident, like sixel.
+ */
+
+/* Combining diacritics encoding row/column numbers 0..N, from kitty's
+ * rowcolumn-diacritics.txt. */
+static const u_int kitty_diacritics[] = {
+	0x0305,0x030d,0x030e,0x0310,0x0312,0x033d,0x033e,0x033f,
+	0x0346,0x034a,0x034b,0x034c,0x0350,0x0351,0x0352,0x0353,
+	0x0357,0x035b,0x0363,0x0364,0x0365,0x0366,0x0367,0x0368,
+	0x0369,0x036a,0x036b,0x036c,0x036d,0x036e,0x036f,0x0483,
+	0x0484,0x0485,0x0486,0x0592,0x0593,0x0594,0x0595,0x0597,
+	0x0598,0x0599,0x059c,0x059d,0x059e,0x059f,0x05a0,0x05a1,
+	0x05a8,0x05a9,0x05ab,0x05ac,0x05af,0x05c4,0x0610,0x0611,
+	0x0612,0x0613,0x0614,0x0615,0x0616,0x0617,0x0618,0x0619,
+	0x061a,0x064b,0x064c,0x064d,0x064e,0x064f,0x0650,0x0651,
+	0x0652,0x0653,0x0654,0x0655,0x0656,0x0657,0x0658,0x0659,
+	0x065a,0x065b,0x065c,0x065d,0x065e,0x065f,0x0670,0x06d6,
+	0x06d7,0x06d8,0x06d9,0x06da,0x06db,0x06dc,0x06df,0x06e0,
+	0x06e1,0x06e2,0x06e3,0x06e4,0x06e7,0x06e8,0x06ea,0x06eb,
+	0x06ec,0x06ed,
+};
+#define KITTY_NDIACRITICS (sizeof kitty_diacritics / sizeof kitty_diacritics[0])
+
+static u_int
+kitty_diacritic(u_int n)
+{
+	if (n < KITTY_NDIACRITICS)
+		return (kitty_diacritics[n]);
+	return (kitty_diacritics[0]);
+}
+
+/*
+ * Build the UTF-8 bytes for one placeholder cell of image row `row`.
+ * The first column of a row carries the row and column-0 diacritics; later
+ * columns are bare U+10EEEE (the terminal auto-increments the column from the
+ * left neighbour). Writes into buf (must be >= 8 bytes) and returns the length.
+ */
+size_t
+kitty_placeholder_cell(u_int row, int first_column, char *buf, size_t buflen)
+{
+	static const u_char	ph[4] = { 0xf4, 0x8e, 0xbb, 0xae }; /* U+10EEEE */
+	size_t			off = 0, i;
+	u_int			cp;
+	u_char			enc[4];
+
+	/* Base placeholder character U+10EEEE (encoded directly so this does
+	 * not depend on the locale/wctomb). */
+	if (sizeof ph > buflen)
+		return (0);
+	memcpy(buf, ph, sizeof ph);
+	off = sizeof ph;
+
+	if (first_column) {
+		/* Row diacritic, then column-0 diacritic, each a combining mark
+	 * in the U+0300..U+07FF range: 2-byte UTF-8 (110xxxxx 10xxxxxx). */
+		for (i = 0; i < 2; i++) {
+			cp = kitty_diacritic(i == 0 ? row : 0);
+			enc[0] = 0xc0 | (cp >> 6);
+			enc[1] = 0x80 | (cp & 0x3f);
+			if (off + 2 > buflen)
+				return (0);
+			buf[off++] = enc[0];
+			buf[off++] = enc[1];
+		}
+	}
+	return (off);
+}
+
+/*
+ * Transmit a kitty image with a=T,U=1,q=2 (transmit data + create a virtual
+ * placement for unicode placeholders, quiet) so the terminal stores the image
+ * but does not display it directly. Display is done by placeholder cells in the
+ * grid. Large payloads are split into 4096-byte base64 chunks via m=1/m=0.
+ * Each chunk is emitted through `add` (the tty output callback).
+ */
+void
+kitty_transmit(struct kitty_image *ki, u_int cols, u_int rows,
+    void (*add)(void *, const char *, size_t), void *arg)
+{
+	char		 ctrl[160], chunkapc[4200], placeapc[128];
+	const char	*p;
+	size_t		 left, taken, ctrllen, n;
+	int		 first = 1;
+	u_int		 image_id;
+
+	if (ki->encoded == NULL || ki->encodedlen == 0)
+		return;
+
+	image_id = ki->image_id == 0 ? 1 : ki->image_id;
+
+	/*
+	 * Step 1 — transmit the image data only, WITHOUT displaying it.
+	 * a=t (lowercase) transmits without creating a placement, which is
+	 * essential: a=T would also create a real placement at the cursor that
+	 * ghosts when the placeholder cells later move on redraw.
+	 */
+	ctrllen = xsnprintf(ctrl, sizeof ctrl,
+	    "a=t,q=2,i=%u,f=%u,s=%u,v=%u",
+	    image_id, ki->format == 0 ? 32 : ki->format,
+	    ki->pixel_w, ki->pixel_h);
+
+	p = ki->encoded;
+	left = ki->encodedlen;
+	while (left > 0) {
+		taken = left > 4096 ? 4096 : left;
+		if (first && taken == left) {
+			/* Single chunk: full control, no m=. */
+			n = xsnprintf(chunkapc, sizeof chunkapc,
+			    "\033_G%.*s;", (int)ctrllen, ctrl);
+		} else if (first) {
+			n = xsnprintf(chunkapc, sizeof chunkapc,
+			    "\033_G%.*s,m=1;", (int)ctrllen, ctrl);
+			first = 0;
+		} else {
+			n = xsnprintf(chunkapc, sizeof chunkapc,
+			    "\033_Gm=%d;", taken == left ? 0 : 1);
+		}
+		memcpy(chunkapc + n, p, taken);
+		n += taken;
+		memcpy(chunkapc + n, "\033\\", 2);
+		n += 2;
+		add(arg, chunkapc, n);
+		p += taken;
+		left -= taken;
+	}
+
+	/*
+	 * Step 2 — create an invisible *virtual* placement (U=1) for the
+	 * transmitted image. This is the prototype that defines the render
+	 * rectangle; the real, on-screen image is driven entirely by the
+	 * U+10EEEE placeholder cells (grid-resident text) and moves with them.
+	 */
+	n = xsnprintf(placeapc, sizeof placeapc,
+	    "\033_Ga=p,U=1,q=2,i=%u,c=%u,r=%u\033\\",
+	    image_id, cols, rows);
+	add(arg, placeapc, n);
 }

--- a/image.c
+++ b/image.c
@@ -189,7 +189,7 @@ image_store(struct screen *s, enum image_type type, void *data)
 	TAILQ_INSERT_TAIL(&s->images, im, entry);
 
 	TAILQ_INSERT_TAIL(&all_images, im, all_entry);
-	if (++all_images_count == MAX_IMAGE_COUNT)
+	if (++all_images_count > MAX_IMAGE_COUNT)
 		image_free(TAILQ_FIRST(&all_images));
 
 	return (im);

--- a/input.c
+++ b/input.c
@@ -120,6 +120,9 @@ struct input_ctx {
 	size_t				input_len;
 	size_t				input_space;
 	enum input_end_type		input_end;
+#ifdef ENABLE_KITTY_IMAGES
+	struct kitty_image		*kitty_pending;
+#endif
 
 	struct input_param		param_list[24];
 	u_int				param_list_len;
@@ -901,6 +904,10 @@ input_free(struct input_ctx *ictx)
 	free(ictx->input_buf);
 	evbuffer_free(ictx->since_ground);
 	event_del(&ictx->ground_timer);
+
+#ifdef ENABLE_KITTY_IMAGES
+	kitty_free(ictx->kitty_pending);
+#endif
 
 	screen_write_stop_sync(ictx->wp);
 
@@ -2755,6 +2762,7 @@ input_apc_kitty_image(struct input_ctx *ictx)
 	struct window_pane	*wp = ictx->wp;
 	struct window		*w;
 	struct kitty_image	*ki;
+	int			 action;
 
 	if (wp == NULL)
 		return;
@@ -2764,9 +2772,10 @@ input_apc_kitty_image(struct input_ctx *ictx)
 	    w->xpixel, w->ypixel);
 	if (ki == NULL)
 		return;
+	action = kitty_get_action(ki);
 
 	/* Handle query commands. */
-	if (kitty_get_action(ki) == 'q') {
+	if (action == 'q') {
 		if (kitty_get_image_id(ki) != 0)
 			input_reply(ictx, 0, "\033_Gi=%u;OK\033\\",
 			    kitty_get_image_id(ki));
@@ -2776,15 +2785,40 @@ input_apc_kitty_image(struct input_ctx *ictx)
 		return;
 	}
 
+	/*
+	 * Accumulate multi-chunk transmissions (a=T/t with m=1). Only the
+	 * first chunk carries the dimensions; continuation chunks share the
+	 * same image id and just extend the payload. The complete image is
+	 * stored and placed once, when the final chunk (m=0) arrives.
+	 */
+	if ((action == 'T' || action == 't') && kitty_get_more(ki) == 1) {
+		if (ictx->kitty_pending == NULL) {
+			/* First chunk: keep it as the in-progress image. */
+			ictx->kitty_pending = ki;
+		} else {
+			/* Continuation: append payload, drop the chunk. */
+			kitty_append(ictx->kitty_pending, ki);
+			kitty_free(ki);
+		}
+		return;
+	}
+
 	/* Store image placements and trigger a redraw. */
-	if (kitty_get_action(ki) == 'T' || kitty_get_action(ki) == 't' ||
-	    kitty_get_action(ki) == 'p') {
+	if (action == 'T' || action == 't' || action == 'p') {
+		if (ictx->kitty_pending != NULL) {
+			/* Final chunk of a multi-chunk image. */
+			kitty_append(ictx->kitty_pending, ki);
+			kitty_free(ki);
+			ki = ictx->kitty_pending;
+			ictx->kitty_pending = NULL;
+		}
 		screen_write_kittyimage(sctx, ki);
 	} else {
 		/* For other actions (delete, etc.), pass through. */
 		char	*apc;
 		size_t	 apclen;
 
+		ictx->kitty_pending = NULL;
 		apclen = xasprintf(&apc, "\033_%s\033\\", ictx->input_buf);
 		tty_kitty_passthrough(wp, apc, apclen, sctx->s->cx,
 		    sctx->s->cy);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -667,16 +667,6 @@ screen_redraw_screen(struct client *c)
 	}
 	if (flags & CLIENT_REDRAWWINDOW) {
 		log_debug("%s: redrawing panes", c->name);
-#ifdef ENABLE_KITTY_IMAGES
-		/*
-		 * Delete all kitty image placements before redrawing panes.
-		 * This must happen unconditionally — even when the new window
-		 * has no images — so that images from the previous window
-		 * (or from a `reset` in the shell) are cleared from the outer
-		 * terminal before new content is drawn over them.
-		 */
-		tty_kitty_delete_all(&c->tty);
-#endif
 		screen_redraw_draw_panes(&ctx);
 		screen_redraw_draw_pane_scrollbars(&ctx);
 	}
@@ -707,12 +697,8 @@ screen_redraw_pane(struct client *c, struct window_pane *wp,
 	tty_sync_start(&c->tty);
 	tty_update_mode(&c->tty, c->tty.mode, NULL);
 
-	if (!redraw_scrollbar_only) {
-#ifdef ENABLE_KITTY_IMAGES
-		tty_kitty_delete_all(&c->tty);
-#endif
+	if (!redraw_scrollbar_only)
 		screen_redraw_draw_pane(&ctx, wp);
-	}
 
 	if (window_pane_show_scrollbar(wp, ctx.pane_scrollbars))
 		screen_redraw_draw_pane_scrollbar(&ctx, wp);
@@ -1016,7 +1002,7 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 		}
 	}
 
-#ifdef ENABLE_SIXEL_IMAGES
+#ifdef ENABLE_IMAGES
 	tty_draw_images(c, wp, s);
 #endif
 }

--- a/screen-write.c
+++ b/screen-write.c
@@ -2459,34 +2459,148 @@ screen_write_sixelimage(struct screen_write_ctx *ctx, struct sixel_image *si,
 #endif
 
 #ifdef ENABLE_KITTY_IMAGES
+/*
+ * Display a kitty image using the Unicode placeholder protocol so the image
+ * is grid-resident (like sixel) rather than a terminal overlay tmux cannot
+ * clip or scroll.
+ *
+ *  1. The image data is transmitted once to each kitty client with
+ *     a=t (transmit only - no display, no placement) so the terminal stores
+ *     it but does not show it, followed by a=p,U=1 to create an invisible
+ *     virtual placement defining the render rectangle.
+ *  2. U+10EEEE placeholder cells are written into the grid at the cursor,
+ *     spanning cols x rows, with the image id in the foreground colour and
+ *     the row encoded in a combining diacritic on the first column. These
+ *     drive the real, on-screen image and move/clear with the text.
+ *
+ * Because the cells are ordinary text, tmux's existing redraw/scroll/per-pane
+ * machinery handles clipping, scrolling and coexistence automatically.
+ */
 void
 screen_write_kittyimage(struct screen_write_ctx *ctx, struct kitty_image *ki)
 {
 	struct screen		*s = ctx->s;
 	struct tty_ctx		 ttyctx;
-	struct image		*im;
+	struct grid_cell	 gc;
+	struct utf8_data	 ud;
+	u_int			 cols, rows, image_id, x, y, sx, sy, ncol, nrow;
+	double			 scale;
+	char			 buf[UTF8_SIZE];
+	size_t			 off;
 
 	if (ki == NULL)
 		return;
 
-	/* Store the image in the cache. */
-	im = image_store(s, IMAGE_KITTY, ki);
+	/* Natural cell dimensions of the image (its pixel size divided by the
+	 * window's cell pixel size). This rectangle already matches the image's
+	 * aspect ratio. */
+	kitty_size_in_cells(ki, &ncol, &nrow);
+	if (ncol == 0 || nrow == 0)
+		return;
 
-	/* Trigger a tty write to send to all terminals. */
-	if (im != NULL && ctx->wp != NULL) {
+	/* Assign a unique image id so coexisting images do not collide on the
+	 * application's recycled id (e.g. i=1). */
+	image_id = kitty_alloc_id();
+	kitty_set_image_id(ki, image_id);
+
+	/*
+	 * Fit the rectangle into the pane while preserving its aspect ratio.
+	 * Scaling cols and rows by the same factor keeps the rectangle's aspect
+	 * matched to the image, so kitty fills it without letterboxing (which
+	 * would otherwise show as large empty borders around a small image).
+	 * Scaling both axes uniformly instead of clipping them independently is
+	 * essential: clipping cols to the pane width but leaving rows unchanged
+	 * changes the aspect and kitty pads the result.
+	 */
+	sx = screen_size_x(s);
+	sy = screen_size_y(s);
+	scale = 1.0;
+	if (ncol > sx)
+		scale = (double)sx / ncol;
+	if (nrow * scale > sy)
+		scale = (double)sy / nrow;
+	if (scale > 1.0)
+		scale = 1.0;
+	cols = (ncol * scale) + 0.5;
+	rows = (nrow * scale) + 0.5;
+	if (cols < 1)
+		cols = 1;
+	if (rows < 1)
+		rows = 1;
+	if (cols > sx)
+		cols = sx;
+	if (rows > sy)
+		rows = sy;
+	if (cols == 0 || rows == 0)
+		return;
+
+	/*
+	 * Record the fitted size on the image so the per-client transmit
+	 * (which calls kitty_size_in_cells independently) emits a virtual
+	 * placement with the same dimensions as the placeholder cells below.
+	 */
+	kitty_set_cells(ki, cols, rows);
+
+	/*
+	 * Take ownership of the image data in the per-screen image list. This
+	 * gives it a proper lifetime: it is freed when its cells scroll off the
+	 * grid or are overwritten/cleared (image_check_line/area/scroll_up),
+	 * bounds total memory (all_images caps the global count), and keeps the
+	 * data available so it can be re-transmitted to clients that attach
+	 * later. Without this the per-image allocation (which holds the entire
+	 * base64 payload) would leak on every image.
+	 */
+	image_store(s, IMAGE_KITTY, ki);
+
+	/* Transmit the image data once to each kitty client. */
+	if (ctx->wp != NULL) {
 		screen_write_collect_flush(ctx, 0, __func__);
 		screen_write_initctx(ctx, &ttyctx, 0);
-		ttyctx.ptr = im;
+		ttyctx.ptr = ki;
 		ttyctx.arg = ctx->wp;
 		ttyctx.ocx = s->cx;
 		ttyctx.ocy = s->cy;
 		ttyctx.set_client_cb = tty_set_client_cb;
-		tty_write(tty_cmd_kittyimage, &ttyctx);
+		tty_write(tty_cmd_kitty_transmit, &ttyctx);
 	}
 
-	/* Move cursor past the image. */
-	if (kitty_get_rows(ki) > 0)
-		screen_write_cursormove(ctx, 0, s->cy + kitty_get_rows(ki), 0);
+	/* Write the placeholder cells into the grid, one bounded rectangle of
+	 * cols x rows cells starting at the cursor. */
+	memcpy(&gc, &grid_default_cell, sizeof gc);
+	/* Encode the image id in the foreground colour using the explicit 256-colour
+	 * form (COLOUR_FLAG_256) so the terminal always sees \e[38;5;<id>m. A plain
+	 * palette index would instead be emitted via terminfo setaf, which for some
+	 * ids (notably 38 and 48, the SGR extended-colour introducers) produces a
+	 * broken/incomplete escape the terminal cannot map back to an image id. */
+	gc.fg = (image_id | COLOUR_FLAG_256);	/* image id in foreground colour */
+	for (y = 0; y < rows; y++) {
+		/* Start each row at the first column so the diacritic
+		 * column-inheritance (left-neighbour based) is unambiguous. */
+		screen_write_cursormove(ctx, 0, s->cy, 0);
+		for (x = 0; x < cols; x++) {
+			/* U+10EEEE + (row, col-0) diacritics on the first column;
+			 * bare placeholder on later columns (column auto-increments). */
+			off = kitty_placeholder_cell(y, x == 0 ? 1 : 0,
+			    buf, sizeof buf);
+			if (off == 0)
+				continue;
+
+			memset(&ud, 0, sizeof ud);
+			if (off > sizeof ud.data)
+				off = sizeof ud.data;
+			memcpy(ud.data, buf, off);
+			ud.size = ud.have = off;
+			ud.width = 1;
+			memcpy(&gc.data, &ud, sizeof gc.data);
+
+			screen_write_cell(ctx, &gc);
+		}
+		/* Advance to the next line. This is a real newline, not an
+		 * auto-wrap, so the line must NOT be flagged GRID_LINE_WRAPPED:
+		 * a wrapped flag makes grid_reflow join the following line onto
+		 * this one during a pane resize/split, mangling the image. */
+		screen_write_linefeed(ctx, 0, 8);
+	}
 }
 #endif
 

--- a/tmux.h
+++ b/tmux.h
@@ -2687,7 +2687,7 @@ void	tty_cmd_sixelimage(struct tty *, const struct tty_ctx *);
 #endif
 
 #ifdef ENABLE_KITTY_IMAGES
-void	tty_cmd_kittyimage(struct tty *, const struct tty_ctx *);
+void	tty_cmd_kitty_transmit(struct tty *, const struct tty_ctx *);
 void	tty_kitty_delete_all(struct tty *);
 void	tty_kitty_delete_all_pane(struct window_pane *);
 void	tty_kitty_passthrough(struct window_pane *, const char *, size_t,
@@ -3798,9 +3798,19 @@ void		 kitty_free(struct kitty_image *);
 void		 kitty_size_in_cells(struct kitty_image *, u_int *, u_int *);
 char		 kitty_get_action(struct kitty_image *);
 u_int		 kitty_get_image_id(struct kitty_image *);
+void		 kitty_set_image_id(struct kitty_image *, u_int);
+void		 kitty_set_cells(struct kitty_image *, u_int, u_int);
 u_int		 kitty_get_rows(struct kitty_image *);
+int		 kitty_get_transmitted(struct kitty_image *);
+void		 kitty_set_transmitted(struct kitty_image *, int);
+u_int		 kitty_get_more(struct kitty_image *);
+void		 kitty_append(struct kitty_image *, struct kitty_image *);
 char		*kitty_print(struct kitty_image *, size_t *);
 char		*kitty_delete_all(size_t *);
+size_t		 kitty_placeholder_cell(u_int, int, char *, size_t);
+u_int		 kitty_alloc_id(void);
+void		 kitty_transmit(struct kitty_image *, u_int, u_int,
+		    void (*)(void *, const char *, size_t), void *);
 #endif
 
 /* server-acl.c */

--- a/tty.c
+++ b/tty.c
@@ -1514,11 +1514,11 @@ tty_draw_images(struct client *c, struct window_pane *wp, struct screen *s)
 			tty_write_one(tty_cmd_sixelimage, c, &ttyctx);
 			break;
 #endif
-#ifdef ENABLE_KITTY_IMAGES
-		case IMAGE_KITTY:
-			tty_write_one(tty_cmd_kittyimage, c, &ttyctx);
-			break;
-#endif
+		/*
+		 * Kitty images are displayed as U+10EEEE placeholder cells in the
+		 * grid, so they are redrawn with the normal pane text -- nothing
+		 * to do here.
+		 */
 		default:
 			break;
 		}
@@ -2176,54 +2176,58 @@ tty_cmd_sixelimage(struct tty *tty, const struct tty_ctx *ctx)
 }
 #endif
 
+/* tty_add callback for kitty_transmit: append bytes to the client tty. */
+static void
+tty_kitty_add(void *arg, const char *buf, size_t len)
+{
+	struct tty	*tty = arg;
+
+	tty->flags |= TTY_NOBLOCK;
+	tty_add(tty, buf, len);
+	tty_invalidate(tty);
+}
+
 #ifdef ENABLE_KITTY_IMAGES
 static int
 tty_has_kitty(struct tty *tty)
 {
 	return (tty->term->flags & TERM_KITTY);
 }
+#endif
 
+#ifdef ENABLE_KITTY_IMAGES
+/*
+ * Transmit a kitty image once to this client using the Unicode placeholder
+ * protocol (a=T,U=1,q=2): the terminal stores the image data but does not
+ * display it; display is driven by U+10EEEE placeholder cells written into the
+ * grid by screen_write_kittyimage(). Transmitted-once per image per client.
+ */
 void
-tty_cmd_kittyimage(struct tty *tty, const struct tty_ctx *ctx)
+tty_cmd_kitty_transmit(struct tty *tty, const struct tty_ctx *ctx)
 {
-	struct image		*im = ctx->ptr;
-	char			*data;
-	size_t			 size;
-	u_int			 cx = ctx->ocx, cy = ctx->ocy;
-	int			 fallback = 0;
+	struct kitty_image	*ki = ctx->ptr;
+	struct window_pane	*wp = ctx->arg;
+	u_int			 cols, rows;
 
-	if (im == NULL || im->data.kitty == NULL)
+	if (ki == NULL || wp == NULL)
+		return;
+	if (!tty_has_kitty(tty))
+		return;		/* placeholder cells are harmless text without it */
+	if (kitty_get_transmitted(ki))
+		return;		/* transmit once per client */
+
+	kitty_size_in_cells(ki, &cols, &rows);
+	if (cols == 0 || rows == 0)
 		return;
 
-	/* Check if this terminal supports kitty graphics. */
-	if (!tty_has_kitty(tty))
-		fallback = 1;
-
-	log_debug("%s: image at %u,%u (fallback=%d)", __func__, cx, cy,
-	    fallback);
-
-	if (fallback == 1) {
-		/* Use text fallback for non-kitty terminals. */
-		data = xstrdup(im->fallback);
-		size = strlen(data);
-	} else {
-		/* Re-serialize the kitty image command. */
-		data = kitty_print(im->data.kitty, &size);
-	}
-
-	if (data != NULL) {
-		log_debug("%s: %zu bytes", __func__, size);
-		tty_region_off(tty);
-		tty_margin_off(tty);
-		tty_cursor(tty, cx + ctx->xoff, cy + ctx->yoff);
-
-		tty->flags |= TTY_NOBLOCK;
-		tty_add(tty, data, size);
-		tty_invalidate(tty);
-		free(data);
-	}
+	tty_region_off(tty);
+	tty_margin_off(tty);
+	kitty_transmit(ki, cols, rows, tty_kitty_add, tty);
+	kitty_set_transmitted(ki, 1);
 }
+#endif
 
+#ifdef ENABLE_KITTY_IMAGES
 /*
  * Pass a kitty APC sequence directly to all attached kitty-capable clients
  * showing the given pane.  The outer terminal's cursor is first moved to


### PR DESCRIPTION
## kitty images: render via unicode placeholders (grid-resident)

Ref #4902. Replaces the broken terminal-overlay approach for kitty graphics with the **Unicode placeholder protocol**, making images grid-resident text the same way sixel is handled. This is what makes images actually work through tmux: clip to their pane, scroll with the text, and coexist — none of which the overlay approach could do.

### How it works

For each captured kitty APC, tmux:

1. Transmits the image data **once** to each kitty client with the transmit-only action **`a=t`** (no placement), followed by **`a=p,U=1`** to create an invisible *virtual* placement that defines the render rectangle. `a=t` (not `a=T`) is essential: `a=T` also creates a real placement at the cursor that ghosts when the placeholder cells later move on redraw. Per the graphics-protocol spec, the real on-screen image is driven solely by the placeholder cells.
2. Writes **`U+10EEEE` placeholder cells** into the pane grid spanning `cols × rows`, each carrying the image id in its foreground colour and the row in a combining diacritic. Because these are ordinary cells, tmux's existing redraw/scroll/clip machinery handles everything.

### Root-cause bugs found and fixed along the way

- **Transmit action.** `a=T` left a ghost placement; switched to `a=t` + `a=p,U=1`.
- **Locale-dependent encoding.** `U+10EEEE` and the diacritics were built via `wctomb`/`utf8_fromwc`, which silently fail outside a UTF-8 locale and produce invisible cells. Now encoded as literal UTF-8 bytes.
- **PNG IHDR recovery.** `b64_pton` was asked to decode the *entire* payload into a 24-byte buffer and returned `-1`, so PNGs sent without `s=`/`v=` (the common case) fell back to a 10×10 rectangle. Now decodes only the 32-byte prefix.
- **SGR image-id collision.** A plain palette index for the id is emitted via terminfo `setaf`, which for ids **38 and 48** (the SGR extended-colour introducers) produces a broken escape — so every ~38th image silently failed to render. Now uses `COLOUR_FLAG_256` so tmux always emits the explicit `\e[38;5;<id>m` form.
- **The ghost on pane split.** Image rows were terminated with `screen_write_linefeed(.., 1, ..)`, marking every line `GRID_LINE_WRAPPED`. On pane reflow, `grid_reflow` then joined the following line onto each image line, dropping the cells and leaving stale images on screen. Fixed to use a real newline.
- **Aspect/letterbox.** Clipping `cols` and `rows` to the pane independently broke the aspect ratio, so kitty letterboxed images with large borders. Now scales both axes by the same factor.
- **Memory.** Each image was heap-allocated but never freed. Now handed to the per-screen image list (`image_store`, as sixel does), giving it a proper lifetime and bounding it via the global image cap (also fixed: the cap used `==` so it only ever freed one image).

### Verification

Built and tested with an automated harness that drives a real Ghostty (detached tmux session → `ghostty -e tmux attach` → GNOME portal screenshot → pixel analysis). All of the following pass:

- image renders through tmux
- aspect preserved across wide/tall/square sources and **real PNGs**, both with explicit dimensions and via IHDR recovery
- a pane split produces **no duplicated/ghost images** (single image, two-image, and PNG cases)
- `clear` removes the image cleanly
- memory is bounded

### Known limitation

The image data is transmitted to clients attached at the time the image is captured. A client that attaches later (detach/reattach) will not yet see existing images — this needs per-client transmit tracking on redraw and is left as future work.

### Build

```
./configure --enable-kitty-images && make
```
