### PR TITLE
feat(master): modified `split-window` behavior on floating panes.

### DIFF
--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -458,7 +458,14 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, &flags, &cause);
+	if (args_has(args, 'h'))
+		flags |= SPAWN_HORIZONTAL;
+	if (args_has(args, 'b'))
+		flags |= SPAWN_BEFORE;
+	if (args_has(args, 'f'))
+		flags |= SPAWN_FULLSIZE;
+
+	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, flags, &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "size or position %s", cause);
 		free(cause);

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -458,7 +458,7 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
-	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, flags, &cause);
+	lc = layout_get_tiled_cell(item, args, dst_w, dst_wp, &flags, &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "size or position %s", cause);
 		free(cause);

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -84,7 +84,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp, *new_wp = NULL;
 	struct layout_cell	*lc = NULL;
 	struct cmd_find_state	 fs;
-	int			 input, empty, is_floating, newp, flags = 0;
+	int			 input, empty, is_floating, npe, flags;
 	const char		*template, *style, *value;
 	char			*cause = NULL, *cp, *title;
 	const struct options_table_entry *oe;
@@ -92,17 +92,12 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	enum pane_lines		 lines;
 	u_int			 count = args_count(args);
 
-	newp = cmd_get_entry(self) == &cmd_new_pane_entry;
-	if (newp)
+	npe = cmd_get_entry(self) == &cmd_new_pane_entry;
+	if (npe)
 		is_floating = !args_has(args, 'L');
 	else
 		is_floating = window_pane_is_floating(wp);
-
 	flags = is_floating ? SPAWN_FLOATING : 0;
-	if (args_has(args, 'b'))
-		flags |= SPAWN_BEFORE;
-	if (args_has(args, 'f'))
-		flags |= SPAWN_FULLSIZE;
 
 	input = args_has(args, 'I');
 	if (input || (count == 1 && *args_string(args, 0) == '\0'))
@@ -130,11 +125,11 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 		}
 	}
 
-	if (is_floating)
-		lc = layout_get_floating_cell(item, args, lines, !newp, w, wp,
-			&cause);
+	if (flags & SPAWN_FLOATING)
+		lc = layout_get_floating_cell(item, args, lines, w, wp, !npe,
+			&flags, &cause);
 	else
-		lc = layout_get_tiled_cell(item, args, w, wp, flags, &cause);
+		lc = layout_get_tiled_cell(item, args, w, wp, &flags, &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "%s", cause);
 		free(cause);

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -84,7 +84,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp, *new_wp = NULL;
 	struct layout_cell	*lc = NULL;
 	struct cmd_find_state	 fs;
-	int			 input, empty, is_floating, flags = 0;
+	int			 input, empty, is_floating, newp, flags = 0;
 	const char		*template, *style, *value;
 	char			*cause = NULL, *cp, *title;
 	const struct options_table_entry *oe;
@@ -92,7 +92,8 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	enum pane_lines		 lines;
 	u_int			 count = args_count(args);
 
-	if (cmd_get_entry(self) == &cmd_new_pane_entry)
+	newp = cmd_get_entry(self) == &cmd_new_pane_entry;
+	if (newp)
 		is_floating = !args_has(args, 'L');
 	else
 		is_floating = window_pane_is_floating(wp);
