### PR TITLE
fix(master): fixed `resize-pane` command parse regression.

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -186,6 +186,12 @@ args_parse_flag_argument(struct args_value *values, u_int count, char **cause,
 out:
 	s = args_value_as_string(new);
 	log_debug("%s: -%c = %s", __func__, flag, s);
+	if (optional_argument && *s == '-') {
+		args_free_value(new);
+		free(new);
+		new = NULL;
+	}
+
 	args_set(args, flag, new, 0);
 	return (0);
 }

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -18,6 +18,7 @@
 
 #include <sys/types.h>
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -149,6 +150,8 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 		argval = args_get(args, flag);
 		if (argval == NULL)
 			argval = "1";
+		else if (!isdigit(*argval) && args_count(args) > 0)
+			argval = args_string(args, 0);
 
 		adjust = strtonum(argval, INT_MIN, INT_MAX, &errstr);
 		if (errstr != NULL) {

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -148,10 +148,12 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			continue;
 
 		argval = args_get(args, flag);
-		if (argval == NULL)
-			argval = "1";
-		else if (!isdigit(*argval) && args_count(args) > 0)
-			argval = args_string(args, 0);
+		if (argval == NULL) {
+			if (args_count(args) == 0)
+				argval = "1";
+			else
+				argval = args_string(args, 0);
+		}
 
 		adjust = strtonum(argval, INT_MIN, INT_MAX, &errstr);
 		if (errstr != NULL) {

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -64,7 +64,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	const char		*errstr, *argval;
 	const char		 flags[4] = { 'U', 'D', 'L', 'R' };
 	char			*cause = NULL, flag;
-	u_int			 opposite = 0;
+	u_int			 opposite;
 	int			 adjust, x, y, status;
 	long unsigned		 i;
 	struct grid		*gd = wp->base.grid;
@@ -164,6 +164,7 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 			type = LAYOUT_LEFTRIGHT;
 
 		if (window_pane_is_floating(wp)) {
+			opposite = 0;
 			if (flag == 'L' || flag == 'U')
 				opposite = 1;
 


### PR DESCRIPTION
Some invocation styles of `resize-pane` were not compatible with the new argument parsing. A check has been added which looks at arg of a direction flag, if it does not start with a digit (likely a flag), then we look for the arg string. I have also fixed a bug that didnt't correctly track the 'opposite' state used for offsetting floating pane movement.