### PR TITLE
fix(mode-tree): guard mode_tree_draw against zero height

### DIFF
--- a/mode-tree.c
+++ b/mode-tree.c
@@ -835,6 +835,12 @@ mode_tree_draw(struct mode_tree_data *mtd)
 	if (mtd->line_size == 0)
 		return;
 
+	w = mtd->width;
+	h = mtd->height;
+
+	if (h == 0)
+		return;
+
 	memcpy(&gc0, &grid_default_cell, sizeof gc0);
 	memcpy(&gc, &grid_default_cell, sizeof gc);
 	style_apply(&gc, oo, "tree-mode-selection-style", NULL);
@@ -843,9 +849,6 @@ mode_tree_draw(struct mode_tree_data *mtd)
 
 	dfg = gc.fg;
 	dfg0 = gc0.fg;
-
-	w = mtd->width;
-	h = mtd->height;
 
 	screen_write_start(&ctx, s);
 	screen_write_clearscreen(&ctx, 8);


### PR DESCRIPTION
The draw loop break condition (i > mtd->offset + h - 1) underflows to UINT_MAX when h is 0, causing iteration over all line items on a zero-row grid and a 100% CPU spin. Bail out early when height is zero.

I believe this is the last one for today(but no promises 😂)