### PR TITLE
Feature-PR: "Team mode" that allows multiple cursors and independent windows/panes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,3 +1,23 @@
+# tmux with teammode
+
+This is a fork of tmux that adds **teammode**: a multi-user mode (enabled by
+default) in which several users attached to the same session each work
+independently. Each user gets their own active pane and their own current
+window, so they can type in different panes and navigate to different windows
+at the same time, and each user sees the other users' cursors drawn as coloured
+markers. Set `set -g teammode off` for classic shared behaviour.
+
+See [TEAMMODE.md](../TEAMMODE.md) for details and usage.
+
+> **Disclaimer:** the teammode changes were fully vibe-coded and should be used
+> with care. They work in manual testing, but have not been exhaustively
+> reviewed or tested — do not rely on them in critical setups without your own
+> verification.
+
+The original tmux README follows.
+
+---
+
 # Welcome to tmux!
 
 tmux is a terminal multiplexer: it enables a number of terminals to be created,

--- a/README
+++ b/README
@@ -8,7 +8,13 @@ window, so they can type in different panes and navigate to different windows
 at the same time, and each user sees the other users' cursors drawn as
 coloured markers. Set "set -g teammode off" for classic shared behaviour.
 
-See TEAMMODE.md for details and usage. The original tmux README follows.
+See TEAMMODE.md for details and usage.
+
+Disclaimer: the teammode changes were fully vibe-coded and should be used with
+care. They work in manual testing, but have not been exhaustively reviewed or
+tested - do not rely on them in critical setups without your own verification.
+
+The original tmux README follows.
 
 --------------------------------------------------------------------------------
 

--- a/README
+++ b/README
@@ -1,23 +1,3 @@
-tmux with teammode
-===================
-
-This is a fork of tmux that adds "teammode": a multi-user mode (enabled by
-default) in which several users attached to the same session each work
-independently. Each user gets their own active pane and their own current
-window, so they can type in different panes and navigate to different windows
-at the same time, and each user sees the other users' cursors drawn as
-coloured markers. Set "set -g teammode off" for classic shared behaviour.
-
-See TEAMMODE.md for details and usage.
-
-Disclaimer: the teammode changes were fully vibe-coded and should be used with
-care. They work in manual testing, but have not been exhaustively reviewed or
-tested - do not rely on them in critical setups without your own verification.
-
-The original tmux README follows.
-
---------------------------------------------------------------------------------
-
 Welcome to tmux!
 
 tmux is a terminal multiplexer: it enables a number of terminals to be created,

--- a/README
+++ b/README
@@ -1,3 +1,17 @@
+tmux with teammode
+===================
+
+This is a fork of tmux that adds "teammode": a multi-user mode (enabled by
+default) in which several users attached to the same session each work
+independently. Each user gets their own active pane and their own current
+window, so they can type in different panes and navigate to different windows
+at the same time, and each user sees the other users' cursors drawn as
+coloured markers. Set "set -g teammode off" for classic shared behaviour.
+
+See TEAMMODE.md for details and usage. The original tmux README follows.
+
+--------------------------------------------------------------------------------
+
 Welcome to tmux!
 
 tmux is a terminal multiplexer: it enables a number of terminals to be created,

