### PR TITLE
clean_name: guard against NULL forbid

### DIFF
--- a/tmux.c
+++ b/tmux.c
@@ -289,9 +289,11 @@ clean_name(const char *name, const char* forbid)
 	if (*name == '\0' || !utf8_isvalid(name))
 		return (NULL);
 	copy = xstrdup(name);
-	for (cp = copy; *cp != '\0'; cp++) {
-		if (strchr(forbid, *cp) != NULL)
-			*cp = '_';
+	if (forbid != NULL) {
+		for (cp = copy; *cp != '\0'; cp++) {
+			if (strchr(forbid, *cp) != NULL)
+				*cp = '_';
+		}
 	}
 	utf8_stravis(&new_name, copy, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
 	free(copy);


### PR DESCRIPTION
## Summary

`clean_name()` dereferences `forbid` without a NULL check. A NULL
`forbid` is reachable today via `cmd-break-pane.c`, which passes `0`
(NULL) to `window_set_name()` on the `-n` branch.

Triggers: `break-pane -n "anything"` on a 2+ pane window crashes the
server.

Fixes #5287

## Repro

```
$ ./tmux -Ltest -f/dev/null new-session -d -s test 'sleep 999'
$ ./tmux -Ltest split-window -v
$ ./tmux -Ltest break-pane -n "anything"
server exited unexpectedly
```

## Crash trace (macOS arm64, master @ 91e30f4f)

```
0  _platform_strchr     +12
1  clean_name           +96    tmux.c:293
2  window_set_name      +28    window.c:426
3  cmd_break_pane_exec  +1080  cmd-break-pane.c:168
4  cmdq_fire_command    +32
5  cmdq_next            +1436
```

`tmux.c:293` is `if (strchr(forbid, *cp) != NULL)` inside the
unconditional `for` loop.

## Patch

```diff
--- a/tmux.c
+++ b/tmux.c
@@ -289,9 +289,11 @@ clean_name(const char *name, const char* forbid)
        if (*name == '\0' || !utf8_isvalid(name))
                return (NULL);
        copy = xstrdup(name);
-       for (cp = copy; *cp != '\0'; cp++) {
-               if (strchr(forbid, *cp) != NULL)
-                       *cp = '_';
+       if (forbid != NULL) {
+               for (cp = copy; *cp != '\0'; cp++) {
+                       if (strchr(forbid, *cp) != NULL)
+                               *cp = '_';
+               }
        }
        utf8_stravis(&new_name, copy, VIS_OCTAL|VIS_CSTYLE|VIS_TAB|VIS_NL);
        free(copy);
```

The empty-string `forbid` already means "no rewrites" (used by
`paste.c` and `screen.c`); this just extends the same convention to
NULL, which is what `cmd-break-pane.c:167` appears to have intended
with `window_set_name(w, name, 0)`.

## Background

`clean_name()` was added in `d339ab51` (2026-04-22). Every caller in
that commit passes a non-NULL forbid, so the function never crashed.
The `cmd-break-pane.c` rewrite in `eb653314` / `64e83caf`
(2026-06-15) introduced the NULL caller via
`window_set_name(w, name, 0)`, which has been latent since.

On the released `tmux 3.7` the inverted condition in
`cmd-break-pane.c` (`if (name != NULL)` should be `if (name == NULL)`;
fixed on master in `30e133d3`) routes `break-pane -n "x"` through the
wrong branch, so the NULL forbid path isn't hit there. As soon as
`30e133d3` is in, this crash fires.

## Notes

* Behaviour-preserving for existing callers — only callers passing
  `forbid == NULL` change behavior, and there are no other such
  callers in the tree.
* The 5-line diff is intentionally the smallest defensible fix; an
  alternative is to change `cmd-break-pane.c:167` to pass
  `WINDOW_NAME_FORBID` instead of `0`, but that papers over the
  unsafe API.
