### PR TITLE
Add a link= style attribute for OSC 8 hyperlinks in formats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 CHANGES FROM 3.6b TO 3.7
 
+* Add a link= style attribute (with nolink to end it) which makes styled text
+  an OSC 8 hyperlink, for example in the status line:
+  status-right "#[link=https://example.com]link#[nolink]". Emitted only to
+  terminals with the hyperlinks feature.
+
 * Add floating panes. These are panes which sit above the layout ("tiled
   panes") like popups but unlike popups are not modal and behave like panes (so
   the same escape sequence support). Floating panes are created with the

--- a/format-draw.c
+++ b/format-draw.c
@@ -723,7 +723,7 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	struct grid_cell	 gc, current_default, base_default;
 	struct style		 sy, saved_sy;
 	struct utf8_data	*ud = &sy.gc.data;
-	const char		*cp, *end;
+	const char		*cp, *end, *link_uri;
 	enum utf8_state		 more;
 	char			*tmp;
 	struct format_range	*fr = NULL, *fr1;
@@ -837,6 +837,21 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 			sy.gc.bg = base->bg;
 			sy.gc.fg = base->fg;
 		}
+
+		/*
+		 * Resolve the style's #[link=...] URI into a hyperlink ID in
+		 * the target screen's set and store it on the cell, so the
+		 * cells drawn below carry an OSC 8 link (emitted later by
+		 * tty_draw_line). The URI doubles as the internal ID so
+		 * repeated links share one entry and the ID stays stable across
+		 * redraws (no spurious status redraws from grid_compare).
+		 */
+		link_uri = style_link(&sy);
+		if (link_uri != NULL && os->hyperlinks != NULL)
+			sy.gc.link = hyperlinks_put(os->hyperlinks, link_uri,
+			    link_uri);
+		else
+			sy.gc.link = 0;
 
 		/* If this style has a fill colour, store it for later. */
 		if (sy.fill != 8)

--- a/hyperlinks.c
+++ b/hyperlinks.c
@@ -42,6 +42,9 @@
 
 #define MAX_HYPERLINKS 5000
 
+/* Maximum length of a stored hyperlink URI. */
+#define MAX_HYPERLINK_URI 1024
+
 static long long hyperlinks_next_external_id = 1;
 static u_int global_hyperlinks_count;
 
