### PR TITLE
Redraw pane after disabling sync updates

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -1011,6 +1011,8 @@ screen_write_stop_sync(struct window_pane *wp)
 		evtimer_del(&wp->sync_timer);
 	wp->base.mode &= ~MODE_SYNC;
 
+	wp->flags |= PANE_REDRAW;
+
 	log_debug("%s: %%%u stopped sync mode", __func__, wp->id);
 }
 


### PR DESCRIPTION
Commit 65a032b2 reordered the 2026 case but failed to carry over the PANE_REDRAW flag due to copy-paste.

For example:

``` bash
tmux -Ltest -f/dev/null new
```

Then in the tmux session, use `nvim --clean cfg.c`, I got the following output:

<img width="434" height="441" alt="image" src="https://github.com/user-attachments/assets/c4b33f43-e27d-400f-ac11-90a1fc9b71f0" />
