### PR TITLE
Dirty whole screen on clear in synchronized update

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -2079,7 +2079,7 @@ screen_write_clearscreen(struct screen_write_ctx *ctx, u_int bg)
 
 	screen_write_collect_clear(ctx, 0, sy);
 
-	if (!screen_write_should_draw_lines(ctx, s->cy, sy - s->cy))
+	if (!screen_write_should_draw_lines(ctx, 0, sy))
 		return;
 	if (~ttyctx.flags & TTY_CTX_PANE_OBSCURED) {
 		tty_write(tty_cmd_clearscreen, &ttyctx);


### PR DESCRIPTION
Since 565db46, ending a synchronized update redraws only the lines that were marked dirty while it was active. screen_write_clearscreen clears the entire view but gives screen_write_should_draw_lines the same range as clearendofscreen (s->cy, sy - s->cy), so after the update ends, only lines from the cursor down are marked, and any lines *above* the cursor keep their old content on the terminal. This is invisible with a common `\e[H\e[2J` because the cursor is already at the top left, but lines stay stale with the cursor elsewhere. Dirty the screen's full range instead.