### PR TITLE
cmd-split-window: fix layout cell double free on spawn failure

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -167,6 +167,12 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	if ((new_wp = spawn_pane(&sc, &cause)) == NULL) {
 		cmdq_error(item, "create pane failed: %s", cause);
 		free(cause);
+		/*
+		 * On failure spawn_pane has already destroyed the layout cell
+		 * (via layout_close_pane in its fork-failure path); clear lc so
+		 * the fail path below does not destroy it a second time.
+		 */
+		lc = NULL;
 		goto fail;
 	}
 
@@ -220,8 +226,16 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		switch (window_pane_start_input(new_wp, item, &cause)) {
 		case -1:
 			server_client_remove_pane(new_wp);
-			if (!is_floating)
+			if (!is_floating) {
+				/*
+				 * layout_close_pane destroys the pane's layout
+				 * cell.
+				 * Clear lc so the fail path below does not
+				 * attempt to destroy it a second time.
+				 */
 				layout_close_pane(new_wp);
+				lc = NULL;
+			}
 			window_remove_pane(wp->window, new_wp);
 			cmdq_error(item, "%s", cause);
 			free(cause);
@@ -272,7 +286,8 @@ fail:
 	if (sc.argv != NULL)
 		cmd_free_argv(sc.argc, sc.argv);
 	environ_free(sc.environ);
-	layout_destroy_cell(w, lc, &w->layout_root);
+	if (lc != NULL)
+		layout_destroy_cell(w, lc, &w->layout_root);
 
 	return (CMD_RETURN_ERROR);
 

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -81,7 +81,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct session		*s = target->s;
 	struct winlink		*wl = target->wl;
 	struct window		*w = wl->window;
-	struct window_pane	*wp = target->wp, *new_wp;
+	struct window_pane	*wp = target->wp, *new_wp = NULL;
 	struct layout_cell	*lc = NULL;
 	struct cmd_find_state	 fs;
 	int			 input, empty, is_floating, flags = 0;
@@ -168,11 +168,10 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "create pane failed: %s", cause);
 		free(cause);
 		/*
-		 * On failure spawn_pane has already destroyed the layout cell
-		 * (via layout_close_pane in its fork-failure path); clear lc so
-		 * the fail path below does not destroy it a second time.
+		 * spawn_pane has already torn the half-built pane down (its
+		 * fork-failure path removes the pane and destroys the layout
+		 * cell), so new_wp is NULL and there is nothing for fail to do.
 		 */
-		lc = NULL;
 		goto fail;
 	}
 
@@ -225,18 +224,6 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	if (input) {
 		switch (window_pane_start_input(new_wp, item, &cause)) {
 		case -1:
-			server_client_remove_pane(new_wp);
-			if (!is_floating) {
-				/*
-				 * layout_close_pane destroys the pane's layout
-				 * cell.
-				 * Clear lc so the fail path below does not
-				 * attempt to destroy it a second time.
-				 */
-				layout_close_pane(new_wp);
-				lc = NULL;
-			}
-			window_remove_pane(wp->window, new_wp);
 			cmdq_error(item, "%s", cause);
 			free(cause);
 			goto fail;
@@ -283,11 +270,20 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	return (CMD_RETURN_NORMAL);
 
 fail:
+	/*
+	 * If the pane was spawned before we failed, tear it down here; this
+	 * also destroys its layout cell. spawn_pane's own failure path has
+	 * already done this, so new_wp is NULL in that case.
+	 */
+	if (new_wp != NULL) {
+		server_client_remove_pane(new_wp);
+		if (!is_floating)
+			layout_close_pane(new_wp);
+		window_remove_pane(wp->window, new_wp);
+	}
 	if (sc.argv != NULL)
 		cmd_free_argv(sc.argc, sc.argv);
 	environ_free(sc.environ);
-	if (lc != NULL)
-		layout_destroy_cell(w, lc, &w->layout_root);
 
 	return (CMD_RETURN_ERROR);
 


### PR DESCRIPTION
This was tricky for me to to fully understand as I do not fully grasp the tmux internals, but I try to explain the finding as good as possible inside the git msg. 

Stumbled upon this while wiring in libghostty-vt into tmux and replace the vt mechanism the repo has. I'm planning to maintain it as a fork but if you'd be interested in any efforts to upstream it I'd be happy to do it! 