### PR TITLE
Avoid macOS grid checks in release builds

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -59,7 +59,12 @@ static const struct grid_cell_entry grid_cleared_entry = {
 	{ .data = { 0, 8, 8, ' ' } }, GRID_FLAG_CLEARED
 };
 
-#ifdef __APPLE__
+/*
+ * These checks are diagnostics for macOS-only grid corruption debugging. They
+ * are intentionally debug only: grid_check_lines() is quadratic in the total
+ * history + visible line count and is called from the linefeed scroll path.
+ */
+#if defined(__APPLE__) && defined(DEBUG)
 static void
 grid_check_lines(struct grid *gd)
 {


### PR DESCRIPTION
`grid_check_lines()` is called from the linefeed scroll path, but it compares each grid line with every later grid line. On macOS release builds this makes large scrollback writes much slower as history grows.

This keeps the macOS grid consistency checks available for debug builds while avoiding the release hot path.

I measured a simple workload that writes lines into a detached 120x40 pane with `history-limit` set to 50000 and waits for completion:

| lines | master | this change |
| ---: | ---: | ---: |
| 1000 | 0.151s | 0.052s |
| 2000 | 0.939s | 0.068s |
| 5000 | 4.647s | 0.103s |
| 10000 | timed out after 10s | 0.166s |

Built on macOS with the existing release configuration.
