### PR TITLE
feat(master): Floating panes can be automatically tiled with `join-pane`

### DIFF
--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -364,6 +364,44 @@ cmd_join_pane_zindex(struct cmdq_item *item, struct winlink *wl,
 }
 
 static enum cmd_retval
+cmd_join_pane_tile(struct cmdq_item *item, struct args *args, struct window *w,
+    struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (!window_pane_is_floating(wp)) {
+		cmdq_error(item, "pane is not floating");
+		return (CMD_RETURN_ERROR);
+	}
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't tile a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+
+	lc->saved_sx = lc->sx;
+	lc->saved_sy = lc->sy;
+	lc->saved_xoff = lc->xoff;
+	lc->saved_yoff = lc->yoff;
+	if (layout_insert_tile(w, lc) != 0) {
+		cmdq_error(item, "no space for a new pane");
+		return (CMD_RETURN_ERROR);
+	}
+	lc->flags &= ~LAYOUT_CELL_FLOATING;
+
+	TAILQ_REMOVE(&w->z_index, wp, zentry);
+	TAILQ_INSERT_TAIL(&w->z_index, wp, zentry);
+
+	if (!args_has(args, 'd'))
+		window_set_active_pane(w, wp, 1);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	notify_window("window-layout-changed", w);
+	server_redraw_window(w);
+
+	return (CMD_RETURN_NORMAL);
+}
+
+static enum cmd_retval
 cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 {
 	struct args		*args = cmd_get_args(self);
@@ -410,6 +448,9 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 	src_wp = source->wp;
 	src_w = src_wl->window;
 	server_unzoom_window(src_w);
+
+	if (!args_has(args, 't') && window_pane_is_floating(src_wp))
+		return (cmd_join_pane_tile(item, args, src_w, src_wp));
 
 	if (src_wp == dst_wp) {
 		cmdq_error(item, "source and target panes must be different");

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -449,10 +449,9 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 	src_w = src_wl->window;
 	server_unzoom_window(src_w);
 
-	if (!args_has(args, 't') && window_pane_is_floating(src_wp))
-		return (cmd_join_pane_tile(item, args, src_w, src_wp));
-
 	if (src_wp == dst_wp) {
+		if (window_pane_is_floating(src_wp))
+			return (cmd_join_pane_tile(item, args, src_w, src_wp));
 		cmdq_error(item, "source and target panes must be different");
 		return (CMD_RETURN_ERROR);
 	}

--- a/layout.c
+++ b/layout.c
@@ -1771,7 +1771,7 @@ layout_remove_tile(struct window *w, struct layout_cell *lc)
 	int			 change;
 
 	if (lc->flags & LAYOUT_CELL_FLOATING)
-		return (0);
+		return (-1);
 
 	lcneighbour = layout_cell_get_neighbour(lc);
 	if (lcneighbour == NULL) {
@@ -1796,7 +1796,7 @@ layout_remove_tile(struct window *w, struct layout_cell *lc)
 	 */
 	if (lc->parent != NULL)
 		layout_set_size(lc, 0, 0, 0, 0);
-	return (1);
+	return (0);
 }
 
 /*
@@ -1813,14 +1813,14 @@ layout_insert_tile(struct window *w, struct layout_cell *lc)
 	if (lc == NULL)
 		fatalx("layout cell cannot be null when tiling");
 
-	lcparent = lc->parent;
-	if (lc->flags & LAYOUT_CELL_FLOATING)
-		return (1);
+	if (layout_cell_is_tiled(lc))
+		return (-1);
 
+	lcparent = lc->parent;
 	if (lcparent == NULL) {
 		/* Only pane in the layout. */
 		layout_set_size(lc, w->sx, w->sy, 0, 0);
-		return (1);
+		return (0);
 	}
 
 	type = lcparent->type;
@@ -1843,7 +1843,7 @@ layout_insert_tile(struct window *w, struct layout_cell *lc)
 		 */
 		lctiled = layout_cell_get_first_tiled(lcneighbour);
 		if (!layout_split_check_space(lctiled->wp, lcneighbour, type))
-			return (0);
+			return (-1);
 		layout_split_sizes(lcneighbour, -1, 0, type, &size1, &size2,
 		    &saved_size);
 		layout_resize_set_size(w, lc, type, size1);
@@ -1860,5 +1860,5 @@ layout_insert_tile(struct window *w, struct layout_cell *lc)
 	}
 	layout_resize_set_size(w, lc, type, size1);
 
-	return (1);
+	return (0);
 }

--- a/tmux.1
+++ b/tmux.1
@@ -3252,7 +3252,7 @@ If
 .Ar src\-pane
 is floating and
 .Ar dst\-pane
-is equal to
+is either unspecified or equal to
 .Ar src\-pane,
 .Ar src\-pane
 is returned to its previous position in the layout.

--- a/tmux.1
+++ b/tmux.1
@@ -3249,10 +3249,11 @@ is omitted and a marked pane is present (see
 the marked pane is used rather than the current pane.
 .Pp
 If
-.Ar dst\-pane
-is not specified and
 .Ar src\-pane
-is floating,
+is floating and
+.Ar dst\-pane
+is equal to
+.Ar src\-pane,
 .Ar src\-pane
 is returned to its previous position in the layout.
 .Tg killp

--- a/tmux.1
+++ b/tmux.1
@@ -3247,6 +3247,14 @@ is omitted and a marked pane is present (see
 .Ic select\-pane
 .Fl m ) ,
 the marked pane is used rather than the current pane.
+.Pp
+If
+.Ar dst\-pane
+is not specified and
+.Ar src\-pane
+is floating,
+.Ar src\-pane
+is returned to its previous position in the layout.
 .Tg killp
 .It Xo Ic kill\-pane
 .Op Fl a


### PR DESCRIPTION
When `join-pane` is invoked on a floating `src-pane` and no `dst-pane` is specified, the pane is put back into the layout in its old position.

This minimally gets the feature working and it is not comprehensive. If there is desire, `join-pane` can be more thoroughly reworked so that floating dimensions are saved across ALL tiling operations, not just auto-tiling. This will be a larger diff and is not necessary at this time. It's on my radar for if an issue is raised in the future.

I also edited the error reporting semantics in remove/insert tile. I don't know why I had them as "true/false" instead of "success/failure".