### PR TITLE
Enlarge style_tostring buffer to prevent fatal overflow on large styles

### DIFF
--- a/style.c
+++ b/style.c
@@ -285,7 +285,13 @@ style_tostring(struct style *sy)
 	struct grid_cell	*gc = &sy->gc;
 	int			 off = 0;
 	const char		*comma = "", *tmp = "";
-	static char		 s[256];
+	/*
+	 * A style with many attributes set serialises to well over 256 bytes
+	 * (the attribute list alone is ~155, plus colours, range, width, pad
+	 * and so on). xsnprintf() below is fatal on overflow, so size this for
+	 * the largest possible style.
+	 */
+	static char		 s[1024];
 	char			 b[21];
 
 	*s = '\0';


### PR DESCRIPTION
Fixes #5278.

`style_tostring()` formats into a fixed 256-byte buffer with `xsnprintf()`, which is fatal on overflow, and it runs on every status redraw (it is an argument to `log_debug()` in `format_draw()`). A style that sets enough attributes serialises to more than 256 bytes and aborts the whole server.

Enlarge the buffer to 1024 — large enough for the largest possible style. Every serialised component is bounded: the attribute list is ~155 bytes, `range=user|…` by `range_string[16]`, the colours by `colour_tostring`, and the numeric fields by `%u`, summing to ~550.

The reproducer from the issue no longer crashes; built warning-clean.
