### PR TITLE
Report the terminal's own theme to panes rather than guessing from the background

### DIFF
--- a/regress/theme-report.sh
+++ b/regress/theme-report.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# Test that the theme reported to a pane (mode 2031 / DSR 996) follows the
+# terminal's reported theme, not a guess from the background colour.
+#
+# An inner client is attached inside an outer tmux pane. The outer pane has a
+# light background, so the outer server answers the inner client's DSR 996 with
+# light. The inner server is given a dark window background, so a guess from the
+# background colour would say dark. A pane in the inner server then queries DSR
+# 996: the answer must be light (2), following the client's reported theme, not
+# dark (1) from the background.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+INNER="$TEST_TMUX -LtestI$$ -f/dev/null"
+OUTER="$TEST_TMUX -LtestO$$ -f/dev/null"
+$INNER kill-server 2>/dev/null
+$OUTER kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap "rm -f $TMP; $INNER kill-server 2>/dev/null; $OUTER kill-server 2>/dev/null" \
+	0 1 15
+
+# Inner server, dark background, keep panes alive across the query respawn.
+$INNER new-session -d -x80 -y24 || exit 1
+$INNER set -g remain-on-exit on
+$INNER set -g window-style 'bg=black'
+
+# Outer server with a light background, running the inner client attached so the
+# inner client has a real terminal that reports a theme.
+$OUTER new-session -d -x80 -y24 || exit 1
+$OUTER set -g window-style 'bg=white'
+$OUTER new-window "$INNER attach" || exit 1
+sleep 2
+
+# Query DSR 996 from an inner pane and capture the CSI ? 997 ; Ps n reply.
+$INNER respawnw -k -t:0 -- sh -c "
+	exec 2>/dev/null
+	stty raw -echo
+	printf '\033[?996n'
+	dd bs=1 count=9 2>/dev/null | cat -v > $TMP
+	sleep 1
+"
+sleep 2
+
+actual=$(cat "$TMP")
+expected='^[[?997;2n'   # 2 = light (from the terminal), not 1 = dark (from bg)
+
+if [ "$actual" = "$expected" ]; then
+	[ -n "$VERBOSE" ] && echo "[PASS] reported terminal theme ($actual)"
+	exit 0
+fi
+
+echo "[FAIL] expected '$expected' (light, from terminal), got '$actual'"
+exit 1

--- a/window.c
+++ b/window.c
@@ -2423,7 +2423,6 @@ window_pane_get_theme(struct window_pane *wp)
 {
 	struct window		*w;
 	struct client		*loop;
-	enum client_theme	 theme;
 	int			 found_light = 0, found_dark = 0;
 
 	if (wp == NULL)
@@ -2431,14 +2430,9 @@ window_pane_get_theme(struct window_pane *wp)
 	w = wp->window;
 
 	/*
-	 * Derive theme from pane background color, if it's not the default
-	 * colour.
+	 * Prefer a theme reported by an attached client with mode 2031 or DSR
+	 * 996: the terminal is authoritative about its own light or dark mode.
 	 */
-	theme = colour_totheme(window_pane_get_bg(wp));
-	if (theme != THEME_UNKNOWN)
-		return (theme);
-
-	/* Try to find a client that has a theme. */
 	TAILQ_FOREACH(loop, &clients, entry) {
 		if (loop->flags & CLIENT_UNATTACHEDFLAGS)
 			continue;
@@ -2455,12 +2449,16 @@ window_pane_get_theme(struct window_pane *wp)
 			break;
 		}
 	}
-
 	if (found_dark && !found_light)
 		return (THEME_DARK);
 	if (found_light && !found_dark)
 		return (THEME_LIGHT);
-	return (THEME_UNKNOWN);
+
+	/*
+	 * Otherwise guess from the pane background colour, for terminals which
+	 * do not report a theme themselves.
+	 */
+	return (colour_totheme(window_pane_get_bg(wp)));
 }
 
 void


### PR DESCRIPTION
When a client's terminal reports its light/dark mode via mode 2031 or DSR 996, that report is authoritative and should be forwarded to panes that query DSR 996 themselves.

`window_pane_get_theme` instead guessed from the pane background colour first and only consulted the client's reported theme when the background was default. So any pane with an explicit background overrode the terminal's own answer, and a client on a light terminal could be told the theme is dark (and vice versa).

This reverses the precedence: check attached clients for a reported theme first, and fall back to the background-colour guess only for terminals that do not report one. This matches the precedence already used in `server_client_update_theme_colours`.

Includes a regress test (`regress/theme-report.sh`) that nests an inner client inside an outer light-background pane while giving the inner server a dark window background: the pane's DSR 996 query must answer `997;2` (light, from the terminal), not `997;1` (dark, from the bg guess). Verified the test fails on the unfixed binary and passes on the fixed one.

Fixes #5342, follow-up to #4353.