### PR TITLE
Do not disable and reenable the mouse on every redraw

### DIFF
--- a/regress/screen-redraw-mouse.sh
+++ b/regress/screen-redraw-mouse.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Test that a redraw does not churn the mouse mode.
+#
+# When the mouse is on, redraw_draw() must preserve the input modes and only
+# drop the (visual) cursor while drawing a frame. A buggy redraw turned every
+# mode off (including mouse) and let reset_state turn it back on, so each
+# refresh emitted a full disable/enable of the mouse (ESC[?1000l ... ESC[?1000h)
+# to the client. That flicker is what this test guards against.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest -f/dev/null"
+TMUX2="$TEST_TMUX -Ltest2 -f/dev/null"
+$TMUX kill-server 2>/dev/null
+$TMUX2 kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap "rm -f $TMP; $TMUX kill-server 2>/dev/null; $TMUX2 kill-server 2>/dev/null" \
+	0 1 15
+
+# Inner session with the mouse enabled, attached inside an outer pane so the
+# outer pane captures whatever the inner tmux writes to its client terminal.
+$TMUX2 new -d -x80 -y24 || exit 1
+$TMUX2 set -g mouse on || exit 1
+$TMUX new -d -x80 -y24 "$TMUX2 attach" || exit 1
+sleep 1
+
+# Capture the inner tmux's raw client output, then force several redraws. A
+# buggy redraw disables the mouse every time, so a few attempts make the test
+# reliable without depending on the timing of a single refresh.
+$TMUX pipe-pane -O "cat >$TMP" || exit 1
+sleep 1
+i=0
+while [ $i -lt 5 ]; do
+	$TMUX2 refresh-client || exit 1
+	sleep 0.5
+	i=$((i + 1))
+done
+$TMUX pipe-pane || exit 1
+
+# After startup, a redraw must not disable the mouse (ESC[?1000l).
+if grep -q '\[?1000l' "$TMP"; then
+	echo "[FAIL] redraw churned the mouse mode"
+	exit 1
+fi
+
+[ -n "$VERBOSE" ] && echo "[PASS] redraw preserved the mouse mode"
+exit 0

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1667,7 +1667,9 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 		}
 	}
 	tty_sync_start(tty);
-	tty_update_mode(tty, 0, NULL);
+	/* Hide the cursor while drawing but keep input modes such as the mouse,
+	   otherwise each redraw disables and reenables them. */
+	tty_update_mode(tty, tty->mode & ~CURSOR_MODES, NULL);
 
 	if (wp != NULL)
 		redraw_draw_pane_lines(&dctx, wp, flags);


### PR DESCRIPTION
With the mouse on, tmux sends a full mouse disable then enable to the
client on every redraw, even though the mode never changes. On frequent
redraws (a status line clock, or apps wrapping frames in DEC 2026) it
flickers. Fixes #5303.

redraw_draw() calls tty_update_mode(tty, 0, NULL) to hide the cursor, but
passing 0 clears the whole mode word, so the mouse is turned off too;
reset_state() then turns it back on. The fix keeps every mode except the
cursor:

    tty_update_mode(tty, tty->mode & ~CURSOR_MODES, NULL);

Not 2026 specific: any redraw hits it, 2026 just makes them frequent.
Adds regress/screen-redraw-mouse.sh, which fails without the fix.