@@ -146,6 +149,13 @@ hyperlinks_put(struct hyperlinks *hl, const char *uri_in,
 
 	utf8_stravis(&uri, uri_in, VIS_OCTAL|VIS_CSTYLE);
 	utf8_stravis(&internal_id, internal_id_in, VIS_OCTAL|VIS_CSTYLE);
+
+	/* Reject an over-long URI so it is never stored. */
+	if (strlen(uri) > MAX_HYPERLINK_URI) {
+		free(uri);
+		free(internal_id);
+		return (0);
+	}
 
 	if (*internal_id_in != '\0') {
 		find.uri = uri;

--- a/style.c
+++ b/style.c
@@ -42,8 +42,16 @@ static struct style style_default = {
 
 	STYLE_WIDTH_DEFAULT, 0, STYLE_PAD_DEFAULT,
 
-	STYLE_DEFAULT_BASE
+	STYLE_DEFAULT_BASE,
+
+	0
 };
+
+/*
+ * Global hyperlink set holding the URIs for #[link=...] styles, so a style
+ * only needs to store a small ID rather than the URI itself.
+ */
+static struct hyperlinks	*style_hyperlinks;
 
 /* Set range string. */
 static void
@@ -91,6 +99,7 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 			sy->gc.us = base->us;
 			sy->gc.attr = base->attr;
 			sy->gc.flags = base->flags;
+			sy->link = 0;
 		} else if (strcasecmp(tmp, "ignore") == 0)
 			sy->ignore = 1;
 		else if (strcasecmp(tmp, "noignore") == 0)
@@ -262,6 +271,17 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 			if (errstr != NULL)
 				goto error;
 			sy->pad = (int)n;
+		} else if (strcasecmp(tmp, "nolink") == 0)
+			sy->link = 0;
+		else if (strncasecmp(tmp, "link=", 5) == 0) {
+			if (tmp[5] == '\0')
+				sy->link = 0;
+			else {
+				if (style_hyperlinks == NULL)
+					style_hyperlinks = hyperlinks_init();
+				sy->link = hyperlinks_put(style_hyperlinks,
+				    tmp + 5, tmp + 5);
+			}
 		} else {
 			if ((value = attributes_fromstring(tmp)) == -1)
 				goto error;
@@ -284,8 +304,8 @@ style_tostring(struct style *sy)
 {
 	struct grid_cell	*gc = &sy->gc;
 	int			 off = 0;
-	const char		*comma = "", *tmp = "";
-	static char		 s[1024];
+	const char		*comma = "", *tmp = "", *uri;
+	static char		 s[2048];
 	char			 b[21];
 
 	*s = '\0';
@@ -389,13 +409,31 @@ style_tostring(struct style *sy)
 		comma = ",";
 	}
 	if (sy->pad >= 0) {
-		xsnprintf(s + off, sizeof s - off, "%spad=%u", comma,
+		off += xsnprintf(s + off, sizeof s - off, "%spad=%u", comma,
 		    sy->pad);
+		comma = ",";
+	}
+	uri = style_link(sy);
+	if (uri != NULL) {
+		xsnprintf(s + off, sizeof s - off, "%slink=%s", comma, uri);
 		comma = ",";
 	}
 	if (*s == '\0')
 		return ("default");
 	return (s);
+}
+
+/* Get the hyperlink URI for a style, or NULL if it has none. */
+const char *
+style_link(struct style *sy)
+{
+	const char	*uri;
+
+	if (sy->link == 0 || style_hyperlinks == NULL)
+		return (NULL);
+	if (!hyperlinks_get(style_hyperlinks, sy->link, &uri, NULL, NULL))
+		return (NULL);
+	return (uri);
 }
 
 /* Apply a style on top of the given style. */

--- a/tmux.1
+++ b/tmux.1
@@ -7220,6 +7220,28 @@ Set the width of the styled area.
 .Ar N
 may be a column count or a percentage (for example
 .Ql 50% ) .
+.It Xo Ic link=uri
+(or
+.Ic nolink )
+.Xc
+Make the styled text an OSC 8 hyperlink to
+.Ar uri ,
+for example
+.Ql #[link=https://example.com]text#[nolink] .
+This is emitted only to terminals with the
+.Ic hyperlinks
+feature (see
+.Ic terminal-features ) ;
+it works in the status line and in other formats drawn with styles.
+The link continues until
+.Ic nolink ,
+.Ic default ,
+or an empty
+.Ic link=
+is given.
+The
+.Ar uri
+may not contain spaces or commas and is limited in length.
 .It Xo Ic list=on ,
 .Ic list=focus ,
 .Ic list=left\-marker ,

--- a/tmux.h
+++ b/tmux.h
@@ -993,6 +993,10 @@ struct style {
 	int			pad;
 
 	enum style_default_type	default_type;
+
+	/* OSC 8 hyperlink: an ID into the global style hyperlink set (see
+	   style.c), or zero for no link. */
+	u_int			link;
 };
 
 #ifdef ENABLE_SIXEL
@@ -3989,6 +3993,7 @@ int		 style_parse(struct style *,const struct grid_cell *,
 int		 style_parse_colour(struct style *,
 		     const struct grid_cell *, const char *);
 const char	*style_tostring(struct style *);
+const char	*style_link(struct style *);
 struct style	*style_add(struct grid_cell *, struct options *,
 		     const char *, struct format_tree *);
 void		 style_apply(struct grid_cell *, struct options *,


### PR DESCRIPTION
Builds on #5279 (its commit is the first one here; this PR shows both commits until #5279 merges, then reduces to just the `link=` commit).

Related to #911 / #2563, which added OSC 8 hyperlinks for pane content. This reuses that infrastructure — the per-screen hyperlink set, the grid cell link ID, and the `hyperlinks` terminal feature — to emit links from formats/styles, which those issues did not cover.

Styled formats had no way to emit a clickable OSC 8 hyperlink: a raw escape sequence in a format is mangled by format expansion, and `#[...]` had no link attribute. This adds `#[link=URI]`, ended by `#[nolink]`, an empty `#[link=]`, or `#[default]`. It applies to any format drawn with styles, so it works throughout the status line (`status-left`, `status-right`, the window list, `status-format`) and in other styled surfaces such as `pane-border-format`.

`format_draw()` resolves the URI into the target screen's hyperlink set and stores the resulting ID on the drawn cells. `tty_draw_line()` already emits the OSC 8 sequence for any cell carrying a link, gated by the existing `hyperlinks` terminal feature, so the output path is unchanged. The URI doubles as the internal ID, so repeated links share one entry and the ID stays stable across redraws.

Emitted only with `set -ga terminal-features '*:hyperlinks'` (same gate as pane hyperlinks). Application-set window/pane titles are `clean_name`'d (`#` → `_`), so a program in a pane cannot inject `#[link=]` via `#{pane_title}` / `#W` — the same protection that already covers `#[fg=]`.

Documented in `tmux.1` and `CHANGES`.
