### PR TITLE
fix(layout): prevent zero-height pane from border subtraction

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -461,7 +461,8 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 		    layout_add_horizontal_border(w, lc, status)) {
 			if (status == PANE_STATUS_TOP)
 				wp->yoff++;
-			sy--;
+			if (sy > 1)
+				sy--;
 		}
 
 		if (window_pane_scrollbar_reserve(wp)) {


### PR DESCRIPTION
layout_fix_panes subtracts 1 from sy for the pane-status border. When a pane cell is 1 row tall with pane-border-status top, sy becomes 0. A zero-height pane triggers pathological behaviour in mode draw routines (e.g. mode_tree_draw iterating with an underflowed row bound). Only subtract the border when sy > 1.