### PR TITLE
fix(master): invalidated scene after changing z_indexes

### DIFF
--- a/window.c
+++ b/window.c
@@ -631,6 +631,7 @@ window_redraw_active_switch(struct window *w, struct window_pane *wp)
 			TAILQ_REMOVE(&w->z_index, wp, zentry);
 			TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 			wp->flags |= PANE_REDRAW;
+			redraw_invalidate_scene(w);
 		}
 
 		wp = w->active;


### PR DESCRIPTION
Most noticeable when using `select-pane` targeting a floating pane that is obscured by one higher in the z_index.