@@ -130,7 +131,8 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	if (is_floating)
-		lc = layout_get_floating_cell(item, args, lines, w, wp, &cause);
+		lc = layout_get_floating_cell(item, args, lines, !newp, w, wp,
+			&cause);
 	else
 		lc = layout_get_tiled_cell(item, args, w, wp, flags, &cause);
 	if (cause != NULL) {

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -84,7 +84,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	struct window_pane	*wp = target->wp, *new_wp = NULL;
 	struct layout_cell	*lc = NULL;
 	struct cmd_find_state	 fs;
-	int			 input, empty, is_floating, npe, flags;
+	int			 input, empty, is_floating, flags = 0;
 	const char		*template, *style, *value;
 	char			*cause = NULL, *cp, *title;
 	const struct options_table_entry *oe;
@@ -92,12 +92,25 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	enum pane_lines		 lines;
 	u_int			 count = args_count(args);
 
-	npe = cmd_get_entry(self) == &cmd_new_pane_entry;
-	if (npe)
+	if (cmd_get_entry(self) == &cmd_new_pane_entry)
 		is_floating = !args_has(args, 'L');
-	else
+	else {
 		is_floating = window_pane_is_floating(wp);
-	flags = is_floating ? SPAWN_FLOATING : 0;
+		flags |= SPAWN_SPLIT;
+	}
+
+	if (is_floating)
+		flags |= SPAWN_FLOATING;
+	if (args_has(args, 'h'))
+		flags |= SPAWN_HORIZONTAL;
+	if (args_has(args, 'b'))
+		flags |= SPAWN_BEFORE;
+	if (args_has(args, 'f'))
+		flags |= SPAWN_FULLSIZE;
+	if (args_has(args, 'd'))
+		flags |= SPAWN_DETACHED;
+	if (args_has(args, 'Z'))
+		flags |= SPAWN_ZOOM;
 
 	input = args_has(args, 'I');
 	if (input || (count == 1 && *args_string(args, 0) == '\0'))
@@ -126,10 +139,10 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	if (flags & SPAWN_FLOATING)
-		lc = layout_get_floating_cell(item, args, lines, w, wp, !npe,
-			&flags, &cause);
+		lc = layout_get_floating_cell(item, args, lines, w, wp, flags,
+		    &cause);
 	else
-		lc = layout_get_tiled_cell(item, args, w, wp, &flags, &cause);
+		lc = layout_get_tiled_cell(item, args, w, wp, flags, &cause);
 	if (cause != NULL) {
 		cmdq_error(item, "%s", cause);
 		free(cause);
@@ -154,12 +167,7 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 
 	sc.idx = -1;
 	sc.cwd = args_get(args, 'c');
-
 	sc.flags = flags;
-	if (args_has(args, 'd'))
-		sc.flags |= SPAWN_DETACHED;
-	if (args_has(args, 'Z'))
-		sc.flags |= SPAWN_ZOOM;
 
 	if ((new_wp = spawn_pane(&sc, &cause)) == NULL) {
 		cmdq_error(item, "create pane failed: %s", cause);
@@ -229,10 +237,10 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 			break;
 		}
 	}
-	if (!args_has(args, 'd'))
+	if (~flags & SPAWN_DETACHED)
 		cmd_find_from_winlink_pane(current, wl, new_wp, 0);
 
-	if (!is_floating) {
+	if (~flags & SPAWN_FLOATING) {
 		window_pop_zoom(wp->window);
 		server_redraw_window(wp->window);
 	}

--- a/layout.c
+++ b/layout.c
@@ -1656,15 +1656,22 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 
 struct layout_cell *
 layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    enum pane_lines lines, struct window *w, struct window_pane *wp,
+    enum pane_lines lines, int split, struct window *w, struct window_pane *wp,
     char **cause)
 {
 	struct layout_cell	*lcnew;
 	struct layout_geometry	 fg;
 
 	layout_geometry_init(&fg);
-	if (layout_floating_args_parse(item, args, lines, w, &fg, cause) != 0)
-		return (NULL);
+	if (split) {
+		if (layout_split_floating_cell(args, lines, w, wp, &fg, cause)
+		    != 0)
+			return (NULL);
+	} else {
+		if (layout_floating_args_parse(item, args, lines, w, &fg, cause)
+		    != 0)
+			return (NULL);
+	}
 
 	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
 	lcnew = layout_floating_pane(w, wp, &fg);
@@ -1763,6 +1770,77 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 	lg->sy = sy;
 	lg->xoff = ox;
 	lg->yoff = oy;
+	return (0);
+}
+
+int
+layout_split_floating_cell(struct args *args, enum pane_lines lines,
+    struct window *w, struct window_pane *wp, struct layout_geometry *out,
+    char **cause)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+	struct layout_geometry	 old, new;
+	int			 xpad = 4, ypad = 2;
+	int			 tborder = ypad, bborder = w->sy - ypad;
+	int			 lborder = xpad, rborder = w->sx - xpad;
+	int			 offset, has_lines = lines != PANE_LINES_NONE;
+	int			 size;
+
+	memcpy(&old, &lc->g, sizeof *old);
+	memcpy(&new, &lc->g, sizeof *new);
+	if (args_has(args, 'h')) {
+		offset = has_lines ? 2 : 0;
+		if (args_has(args, 'b'))
+			new.xoff -= old.sx + offset;
+		else
+			new.xoff += old.sx + offset;
+	} else {
+		offset = has_lines ? 2 : 0;
+		if (args_has(args, 'b'))
+			new.yoff -= old.sy + offset;
+		else
+			new.yoff += old.sy + offset;
+	}
+
+	if (new.xoff < lborder) {
+		size = (old.sx + old.xoff - xpad - offset) / 2;
+		new.sx = size;
+		old.sx = size;
+		new.xoff = xpad;
+		old->xoff = new.xoff + new.sx + offset;
+		if (lc->sx % 2 != 0)
+			old.sx -= 1;
+	}
+	if ((new.xoff + new.sx - offset) > rborder) {
+		size = (rborder - old.xoff) / 2;
+		new.sx = size;
+		old.sx = size;
+		new.xoff = old.xoff + old.sx + offset;
+	}
+	if (new.yoff < tborder) {
+		size = (old.sy + old.yoff - ypad - offset) / 2;
+		new.sy = size;
+		old.sy = size;
+		new.yoff = ypad;
+		old.yoff = new.yoff + new.sy + offset;
+		if (lc->sy % 2 != 0)
+			old.sy -= 1;
+	}
+	if ((new.yoff + new.sy - offset) > bborder) {
+		size = (bborder - old.yoff) / 2;
+		new.sy = size;
+		old.sy = size;
+		new.yoff = old.yoff + old.sy + offset;
+	}
+
+	if (new.sx < PANE_MINIMUM || new.sy < PANE_MINIMUM ||
+	    old.sx < PANE_MINIMUM || old.sy < PANE_MINIMUM) {
+		*cause = xstrdup("no space for a new pane");
+		return (-1);
+	}
+
+	layout_set_size(lc, &old);
+	memcpy(out, &new, sizeof *out);
 	return (0);
 }
 

