### PR TITLE
refactor(master): `layout_set_size` now uses `struct layout_geometry`.

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -70,7 +70,7 @@ cmd_break_pane_float(struct cmdq_item *item, struct args *args,
 		return (CMD_RETURN_ERROR);
 	}
 	layout_remove_tile(w, lc);
-	layout_set_size(lc, fg->sx, fg->sy, fg->xoff, fg->yoff);
+	layout_set_size(lc, fg);
 
 	lc->flags |= LAYOUT_CELL_FLOATING;
 	TAILQ_REMOVE(&w->z_index, wp, zentry);

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -234,9 +234,10 @@ cmd_resize_pane_mouse_resize_move_floating(struct client *c,
 	struct window		*w;
 	struct window_pane	*wp;
 	struct layout_cell	*lc;
-	int			 y, ly, x, lx, sx, sy, new_sx, new_sy;
+	struct layout_geometry	 lg;
+	int			 y, ly, x, lx, sy;
 	int			 left, right;
-	int			 new_xoff, new_yoff, resizes = 0;
+	int			 resizes = 0;
 
 	wp = cmd_mouse_pane(m, NULL, &wl);
 	if (wp == NULL) {
@@ -245,10 +246,10 @@ cmd_resize_pane_mouse_resize_move_floating(struct client *c,
 	}
 	w = wl->window;
 	lc = wp->layout_cell;
-	sx = wp->sx;
 	sy = wp->sy;
 	left = wp->xoff - 1;
-	right = wp->xoff + sx;
+	right = wp->xoff + wp->sx;
+	memcpy(&lg, &lc->g, sizeof lg);
 	if (window_pane_scrollbar_reserve(wp) &&
 	    w->sb_pos == PANE_SCROLLBARS_LEFT) {
 		left -= wp->scrollbar_style.width + wp->scrollbar_style.pad;
@@ -270,78 +271,65 @@ cmd_resize_pane_mouse_resize_move_floating(struct client *c,
 
 	if ((lx == left || lx == left + 1) && ly == wp->yoff - 1) {
 		/* Top left corner. */
-		new_sx = lc->g.sx + (lx - x);
-		if (new_sx < PANE_MINIMUM)
-			new_sx = PANE_MINIMUM;
-		new_sy = lc->g.sy + (ly - y);
-		if (new_sy < PANE_MINIMUM)
-			new_sy = PANE_MINIMUM;
-		new_xoff = x + 1; /* because mouse is on border at xoff - 1 */
-		new_yoff = y + 1;
-		layout_set_size(lc, new_sx, new_sy, new_xoff, new_yoff);
+		if ((lg.sx = lc->g.sx + (lx - x)) < PANE_MINIMUM)
+			lg.sx = PANE_MINIMUM;
+		if ((lg.sy = lc->g.sy + (ly - y)) < PANE_MINIMUM)
+			lg.sy = PANE_MINIMUM;
+		lg.xoff = x + 1; /* because mouse is on border at xoff - 1 */
+		lg.yoff = y + 1;
+		layout_set_size(lc, &lg);
 		resizes++;
-	} else if ((lx == right + 1 || lx == right) &&
-	    ly == wp->yoff - 1) {
+	} else if ((lx == right + 1 || lx == right) && ly == wp->yoff - 1) {
 		/* Top right corner. */
-		new_sx = x - lc->g.xoff;
-		if (new_sx < PANE_MINIMUM)
-			new_sx = PANE_MINIMUM;
-		new_sy = lc->g.sy + (ly - y);
-		if (new_sy < PANE_MINIMUM)
-			new_sy = PANE_MINIMUM;
-		new_yoff = y + 1;
-		layout_set_size(lc, new_sx, new_sy, lc->g.xoff, new_yoff);
+		if ((lg.sx = x - lc->g.xoff) < PANE_MINIMUM)
+			lg.sx = PANE_MINIMUM;
+		if ((lg.sy = lc->g.sy + (ly - y)) < PANE_MINIMUM)
+			lg.sy = PANE_MINIMUM;
+		lg.yoff = y + 1;
+		lg.xoff = lc->g.xoff;
+		layout_set_size(lc, &lg);
 		resizes++;
-	} else if ((lx == left || lx == left + 1) &&
-	    ly == wp->yoff + sy) {
+	} else if ((lx == left || lx == left + 1) && ly == wp->yoff + sy) {
 		/* Bottom left corner. */
-		new_sx = lc->g.sx + (lx - x);
-		if (new_sx < PANE_MINIMUM)
-			new_sx = PANE_MINIMUM;
-		new_sy = y - lc->g.yoff;
-		if (new_sy < PANE_MINIMUM)
+		if ((lg.sx = lc->g.sx + (lx - x)) < PANE_MINIMUM)
+			lg.sx = PANE_MINIMUM;
+		if ((lg.sy = y - lc->g.yoff) < PANE_MINIMUM)
 			return;
-		new_xoff = x + 1;
-		layout_set_size(lc, new_sx, new_sy, new_xoff, lc->g.yoff);
+		lg.xoff = x + 1;
+		layout_set_size(lc, &lg);
 		resizes++;
-	} else if ((lx == right + 1 || lx == right) &&
-	    ly == wp->yoff + sy) {
+	} else if ((lx == right + 1 || lx == right) && ly == wp->yoff + sy) {
 		/* Bottom right corner. */
-		new_sx = x - lc->g.xoff;
-		if (new_sx < PANE_MINIMUM)
-			new_sx = PANE_MINIMUM;
-		new_sy = y - lc->g.yoff;
-		if (new_sy < PANE_MINIMUM)
-			new_sy = PANE_MINIMUM;
-		layout_set_size(lc, new_sx, new_sy, lc->g.xoff, lc->g.yoff);
+		if ((lg.sx = x - lc->g.xoff) < PANE_MINIMUM)
+			lg.sx = PANE_MINIMUM;
+		if ((lg.sy = y - lc->g.yoff) < PANE_MINIMUM)
+			lg.sy = PANE_MINIMUM;
+		layout_set_size(lc, &lg);
 		resizes++;
 	} else if (lx == right) {
 		/* Right border. */
-		new_sx = x - lc->g.xoff;
-		if (new_sx < PANE_MINIMUM)
+		if ((lg.sx = x - lc->g.xoff) < PANE_MINIMUM)
 			return;
-		layout_set_size(lc, new_sx, lc->g.sy, lc->g.xoff, lc->g.yoff);
+		layout_set_size(lc, &lg);
 		resizes++;
 	} else if (lx == left) {
 		/* Left border. */
-		new_sx = lc->g.sx + (lx - x);
-		if (new_sx < PANE_MINIMUM)
+		if ((lg.sx = lc->g.sx + (lx - x)) < PANE_MINIMUM)
 			return;
-		new_xoff = x + 1;
-		layout_set_size(lc, new_sx, lc->g.sy, new_xoff, lc->g.yoff);
+		lg.xoff = x + 1;
+		layout_set_size(lc, &lg);
 		resizes++;
 	} else if (ly == wp->yoff + sy) {
 		/* Bottom border. */
-		new_sy = y - lc->g.yoff;
-		if (new_sy < PANE_MINIMUM)
+		if ((lg.sy = y - lc->g.yoff) < PANE_MINIMUM)
 			return;
-		layout_set_size(lc, lc->g.sx, new_sy, lc->g.xoff, lc->g.yoff);
+		layout_set_size(lc, &lg);
 		resizes++;
 	} else if (ly == wp->yoff - 1) {
 		/* Top border (move instead of resize). */
-		new_xoff = lc->g.xoff + (x - lx);
-		new_yoff = y + 1;
-		layout_set_size(lc, lc->g.sx, lc->g.sy, new_xoff, new_yoff);
+		lg.xoff = lc->g.xoff + (x - lx);
+		lg.yoff = y + 1;
+		layout_set_size(lc, &lg);
 		resizes++;
 	}
 	if (resizes != 0) {

--- a/layout-custom.c
+++ b/layout-custom.c
@@ -100,10 +100,10 @@ layout_append(struct layout_cell *lc, char *buf, size_t len)
 	if (lc == NULL)
 		return (0);
 	if (lc->wp != NULL) {
-		tmplen = xsnprintf(tmp, sizeof tmp, "%ux%u,%d,%d,%u",
+		tmplen = xsnprintf(tmp, sizeof tmp, "%dx%d,%d,%d,%u",
 		    lc->g.sx, lc->g.sy, lc->g.xoff, lc->g.yoff, lc->wp->id);
 	} else {
-		tmplen = xsnprintf(tmp, sizeof tmp, "%ux%u,%d,%d",
+		tmplen = xsnprintf(tmp, sizeof tmp, "%dx%d,%d,%d",
 		    lc->g.sx, lc->g.sy, lc->g.xoff, lc->g.yoff);
 	}
 	if (tmplen > (sizeof tmp) - 1)
@@ -138,7 +138,7 @@ static int
 layout_check(struct layout_cell *lc)
 {
 	struct layout_cell	*lcchild;
-	u_int			 n = 0;
+	int			 n = 0;
 
 	switch (lc->type) {
 	case LAYOUT_WINDOWPANE:
@@ -174,10 +174,11 @@ int
 layout_parse(struct window *w, const char *layout, char **cause)
 {
 	struct layout_cell	*lcchild, *tiled_lc = NULL;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
 	struct window_pane	*wp;
-	u_int			 npanes, ncells, sx = 0, sy = 0;
+	u_int			 npanes, ncells;
 	u_short			 csum;
-	int			 n;
+	int			 n, sx = 0, sy = 0;
 
 	/* Check validity. */
 	if (sscanf(layout, "%hx,%n", &csum, &n) != 1 || n != 5) {
@@ -199,7 +200,7 @@ layout_parse(struct window *w, const char *layout, char **cause)
 		/* A stub layout cell for an empty window. */
 		tiled_lc = layout_create_cell(NULL);
 		tiled_lc->type = LAYOUT_LEFTRIGHT;
-		layout_set_size(tiled_lc, w->sx, w->sy, 0, 0);
+		layout_set_size(tiled_lc, &lg);
 	}
 	if (*layout != '\0') {
 		*cause = xstrdup("invalid layout");

--- a/layout-set.c
+++ b/layout-set.c
@@ -140,7 +140,8 @@ layout_set_even(struct window *w, enum layout_type type)
 {
 	struct window_pane	*wp;
 	struct layout_cell	*lcroot, *lcchild;
-	u_int			 n, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n;
 
 	layout_print_cell(w->layout_root, __func__, 1);
 
@@ -149,20 +150,20 @@ layout_set_even(struct window *w, enum layout_type type)
 		return;
 
 	if (type == LAYOUT_LEFTRIGHT) {
-		sx = (n * (PANE_MINIMUM + 1)) - 1;
-		if (sx < w->sx)
-			sx = w->sx;
-		sy = w->sy;
+		lg.sx = (n * (PANE_MINIMUM + 1)) - 1;
+		if (lg.sx < (int)w->sx)
+			lg.sx = w->sx;
+		lg.sy = w->sy;
 	} else {
-		sy = (n * (PANE_MINIMUM + 1)) - 1;
-		if (sy < w->sy)
-			sy = w->sy;
-		sx = w->sx;
+		lg.sy = (n * (PANE_MINIMUM + 1)) - 1;
+		if (lg.sy < (int)w->sy)
+			lg.sy = w->sy;
+		lg.sx = w->sx;
 	}
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, sx, sy, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, type);
 
 	TAILQ_FOREACH(wp, &w->panes, entry) {
@@ -204,7 +205,8 @@ layout_set_main_h(struct window *w)
 {
 	struct window_pane	*wp, *wpmain;
 	struct layout_cell	*lcroot, *lcmain, *lcother, *lcchild;
-	u_int			 n, mainh, otherh, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n, mainh, otherh, sy;
 	char			*cause;
 	const char		*s;
 
@@ -246,21 +248,24 @@ layout_set_main_h(struct window *w)
 	}
 
 	/* Work out what width is needed. */
-	sx = (n * (PANE_MINIMUM + 1)) - 1;
-	if (sx < w->sx)
-		sx = w->sx;
+	lg.sx = (n * (PANE_MINIMUM + 1)) - 1;
+	if (lg.sx < (int)w->sx)
+		lg.sx = w->sx;
+	lg.sy = mainh + otherh + 1;
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, sx, mainh + otherh + 1, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, LAYOUT_TOPBOTTOM);
 
 	wpmain = layout_set_first_tiled(w);
 	lcmain = wpmain->layout_cell;
 	lcmain->parent = lcroot;
-	layout_set_size(lcmain, sx, mainh, 0, 0);
+	lg.sy = mainh;
+	layout_set_size(lcmain, &lg);
 	TAILQ_INSERT_TAIL(&lcroot->cells, lcmain, entry);
 
+	lg.sy = otherh;
 	if (n == 1) {
 		wp = TAILQ_NEXT(wpmain, entry);
 		while (wp != NULL && !layout_cell_is_tiled(wp->layout_cell))
@@ -269,10 +274,11 @@ layout_set_main_h(struct window *w)
 		wp->layout_cell->parent = lcroot;
 	} else {
 		lcother = layout_create_cell(lcroot);
-		layout_set_size(lcother, sx, otherh, 0, 0);
+		layout_set_size(lcother, &lg);
 		layout_make_node(lcother, LAYOUT_LEFTRIGHT);
 		TAILQ_INSERT_TAIL(&lcroot->cells, lcother, entry);
 
+		lg.sx = PANE_MINIMUM;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
 			if (wp == wpmain)
 				continue;
@@ -280,8 +286,7 @@ layout_set_main_h(struct window *w)
 			TAILQ_INSERT_TAIL(&lcother->cells, lcchild, entry);
 			lcchild->parent = lcother;
 			if (layout_cell_is_tiled(lcchild))
-				layout_set_size(lcchild, PANE_MINIMUM, otherh,
-				    0, 0);
+				layout_set_size(lcchild, &lg);
 		}
 		layout_spread_cell(w, lcother);
 	}
@@ -301,7 +306,8 @@ layout_set_main_h_mirrored(struct window *w)
 {
 	struct window_pane	*wp, *wpmain;
 	struct layout_cell	*lcroot, *lcmain, *lcother, *lcchild;
-	u_int			 n, mainh, otherh, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n, mainh, otherh, sy;
 	char			*cause;
 	const char		*s;
 
@@ -343,19 +349,21 @@ layout_set_main_h_mirrored(struct window *w)
 	}
 
 	/* Work out what width is needed. */
-	sx = (n * (PANE_MINIMUM + 1)) - 1;
-	if (sx < w->sx)
-		sx = w->sx;
+	lg.sx = (n * (PANE_MINIMUM + 1)) - 1;
+	if (lg.sx < (int)w->sx)
+		lg.sx = w->sx;
+	lg.sy = mainh + otherh + 1;
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, sx, mainh + otherh + 1, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, LAYOUT_TOPBOTTOM);
 
 	wpmain = layout_set_first_tiled(w);
 	lcmain = wpmain->layout_cell;
 	lcmain->parent = lcroot;
-	layout_set_size(lcmain, sx, mainh, 0, 0);
+	lg.sy = mainh;
+	layout_set_size(lcmain, &lg);
 	TAILQ_INSERT_TAIL(&lcroot->cells, lcmain, entry);
 
 	if (n == 1) {
@@ -365,11 +373,13 @@ layout_set_main_h_mirrored(struct window *w)
 		TAILQ_INSERT_HEAD(&lcroot->cells, wp->layout_cell, entry);
 		wp->layout_cell->parent = lcroot;
 	} else {
+		lg.sy = otherh;
 		lcother = layout_create_cell(lcroot);
-		layout_set_size(lcother, sx, otherh, 0, 0);
+		layout_set_size(lcother, &lg);
 		layout_make_node(lcother, LAYOUT_LEFTRIGHT);
 		TAILQ_INSERT_HEAD(&lcroot->cells, lcother, entry);
 
+		lg.sx = PANE_MINIMUM;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
 			if (wp == wpmain)
 				continue;
@@ -377,8 +387,7 @@ layout_set_main_h_mirrored(struct window *w)
 			TAILQ_INSERT_TAIL(&lcother->cells, lcchild, entry);
 			lcchild->parent = lcother;
 			if (layout_cell_is_tiled(lcchild))
-				layout_set_size(lcchild, PANE_MINIMUM, otherh,
-				    0, 0);
+				layout_set_size(lcchild, &lg);
 		}
 		layout_spread_cell(w, lcother);
 	}
@@ -398,7 +407,8 @@ layout_set_main_v(struct window *w)
 {
 	struct window_pane	*wp, *wpmain;
 	struct layout_cell	*lcroot, *lcmain, *lcother, *lcchild;
-	u_int			 n, mainw, otherw, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n, mainw, otherw, sx;
 	char			*cause;
 	const char		*s;
 
@@ -440,19 +450,21 @@ layout_set_main_v(struct window *w)
 	}
 
 	/* Work out what height is needed. */
-	sy = (n * (PANE_MINIMUM + 1)) - 1;
-	if (sy < w->sy)
-		sy = w->sy;
+	lg.sy = (n * (PANE_MINIMUM + 1)) - 1;
+	if (lg.sy < (int)w->sy)
+		lg.sy = w->sy;
+	lg.sx = mainw + otherw + 1;
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, mainw + otherw + 1, sy, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, LAYOUT_LEFTRIGHT);
 
 	wpmain = layout_set_first_tiled(w);
 	lcmain = wpmain->layout_cell;
 	lcmain->parent = lcroot;
-	layout_set_size(lcmain, mainw, sy, 0, 0);
+	lg.sx = mainw;
+	layout_set_size(lcmain, &lg);
 	TAILQ_INSERT_TAIL(&lcroot->cells, lcmain, entry);
 
 	if (n == 1) {
@@ -462,11 +474,13 @@ layout_set_main_v(struct window *w)
 		TAILQ_INSERT_TAIL(&lcroot->cells, wp->layout_cell, entry);
 		wp->layout_cell->parent = lcroot;
 	} else {
+		lg.sx = otherw;
 		lcother = layout_create_cell(lcroot);
 		layout_make_node(lcother, LAYOUT_TOPBOTTOM);
-		layout_set_size(lcother, otherw, sy, 0, 0);
+		layout_set_size(lcother, &lg);
 		TAILQ_INSERT_TAIL(&lcroot->cells, lcother, entry);
 
+		lg.sy = PANE_MINIMUM;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
 			if (wp == wpmain)
 				continue;
@@ -474,8 +488,7 @@ layout_set_main_v(struct window *w)
 			TAILQ_INSERT_TAIL(&lcother->cells, lcchild, entry);
 			lcchild->parent = lcother;
 			if (layout_cell_is_tiled(lcchild))
-				layout_set_size(lcchild, otherw, PANE_MINIMUM,
-				    0, 0);
+				layout_set_size(lcchild, &lg);
 		}
 		layout_spread_cell(w, lcother);
 	}
@@ -495,7 +508,8 @@ layout_set_main_v_mirrored(struct window *w)
 {
 	struct window_pane	*wp, *wpmain;
 	struct layout_cell	*lcroot, *lcmain, *lcother, *lcchild;
-	u_int			 n, mainw, otherw, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n, mainw, otherw, sx;
 	char			*cause;
 	const char		*s;
 
@@ -538,19 +552,21 @@ layout_set_main_v_mirrored(struct window *w)
 	}
 
 	/* Work out what height is needed. */
-	sy = (n * (PANE_MINIMUM + 1)) - 1;
-	if (sy < w->sy)
-		sy = w->sy;
+	lg.sy = (n * (PANE_MINIMUM + 1)) - 1;
+	if (lg.sy < (int)w->sy)
+		lg.sy = w->sy;
+	lg.sx = mainw + otherw + 1;
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, mainw + otherw + 1, sy, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, LAYOUT_LEFTRIGHT);
 
 	wpmain = layout_set_first_tiled(w);
 	lcmain = wpmain->layout_cell;
 	lcmain->parent = lcroot;
-	layout_set_size(lcmain, mainw, sy, 0, 0);
+	lg.sx = mainw;
+	layout_set_size(lcmain, &lg);
 	TAILQ_INSERT_TAIL(&lcroot->cells, lcmain, entry);
 
 	if (n == 1) {
@@ -560,11 +576,13 @@ layout_set_main_v_mirrored(struct window *w)
 		TAILQ_INSERT_HEAD(&lcroot->cells, wp->layout_cell, entry);
 		wp->layout_cell->parent = lcroot;
 	} else {
+		lg.sx = otherw;
 		lcother = layout_create_cell(lcroot);
 		layout_make_node(lcother, LAYOUT_TOPBOTTOM);
-		layout_set_size(lcother, otherw, sy, 0, 0);
+		layout_set_size(lcother, &lg);
 		TAILQ_INSERT_HEAD(&lcroot->cells, lcother, entry);
 
+		lg.sy = PANE_MINIMUM;
 		TAILQ_FOREACH(wp, &w->panes, entry) {
 			if (wp == wpmain)
 				continue;
@@ -572,8 +590,7 @@ layout_set_main_v_mirrored(struct window *w)
 			TAILQ_INSERT_TAIL(&lcother->cells, lcchild, entry);
 			lcchild->parent = lcother;
 			if (layout_cell_is_tiled(lcchild))
-				layout_set_size(lcchild, otherw, PANE_MINIMUM,
-				    0, 0);
+				layout_set_size(lcchild, &lg);
 		}
 		layout_spread_cell(w, lcother);
 	}
@@ -594,7 +611,8 @@ layout_set_tiled(struct window *w)
 	struct options		*oo = w->options;
 	struct window_pane	*wp;
 	struct layout_cell	*lcroot, *lcrow, *lcchild;
-	u_int			 n, width, height, used, sx, sy;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
+	u_int			 n, width, height, used;
 	u_int			 i, j, columns, rows, max_columns;
 
 	layout_print_cell(w->layout_root, __func__, 1);
@@ -624,16 +642,16 @@ layout_set_tiled(struct window *w)
 	if (height < PANE_MINIMUM)
 		height = PANE_MINIMUM;
 
-	sx = ((width + 1) * columns) - 1;
-	if (sx < w->sx)
-		sx = w->sx;
-	sy = ((height + 1) * rows) - 1;
-	if (sy < w->sy)
-		sy = w->sy;
+	lg.sx = ((width + 1) * columns) - 1;
+	if (lg.sx < (int)w->sx)
+		lg.sx = w->sx;
+	lg.sy = ((height + 1) * rows) - 1;
+	if (lg.sy < (int)w->sy)
+		lg.sy = w->sy;
 
 	layout_free(w, 1);
 	lcroot = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lcroot, sx, sy, 0, 0);
+	layout_set_size(lcroot, &lg);
 	layout_make_node(lcroot, LAYOUT_TOPBOTTOM);
 
 	/* Create a grid of the tiled cells. */
@@ -646,12 +664,14 @@ layout_set_tiled(struct window *w)
 			break;
 
 		lcchild = wp->layout_cell;
+		lg.sx = w->sx;
+		lg.sy = height;
 
 		/* If only one column, just use the row directly. */
 		if (n - (j * columns) == 1 || columns == 1) {
 			lcchild->parent = lcroot;
 			TAILQ_INSERT_TAIL(&lcroot->cells, lcchild, entry);
-			layout_set_size(lcchild, w->sx, height, 0, 0);
+			layout_set_size(lcchild, &lg);
 			wp = TAILQ_NEXT(wp, entry);
 			continue;
 		}
@@ -659,15 +679,16 @@ layout_set_tiled(struct window *w)
 		/* Create the new row. */
 		lcrow = layout_create_cell(lcroot);
 		layout_make_node(lcrow, LAYOUT_LEFTRIGHT);
-		layout_set_size(lcrow, w->sx, height, 0, 0);
+		layout_set_size(lcrow, &lg);
 		TAILQ_INSERT_TAIL(&lcroot->cells, lcrow, entry);
+		lg.sx = width;
 
 		/* Add in the columns. */
 		for (i = 0; i < columns; i++) {
 			/* Create and add a pane cell. */
 			lcchild->parent = lcrow;
 			TAILQ_INSERT_TAIL(&lcrow->cells, lcchild, entry);
-			layout_set_size(lcchild, width, height, 0, 0);
+			layout_set_size(lcchild, &lg);
 
 			/* Move to the next non-floating cell. */
 			wp = TAILQ_NEXT(wp, entry);

--- a/layout.c
+++ b/layout.c
@@ -56,12 +56,12 @@ static int	layout_set_size_check(struct window *, struct layout_cell *,
 static void	layout_resize_child_cells(struct window *,
 		    struct layout_cell *);
 
-/* Initializes cell geometry to sentinel values. */
+/* Initialize cell geometry to sentinel values. */
 static void
 layout_geometry_init(struct layout_geometry *lg)
 {
-	lg->sx = UINT_MAX;
-	lg->sy = UINT_MAX;
+	lg->sx = INT_MAX;
+	lg->sy = INT_MAX;
 	lg->xoff = INT_MAX;
 	lg->yoff = INT_MAX;
 }
@@ -140,7 +140,7 @@ layout_print_cell(struct layout_cell *lc, const char *hdr, u_int n)
 		type = "UNKNOWN";
 		break;
 	}
-	log_debug("%s:%*s%p type %s [parent %p] wp=%p [%d,%d %ux%u]", hdr, n,
+	log_debug("%s:%*s%p type %s [parent %p] wp=%p [%d,%d %dx%d]", hdr, n,
 	    " ", lc, type, lc->parent, lc->wp, lc->g.xoff, lc->g.yoff, lc->g.sx,
 	    lc->g.sy);
 	switch (lc->type) {
@@ -197,13 +197,13 @@ layout_search_by_border(struct layout_cell *lc, u_int x, u_int y)
 
 /* Set cell size. */
 void
-layout_set_size(struct layout_cell *lc, u_int sx, u_int sy, int xoff, int yoff)
+layout_set_size(struct layout_cell *lc, struct layout_geometry *lg)
 {
-	lc->g.sx = sx;
-	lc->g.sy = sy;
+	lc->g.sx = lg->sx;
+	lc->g.sy = lg->sy;
 
-	lc->g.xoff = xoff;
-	lc->g.yoff = yoff;
+	lc->g.xoff = lg->xoff;
+	lc->g.yoff = lg->yoff;
 }
 
 /* Make a cell a leaf cell. */
@@ -759,9 +759,10 @@ void
 layout_init(struct window *w, struct window_pane *wp)
 {
 	struct layout_cell	*lc;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
 
 	lc = w->layout_root = layout_create_cell(NULL);
-	layout_set_size(lc, w->sx, w->sy, 0, 0);
+	layout_set_size(lc, &lg);
 	layout_make_leaf(lc, wp);
 	layout_fix_panes(w, NULL);
 }
@@ -800,7 +801,7 @@ layout_resize(struct window *w, u_int sx, u_int sy)
 	if (xchange < 0 && xchange < -xlimit)
 		xchange = -xlimit;
 	if (xlimit == 0) {
-		if (sx <= lc->g.sx)	/* lc->g.sx is minimum possible */
+		if ((int)sx <= lc->g.sx)	/* lc->g.sx is minimum possible */
 			xchange = 0;
 		else
 			xchange = sx - lc->g.sx;
@@ -814,7 +815,7 @@ layout_resize(struct window *w, u_int sx, u_int sy)
 	if (ychange < 0 && ychange < -ylimit)
 		ychange = -ylimit;
 	if (ylimit == 0) {
-		if (sy <= lc->g.sy)	/* lc->g.sy is minimum possible */
+		if ((int)sy <= lc->g.sy)	/* lc->g.sy is minimum possible */
 			ychange = 0;
 		else
 			ychange = sy - lc->g.sy;
@@ -881,11 +882,11 @@ layout_resize_floating_pane_to(struct window_pane *wp, enum layout_type type,
 	}
 
 	if (type == LAYOUT_TOPBOTTOM) {
-		if (lc->g.sy == size)
+		if (lc->g.sy == (int)size)
 			return (0);
 		lc->g.sy = size;
 	} else {
-		if (lc->g.sx == size)
+		if (lc->g.sx == (int)size)
 			return (0);
 		lc->g.sx = size;
 	}
@@ -1238,7 +1239,7 @@ layout_replace_with_node(struct window *w, struct layout_cell *lc,
 
 	lcparent = layout_create_cell(lc->parent);
 	layout_make_node(lcparent, type);
-	layout_set_size(lcparent, lc->g.sx, lc->g.sy, lc->g.xoff, lc->g.yoff);
+	layout_set_size(lcparent, &lc->g);
 	if (lc->parent == NULL)
 		w->layout_root = lcparent;
 	else
@@ -1328,7 +1329,8 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
     int flags)
 {
 	struct layout_cell	*lc, *lcparent, *lcnew, *lc1, *lc2;
-	u_int			 sx, sy, xoff, yoff, size1, size2;
+	struct layout_geometry	 lg1, lg2;
+	u_int			 size1, size2;
 	u_int			 new_size, saved_size, resize_first = 0;
 	int			 full_size = (flags & SPAWN_FULLSIZE);
 	int			 before = (flags & SPAWN_BEFORE);
@@ -1343,10 +1345,8 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 		lc = wp->layout_cell;
 
 	/* Copy the old cell size. */
-	sx = lc->g.sx;
-	sy = lc->g.sy;
-	xoff = lc->g.xoff;
-	yoff = lc->g.yoff;
+	memcpy(&lg1, &lc->g, sizeof lg1);
+	memcpy(&lg2, &lc->g, sizeof lg2);
 
 	/* Check there is enough space for the two new panes. */
 	if (!layout_split_check_space(wp, lc, type))
@@ -1401,9 +1401,10 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 		lcnew = layout_create_cell(lc);
 		size = saved_size - 1 - new_size;
 		if (lc->type == LAYOUT_LEFTRIGHT)
-			layout_set_size(lcnew, size, sy, 0, 0);
+			lg1.sx = size;
 		else if (lc->type == LAYOUT_TOPBOTTOM)
-			layout_set_size(lcnew, sx, size, 0, 0);
+			lg1.sy = size;
+		layout_set_size(lcnew, &lg1);
 		if (flags & SPAWN_BEFORE)
 			TAILQ_INSERT_HEAD(&lc->cells, lcnew, entry);
 		else
@@ -1436,18 +1437,22 @@ layout_split_pane(struct window_pane *wp, enum layout_type type, int size,
 	 * bottom/right.
 	 */
 	if (!resize_first && type == LAYOUT_LEFTRIGHT) {
-		layout_set_size(lc1, size1, sy, xoff, yoff);
-		layout_set_size(lc2, size2, sy, xoff + lc1->g.sx + 1, yoff);
+		lg1.sx = size1;
+		lg2.sx = size2;
+		layout_set_size(lc1, &lg1);
+		layout_set_size(lc2, &lg2);
 	} else if (!resize_first && type == LAYOUT_TOPBOTTOM) {
-		layout_set_size(lc1, sx, size1, xoff, yoff);
-		layout_set_size(lc2, sx, size2, xoff, yoff + lc1->g.sy + 1);
+		lg1.sy = size1;
+		lg2.sy = size2;
+		layout_set_size(lc1, &lg1);
+		layout_set_size(lc2, &lg2);
 	}
 	if (full_size) {
 		if (!resize_first)
 			layout_resize_child_cells(wp->window, lc);
-		layout_fix_offsets(wp->window);
 	} else
 		layout_make_leaf(lc, wp);
+	layout_fix_offsets(wp->window);
 
 	return (lcnew);
 }
@@ -1479,7 +1484,7 @@ layout_floating_pane(struct window *w, struct window_pane *wp,
 	lcnew = layout_create_cell(lcparent);
 	TAILQ_INSERT_AFTER(&lcparent->cells, lc, lcnew, entry);
 	lcnew->flags |= LAYOUT_CELL_FLOATING;
-	layout_set_size(lcnew, lg->sx, lg->sy, lg->xoff, lg->yoff);
+	layout_set_size(lcnew, lg);
 
 	return (lcnew);
 }
@@ -1679,8 +1684,8 @@ layout_floating_args_parse(struct cmdq_item *item, struct args *args,
 	int	 sx, sy, ox, oy;
 	char	*error = NULL;
 
-	sx = lg->sx == UINT_MAX ? w->sx / 2 : lg->sx;
-	sy = lg->sy == UINT_MAX ? w->sy / 4 : lg->sy;
+	sx = lg->sx == INT_MAX ? (int)w->sx / 2 : lg->sx;
+	sy = lg->sy == INT_MAX ? (int)w->sy / 4 : lg->sy;
 	ox = lg->xoff;
 	oy = lg->yoff;
 
@@ -1774,6 +1779,7 @@ int
 layout_remove_tile(struct window *w, struct layout_cell *lc)
 {
 	struct layout_cell	*lcneighbour, *lcparent;
+	struct layout_geometry	 lg = { 0 };
 	enum layout_type	 type;
 	int			 change;
 
@@ -1802,7 +1808,7 @@ layout_remove_tile(struct window *w, struct layout_cell *lc)
 	 * is the top level node.
 	 */
 	if (lc->parent != NULL)
-		layout_set_size(lc, 0, 0, 0, 0);
+		layout_set_size(lc, &lg);
 	return (0);
 }
 
@@ -1814,6 +1820,7 @@ int
 layout_insert_tile(struct window *w, struct layout_cell *lc)
 {
 	struct layout_cell	*lcneighbour, *lctiled, *lcparent;
+	struct layout_geometry	 lg = { w->sx, w->sy, 0, 0 };
 	enum layout_type	 type;
 	u_int			 size1, size2, saved_size;
 
@@ -1826,7 +1833,7 @@ layout_insert_tile(struct window *w, struct layout_cell *lc)
 	lcparent = lc->parent;
 	if (lcparent == NULL) {
 		/* Only pane in the layout. */
-		layout_set_size(lc, w->sx, w->sy, 0, 0);
+		layout_set_size(lc, &lg);
 		return (0);
 	}
 

--- a/resize.c
+++ b/resize.c
@@ -46,12 +46,12 @@ resize_window(struct window *w, u_int sx, u_int sy, int xpixel, int ypixel)
 	layout_resize(w, sx, sy);
 
 	/* Resize the window, it can be no smaller than the layout. */
-	if (sx < w->layout_root->g.sx)
+	if ((int)sx < w->layout_root->g.sx)
 		sx = w->layout_root->g.sx;
-	if (sy < w->layout_root->g.sy)
+	if ((int)sy < w->layout_root->g.sy)
 		sy = w->layout_root->g.sy;
 	window_resize(w, sx, sy, xpixel, ypixel);
-	log_debug("%s: @%u resized to %ux%u; layout %ux%u", __func__, w->id,
+	log_debug("%s: @%u resized to %ux%u; layout %dx%d", __func__, w->id,
 	    sx, sy, w->layout_root->g.sx, w->layout_root->g.sy);
 
 	/* Restore the window zoom state. */

--- a/tmux.h
+++ b/tmux.h
@@ -1507,8 +1507,8 @@ enum layout_type {
 
 /* Layout cell sizes and position. */
 struct layout_geometry {
-	u_int	sx;
-	u_int	sy;
+	int	sx;
+	int	sy;
 	int	xoff;
 	int	yoff;
 };
@@ -3721,7 +3721,7 @@ void		 layout_destroy_cell(struct window *, struct layout_cell *,
 void		 layout_resize_layout(struct window *, struct layout_cell *,
 		     enum layout_type, int, int);
 struct layout_cell *layout_search_by_border(struct layout_cell *, u_int, u_int);
-void		 layout_set_size(struct layout_cell *, u_int, u_int, int, int);
+void		 layout_set_size(struct layout_cell *, struct layout_geometry *);
 void		 layout_make_leaf(struct layout_cell *, struct window_pane *);
 void		 layout_make_node(struct layout_cell *, enum layout_type);
 void		 layout_fix_zindexes(struct window *, struct layout_cell *);


### PR DESCRIPTION
I have also changed the `sx` and `sy` fields of `struct layout_geometry` to signed. Some calculations use signed values to hold temporary sizes and check against going negative. This change allows for inline assignment of field values in these calculations. There is a loss of semantic significance though. I kind of like it, but I can certainly change it back.

This PR is groundwork for a size history in floating panes.