--- a/TEAMMODE.md
+++ b/TEAMMODE.md
@@ -1,0 +1,166 @@
+# Team Mode (Multi-User Cursors)
+
+This build of tmux adds **team mode**, which lets multiple users attached to the
+same set of windows each work in their own pane at the same time and see each
+other's cursors.
+
+**Team mode is enabled by default** (the `teammode` session option defaults to
+`on`).
+
+## What it does
+
+When `teammode` is on:
+
+1. **Independent active pane per user.** Each attached client controls its own
+   active pane (via tmux's existing `active-pane` client flag, which the option
+   sets automatically on attach). Keystrokes from each user go to *their* pane,
+   and each user's terminal cursor sits in *their* pane.
+
+2. **Visible remote cursors.** Each client draws a coloured marker at the cursor
+   position of every *other* client viewing the same window. Every user is
+   assigned a distinct colour so you can tell collaborators apart. Markers are
+   transient — painted over the pane content on each redraw and never stored in
+   the screen.
+
+3. **Independent window navigation** (via session groups). Each user attaches to
+   their own session in a *session group*; the sessions share the same windows
+   and panes (same processes) but keep an independent "current window", so users
+   can move between windows independently.
+
+### Design constraints
+
+- A pane runs a single program with a single cursor, so independent cursors only
+  exist **across different panes**, never within one pane.
+- The marker colour is derived from the client name, so a given user keeps the
+  same colour across detach/reattach.
+
+## Does `Ctrl+b c` (new-window) give each user their own window?
+
+**Only if each user is on their own session in a group.** It depends on the
+workflow:
+
+- **Same session** (`tmux new -s foo` then `tmux a -t foo`): both clients share
+  one session, so they share the *current window*. When either user presses
+  `Ctrl+b c` (or switches windows), **both** terminals jump to the new/other
+  window. Team mode still gives independent panes and remote cursors — only
+  window *navigation* is linked.
+- **Grouped sessions** (`tmux new -s foo` then `tmux new -s foo2 -t foo`): the
+  sessions share windows/panes but each has its own current window, so
+  `Ctrl+b c` and window switching are **independent** per user.
+
+## Changes in this build
+
+| File | Change |
+|------|--------|
+| `options-table.c` | New session option `teammode` (flag, **default on**). |
+| `server-client.c` | Auto-set `CLIENT_ACTIVEPANE` on attach when `teammode` is on; assign a stable per-user marker colour (`server_client_team_colour`); detect cursor-only moves and redraw observers (`server_client_window_teammode`, in `server_client_loop`). |
+| `screen-redraw.c` | New `redraw_draw_remote_cursors()`, called on full-window redraws, paints each other client's cursor as a coloured cell. |
+| `tmux.h` | `struct client.team_colour`; `struct window_pane.lastcx/lastcy`. |
+| `tmux.1` | Documentation for the `teammode` option and workflow. |
+
+Total: ~187 added lines across 5 files.
+
+### How it works internally
+
+- Pane selection, input routing, and per-client cursor placement already support
+  a per-client active pane through the pre-existing `CLIENT_ACTIVEPANE` flag
+  (`server_client_get_pane`). The option simply turns this flag on automatically.
+- `redraw_draw_remote_cursors()` iterates the client list; for each other client
+  on the same window it reads that client's active-pane cursor
+  (`server_client_get_pane` → `screen->cx/cy`), converts to the observing
+  client's viewport coordinates (same math as `server_client_reset_state`), and
+  writes a restyled cell with `tty_cell()`.
+- A bare cursor move (e.g. arrow keys in an editor) does not normally trigger a
+  redraw. `server_client_loop()` detects such moves in team-mode windows
+  (comparing each pane's cursor to cached `lastcx/lastcy`) and forces a redraw of
+  the observers so markers stay current.
+
+## Step-by-step usage
+
+### 1. Build (if not already built)
+
+```sh
+cd /shared/tmux
+sh autogen.sh
+./configure
+make
+```
+
+The binary is `/shared/tmux/tmux`. Use it directly as `./tmux` or install it with
+`make install` (needs sudo; default location `/usr/local/bin/tmux`).
+
+### 2. Same window, different panes (simplest — nothing to enable)
+
+Team mode is on by default, so just attach two clients to one session:
+
+```sh
+# User A – create the session and split into panes:
+./tmux new-session -s work
+#   (inside tmux: prefix + %  or  prefix + "  to create panes)
+
+# User B – attach to the same session (in another terminal):
+./tmux attach -t work
+```
+
+Each user selects a different pane (`prefix + arrow`, `prefix + o`, or click) and
+types independently. Each user sees the other's cursor as a coloured block.
+
+> Note: on a shared session, `Ctrl+b c` / window switching affects both users
+> (see the section above). Use grouped sessions for independent navigation.
+
+### 3. Independent window navigation (session groups)
+
+Give each user their own session in a group so they can move between windows
+independently while sharing the same windows/panes:
+
+```sh
+# User A – create the session:
+./tmux new-session -s work
+
+# User B – create a grouped session sharing A's windows, and attach:
+./tmux new-session -t work
+```
+
+`new-session -t work` creates a session linked to the same windows/panes and
+attaches to it in one step. Both users now:
+
+- share the same windows and the programs running in them;
+- switch windows independently (`prefix + n/p/<number>`, `prefix + c`);
+- keep independent active panes and see each other's cursors.
+
+Setting `aggressive-resize on` is recommended so a window is sized only by the
+users currently viewing it:
+
+```sh
+./tmux set-option -g aggressive-resize on
+```
+
+### 4. Turning team mode off
+
+It is on by default. To disable it (globally, in `~/.tmux.conf` or at runtime):
+
+```
+set -g teammode off
+```
+
+The option takes effect for a client **when it attaches**, so change it before
+attaching (a config setting does this automatically). To change it for an
+already-attached client, detach and reattach.
+
+### 5. Verify
+
+```sh
+./tmux show-options -g teammode                       # -> teammode on
+./tmux list-clients -F '#{client_name} [#{client_flags}]'
+#   each attached client line should include: active-pane
+```
+
+## Notes and limitations
+
+- **Marker refresh cost.** Cursor-only moves currently trigger a full-window
+  redraw of observers. Correct but potentially heavy if a program animates the
+  cursor rapidly in a shared window; a lighter cursor-only redraw path is a
+  possible future optimization.
+- **One cursor per pane.** Two users cannot have separate cursors in the *same*
+  pane. Use different panes.
+- **Read-only / control clients** do not draw markers.

--- a/TEAMMODE.md
+++ b/TEAMMODE.md
@@ -1,83 +1,83 @@
-# Team Mode (Multi-User Cursors)
+# Team Mode (Multi-User Independent Panes, Windows and Cursors)
 
 This build of tmux adds **team mode**, which lets multiple users attached to the
-same set of windows each work in their own pane at the same time and see each
-other's cursors.
+same session each work fully independently — their own pane, their own current
+window, and a view of everyone else's cursors.
 
 **Team mode is enabled by default** (the `teammode` session option defaults to
 `on`).
 
 ## What it does
 
-When `teammode` is on:
+When `teammode` is on, each client attached to the session is independent:
 
-1. **Independent active pane per user.** Each attached client controls its own
-   active pane (via tmux's existing `active-pane` client flag, which the option
-   sets automatically on attach). Keystrokes from each user go to *their* pane,
-   and each user's terminal cursor sits in *their* pane.
+1. **Independent active pane per user.** Each client controls its own active
+   pane (auto `active-pane` client flag). Keystrokes go to *that user's* pane and
+   each user's terminal cursor sits in *their* pane.
 
-2. **Visible remote cursors.** Each client draws a coloured marker at the cursor
-   position of every *other* client viewing the same window. Every user is
-   assigned a distinct colour so you can tell collaborators apart. Markers are
-   transient — painted over the pane content on each redraw and never stored in
-   the screen.
+2. **Independent current window per user.** Each client has its own current
+   window (auto `active-window` client flag), so users can view and navigate to
+   different windows of the *one* session independently. `select-window`,
+   `next-window`, `previous-window`, `last-window`, `new-window` and the numeric
+   window keys affect only the issuing client — `Ctrl+b c` in one terminal no
+   longer drags the others to the new window.
 
-3. **Independent window navigation** (via session groups). Each user attaches to
-   their own session in a *session group*; the sessions share the same windows
-   and panes (same processes) but keep an independent "current window", so users
-   can move between windows independently.
+3. **Visible remote cursors.** Each client draws a coloured marker at the cursor
+   position of every *other* client viewing the same window. Every user gets a
+   distinct colour. Markers are transient — painted over the pane content on each
+   redraw and never stored in the screen.
+
+When `teammode` is **off**, all clients on a session share one active pane and one
+current window, as classic tmux does (useful for mirroring a session on a
+projector).
 
 ### Design constraints
 
 - A pane runs a single program with a single cursor, so independent cursors only
   exist **across different panes**, never within one pane.
-- The marker colour is derived from the client name, so a given user keeps the
-  same colour across detach/reattach.
+- The marker colour is derived from the client name, so a user keeps the same
+  colour across detach/reattach.
+- `last-window` uses a single per-client "last window" pointer (not a full
+  stack).
 
 ## Does `Ctrl+b c` (new-window) give each user their own window?
 
-**Only if each user is on their own session in a group.** It depends on the
-workflow:
+**Yes**, with team mode on (the default): windows are per-client within a single
+session. `Ctrl+b c` creates a window and switches *only the client that pressed
+it*; other users stay where they are (the new window still appears in everyone's
+window list). Window switching (`Ctrl+b n/p/l/<number>`) is likewise per-client.
 
-- **Same session** (`tmux new -s foo` then `tmux a -t foo`): both clients share
-  one session, so they share the *current window*. When either user presses
-  `Ctrl+b c` (or switches windows), **both** terminals jump to the new/other
-  window. Team mode still gives independent panes and remote cursors — only
-  window *navigation* is linked.
-- **Grouped sessions** (`tmux new -s foo` then `tmux new -s foo2 -t foo`): the
-  sessions share windows/panes but each has its own current window, so
-  `Ctrl+b c` and window switching are **independent** per user.
+With `teammode off`, `Ctrl+b c` and window switches move every client on the
+session together, as before.
+
+## Recommended companion setting
+
+Enable `aggressive-resize` so a window is sized only by the clients currently
+viewing it — two users on different windows then won't shrink each other:
+
+```
+set -g aggressive-resize on
+```
 
 ## Changes in this build
 
 | File | Change |
 |------|--------|
-| `options-table.c` | New session option `teammode` (flag, **default on**). |
-| `server-client.c` | Auto-set `CLIENT_ACTIVEPANE` on attach when `teammode` is on; assign a stable per-user marker colour (`server_client_team_colour`); detect cursor-only moves and redraw observers (`server_client_window_teammode`, in `server_client_loop`). |
-| `screen-redraw.c` | New `redraw_draw_remote_cursors()`, called on full-window redraws, paints each other client's cursor as a coloured cell. |
-| `tmux.h` | `struct client.team_colour`; `struct window_pane.lastcx/lastcy`. |
-| `tmux.1` | Documentation for the `teammode` option and workflow. |
+| `options-table.c` | Session option `teammode` (flag, **default on**). |
+| `tmux.h` | `client.curw` / `client.last_curw`; `CLIENT_ACTIVEWINDOW` flag; `client.team_colour`; `window_pane.lastcx/lastcy`. |
+| `server-client.c` | Auto-set `CLIENT_ACTIVEPANE`+`CLIENT_ACTIVEWINDOW` on attach; per-client window accessors `server_client_get_curw` / `is_viewing` / `set_curw` + next/previous/last; `server_client_remove_window`; per-user marker colour; cursor-move redraw; ~20 client-scoped `curw` reads switched to the per-client accessor. |
+| `server-fn.c`, `screen-write.c`, `tty.c`, `screen-redraw.c`, `window.c`, `tty-keys.c`, `resize.c` | Client-scoped "is this client viewing window w / what window does this client see" reads switched to `server_client_is_viewing` / `server_client_get_curw`. |
+| `cmd-select-window.c`, `cmd-new-window.c`, `spawn.c`, `cmd-switch-client.c` | Per-client window navigation when the issuing client has `active-window`. |
+| `format.c` | Client-context formats (status line, window list, `#{window_active}`) resolve the current window per-client. |
+| `session.c` | `session_detach` repoints per-client current windows off a removed winlink. |
+| `tmux.1` | Documentation. |
 
-Total: ~187 added lines across 5 files.
-
-### How it works internally
-
-- Pane selection, input routing, and per-client cursor placement already support
-  a per-client active pane through the pre-existing `CLIENT_ACTIVEPANE` flag
-  (`server_client_get_pane`). The option simply turns this flag on automatically.
-- `redraw_draw_remote_cursors()` iterates the client list; for each other client
-  on the same window it reads that client's active-pane cursor
-  (`server_client_get_pane` → `screen->cx/cy`), converts to the observing
-  client's viewport coordinates (same math as `server_client_reset_state`), and
-  writes a restyled cell with `tty_cell()`.
-- A bare cursor move (e.g. arrow keys in an editor) does not normally trigger a
-  redraw. `server_client_loop()` detects such moves in team-mode windows
-  (comparing each pane's cursor to cached `lastcx/lastcy`) and forces a redraw of
-  the observers so markers stay current.
+Session-scoped uses of `session->curw` (command targeting in `cmd-find.c`,
+session internals, session-level formats) are intentionally left unchanged.
 
 ## Step-by-step usage
 
-### 1. Build (if not already built)
+### 1. Build
 
 ```sh
 cd /shared/tmux
@@ -86,81 +86,52 @@ sh autogen.sh
 make
 ```
 
-The binary is `/shared/tmux/tmux`. Use it directly as `./tmux` or install it with
-`make install` (needs sudo; default location `/usr/local/bin/tmux`).
+The binary is `/shared/tmux/tmux`.
 
-### 2. Same window, different panes (simplest — nothing to enable)
-
-Team mode is on by default, so just attach two clients to one session:
+### 2. Two users, one session (nothing to enable)
 
 ```sh
-# User A – create the session and split into panes:
-./tmux new-session -s work
-#   (inside tmux: prefix + %  or  prefix + "  to create panes)
-
-# User B – attach to the same session (in another terminal):
+# User A:
+./tmux new-session -s work            # create some windows/panes
+# User B, in another terminal:
 ./tmux attach -t work
 ```
 
-Each user selects a different pane (`prefix + arrow`, `prefix + o`, or click) and
-types independently. Each user sees the other's cursor as a coloured block.
+Each user independently:
+- selects a different pane and types into it;
+- switches to / creates different windows (`Ctrl+b c`, `Ctrl+b n/p`, `Ctrl+b <n>`);
+- sees the others' cursors as coloured blocks when viewing the same window.
 
-> Note: on a shared session, `Ctrl+b c` / window switching affects both users
-> (see the section above). Use grouped sessions for independent navigation.
+### 3. Turning team mode off (restore classic shared session)
 
-### 3. Independent window navigation (session groups)
-
-Give each user their own session in a group so they can move between windows
-independently while sharing the same windows/panes:
-
-```sh
-# User A – create the session:
-./tmux new-session -s work
-
-# User B – create a grouped session sharing A's windows, and attach:
-./tmux new-session -t work
-```
-
-`new-session -t work` creates a session linked to the same windows/panes and
-attaches to it in one step. Both users now:
-
-- share the same windows and the programs running in them;
-- switch windows independently (`prefix + n/p/<number>`, `prefix + c`);
-- keep independent active panes and see each other's cursors.
-
-Setting `aggressive-resize on` is recommended so a window is sized only by the
-users currently viewing it:
-
-```sh
-./tmux set-option -g aggressive-resize on
-```
-
-### 4. Turning team mode off
-
-It is on by default. To disable it (globally, in `~/.tmux.conf` or at runtime):
+In `~/.tmux.conf` or at runtime:
 
 ```
 set -g teammode off
 ```
 
 The option takes effect for a client **when it attaches**, so change it before
-attaching (a config setting does this automatically). To change it for an
+attaching (a config setting does this automatically); to change an
 already-attached client, detach and reattach.
 
-### 5. Verify
+### 4. Verify
 
 ```sh
-./tmux show-options -g teammode                       # -> teammode on
+./tmux show-options -g teammode                        # -> teammode on
 ./tmux list-clients -F '#{client_name} [#{client_flags}]'
-#   each attached client line should include: active-pane
+#   attached clients show: active-pane, active-window
+./tmux list-clients -F 'curwin=#{window_index}'        # differs per client
 ```
 
 ## Notes and limitations
 
-- **Marker refresh cost.** Cursor-only moves currently trigger a full-window
-  redraw of observers. Correct but potentially heavy if a program animates the
-  cursor rapidly in a shared window; a lighter cursor-only redraw path is a
+- **Marker / view refresh cost.** A bare cursor move or window switch triggers a
+  redraw of the affected observers. Correct but potentially heavy with rapid
+  cursor animation in a shared window; a lighter cursor-only redraw path is a
   possible future optimization.
-- **One cursor per pane.** Two users cannot have separate cursors in the *same*
-  pane. Use different panes.
-- **Read-only / control clients** do not draw markers.
+- **One cursor per pane.** Two users cannot have separate cursors in the same
+  pane — use different panes.
+- **last-window** is a single per-client pointer, not a stack.
+- **Alerts / window flags** are per-session (shared by clients on a session) and
+  clear when a viewing client selects the window.
+- **Read-only / control clients** do not draw cursor markers.

--- a/cmd-find.c
+++ b/cmd-find.c
@@ -890,7 +890,7 @@ cmd_find_from_client(struct cmd_find_state *fs, struct client *c, int flags)
 			return (0);
 		}
 		fs->s = c->session;
-		fs->wl = fs->s->curw;
+		fs->wl = server_client_get_curw(c);
 		fs->w = fs->wl->window;
 
 		cmd_find_log_state(__func__, fs);

--- a/cmd-new-window.c
+++ b/cmd-new-window.c
@@ -100,7 +100,10 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 			free(wname);
 			if (args_has(args, 'd'))
 				return (CMD_RETURN_NORMAL);
-			if (session_set_current(s, new_wl) == 0)
+			if (c != NULL && c->session == s &&
+			    (c->flags & CLIENT_ACTIVEWINDOW))
+				server_client_set_curw(c, new_wl);
+			else if (session_set_current(s, new_wl) == 0)
 				server_redraw_session(s);
 			if (c != NULL && c->session != NULL)
 				s->curw->window->latest = c;
@@ -149,6 +152,11 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 		server_redraw_session_group(s);
 	} else
 		server_status_session_group(s);
