### PR TITLE
Add a default set of features for Ghostty

### DIFF
--- a/tty-features.c
+++ b/tty-features.c
@@ -583,6 +583,18 @@ tty_default_features(int *feat, const char *name, u_int version)
 		  	      "hyperlinks,"
 			      "usstyle"
 		},
+		{ .name = "ghostty",
+		  .features = TTY_FEATURES_BASE_MODERN_XTERM ","
+			      "ccolour,"
+			      "cstyle,"
+			      "extkeys,"
+			      "focus,"
+			      "hyperlinks,"
+			      "osc7,"
+			      "sync,"
+			      "usstyle,"
+			      "progressbar"
+		},
 		{ .name = "XTerm",
 		  /*
 		   * xterm also supports DECSLRM and DECFRA, but they can be

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1663,6 +1663,8 @@ tty_keys_extended_device_attributes(struct tty *tty, const char *buf,
 		tty_default_features(features, "foot", 0);
 	else if (strncmp(tmp, "WezTerm ", 7) == 0)
 		tty_default_features(features, "WezTerm", 0);
+	else if (strncmp(tmp, "ghostty ", 8) == 0)
+		tty_default_features(features, "ghostty", 0);
 	log_debug("%s: received extended DA %.*s", c->name, (int)*size, buf);
 
 	free(c->term_type);


### PR DESCRIPTION
Ghostty reports itself in its extended device attributes (XTVERSION /
`CSI > q`) response as `ghostty <version>` (e.g. `ghostty 1.3.1`). tmux
doesn't recognise this prefix, so Ghostty receives none of the default
terminal features and users have to set `terminal-features` by hand.

This adds a `ghostty` branch to the XTVERSION parsing in `tty-keys.c` and a
matching entry in `tty_default_features()`, following the existing iTerm2 and
WezTerm entries.

Features set:

- `256`, `RGB`, `bpaste`, `clipboard`, `mouse`, `strikethrough`, `title`
  (the modern xterm base)
- `ccolour` (OSC 12), `cstyle` (DECSCUSR), `extkeys`, `focus`, `usstyle`
  (styled underlines)
- `osc7`, `hyperlinks` (OSC 8)
- `sync` (DECSET 2026 synchronised output)
- `progressbar` (OSC 9;4), so the progress bar from #4972 is forwarded to
  Ghostty automatically

All of these are implemented by Ghostty; the underline, cursor, clipboard and
sync ones are also present in its terminfo (`Smulx`, `Setulc`, `Ss`/`Se`,
`Ms`, `Sync`), and the OSC 9;4 progress sequence is documented at
https://ghostty.org/docs/vt/osc/conemu.

Tested on Ghostty 1.3.1 (macOS): `#{client_termfeatures}` then lists the above
— including `progressbar` — with no manual configuration.
