### PR TITLE
Do not exit copy mode on scroll-exit if there is an active selection

### DIFF
--- a/regress/copy-mode-scroll-exit.sh
+++ b/regress/copy-mode-scroll-exit.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+cleanup()
+{
+	$TMUX kill-server 2>/dev/null
+}
+trap cleanup 0
+trap 'exit 1' 1 2 3 15
+
+$TMUX new -d -x40 -y10 \
+	'i=0; while [ $i -lt 80 ]; do echo "line $i"; i=$((i + 1)); done; cat' ||
+	exit 1
+$TMUX set -g window-size manual || exit 1
+
+$TMUX copy-mode -e || exit 1
+$TMUX send-keys -X history-top || exit 1
+$TMUX send-keys -X start-of-line || exit 1
+$TMUX send-keys -X begin-selection || exit 1
+$TMUX send-keys -X cursor-down || exit 1
+
+[ "$($TMUX display-message -p '#{selection_present}')" = "1" ] || exit 1
+$TMUX send-keys -N200 -X scroll-down || exit 1
+[ "$($TMUX display-message -p '#{pane_in_mode} #{scroll_position}')" = "1 0" ] ||
+	exit 1
+
+$TMUX send-keys -X clear-selection || exit 1
+$TMUX send-keys -X scroll-down || exit 1
+[ "$($TMUX display-message -p '#{pane_in_mode}')" = "0" ] || exit 1
+
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -2342,7 +2342,8 @@ but also exit copy mode if the cursor reaches the bottom.
 .It Xo
 .Ic scroll\-exit\-on
 .Xc
-Turn on exiting copy mode when scrolling to the end of the buffer.
+Turn on exiting copy mode when scrolling to the end of the buffer, unless a
+selection is present.
 .It Xo
 .Ic scroll\-exit\-off
 .Xc
@@ -2619,6 +2620,7 @@ instead of
 .Fl e
 specifies that scrolling to the bottom of the history (to the visible screen)
 should exit copy mode.
+This will not happen if a selection is present.
 While in copy mode, pressing a key other than those used for scrolling will
 disable this behaviour.
 This is intended to allow fast scrolling through a pane's history, for

--- a/window-copy.c
+++ b/window-copy.c
@@ -72,6 +72,8 @@ static void	window_copy_write_lines(struct window_mode_entry *,
 static char    *window_copy_match_at_cursor(struct window_copy_mode_data *);
 static void	window_copy_scroll_to(struct window_mode_entry *, u_int, u_int,
 		    int);
+static int	window_copy_should_scroll_exit(struct window_copy_mode_data *,
+		    int);
 static int	window_copy_search_compare(struct grid *, u_int, u_int,
 		    struct grid *, u_int, int);
 static int	window_copy_search_lr(struct grid *, struct grid *, u_int *,
@@ -662,6 +664,13 @@ window_copy_view_init(struct window_mode_entry *wme,
 	return (&data->screen);
 }
 
+static int
+window_copy_should_scroll_exit(struct window_copy_mode_data *data,
+    int scroll_exit)
+{
+	return (scroll_exit && data->oy == 0 && data->screen.sel == NULL);
+}
+
 static void
 window_copy_free(struct window_mode_entry *wme)
 {
@@ -854,7 +863,7 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 			window_copy_cursor_end_of_line(wme);
 	}
 
-	if (scroll_exit && data->oy == 0) {
+	if (window_copy_should_scroll_exit(data, scroll_exit)) {
 		window_pane_reset_mode(wp);
 		return;
 	}
@@ -972,7 +981,7 @@ window_copy_pagedown1(struct window_mode_entry *wme, int half_page,
 			window_copy_cursor_end_of_line(wme);
 	}
 
-	if (scroll_exit && data->oy == 0)
+	if (window_copy_should_scroll_exit(data, scroll_exit))
 		return (1);
 	if (data->searchmark != NULL && !data->timeout)
 		window_copy_search_marks(wme, NULL, data->searchregex, 1);
@@ -2352,7 +2361,7 @@ window_copy_cmd_scroll_down(struct window_copy_cmd_state *cs)
 
 	for (; np != 0; np--)
 		window_copy_cursor_down(wme, 1);
-	if (data->scroll_exit && data->oy == 0)
+	if (window_copy_should_scroll_exit(data, data->scroll_exit))
 		return (WINDOW_COPY_CMD_CANCEL);
 	return (WINDOW_COPY_CMD_NOTHING);
 }


### PR DESCRIPTION
Right now, when you enter copy mode with `-e` (which is the default behavior when you scroll up with the mouse), scrolling back to the bottom exits copy mode automatically. This is super handy for a quick peek at the pane history, but it gets a bit annoying when you're trying to select text with the mouse.

For instance, if you want to select text that starts above the current screen: you'd scroll up to enter copy mode, start your selection, and then scroll down to extend it. But if you scroll all the way back to the bottom, copy mode exits right away and cuts off your selection before you can finish.

To make this feel smoother, this change stops copy mode from exiting if there is an active selection. If you don't have anything selected, it will still exit automatically just like before.

This applies to all the usual scroll-exit actions, whether you are scrolling down, paging down, or using the scrollbar.

I have also added a regression test and updated the manual page to reflect this.