### PR TITLE
Clip the status line and menu against an open popup overlay

### DIFF
--- a/popup.c
+++ b/popup.c
@@ -244,7 +244,7 @@ popup_check_cb(struct client* c, void *data, u_int px, u_int py, u_int nx)
 		*/
 		for (i = 0; i < mr->used; i++) {
 			server_client_overlay_range(pd->px, pd->py, pd->sx,
-			    pd->sy, r->ranges[i].px, py, r->ranges[i].nx,
+			    pd->sy, mr->ranges[i].px, py, mr->ranges[i].nx,
 			    &pd->or[i]);
 		}
 

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1588,8 +1588,10 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 	struct screen		*sl;
 	struct redraw_scene	*scene;
 	struct window_pane	*loop;
-	u_int			 width, i, y, lines;
+	u_int			 width, i, y, lines, j;
 	struct redraw_span	*first;
+	struct visible_ranges	*r;
+	struct visible_range	*rr;
 	int			 redraw;
 
 	if (c->flags & CLIENT_SUSPENDED)
@@ -1694,8 +1696,21 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 		else
 			y = c->tty.sy - lines;
 		sl = c->status.active;
-		for (i = 0; i < lines; i++)
-			tty_draw_line(tty, sl, 0, i, UINT_MAX, 0, y + i, NULL);
+		for (i = 0; i < lines; i++) {
+			/*
+			 * Clip around the overlay: a status-only redraw does not
+			 * repaint the overlay, so drawing the full line would
+			 * paint over an open popup.
+			 */
+			r = tty_check_overlay_range(tty, 0, y + i, tty->sx);
+			for (j = 0; j < r->used; j++) {
+				rr = &r->ranges[j];
+				if (rr->nx == 0)
+					continue;
+				tty_draw_line(tty, sl, rr->px, i, rr->nx,
+				    rr->px, y + i, NULL);
+			}
+		}
 	}
 	if (c->overlay_draw != NULL && (flags & REDRAW_OVERLAY))
 		c->overlay_draw(c, c->overlay_data);


### PR DESCRIPTION
Two related overlay-clipping bugs: content that isn't clipped against the
client overlay can be drawn over an open `display-popup`. Found while looking
into #5336.

### 1. Status line drawn over a popup

`redraw_draw()` draws the status line with `tty_draw_line(tty, sl, 0, i,
UINT_MAX, 0, y + i, NULL)`. `tty_draw_line()` writes straight to the terminal
and does not consult the overlay — callers are expected to pass already-clipped
ranges (as `tty_draw_pane()` does), but the status caller passes the full width.
A status-only redraw also does not set `REDRAW_OVERLAY`, so the overlay is not
repainted afterwards. So whenever the status line is redrawn while a popup is
open — clock tick, activity, an option change — the status line paints over the
popup.

Reproduce:
```sh
tmux -f/dev/null new-session -d -x80 -y24
tmux set -g status-interval 1
tmux set -g status-right '%H:%M:%S'
tmux display-popup -w60 -h6 -yS -E 'sleep 30'
```
Each clock tick draws the time over the bottom of the popup. (Also reproducible
with `tmux refresh-client -S` while the popup is open.)

This commit splits each status line into the ranges left visible by the overlay
(`tty_check_overlay_range`) and draws only those, the same way panes and borders
are drawn. Repainting the overlay on every status redraw would also hide it but
makes an open popup flicker on each tick (see #5336), so clipping is preferred.

### 2. Menu open over a popup uses the wrong ranges

In `popup_check_cb()`, the menu branch computes the ranges left visible by the
menu into `mr`, but when intersecting them with the popup it indexed
`r->ranges[i]` — `r` is `&pd->r`, its own output buffer, still holding the
result of a previous call — instead of `mr->ranges[i]`. With a menu open over a
popup this yields wrong visible ranges. Fixed to use `mr->ranges[i]`.

### Note

The per-caller clip loops (`tty_draw_pane`, `tty_cmd_redrawline`, the status
draw) all repeat the same check_overlay_range → loop → draw idiom, and the
status caller's bug was simply forgetting it. Moving the clip into
`tty_draw_line()` itself would remove the duplication and make the omission
impossible; I kept the change minimal here but am happy to send that version
instead if you prefer.