+
+	/* In team mode only the creating client switches to the new window. */
+	if (c != NULL && c->session == s && (c->flags & CLIENT_ACTIVEWINDOW) &&
+	    !args_has(args, 'd'))
+		server_client_set_curw(c, new_wl);
 
 	if (args_has(args, 'P')) {
 		if ((template = args_get(args, 'F')) == NULL)

--- a/cmd-select-window.c
+++ b/cmd-select-window.c
@@ -102,6 +102,36 @@ cmd_select_window_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_has(args, 'l'))
 		last = 1;
 
+	/*
+	 * In team mode the issuing client navigates its own current window
+	 * independently of the session and other clients.
+	 */
+	if (c != NULL && c->session == s && (c->flags & CLIENT_ACTIVEWINDOW)) {
+		activity = args_has(args, 'a');
+		if (next) {
+			if (server_client_next_window(c, activity) != 0) {
+				cmdq_error(item, "no next window");
+				return (CMD_RETURN_ERROR);
+			}
+		} else if (previous) {
+			if (server_client_previous_window(c, activity) != 0) {
+				cmdq_error(item, "no previous window");
+				return (CMD_RETURN_ERROR);
+			}
+		} else if (last ||
+		    (args_has(args, 'T') && wl == server_client_get_curw(c))) {
+			if (server_client_last_window(c) != 0) {
+				cmdq_error(item, "no last window");
+				return (CMD_RETURN_ERROR);
+			}
+		} else
+			server_client_set_curw(c, wl);
+		cmd_find_from_client(current, c, 0);
+		cmdq_insert_hook(s, item, current, "after-select-window");
+		recalculate_sizes();
+		return (CMD_RETURN_NORMAL);
+	}
+
 	if (next || previous || last) {
 		activity = args_has(args, 'a');
 		if (next) {

--- a/cmd-switch-client.c
+++ b/cmd-switch-client.c
@@ -156,6 +156,8 @@ cmd_switch_client_exec(struct cmd *self, struct cmdq_item *item)
 		environ_update(s->options, tc->environ, s->environ);
 
 	server_client_set_session(tc, s);
+	if (wl != NULL && (tc->flags & CLIENT_ACTIVEWINDOW))
+		server_client_set_curw(tc, wl);
 	if (~cmdq_get_flags(item) & CMDQ_STATE_REPEAT)
 		server_client_set_key_table(tc, NULL);
 

--- a/format.c
+++ b/format.c
@@ -4887,9 +4887,9 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 		fatalx("out of memory");
 
 	/*
-	 * In team mode each client views its own current window, so the "active"
-	 * window in a client's status line is that client's window, not the
-	 * session's.
+	 * In team mode each client views its own current window, so the
+	 * "active" window in a client's status line is that client's window,
+	 * not the session's.
 	 */
 	if (c != NULL)
 		curw = server_client_get_curw(c);

--- a/format.c
+++ b/format.c
@@ -2756,8 +2756,14 @@ format_cb_last_window_index(struct format_tree *ft)
 static void *
 format_cb_window_active(struct format_tree *ft)
 {
+	struct winlink	*curw;
+
 	if (ft->wl != NULL) {
-		if (ft->wl == ft->wl->session->curw)
+		if (ft->c != NULL && ft->c->session == ft->wl->session)
+			curw = server_client_get_curw(ft->c);
+		else
+			curw = ft->wl->session->curw;
+		if (ft->wl == curw)
 			return (xstrdup("1"));
 		return (xstrdup("0"));
 	}
@@ -4821,7 +4827,7 @@ format_window_name(struct format_expand_state *es, const char *fmt)
 /* Add neighbor window variables to the format tree. */
 static void
 format_add_window_neighbor(struct format_tree *nft, struct winlink *wl,
-    struct session *s, const char *prefix)
+    struct winlink *curw, const char *prefix)
 {
 	struct options_entry	*o;
 	const char		*oname;
@@ -4832,7 +4838,7 @@ format_add_window_neighbor(struct format_tree *nft, struct winlink *wl,
 	free(key);
 
 	xasprintf(&key, "%s_window_active", prefix);
-	format_add(nft, key, "%d", wl == s->curw);
+	format_add(nft, key, "%d", wl == curw);
 	free(key);
 
 	o = options_first(wl->window->options);
@@ -4862,7 +4868,7 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 	char				 *all, *active, *use, *expanded, *value;
 	struct evbuffer			 *buffer;
 	size_t				  size;
-	struct winlink			 *wl, **l;
+	struct winlink			 *wl, **l, *curw;
 	struct window			 *w;
 	int				  i, n;
 
@@ -4880,12 +4886,22 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 	if (buffer == NULL)
 		fatalx("out of memory");
 
+	/*
+	 * In team mode each client views its own current window, so the "active"
+	 * window in a client's status line is that client's window, not the
+	 * session's.
+	 */
+	if (c != NULL)
+		curw = server_client_get_curw(c);
+	else
+		curw = ft->s->curw;
+
 	l = sort_get_winlinks_session(ft->s, &n, sc);
 	for (i = 0; i < n; i++) {
 		wl = l[i];
 		w = wl->window;
 		format_log(es, "window loop: %u @%u", wl->idx, w->id);
-		if (active != NULL && wl == ft->s->curw)
+		if (active != NULL && wl == curw)
 			use = active;
 		else
 			use = all;
@@ -4897,13 +4913,13 @@ format_loop_windows(struct format_expand_state *es, const char *fmt)
 
 		/* Add neighbor window data to the format tree. */
 		format_add(nft, "window_after_active", "%d",
-		    i > 0 && l[i - 1] == ft->s->curw);
+		    i > 0 && l[i - 1] == curw);
 		format_add(nft, "window_before_active", "%d",
-		    i + 1 < n && l[i + 1] == ft->s->curw);
+		    i + 1 < n && l[i + 1] == curw);
 		if (i + 1 < n)
-			format_add_window_neighbor(nft, l[i + 1], ft->s, "next");
+			format_add_window_neighbor(nft, l[i + 1], curw, "next");
 		if (i > 0)
-			format_add_window_neighbor(nft, l[i - 1], ft->s, "prev");
+			format_add_window_neighbor(nft, l[i - 1], curw, "prev");
 
 		format_copy_state(&next, es, 0);
 		next.ft = nft;
@@ -6094,8 +6110,13 @@ format_defaults(struct format_tree *ft, struct client *c, struct session *s,
 
 	if (s == NULL && c != NULL)
 		s = c->session;
-	if (wl == NULL && s != NULL)
-		wl = s->curw;
+	if (wl == NULL) {
+		/* In team mode default to the client's own current window. */
+		if (c != NULL && c->session == s)
+			wl = server_client_get_curw(c);
+		else if (s != NULL)
+			wl = s->curw;
+	}
 	if (wp == NULL && wl != NULL)
 		wp = wl->window->active;
 

--- a/options-table.c
+++ b/options-table.c
@@ -1226,8 +1226,8 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 1,
 	  .text = "Whether attached clients each control an independent active "
 		  "pane and see each other's cursors. Enabled by default. Set "
-		  "this globally so that grouped sessions (used for independent "
-		  "window navigation) inherit it."
+		  "this globally so that grouped sessions (used for "
+		  "independent window navigation) inherit it."
 	},
 
 	{ .name = "update-environment",

--- a/options-table.c
+++ b/options-table.c
@@ -1220,6 +1220,16 @@ const struct options_table_entry options_table[] = {
 		  "session."
 	},
 
+	{ .name = "teammode",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .default_num = 1,
+	  .text = "Whether attached clients each control an independent active "
+		  "pane and see each other's cursors. Enabled by default. Set "
+		  "this globally so that grouped sessions (used for independent "
+		  "window navigation) inherit it."
+	},
+
 	{ .name = "update-environment",
 	  .type = OPTIONS_TABLE_STRING,
 	  .scope = OPTIONS_TABLE_SESSION,

--- a/resize.c
+++ b/resize.c
@@ -345,7 +345,7 @@ recalculate_size_skip_client(struct client *loop, __unused int type,
 	if (loop->session->curw == NULL)
 		return (1);
 	if (current)
-		return (loop->session->curw->window != w);
+		return (!server_client_is_viewing(loop, w));
 	return (session_has(loop->session, w) == 0);
 }
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1087,8 +1087,8 @@ redraw_get_default_border_style(struct redraw_draw_ctx *dctx,
 	struct grid_cell	*dgc = &dctx->default_gc;
 
 	if (~dctx->flags & REDRAW_DEFAULT_SET) {
-		ft = format_create_defaults(NULL, c, s, server_client_get_curw(c),
-		    NULL);
+		ft = format_create_defaults(NULL, c, s,
+		    server_client_get_curw(c), NULL);
 		memcpy(dgc, &grid_default_cell, sizeof *dgc);
 		style_add(dgc, oo, "pane-border-style", ft);
 		format_free(ft);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1577,6 +1577,72 @@ redraw_draw_pane_prompt(struct redraw_draw_ctx *dctx, struct window_pane *wp)
 	screen_free(&screen);
 }
 
+/*
+ * Draw markers at the cursor positions of other clients viewing the same
+ * window (team mode). Each remote user gets a distinct colour. The markers are
+ * transient: they are painted over the pane content every redraw and never
+ * mutate the grid.
+ */
+static void
+redraw_draw_remote_cursors(struct redraw_draw_ctx *dctx)
+{
+	struct redraw_scene	*scene = dctx->scene;
+	struct client		*c = scene->c, *c2;
+	struct window		*w = scene->w;
+	struct tty		*tty = &c->tty;
+	struct window_pane	*wp;
+	struct screen		*s2;
+	struct grid_cell	 gc;
+	int			 ox = scene->ox, oy = scene->oy;
+	int			 sx = scene->sx, sy = scene->sy;
+	int			 cx, cy;
+
+	if (c->session == NULL ||
+	    !options_get_number(c->session->options, "teammode"))
+		return;
+
+	TAILQ_FOREACH(c2, &clients, entry) {
+		if (c2 == c || c2->session == NULL)
+			continue;
+		if (c2->flags & (CLIENT_SUSPENDED|CLIENT_CONTROL))
+			continue;
+		if (c2->session->curw == NULL ||
+		    c2->session->curw->window != w)
+			continue;
+
+		wp = server_client_get_pane(c2);
+		if (wp == NULL || !window_pane_is_visible(wp))
+			continue;
+		s2 = wp->screen;
+		if (~s2->mode & MODE_CURSOR)
+			continue;
+		if (wp->base.mode & MODE_SYNC)
+			continue;
+
+		/* Is the remote cursor within this client's viewport? */
+		if (wp->xoff + (int)s2->cx < ox ||
+		    wp->xoff + (int)s2->cx >= ox + sx ||
+		    wp->yoff + (int)s2->cy < oy ||
+		    wp->yoff + (int)s2->cy >= oy + sy)
+			continue;
+		cx = wp->xoff + (int)s2->cx - ox;
+		cy = wp->yoff + (int)s2->cy - oy;
+		if (dctx->flags & REDRAW_STATUS_TOP)
+			cy += dctx->status_lines;
+
+		/* Restyle the cell under the remote cursor as a marker. */
+		grid_view_get_cell(s2->grid, s2->cx, s2->cy, &gc);
+		if (gc.flags & GRID_FLAG_PADDING)
+			continue;
+		gc.bg = c2->team_colour;
+		gc.fg = 0;
+		gc.attr &= ~GRID_ATTR_BLINK;
+
+		tty_cursor(tty, cx, cy);
+		tty_cell(tty, &gc, NULL);
+	}
+}
+
 /* Draw scene to client. */
 static void
 redraw_draw(struct client *c, struct window_pane *wp, int flags)
@@ -1682,6 +1748,9 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 			}
 		}
 	}
+
+	if (wp == NULL)
+		redraw_draw_remote_cursors(&dctx);
 
 	if (flags & REDRAW_STATUS) {
 		lines = dctx.status_lines;

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -281,8 +281,7 @@ redraw_get_window_offset(struct client *c, u_int *ox, u_int *oy, u_int *sx,
 static void
 redraw_set_context(struct client *c, struct redraw_build_ctx *bctx)
 {
-	struct session	*s = c->session;
-	struct window	*w = s->curw->window;
+	struct window	*w = server_client_get_curw(c)->window;
 
 	memset(bctx, 0, sizeof *bctx);
 	bctx->c = c;
@@ -917,8 +916,7 @@ redraw_build_cells(struct redraw_build_ctx *bctx)
 static struct redraw_scene *
 redraw_make_scene(struct client *c)
 {
-	struct session			*s = c->session;
-	struct window			*w = s->curw->window;
+	struct window			*w = server_client_get_curw(c)->window;
 	struct redraw_build_ctx		 bctx;
 	struct redraw_scene		*scene;
 	struct redraw_build_cell	*bc, *last;
@@ -1028,7 +1026,7 @@ static struct redraw_scene *
 redraw_get_scene(struct client *c)
 {
 	struct redraw_scene	*scene = c->redraw_scene;
-	struct window		*w = c->session->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	const char		*reason = NULL;
 	u_int			 ox, oy, sx, sy;
 
@@ -1089,7 +1087,8 @@ redraw_get_default_border_style(struct redraw_draw_ctx *dctx,
 	struct grid_cell	*dgc = &dctx->default_gc;
 
 	if (~dctx->flags & REDRAW_DEFAULT_SET) {
-		ft = format_create_defaults(NULL, c, s, s->curw, NULL);
+		ft = format_create_defaults(NULL, c, s, server_client_get_curw(c),
+		    NULL);
 		memcpy(dgc, &grid_default_cell, sizeof *dgc);
 		style_add(dgc, oo, "pane-border-style", ft);
 		format_free(ft);
@@ -1508,7 +1507,7 @@ redraw_set_draw_context(struct redraw_draw_ctx *dctx,
 	memset(dctx, 0, sizeof *dctx);
 	dctx->scene = scene;
 
-	if (server_is_marked(s, s->curw, marked_pane.wp))
+	if (server_is_marked(s, server_client_get_curw(c), marked_pane.wp))
 		dctx->marked = marked_pane.wp;
 	dctx->active = server_client_get_pane(c);
 
@@ -1606,8 +1605,7 @@ redraw_draw_remote_cursors(struct redraw_draw_ctx *dctx)
 			continue;
 		if (c2->flags & (CLIENT_SUSPENDED|CLIENT_CONTROL))
 			continue;
-		if (c2->session->curw == NULL ||
-		    c2->session->curw->window != w)
+		if (!server_client_is_viewing(c2, w))
 			continue;
 
 		wp = server_client_get_pane(c2);
@@ -1648,8 +1646,7 @@ static void
 redraw_draw(struct client *c, struct window_pane *wp, int flags)
 {
 	struct redraw_draw_ctx	 dctx;
-	struct session		*s = c->session;
-	struct window		*w = s->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct tty		*tty = &c->tty;
 	struct screen		*sl;
 	struct redraw_scene	*scene;

--- a/screen-write.c
+++ b/screen-write.c
@@ -141,7 +141,7 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 		return (0);
 	}
 
-	if (c->session->curw->window != wp->window)
+	if (!server_client_is_viewing(c, wp->window))
 		return (0);
 	if (wp->layout_cell == NULL)
 		return (0);

--- a/server-client.c
+++ b/server-client.c
@@ -1653,6 +1653,7 @@ server_client_handle_key0(struct client *c, struct key_event *event,
 {
 	struct session		*s = c->session;
 	struct cmdq_item	*item;
+	struct window		*w;
 	struct window_pane	*wp;
 
 	/* Check the client is good to accept input. */
@@ -1706,10 +1707,10 @@ server_client_handle_key0(struct client *c, struct key_event *event,
 			}
 		}
 
-		wp = server_client_get_curw(c)->window->active;
+		w = server_client_get_curw(c)->window;
+		wp = w->active;
 		if (wp == NULL || !window_pane_has_prompt(wp)) {
-			TAILQ_FOREACH(wp, &server_client_get_curw(c)->window->panes,
-			    entry) {
+			TAILQ_FOREACH(wp, &w->panes, entry) {
 				if (window_pane_has_prompt(wp) &&
 				    window_pane_is_visible(wp))
 					break;

--- a/server-client.c
+++ b/server-client.c
@@ -122,7 +122,7 @@ server_client_set_overlay(struct client *c, u_int delay,
 		c->tty.flags |= TTY_FREEZE;
 	if (c->overlay_mode == NULL)
 		c->tty.flags |= TTY_NOCURSOR;
-	window_update_focus(c->session->curw->window);
+	window_update_focus(server_client_get_curw(c)->window);
 	server_redraw_client(c);
 }
 
@@ -149,7 +149,7 @@ server_client_clear_overlay(struct client *c)
 
 	c->tty.flags &= ~(TTY_FREEZE|TTY_NOCURSOR);
 	if (c->session != NULL)
-		window_update_focus(c->session->curw->window);
+		window_update_focus(server_client_get_curw(c)->window);
 	server_redraw_client(c);
 }
 
@@ -396,7 +396,8 @@ server_client_attached_lost(struct client *c)
 		found = NULL;
 		TAILQ_FOREACH(loop, &clients, entry) {
 			s = loop->session;
-			if (loop == c || s == NULL || s->curw->window != w)
+			if (loop == c || s == NULL ||
+			    !server_client_is_viewing(loop, w))
 				continue;
 			if (found == NULL || timercmp(&loop->activity_time,
 			    &found->activity_time, >))
@@ -443,9 +444,7 @@ server_client_window_teammode(struct window *w)
 	u_int		 n = 0;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session == NULL || c->session->curw == NULL)
-			continue;
-		if (c->session->curw->window != w)
+		if (c->session == NULL || !server_client_is_viewing(c, w))
 			continue;
 		n++;
 		if (options_get_number(c->session->options, "teammode"))
@@ -471,9 +470,13 @@ server_client_set_session(struct client *c, struct session *s)
 		window_update_focus(old->curw->window);
 	if (s != NULL) {
 		if (options_get_number(s->options, "teammode")) {
-			c->flags |= CLIENT_ACTIVEPANE;
+			c->flags |= (CLIENT_ACTIVEPANE|CLIENT_ACTIVEWINDOW);
 			if (c->team_colour == -1)
 				c->team_colour = server_client_team_colour(c);
+		}
+		if (old != s) {
+			c->curw = s->curw;
+			c->last_curw = NULL;
 		}
 		s->curw->window->latest = c;
 		recalculate_sizes();
@@ -692,7 +695,7 @@ server_client_in_scrollbar_area(struct window_pane *wp, int px, int py)
 static void
 server_client_update_scrollbar_hover(struct client *c, int type, int px, int py)
 {
-	struct window		*w = c->session->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct window_pane	*wp;
 
 	if (type != KEYC_TYPE_MOUSEMOVE)
@@ -865,7 +868,7 @@ server_client_check_mouse(struct client *c, struct key_event *event)
 {
 	struct mouse_event		*m = &event->m;
 	struct session			*s = c->session, *fs;
-	struct window			*w = s->curw->window;
+	struct window			*w = server_client_get_curw(c)->window;
 	struct winlink			*fwl;
 	struct window_pane		*wp, *fwp, *lwp = NULL;
 	u_int				 x, y, sx, sy, px, py, n, sl_mpos = 0;
@@ -1329,7 +1332,7 @@ server_client_update_latest(struct client *c)
 
 	if (c->session == NULL)
 		return;
-	w = c->session->curw->window;
+	w = server_client_get_curw(c)->window;
 
 	if (w->latest == c)
 		return;
@@ -1393,7 +1396,7 @@ server_client_key_callback(struct cmdq_item *item, void *data)
 	/* Check the client is good to accept input. */
 	if (s == NULL || (c->flags & CLIENT_UNATTACHEDFLAGS))
 		goto out;
-	wl = s->curw;
+	wl = server_client_get_curw(c);
 
 	/* Update the activity timer. */
 	memcpy(&c->last_activity_time, &c->activity_time,
@@ -1703,9 +1706,10 @@ server_client_handle_key0(struct client *c, struct key_event *event,
 			}
 		}
 
-		wp = s->curw->window->active;
+		wp = server_client_get_curw(c)->window->active;
 		if (wp == NULL || !window_pane_has_prompt(wp)) {
-			TAILQ_FOREACH(wp, &s->curw->window->panes, entry) {
+			TAILQ_FOREACH(wp, &server_client_get_curw(c)->window->panes,
+			    entry) {
 				if (window_pane_has_prompt(wp) &&
 				    window_pane_is_visible(wp))
 					break;
@@ -2063,7 +2067,7 @@ static void
 server_client_reset_state(struct client *c)
 {
 	struct tty		*tty = &c->tty;
-	struct window		*w = c->session->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct window_pane	*wp = server_client_get_pane(c), *loop;
 	struct screen		*s = NULL;
 	struct options		*oo = c->session->options;
@@ -2286,7 +2290,7 @@ server_client_redraw_timer(__unused int fd, __unused short events,
 static void
 server_client_check_modes(struct client *c)
 {
-	struct window			*w = c->session->curw->window;
+	struct window			*w = server_client_get_curw(c)->window;
 	struct window_pane		*wp;
 	struct window_mode_entry	*wme;
 
@@ -2305,8 +2309,7 @@ server_client_check_modes(struct client *c)
 static int
 server_client_any_pane_redraw(struct client *c)
 {
-	struct session		*s = c->session;
-	struct window		*w = s->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct window_pane	*wp;
 
 	if (c->flags & CLIENT_REDRAWWINDOW)
@@ -2324,7 +2327,7 @@ server_client_check_redraw(struct client *c)
 {
 	struct session		*s = c->session;
 	struct tty		*tty = &c->tty;
-	struct window		*w = s->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct window_pane	*wp;
 	int			 needed, tflags, mode = tty->mode;
 	struct timeval		 tv = { .tv_usec = 1000 };
@@ -2453,15 +2456,15 @@ server_client_set_title(struct client *c)
 static void
 server_client_set_path(struct client *c)
 {
-	struct session	*s = c->session;
+	struct winlink	*wl = server_client_get_curw(c);
 	const char	*path;
 
-	if (s->curw == NULL || s->curw->window->active == NULL)
+	if (wl == NULL || wl->window->active == NULL)
 		return;
-	if (s->curw->window->active->base.path == NULL)
+	if (wl->window->active->base.path == NULL)
 		path = "";
 	else
-		path = s->curw->window->active->base.path;
+		path = wl->window->active->base.path;
 	if (c->path == NULL || strcmp(path, c->path) != 0) {
 		free(c->path);
 		c->path = xstrdup(path);
@@ -2473,12 +2476,12 @@ server_client_set_path(struct client *c)
 static void
 server_client_set_progress_bar(struct client *c)
 {
-	struct session		*s = c->session;
+	struct winlink		*wl = server_client_get_curw(c);
 	struct progress_bar	*pane_pb;
 
-	if (s->curw == NULL || s->curw->window->active == NULL)
+	if (wl == NULL || wl->window->active == NULL)
 		return;
-	pane_pb = &s->curw->window->active->base.progress_bar;
+	pane_pb = &wl->window->active->base.progress_bar;
 	if (pane_pb->state == c->progress_bar.state &&
 	    pane_pb->progress == c->progress_bar.progress)
 		return;
@@ -2945,6 +2948,8 @@ server_client_set_flags(struct client *c, const char *flags)
 			flag = CLIENT_IGNORESIZE;
 		else if (strcmp(next, "active-pane") == 0)
 			flag = CLIENT_ACTIVEPANE;
+		else if (strcmp(next, "active-window") == 0)
+			flag = CLIENT_ACTIVEWINDOW;
 		else if (strcmp(next, "no-detach-on-destroy") == 0)
 			flag = CLIENT_NO_DETACH_ON_DESTROY;
 		if (flag == 0)
@@ -2995,6 +3000,8 @@ server_client_get_flags(struct client *c)
 		strlcat(s, "read-only,", sizeof s);
 	if (c->flags & CLIENT_ACTIVEPANE)
 		strlcat(s, "active-pane,", sizeof s);
+	if (c->flags & CLIENT_ACTIVEWINDOW)
+		strlcat(s, "active-window,", sizeof s);
 	if (c->flags & CLIENT_SUSPENDED)
 		strlcat(s, "suspended,", sizeof s);
 	if (c->flags & CLIENT_UTF8)
@@ -3028,21 +3035,47 @@ server_client_add_client_window(struct client *c, u_int id)
 	return (cw);
 }
 
+/*
+ * Get the window this client is currently viewing. In team mode each client
+ * has its own current window (c->curw); otherwise all clients on a session
+ * share the session's current window.
+ */
+struct winlink *
+server_client_get_curw(struct client *c)
+{
+	struct session	*s = c->session;
+
+	if (s == NULL)
+		return (NULL);
+	if ((~c->flags & CLIENT_ACTIVEWINDOW) || c->curw == NULL)
+		return (s->curw);
+	return (c->curw);
+}
+
+/* Is this client currently viewing window w? */
+int
+server_client_is_viewing(struct client *c, struct window *w)
+{
+	struct winlink	*wl = server_client_get_curw(c);
+
+	return (wl != NULL && wl->window == w);
+}
+
 /* Get client active pane. */
 struct window_pane *
 server_client_get_pane(struct client *c)
 {
-	struct session		*s = c->session;
+	struct winlink		*wl = server_client_get_curw(c);
 	struct client_window	*cw;
 
-	if (s == NULL)
+	if (wl == NULL)
 		return (NULL);
 
 	if (~c->flags & CLIENT_ACTIVEPANE)
-		return (s->curw->window->active);
-	cw = server_client_get_client_window(c, s->curw->window->id);
+		return (wl->window->active);
+	cw = server_client_get_client_window(c, wl->window->id);
 	if (cw == NULL)
-		return (s->curw->window->active);
+		return (wl->window->active);
 	return (cw->pane);
 }
 
@@ -3050,13 +3083,13 @@ server_client_get_pane(struct client *c)
 void
 server_client_set_pane(struct client *c, struct window_pane *wp)
 {
-	struct session		*s = c->session;
+	struct winlink		*wl = server_client_get_curw(c);
 	struct client_window	*cw;
 
-	if (s == NULL)
+	if (wl == NULL)
 		return;
 
-	cw = server_client_add_client_window(c, s->curw->window->id);
+	cw = server_client_add_client_window(c, wl->window->id);
 	cw->pane = wp;
 	log_debug("%s pane now %%%u", c->name, wp->id);
 }
@@ -3079,6 +3112,128 @@ server_client_remove_pane(struct window_pane *wp)
 			c->tty.mouse_last_pane = -1;
 			c->tty.mouse_drag_update = NULL;
 			c->tty.mouse_scrolling_flag = 0;
+		}
+	}
+}
+
+/*
+ * Set the window this client is viewing. Per-client analog of
+ * session_set_current(): applies the same per-client side effects (focus,
+ * window offset, redraw) without touching the shared session->curw. Falls back
+ * to session_set_current if the client is not in per-client window mode.
+ */
+void
+server_client_set_curw(struct client *c, struct winlink *wl)
+{
+	struct session	*s = c->session;
+	struct winlink	*old;
+
+	if (s == NULL || wl == NULL)
+		return;
+	if (~c->flags & CLIENT_ACTIVEWINDOW) {
+		session_set_current(s, wl);
+		return;
+	}
+
+	old = server_client_get_curw(c);
+	if (wl == old)
+		return;
+
+	c->last_curw = old;
+	c->curw = wl;
+
+	if (options_get_number(global_options, "focus-events")) {
+		if (old != NULL)
+			window_update_focus(old->window);
+		window_update_focus(wl->window);
+	}
+	winlink_clear_flags(wl);
+	window_update_activity(wl->window);
+	wl->window->latest = c;
+	tty_update_window_offset(wl->window);
+	if (old != NULL)
+		tty_update_window_offset(old->window);
+	recalculate_sizes();
+	server_redraw_client(c);
+	log_debug("%s curw now @%u", c->name, wl->window->id);
+}
+
+/* Move this client to the next window. */
+int
+server_client_next_window(struct client *c, int alert)
+{
+	struct session	*s = c->session;
+	struct winlink	*wl, *curw = server_client_get_curw(c);
+
+	if (~c->flags & CLIENT_ACTIVEWINDOW)
+		return (session_next(s, alert));
+	if (curw == NULL)
+		return (-1);
+
+	wl = winlink_next(curw);
+	if (wl == NULL)
+		wl = RB_MIN(winlinks, &s->windows);
+	if (wl == NULL || wl == curw)
+		return (-1);
+	server_client_set_curw(c, wl);
+	return (0);
+}
+
+/* Move this client to the previous window. */
+int
+server_client_previous_window(struct client *c, int alert)
+{
+	struct session	*s = c->session;
+	struct winlink	*wl, *curw = server_client_get_curw(c);
+
+	if (~c->flags & CLIENT_ACTIVEWINDOW)
+		return (session_previous(s, alert));
+	if (curw == NULL)
+		return (-1);
+
+	wl = winlink_previous(curw);
+	if (wl == NULL)
+		wl = RB_MAX(winlinks, &s->windows);
+	if (wl == NULL || wl == curw)
+		return (-1);
+	server_client_set_curw(c, wl);
+	return (0);
+}
+
+/* Move this client to its last window. */
+int
+server_client_last_window(struct client *c)
+{
+	struct winlink	*wl = c->last_curw;
+
+	if (~c->flags & CLIENT_ACTIVEWINDOW)
+		return (session_last(c->session));
+	if (wl == NULL)
+		return (-1);
+	if (wl == server_client_get_curw(c))
+		return (1);
+	server_client_set_curw(c, wl);
+	return (0);
+}
+
+/*
+ * A winlink is being freed: clear it from any client's per-client current or
+ * last window so nothing dangles. The accessor then falls back to the session's
+ * current window, which the caller has already fixed up. Called from
+ * winlink_remove so every removal path is covered.
+ */
+void
+server_client_remove_window(struct winlink *wl)
+{
+	struct client	*c;
+
+	TAILQ_FOREACH(c, &clients, entry) {
+		if (c->last_curw == wl)
+			c->last_curw = NULL;
+		if (c->curw == wl) {
+			c->curw = NULL;
+			if (c->flags & CLIENT_ACTIVEWINDOW)
+				server_redraw_client(c);
 		}
 	}
 }

--- a/server-client.c
+++ b/server-client.c
@@ -44,6 +44,8 @@ static void	server_client_set_path(struct client *);
 static void	server_client_set_progress_bar(struct client *);
 static void	server_client_reset_state(struct client *);
 static void	server_client_update_latest(struct client *);
+static int	server_client_team_colour(struct client *);
+static int	server_client_window_teammode(struct window *);
 static void	server_client_dispatch(struct imsg *, void *);
 static int	server_client_dispatch_command(struct client *, struct imsg *);
 static int	server_client_dispatch_identify(struct client *, struct imsg *);
@@ -306,6 +308,8 @@ server_client_create(int fd)
 	c->fd = -1;
 	c->out_fd = -1;
 
+	c->team_colour = -1;
+
 	c->queue = cmdq_new();
 	RB_INIT(&c->windows);
 	RB_INIT(&c->files);
@@ -403,6 +407,53 @@ server_client_attached_lost(struct client *c)
 	}
 }
 
+/*
+ * Pick a stable, distinct colour for a client's team-mode cursor marker.
+ * Derived from the client name so a given user keeps the same colour across
+ * detach and reattach.
+ */
+static int
+server_client_team_colour(struct client *c)
+{
+	static const int	 palette[] = {
+		203, 214, 220, 84, 45, 171, 213, 39
+	};
+	const char		*name = c->name;
+	unsigned long		 hash = 5381;
+
+	if (name == NULL)
+		hash = (unsigned long)(uintptr_t)c;
+	else {
+		for (; *name != '\0'; name++)
+			hash = ((hash << 5) + hash) + (unsigned char)*name;
+	}
+	return (palette[hash % nitems(palette)] | COLOUR_FLAG_256);
+}
+
+/*
+ * Return non-zero if window w is currently viewed by more than one client and
+ * at least one of them has the teammode option set - i.e. remote-cursor
+ * markers may need to be drawn for it.
+ */
+static int
+server_client_window_teammode(struct window *w)
+{
+	struct client	*c;
+	int		 team = 0;
+	u_int		 n = 0;
+
+	TAILQ_FOREACH(c, &clients, entry) {
+		if (c->session == NULL || c->session->curw == NULL)
+			continue;
+		if (c->session->curw->window != w)
+			continue;
+		n++;
+		if (options_get_number(c->session->options, "teammode"))
+			team = 1;
+	}
+	return (team && n > 1);
+}
+
 /* Set client session. */
 void
 server_client_set_session(struct client *c, struct session *s)
@@ -419,6 +470,11 @@ server_client_set_session(struct client *c, struct session *s)
 	if (old != NULL && old->curw != NULL)
 		window_update_focus(old->curw->window);
 	if (s != NULL) {
+		if (options_get_number(s->options, "teammode")) {
+			c->flags |= CLIENT_ACTIVEPANE;
+			if (c->team_colour == -1)
+				c->team_colour = server_client_team_colour(c);
+		}
 		s->curw->window->latest = c;
 		recalculate_sizes();
 		window_update_focus(s->curw->window);
@@ -1725,6 +1781,24 @@ server_client_loop(void)
 				    wme->mode->style_changed != NULL)
 					wme->mode->style_changed(wme);
 			}
+		}
+	}
+
+	/*
+	 * In team mode a bare cursor move (no content change) does not trigger
+	 * a redraw, but observers need one to refresh the remote-cursor
+	 * markers. Detect such moves and redraw the affected windows.
+	 */
+	RB_FOREACH(w, windows, &windows) {
+		if (!server_client_window_teammode(w))
+			continue;
+		TAILQ_FOREACH(wp, &w->panes, entry) {
+			if (wp->screen->cx == wp->lastcx &&
+			    wp->screen->cy == wp->lastcy)
+				continue;
+			wp->lastcx = wp->screen->cx;
+			wp->lastcy = wp->screen->cy;
+			server_redraw_window(w);
 		}
 	}
 

--- a/server-fn.c
+++ b/server-fn.c
@@ -96,9 +96,7 @@ server_redraw_window(struct window *w)
 	struct client	*c;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session != NULL &&
-		    c->session->curw != NULL &&
-		    c->session->curw->window == w)
+		if (c->session != NULL && server_client_is_viewing(c, w))
 			server_redraw_client(c);
 	}
 }
@@ -109,9 +107,7 @@ server_redraw_window_borders(struct window *w)
 	struct client	*c;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session != NULL &&
-		    c->session->curw != NULL &&
-		    c->session->curw->window == w)
+		if (c->session != NULL && server_client_is_viewing(c, w))
 			c->flags |= CLIENT_REDRAWBORDERS;
 	}
 }

--- a/tmux.1
+++ b/tmux.1
@@ -5088,6 +5088,35 @@ Set action on a bell in a window when
 is on.
 The values are the same as those for
 .Ic activity\-action .
+.It Xo Ic teammode
+.Op Ic on | off
+.Xc
+Enable team mode.
+This is enabled by default.
+When on, each client attached to the session controls its own active pane
+independently (as if the
+.Ic active\-pane
+client flag was given, see
+.Ic attach\-session ) ,
+so multiple users may work in different panes at the same time.
+In addition, each client sees the cursor of every other client viewing the
+same window, drawn as a coloured marker; each user is assigned a distinct
+colour.
+.Pp
+Because the cursor of a pane belongs to the program running in it, independent
+cursors only exist across different panes, never within a single pane.
+For users to also navigate windows independently, give each user their own
+session in a session group sharing the same windows, for example with
+.Ql tmux new\-session \-t Ar target ,
+and set this option globally with
+.Ql set\-option \-g teammode on
+so grouped sessions inherit it.
+Setting
+.Ic aggressive\-resize
+is recommended so that users viewing different windows do not resize each
+other.
+This option takes effect for a client when it attaches, so change it before
+attaching.
 .It Ic default\-command Ar shell\-command
 Set the command used for new windows (if not specified when the window is
 created) to

--- a/tmux.1
+++ b/tmux.1
@@ -5093,24 +5093,35 @@ The values are the same as those for
 .Xc
 Enable team mode.
 This is enabled by default.
-When on, each client attached to the session controls its own active pane
-independently (as if the
+When on, each client attached to the same session works independently, as if
+the
 .Ic active\-pane
-client flag was given, see
-.Ic attach\-session ) ,
-so multiple users may work in different panes at the same time.
-In addition, each client sees the cursor of every other client viewing the
-same window, drawn as a coloured marker; each user is assigned a distinct
-colour.
+and
+.Ic active\-window
+client flags were given (see
+.Ic attach\-session ) :
+.Bl -bullet -offset indent
+.It
+Each client has its own active pane, so multiple users may type in different
+panes at the same time.
+.It
+Each client has its own current window, so users may view and navigate to
+different windows of the one session independently
+.Po
+.Ic select\-window ,
+.Ic next\-window ,
+.Ic new\-window
+and so on affect only the issuing client
+.Pc .
+.It
+Each client sees the cursor of every other client viewing the same window,
+drawn as a coloured marker; each user is assigned a distinct colour.
+.El
 .Pp
 Because the cursor of a pane belongs to the program running in it, independent
 cursors only exist across different panes, never within a single pane.
-For users to also navigate windows independently, give each user their own
-session in a session group sharing the same windows, for example with
-.Ql tmux new\-session \-t Ar target ,
-and set this option globally with
-.Ql set\-option \-g teammode on
-so grouped sessions inherit it.
+When it is off, all clients on a session share one active pane and one current
+window, as usual (useful for mirroring a session).
 Setting
 .Ic aggressive\-resize
 is recommended so that users viewing different windows do not resize each

--- a/tmux.h
+++ b/tmux.h
@@ -2244,7 +2244,7 @@ struct client {
 #define CLIENT_CONTROL_PAUSEAFTER 0x100000000ULL
 #define CLIENT_CONTROL_WAITEXIT 0x200000000ULL
 #define CLIENT_WINDOWSIZECHANGED 0x400000000ULL
-/* 0x800000000ULL unused */
+#define CLIENT_ACTIVEWINDOW 0x800000000ULL
 #define CLIENT_BRACKETPASTING 0x1000000000ULL
 #define CLIENT_ASSUMEPASTING 0x2000000000ULL
 /* 0x4000000000ULL unused */
@@ -2290,6 +2290,9 @@ struct client {
 
 	struct session		*session;
 	struct session		*last_session;
+
+	struct winlink		*curw;		/* per-client current window */
+	struct winlink		*last_curw;	/* per-client last window */
 
 	int			 references;
 
@@ -3189,6 +3192,13 @@ struct client_window *server_client_add_client_window(struct client *, u_int);
 struct window_pane *server_client_get_pane(struct client *);
 void	 server_client_set_pane(struct client *, struct window_pane *);
 void	 server_client_remove_pane(struct window_pane *);
+struct winlink *server_client_get_curw(struct client *);
+int	 server_client_is_viewing(struct client *, struct window *);
+void	 server_client_set_curw(struct client *, struct winlink *);
+int	 server_client_next_window(struct client *, int);
+int	 server_client_previous_window(struct client *, int);
+int	 server_client_last_window(struct client *);
+void	 server_client_remove_window(struct winlink *);
 void	 server_client_print(struct client *, int, struct evbuffer *);
 
 /* server-fn.c */

--- a/tmux.h
+++ b/tmux.h
@@ -1294,6 +1294,10 @@ struct window_pane {
 #define PANE_UNSEENCHANGES 0x4000
 #define PANE_REDRAWSCROLLBAR 0x8000
 
+	/* Last cursor position broadcast to team-mode observers. */
+	u_int		 lastcx;
+	u_int		 lastcy;
+
 	u_int		 sb_slider_y;
 	u_int		 sb_slider_h;
 	int		 sb_auto_visible;
@@ -2189,6 +2193,8 @@ struct client {
 	size_t			 redraw;
 
 	struct redraw_scene	*redraw_scene;
+
+	int			 team_colour;
 
 	struct event		 repeat_timer;
 

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1006,12 +1006,12 @@ complete_key:
 	/* Check for focus events. */
 	if (key == KEYC_FOCUS_OUT) {
 		c->flags &= ~CLIENT_FOCUSED;
-		window_update_focus(c->session->curw->window);
+		window_update_focus(server_client_get_curw(c)->window);
 		notify_client("client-focus-out", c);
 	} else if (key == KEYC_FOCUS_IN) {
 		c->flags |= CLIENT_FOCUSED;
 		notify_client("client-focus-in", c);
-		window_update_focus(c->session->curw->window);
+		window_update_focus(server_client_get_curw(c)->window);
 	}
 
 	/* Fire the key. */

--- a/tty.c
+++ b/tty.c
@@ -937,7 +937,7 @@ int
 tty_window_bigger(struct tty *tty)
 {
 	struct client	*c = tty->client;
-	struct window	*w = c->session->curw->window;
+	struct window	*w = server_client_get_curw(c)->window;
 
 	return (tty->sx < w->sx || tty->sy - status_line_size(c) < w->sy);
 }
@@ -959,7 +959,7 @@ static int
 tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 {
 	struct client		*c = tty->client;
-	struct window		*w = c->session->curw->window;
+	struct window		*w = server_client_get_curw(c)->window;
 	struct window_pane	*wp = server_client_get_pane(c);
 	u_int			 cx, cy, lines;
 
@@ -1025,9 +1025,7 @@ tty_update_window_offset(struct window *w)
 	struct client	*c;
 
 	TAILQ_FOREACH(c, &clients, entry) {
-		if (c->session != NULL &&
-		    c->session->curw != NULL &&
-		    c->session->curw->window == w)
+		if (c->session != NULL && server_client_is_viewing(c, w))
 			tty_update_client_offset(c);
 	}
 }
@@ -1529,7 +1527,7 @@ tty_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 {
 	struct window_pane	*wp = ttyctx->arg;
 
-	if (c->session->curw->window != wp->window)
+	if (!server_client_is_viewing(c, wp->window))
 		return (0);
 	if (wp->layout_cell == NULL)
 		return (0);

--- a/window.c
+++ b/window.c
@@ -207,6 +207,8 @@ winlink_remove(struct winlinks *wwl, struct winlink *wl)
 {
 	struct window	*w = wl->window;
 
+	server_client_remove_window(wl);
+
 	if (w != NULL) {
 		TAILQ_REMOVE(&w->winlinks, wl, wentry);
 		window_remove_ref(w, __func__);
@@ -527,7 +529,7 @@ window_pane_update_focus(struct window_pane *wp)
 				if (c->session != NULL &&
 				    c->session->attached != 0 &&
 				    (c->flags & CLIENT_FOCUSED) &&
-				    c->session->curw->window == wp->window &&
+				    server_client_is_viewing(c, wp->window) &&
 				    c->overlay_draw == NULL) {
 					focused = 1;
 					break;


### PR DESCRIPTION
Hi there, 

first of all a disclaimer: I have a CS background, but I'm not a proficient C/C++ programmer, and without a deep understanding of tmux's codebase, I simply asked Claude Opus to implement a feature in tmux that my colleagues and I were missing for a long time. Thus, I don't expect this PR to be merged as-is, but hope that it can serve as inspiration and a PoC for a "team mode"  feature. 

The idea of "team mode" is that multiple people can join the same tmux session (`tmux new -s teammode` and `tmux a -t teammode`) and have separate cursors and independent navigation between the panes and windows of the session. 

As you can see in the screenshot below, there are 3 different "users" (terminals), all connected to the same session. In the top two terminals both users are in different panes can work independently in the shared session. Bottom right is the third user that is in the second window of the session, independently of the other users first window.  

<img width="2253" height="1460" alt="Screenshot_2026-07-05_13-38-18" src="https://github.com/user-attachments/assets/ed2c4fc6-6e19-490b-ba56-85157b752bfa" />

To some extent, this mirrors the behavior and functionality offered by screen, where users can work independently in a shared screen session. 

I'd appreciate if someone with better understanding of tmux could have a look and help bring such a feature into upstream tmux :) 

All the best and thanks in advance,
@gehaxelt 