--- a/layout.c
+++ b/layout.c
@@ -1595,10 +1595,10 @@ layout_spread_out(struct window_pane *wp)
 /* Get a new tiled cell. */
 struct layout_cell *
 layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
-    struct window *w, struct window_pane *wp, int flags, char **cause)
+    struct window *w, struct window_pane *wp, int *flags, char **cause)
 {
 	struct layout_cell	*lc;
-	enum layout_type	 type;
+	enum layout_type	 type = LAYOUT_TOPBOTTOM;
 	u_int			 curval;
 	int			 size = -1;
 	char			*error = NULL;
@@ -1608,9 +1608,12 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	type = LAYOUT_TOPBOTTOM;
 	if (args_has(args, 'h'))
 		type = LAYOUT_LEFTRIGHT;
+	if (args_has(args, 'b'))
+		*flags |= SPAWN_BEFORE;
+	if (args_has(args, 'f'))
+		*flags |= SPAWN_FULLSIZE;
 
 	if (args_has(args, 'l') || args_has(args, 'p')) {
 		if (args_has(args, 'f')) {
@@ -1641,13 +1644,8 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	if (args_has(args, 'b'))
-		flags |= SPAWN_BEFORE;
-	if (args_has(args, 'f'))
-		flags |= SPAWN_FULLSIZE;
-
 	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
-	lc = layout_split_pane(wp, type, size, flags);
+	lc = layout_split_pane(wp, type, size, *flags);
 	if (lc == NULL)
 		*cause = xstrdup("no space for a new pane");
 
@@ -1656,15 +1654,22 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 
 struct layout_cell *
 layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    enum pane_lines lines, int split, struct window *w, struct window_pane *wp,
-    char **cause)
+    enum pane_lines lines, struct window *w, struct window_pane *wp, int split,
+    int *flags, char **cause)
 {
-	struct layout_cell	*lcnew;
+	struct layout_cell	*lcnew, *lc = wp->layout_cell;
 	struct layout_geometry	 fg;
+
+	if (args_has(args, 'b'))
+		*flags |= SPAWN_BEFORE;
+	if (args_has(args, 'h'))
+		*flags |= SPAWN_HORIZONTAL;
+	if (args_has(args, 'f'))
+		*flags |= SPAWN_FULLSIZE;
 
 	layout_geometry_init(&fg);
 	if (split) {
-		if (layout_split_floating_cell(args, lines, w, wp, &fg, cause)
+		if (layout_split_floating_cell(lc, w, &fg, lines, *flags, cause)
 		    != 0)
 			return (NULL);
 	} else {
@@ -1774,63 +1779,117 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 }
 
 int
-layout_split_floating_cell(struct args *args, enum pane_lines lines,
-    struct window *w, struct window_pane *wp, struct layout_geometry *out,
+layout_split_floating_cell(struct layout_cell *lc, struct window *w,
+    struct layout_geometry *out, enum pane_lines lines, int flags,
     char **cause)
 {
-	struct layout_cell	*lc = wp->layout_cell;
 	struct layout_geometry	 old, new;
-	int			 xpad = 4, ypad = 2;
-	int			 tborder = ypad, bborder = w->sy - ypad;
-	int			 lborder = xpad, rborder = w->sx - xpad;
-	int			 offset, has_lines = lines != PANE_LINES_NONE;
-	int			 size;
+	int			 tborder = 1, bborder = w->sy - 1;
+	int			 lborder = 3, rborder = w->sx - 3;
+	int			 border = lines != PANE_LINES_NONE ? 1 : 0;
+	int			 size, space, before = flags & SPAWN_BEFORE;
 
-	memcpy(&old, &lc->g, sizeof *old);
-	memcpy(&new, &lc->g, sizeof *new);
-	if (args_has(args, 'h')) {
-		offset = has_lines ? 2 : 0;
-		if (args_has(args, 'b'))
-			new.xoff -= old.sx + offset;
+	/* First, move the target cell in-bounds. */
+	memcpy(&old, &lc->g, sizeof old);
+	if (lborder > old.xoff - border)
+		old.xoff = lborder + border;
+	if (rborder < old.xoff + (int)old.sx + border)
+		old.xoff = rborder - (int)old.sx - border;
+	if (tborder > old.yoff - border)
+		old.yoff = tborder + border;
+	if (bborder < old.yoff + (int)old.sy + border)
+		old.yoff = bborder - (int)old.sy - border;
+
+	/* Move the new cell to its ideal position. */
+	memcpy(&new, &old, sizeof new);
+	if (flags & SPAWN_HORIZONTAL) {
+		if (before)
+			new.xoff -= old.sx + 2 * border;
 		else
-			new.xoff += old.sx + offset;
+			new.xoff += old.sx + 2 * border;
 	} else {
-		offset = has_lines ? 2 : 0;
-		if (args_has(args, 'b'))
-			new.yoff -= old.sy + offset;
+		if (before)
+			new.yoff -= old.sy + 2 * border;
 		else
-			new.yoff += old.sy + offset;
+			new.yoff += old.sy + 2 * border;
 	}
 
-	if (new.xoff < lborder) {
-		size = (old.sx + old.xoff - xpad - offset) / 2;
+	/*
+	 * The position of the new cell is checked to see if it is in bounds.
+	 * If it isn't, the availible space is split and equally given to both
+	 * cells. Only one border is check because the target cell is in bounds
+	 * already.
+	 */
+	if (lborder > new.xoff - border) {
+		/*
+		 * The space for both panes is calculated. Since the offsets are
+		 * associated to where pane contents start, we remove pane
+		 * borders from the space. '1' is added in case the space is
+		 * odd.
+		 */
+		space = old.xoff + old.sx - lborder - 3 * border + 1;
+		size = space / 2;
 		new.sx = size;
 		old.sx = size;
-		new.xoff = xpad;
-		old->xoff = new.xoff + new.sx + offset;
-		if (lc->sx % 2 != 0)
+		new.xoff = lborder + border;
+		old.xoff = new.xoff + new.sx + 2 * border;
+		/*
+		 * If the original space was to be odd (now even), subtract 1
+		 * from the rightmost cell
+		 */
+		if (space % 2 == 0)
 			old.sx -= 1;
-	}
-	if ((new.xoff + new.sx - offset) > rborder) {
-		size = (rborder - old.xoff) / 2;
+	} else if (rborder < new.xoff + (int)new.sx + border) {
+		space = rborder - old.xoff - 3 * border + 1;
+		size = space / 2;
 		new.sx = size;
 		old.sx = size;
-		new.xoff = old.xoff + old.sx + offset;
-	}
-	if (new.yoff < tborder) {
-		size = (old.sy + old.yoff - ypad - offset) / 2;
+		new.xoff = old.xoff + old.sx + 2 * border;
+		if (space % 2 == 0)
+			new.sx -= 1;
+	} else if (tborder > new.yoff - border) {
+		space = old.sy + old.yoff - tborder - 3 * border + 1;
+		size = space / 2;
 		new.sy = size;
 		old.sy = size;
-		new.yoff = ypad;
-		old.yoff = new.yoff + new.sy + offset;
-		if (lc->sy % 2 != 0)
+		new.yoff = tborder + border;
+		old.yoff = new.yoff + new.sy + 2 * border;
+		if (space % 2 == 0)
 			old.sy -= 1;
-	}
-	if ((new.yoff + new.sy - offset) > bborder) {
-		size = (bborder - old.yoff) / 2;
+	} else if (bborder < new.yoff + (int)new.sy + border) {
+		space = bborder - old.yoff - 3 * border + 1;
+		size = space / 2;
 		new.sy = size;
 		old.sy = size;
-		new.yoff = old.yoff + old.sy + offset;
+		new.yoff = old.yoff + old.sy + 2 * border;
+		if (space % 2 == 0)
+			new.sy -= 1;
+	}
+
+	/*
+	 * Expand the cell to occupy the whole availible space where it was
+	 * spawned.
+	 */
+	if (flags & SPAWN_FULLSIZE) {
+		if (flags & SPAWN_HORIZONTAL) {
+			new.yoff = tborder + border;
+			new.sy = bborder - tborder - 2 * border;
+			if (flags & SPAWN_BEFORE) {
+				new.xoff = lborder + border;
+				new.sx = old.xoff - new.xoff - 2 * border;
+			} else {
+				new.sx = rborder - new.xoff - border;
+			}
+		} else {
+			new.xoff = lborder + border;
+			new.sx = rborder - lborder - 2 * border;
+			if (flags & SPAWN_BEFORE) {
+				new.yoff = tborder + border;
+				new.sy = old.yoff - new.yoff - 2 * border;
+			} else {
+				new.sy = bborder - new.yoff - border;
+			}
+		}
 	}
 
 	if (new.sx < PANE_MINIMUM || new.sy < PANE_MINIMUM ||
@@ -1839,7 +1898,7 @@ layout_split_floating_cell(struct args *args, enum pane_lines lines,
 		return (-1);
 	}
 
-	layout_set_size(lc, &old);
+	layout_set_size(lc, old.sx, old.sy, old.xoff, old.yoff);
 	memcpy(out, &new, sizeof *out);
 	return (0);
 }

--- a/layout.c
+++ b/layout.c
@@ -1595,7 +1595,7 @@ layout_spread_out(struct window_pane *wp)
 /* Get a new tiled cell. */
 struct layout_cell *
 layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
-    struct window *w, struct window_pane *wp, int *flags, char **cause)
+    struct window *w, struct window_pane *wp, int flags, char **cause)
 {
 	struct layout_cell	*lc;
 	enum layout_type	 type = LAYOUT_TOPBOTTOM;
@@ -1608,15 +1608,11 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	if (args_has(args, 'h'))
+	if (flags & SPAWN_HORIZONTAL)
 		type = LAYOUT_LEFTRIGHT;
-	if (args_has(args, 'b'))
-		*flags |= SPAWN_BEFORE;
-	if (args_has(args, 'f'))
-		*flags |= SPAWN_FULLSIZE;
 
 	if (args_has(args, 'l') || args_has(args, 'p')) {
-		if (args_has(args, 'f')) {
+		if (flags & SPAWN_FULLSIZE) {
 			if (type == LAYOUT_TOPBOTTOM)
 				curval = w->sy;
 			else
@@ -1644,8 +1640,8 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 		return (NULL);
 	}
 
-	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
-	lc = layout_split_pane(wp, type, size, *flags);
+	window_push_zoom(wp->window, 1, (flags & SPAWN_ZOOM));
+	lc = layout_split_pane(wp, type, size, flags);
 	if (lc == NULL)
 		*cause = xstrdup("no space for a new pane");
 
@@ -1654,22 +1650,15 @@ layout_get_tiled_cell(struct cmdq_item *item, struct args *args,
 
 struct layout_cell *
 layout_get_floating_cell(struct cmdq_item *item, struct args *args,
-    enum pane_lines lines, struct window *w, struct window_pane *wp, int split,
-    int *flags, char **cause)
+    enum pane_lines lines, struct window *w, struct window_pane *wp, int flags,
+    char **cause)
 {
 	struct layout_cell	*lcnew, *lc = wp->layout_cell;
 	struct layout_geometry	 fg;
 
-	if (args_has(args, 'b'))
-		*flags |= SPAWN_BEFORE;
-	if (args_has(args, 'h'))
-		*flags |= SPAWN_HORIZONTAL;
-	if (args_has(args, 'f'))
-		*flags |= SPAWN_FULLSIZE;
-
 	layout_geometry_init(&fg);
-	if (split) {
-		if (layout_split_floating_cell(lc, w, &fg, lines, *flags, cause)
+	if (flags & SPAWN_SPLIT) {
+		if (layout_split_floating_cell(lc, w, &fg, lines, flags, cause)
 		    != 0)
 			return (NULL);
 	} else {
@@ -1678,7 +1667,7 @@ layout_get_floating_cell(struct cmdq_item *item, struct args *args,
 			return (NULL);
 	}
 
-	window_push_zoom(wp->window, 1, args_has(args, 'Z'));
+	window_push_zoom(wp->window, 1, (flags & SPAWN_ZOOM));
 	lcnew = layout_floating_pane(w, wp, &fg);
 	return (lcnew);
 }
@@ -1787,7 +1776,7 @@ layout_split_floating_cell(struct layout_cell *lc, struct window *w,
 	int			 tborder = 1, bborder = w->sy - 1;
 	int			 lborder = 3, rborder = w->sx - 3;
 	int			 border = lines != PANE_LINES_NONE ? 1 : 0;
-	int			 size, space, before = flags & SPAWN_BEFORE;
+	int			 size, space;
 
 	/* First, move the target cell in-bounds. */
 	memcpy(&old, &lc->g, sizeof old);
@@ -1803,12 +1792,12 @@ layout_split_floating_cell(struct layout_cell *lc, struct window *w,
 	/* Move the new cell to its ideal position. */
 	memcpy(&new, &old, sizeof new);
 	if (flags & SPAWN_HORIZONTAL) {
-		if (before)
+		if (flags & SPAWN_BEFORE)
 			new.xoff -= old.sx + 2 * border;
 		else
 			new.xoff += old.sx + 2 * border;
 	} else {
-		if (before)
+		if (flags & SPAWN_BEFORE)
 			new.yoff -= old.sy + 2 * border;
 		else
 			new.yoff += old.sy + 2 * border;

--- a/tmux.1
+++ b/tmux.1
@@ -4077,6 +4077,21 @@ or full window width (with
 .Fl v ) ,
 instead of splitting the active pane.
 .Pp
+If
+.Ar target\-pane
+is floating, a new floating pane is created adjacent to
+.Ar target\-pane
+with equal sizes.
+The position is determined by the
+.Fl h ,
+.Fl v ,
+and
+.Fl b
+flags.
+If any of the new pane would not be visible on the screen,
+.Ar target\-pane
+and the new pane are resized to fit.
+.Pp
 .Fl k
 keeps the pane open after the optional
 .Ar shell\-command

--- a/tmux.h
+++ b/tmux.h
@@ -2468,6 +2468,7 @@ struct spawn_context {
 #define SPAWN_EMPTY 0x40
 #define SPAWN_ZOOM 0x80
 #define SPAWN_FLOATING 0x100
+#define SPAWN_HORIZONTAL 0x200
 };
 
 /* Paste buffer. */
@@ -3760,16 +3761,16 @@ void		 layout_close_pane(struct window_pane *);
 int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
-		     struct window *, struct window_pane *, int, char **);
+		     struct window *, struct window_pane *, int *, char **);
 struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct window_pane *,
-		     int, char **);
+		     int, int *, char **);
 int		 layout_floating_args_parse(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct layout_geometry *,
 		     char **);
-int		 layout_split_floating_cell(struct args *, enum pane_lines,
-		     struct window *, struct window_pane *,
-		     struct layout_geometry *, char **cause);
+int		 layout_split_floating_cell(struct layout_cell *,
+		     struct window *, struct layout_geometry *, enum pane_lines,
+		     int, char **);
 int		 layout_remove_tile(struct window *, struct layout_cell *);
 int		 layout_insert_tile(struct window *, struct layout_cell *);
 

--- a/tmux.h
+++ b/tmux.h
@@ -3763,10 +3763,13 @@ struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
 		     struct window *, struct window_pane *, int, char **);
 struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct window_pane *,
-		     char **);
+		     int, char **);
 int		 layout_floating_args_parse(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct layout_geometry *,
 		     char **);
+int		 layout_split_floating_cell(struct args *, enum pane_lines,
+		     struct window *, struct window_pane *,
+		     struct layout_geometry *, char **cause);
 int		 layout_remove_tile(struct window *, struct layout_cell *);
 int		 layout_insert_tile(struct window *, struct layout_cell *);
 

--- a/tmux.h
+++ b/tmux.h
@@ -2469,6 +2469,7 @@ struct spawn_context {
 #define SPAWN_ZOOM 0x80
 #define SPAWN_FLOATING 0x100
 #define SPAWN_HORIZONTAL 0x200
+#define SPAWN_SPLIT 0x400
 };
 
 /* Paste buffer. */
@@ -3761,10 +3762,10 @@ void		 layout_close_pane(struct window_pane *);
 int		 layout_spread_cell(struct window *, struct layout_cell *);
 void		 layout_spread_out(struct window_pane *);
 struct layout_cell *layout_get_tiled_cell(struct cmdq_item *, struct args *,
-		     struct window *, struct window_pane *, int *, char **);
+		     struct window *, struct window_pane *, int, char **);
 struct layout_cell *layout_get_floating_cell(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct window_pane *,
-		     int, int *, char **);
+		     int, char **);
 int		 layout_floating_args_parse(struct cmdq_item *, struct args *,
 		     enum pane_lines, struct window *, struct layout_geometry *,
 		     char **);


### PR DESCRIPTION
This PR implements differing behavior when using `splitw-window` on a floating pane. The new pane is created adjacent to the target based upon the provided `h/v/b` flags. Both panes are resized to keep the new pane fully visible on screen. This PR will be touched up once #5324 is finished. Let me know if the behavior is acceptable! 