### PR TITLE
Fix flickering in copy-mode where the lines were being needlessly redrawn

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -49,8 +49,8 @@ static void	window_copy_next_paragraph(struct window_mode_entry *);
 static void	window_copy_previous_paragraph(struct window_mode_entry *);
 static void	window_copy_redraw_selection(struct window_mode_entry *, u_int);
 static void	window_copy_redraw_lines(struct window_mode_entry *, u_int,
-		    u_int);
-static void	window_copy_redraw_screen(struct window_mode_entry *);
+		    u_int, int);
+static void	window_copy_redraw_screen(struct window_mode_entry *, int);
 static void	window_copy_do_refresh(struct window_mode_entry *, int);
 static void	window_copy_refresh_timer(int, short, void *);
 static void	window_copy_refresh_arm(struct window_mode_entry *);
@@ -66,7 +66,7 @@ static u_int	window_copy_cursor_offset(struct window_mode_entry *, u_int,
 static u_int	window_copy_cursor_unoffset(struct window_mode_entry *, u_int,
 		    u_int);
 static void	window_copy_write_line(struct window_mode_entry *,
-		    struct screen_write_ctx *, u_int);
+		    struct screen_write_ctx *, u_int, int);
 static void	window_copy_write_lines(struct window_mode_entry *,
 		    struct screen_write_ctx *, u_int, u_int);
 static char    *window_copy_match_at_cursor(struct window_copy_mode_data *);
@@ -211,6 +211,7 @@ enum {
 };
 
 enum window_copy_cmd_action {
+	WINDOW_COPY_CMD_NOREDRAW,
 	WINDOW_COPY_CMD_NOTHING,
 	WINDOW_COPY_CMD_REDRAW,
 	WINDOW_COPY_CMD_CANCEL,
@@ -628,7 +629,7 @@ window_copy_init(struct window_mode_entry *wme,
 
 	screen_write_start(&ctx, &data->screen);
 	for (i = 0; i < screen_size_y(&data->screen); i++)
-		window_copy_write_line(wme, &ctx, i);
+		window_copy_write_line(wme, &ctx, i, 1);
 	screen_write_cursormove(&ctx, window_copy_cursor_offset(wme, data->cx,
 	    screen_size_x(&data->screen)), data->cy, 0);
 	screen_write_stop(&ctx);
@@ -742,10 +743,10 @@ window_copy_vadd(struct window_pane *wp, int parse, const char *fmt, va_list ap)
 	 * (If there's any history at all, it has changed.)
 	 */
 	if (screen_hsize(data->backing))
-		window_copy_redraw_lines(wme, 0, 1);
+		window_copy_redraw_lines(wme, 0, 1, 1);
 
 	/* Write the new lines. */
-	window_copy_redraw_lines(wme, old_cy, backing->cy - old_cy + 1);
+	window_copy_redraw_lines(wme, old_cy, backing->cy - old_cy + 1, 1);
 
 	screen_write_stop(&ctx);
 }
@@ -863,7 +864,7 @@ window_copy_scroll1(struct window_mode_entry *wme, struct window_pane *wp,
 		window_copy_search_marks(wme, NULL, data->searchregex, 1);
 	window_copy_update_selection(wme, 1, 0);
 	window_pane_scrollbar_show(wp, 1);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 void
@@ -917,7 +918,7 @@ window_copy_pageup1(struct window_mode_entry *wme, int half_page)
 		window_copy_search_marks(wme, NULL, data->searchregex, 1);
 	window_copy_update_selection(wme, 1, 0);
 	window_pane_scrollbar_show(wme->wp, 1);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 void
@@ -978,7 +979,7 @@ window_copy_pagedown1(struct window_mode_entry *wme, int half_page,
 		window_copy_search_marks(wme, NULL, data->searchregex, 1);
 	window_copy_update_selection(wme, 1, 0);
 	window_pane_scrollbar_show(wme->wp, 1);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 	return (0);
 }
 
@@ -1223,7 +1224,7 @@ window_copy_resize(struct window_mode_entry *wme, u_int sx, u_int sy)
 	}
 
 	window_copy_size_changed(wme);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static const char *
@@ -1548,7 +1549,7 @@ window_copy_cmd_copy_selection_no_clear(struct window_copy_cmd_state *cs)
 		window_copy_copy_selection(wme, prefix, set_paste, set_clip);
 
 	free(prefix);
-	return (WINDOW_COPY_CMD_NOTHING);
+	return (WINDOW_COPY_CMD_NOREDRAW);
 }
 
 static enum window_copy_cmd_action
@@ -2350,6 +2351,16 @@ window_copy_cmd_scroll_down(struct window_copy_cmd_state *cs)
 	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 
+	/*
+	 * If at the bottom and scroll_exit is active with no selection, cancel/exit
+	 * copy-mode.  Otherwise nothing can change, so return WINDOW_COPY_CMD_NOREDRAW
+	 * and do not repaint anything.
+	 */
+	if (data->oy == 0) {
+		if (data->scroll_exit && data->screen.sel == NULL)
+			return (WINDOW_COPY_CMD_CANCEL);
+		return (WINDOW_COPY_CMD_NOREDRAW);
+	}
 	for (; np != 0; np--)
 		window_copy_cursor_down(wme, 1);
 	if (data->scroll_exit && data->oy == 0 && data->screen.sel == NULL)
@@ -2375,8 +2386,15 @@ static enum window_copy_cmd_action
 window_copy_cmd_scroll_up(struct window_copy_cmd_state *cs)
 {
 	struct window_mode_entry	*wme = cs->wme;
+	struct window_copy_mode_data	*data = wme->data;
 	u_int				 np = wme->prefix;
 
+	/*
+	 * If at the top, nothing can change, so return WINDOW_COPY_CMD_NOREDRAW
+	 * and do not repaint anything.
+	 */
+	if (data->oy == screen_hsize(data->backing))
+		return (WINDOW_COPY_CMD_NOREDRAW);
 	for (; np != 0; np--)
 		window_copy_cursor_up(wme, 1);
 	return (WINDOW_COPY_CMD_NOTHING);
@@ -2481,7 +2499,7 @@ window_copy_cmd_select_word(struct window_copy_cmd_state *cs)
 	else {
 		window_copy_update_cursor(wme, px, data->cy);
 		if (window_copy_update_selection(wme, 1, 1))
-			window_copy_redraw_lines(wme, data->cy, 1);
+			window_copy_redraw_lines(wme, data->cy, 1, 1);
 	}
 	data->endselrx = data->cx;
 	data->endselry = screen_hsize(data->backing) + data->cy - data->oy;
@@ -2551,7 +2569,7 @@ window_copy_cmd_copy_pipe_no_clear(struct window_copy_cmd_state *cs)
 	free(command);
 
 	free(prefix);
-	return (WINDOW_COPY_CMD_NOTHING);
+	return (WINDOW_COPY_CMD_NOREDRAW);
 }
 
 static enum window_copy_cmd_action
@@ -2989,7 +3007,7 @@ window_copy_refresh_timer(__unused int fd, __unused short events, void *arg)
 		follow = (data->oy == 0 &&
 		    data->cy == screen_size_y(&data->screen) - 1);
 		window_copy_do_refresh(wme, follow);
-		window_copy_redraw_screen(wme);
+		window_copy_redraw_screen(wme, 1);
 		/* The timer runs outside key handling, so force a repaint. */
 		wp->flags |= PANE_REDRAW;
 		wp->flags &= ~PANE_UNSEENCHANGES;
@@ -3763,7 +3781,9 @@ window_copy_command(struct window_mode_entry *wme, struct client *c,
 	if (action == WINDOW_COPY_CMD_CANCEL)
 		window_pane_reset_mode(wp);
 	else if (action == WINDOW_COPY_CMD_REDRAW)
-		window_copy_redraw_screen(wme);
+		window_copy_redraw_screen(wme, 1);
+	else if (action == WINDOW_COPY_CMD_NOREDRAW)
+		return;
 	else if (action == WINDOW_COPY_CMD_NOTHING) {
 		/*
 		 * Nothing is not actually nothing - most commands at least
@@ -3771,7 +3791,7 @@ window_copy_command(struct window_mode_entry *wme, struct client *c,
 		 * literally does nothing?) and in that case we need to redraw
 		 * the first line to update the indicator.
 		 */
-		window_copy_redraw_lines(wme, 0, 1);
+		window_copy_redraw_lines(wme, 0, 1, 0);
 	}
 }
 
@@ -3808,7 +3828,7 @@ window_copy_scroll_to(struct window_mode_entry *wme, u_int px, u_int py,
 	if (data->oy != old_oy)
 		window_pane_scrollbar_show(wme->wp, 1);
 	if (!no_redraw)
-		window_copy_redraw_screen(wme);
+		window_copy_redraw_screen(wme, 1);
 }
 
 static int
@@ -4596,7 +4616,7 @@ window_copy_search(struct window_mode_entry *wme, int direction, int regex)
 			}
 		}
 	}
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 
 	screen_free(&ss);
 	return (found);
@@ -4849,7 +4869,7 @@ window_copy_goto_line(struct window_mode_entry *wme, const char *linestr)
 	}
 
 	window_copy_update_selection(wme, 1, 0);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static void
@@ -5119,7 +5139,7 @@ window_copy_set_line_numbers(struct window_pane *wp, int enabled)
 	if (data == NULL || data->line_numbers == enabled)
 		return;
 	data->line_numbers = enabled;
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 int
@@ -5141,7 +5161,7 @@ window_copy_get_current_offset(struct window_pane *wp, u_int *offset,
 
 static void
 window_copy_write_line(struct window_mode_entry *wme,
-    struct screen_write_ctx *ctx, u_int py)
+    struct screen_write_ctx *ctx, u_int py, int clear)
 {
 	struct window_pane		*wp = wme->wp;
 	struct window_copy_mode_data	*data = wme->data;
@@ -5166,7 +5186,8 @@ window_copy_write_line(struct window_mode_entry *wme,
 		content_sx = sx;
 
 	screen_write_cursormove(ctx, 0, py, 0);
-	screen_write_clearline(ctx, 8);
+	if (clear)
+		screen_write_clearline(ctx, 8);
 
 	ft = format_create_defaults(NULL, NULL, NULL, NULL, wp);
 
@@ -5237,7 +5258,7 @@ window_copy_write_lines(struct window_mode_entry *wme,
 	u_int	yy;
 
 	for (yy = py; yy < py + ny; yy++)
-		window_copy_write_line(wme, ctx, yy);
+		window_copy_write_line(wme, ctx, yy, 1);
 }
 
 static void
@@ -5265,11 +5286,12 @@ window_copy_redraw_selection(struct window_mode_entry *wme, u_int old_y)
 		if (end < gd->sy + data->oy - 1)
 			end++;
 	}
-	window_copy_redraw_lines(wme, start, end - start + 1);
+	window_copy_redraw_lines(wme, start, end - start + 1, 0);
 }
 
 static void
-window_copy_redraw_lines(struct window_mode_entry *wme, u_int py, u_int ny)
+window_copy_redraw_lines(struct window_mode_entry *wme, u_int py, u_int ny,
+    int clear)
 {
 	struct window_pane		*wp = wme->wp;
 	struct window_copy_mode_data	*data = wme->data;
@@ -5280,7 +5302,7 @@ window_copy_redraw_lines(struct window_mode_entry *wme, u_int py, u_int ny)
 	if (window_copy_line_number_width(wme) != 0) {
 		screen_write_start(&ctx, &data->screen);
 		for (i = py; i < py + ny; i++)
-			window_copy_write_line(wme, &ctx, i);
+			window_copy_write_line(wme, &ctx, i, clear);
 		screen_write_cursormove(&ctx,
 		    window_copy_cursor_offset(wme, data->cx, screen_size_x(s)),
 		    data->cy, 0);
@@ -5294,7 +5316,7 @@ window_copy_redraw_lines(struct window_mode_entry *wme, u_int py, u_int ny)
 	else
 		screen_write_start_pane(&ctx, wp, NULL);
 	for (i = py; i < py + ny; i++)
-		window_copy_write_line(wme, &ctx, i);
+		window_copy_write_line(wme, &ctx, i, clear);
 	screen_write_cursormove(&ctx,
 	    window_copy_cursor_offset(wme, data->cx, screen_size_x(s)), data->cy,
 	    0);
@@ -5304,11 +5326,11 @@ window_copy_redraw_lines(struct window_mode_entry *wme, u_int py, u_int ny)
 }
 
 static void
-window_copy_redraw_screen(struct window_mode_entry *wme)
+window_copy_redraw_screen(struct window_mode_entry *wme, int clear)
 {
 	struct window_copy_mode_data	*data = wme->data;
 
-	window_copy_redraw_lines(wme, 0, screen_size_y(&data->screen));
+	window_copy_redraw_lines(wme, 0, screen_size_y(&data->screen), clear);
 }
 
 static void
@@ -5318,7 +5340,7 @@ window_copy_style_changed(struct window_mode_entry *wme)
 
 	if (data->screen.sel != NULL)
 		window_copy_set_selection(wme, 0, 1);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static void
@@ -5439,7 +5461,7 @@ window_copy_update_cursor(struct window_mode_entry *wme, u_int cx, u_int cy)
 
 		if (s->sel != NULL || data->lineflag != LINE_SEL_NONE ||
 		    old_cy != data->cy) {
-			window_copy_redraw_screen(wme);
+			window_copy_redraw_screen(wme, 0);
 			return;
 		}
 		if (width >= screen_size_x(s))
@@ -5447,7 +5469,7 @@ window_copy_update_cursor(struct window_mode_entry *wme, u_int cx, u_int cy)
 		else
 			content_sx = screen_size_x(s) - width;
 		if (old_cx >= content_sx || data->cx >= content_sx) {
-			window_copy_redraw_screen(wme);
+			window_copy_redraw_screen(wme, 0);
 			return;
 		}
 		screen_write_start_pane(&ctx, wp, NULL);
@@ -5458,9 +5480,9 @@ window_copy_update_cursor(struct window_mode_entry *wme, u_int cx, u_int cy)
 		return;
 	}
 	if (old_cx == screen_size_x(s))
-		window_copy_redraw_lines(wme, old_cy, 1);
+		window_copy_redraw_lines(wme, old_cy, 1, 1);
 	if (data->cx == screen_size_x(s))
-		window_copy_redraw_lines(wme, data->cy, 1);
+		window_copy_redraw_lines(wme, data->cy, 1, 1);
 	else {
 		screen_write_start_pane(&ctx, wp, NULL);
 		screen_write_cursormove(&ctx,
@@ -5587,16 +5609,16 @@ window_copy_set_selection(struct window_mode_entry *wme, int may_redraw,
 		cy = data->cy;
 		if (data->cursordrag == CURSORDRAG_ENDSEL) {
 			if (sy < cy)
-				window_copy_redraw_lines(wme, sy, cy - sy + 1);
+				window_copy_redraw_lines(wme, sy, cy - sy + 1, 1);
 			else
-				window_copy_redraw_lines(wme, cy, sy - cy + 1);
+				window_copy_redraw_lines(wme, cy, sy - cy + 1, 1);
 		} else {
 			if (endsy < cy) {
 				window_copy_redraw_lines(wme, endsy,
-				    cy - endsy + 1);
+				    cy - endsy + 1, 1);
 			} else {
 				window_copy_redraw_lines(wme, cy,
-				    endsy - cy + 1);
+				    endsy - cy + 1, 1);
 			}
 		}
 	}
@@ -6076,7 +6098,7 @@ window_copy_other_end(struct window_mode_entry *wme)
 		data->cx = hsize;
 
 	window_copy_update_selection(wme, 1, 1);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static void
@@ -6153,9 +6175,9 @@ window_copy_cursor_up(struct window_mode_entry *wme, int scroll_only)
 		window_copy_scroll_down(wme, 1);
 		if (scroll_only) {
 			if (data->cy == screen_size_y(s) - 1)
-				window_copy_redraw_lines(wme, data->cy, 1);
+				window_copy_redraw_lines(wme, data->cy, 1, 0);
 			else
-				window_copy_redraw_lines(wme, data->cy, 2);
+				window_copy_redraw_lines(wme, data->cy, 2, 0);
 		}
 	} else {
 		if (norectsel) {
@@ -6165,9 +6187,9 @@ window_copy_cursor_up(struct window_mode_entry *wme, int scroll_only)
 			window_copy_update_cursor(wme, data->cx, data->cy - 1);
 		if (window_copy_update_selection(wme, 1, 0)) {
 			if (data->cy == screen_size_y(s) - 1)
-				window_copy_redraw_lines(wme, data->cy, 1);
+				window_copy_redraw_lines(wme, data->cy, 1, 1);
 			else
-				window_copy_redraw_lines(wme, data->cy, 2);
+				window_copy_redraw_lines(wme, data->cy, 2, 1);
 		}
 	}
 
@@ -6179,7 +6201,7 @@ window_copy_cursor_up(struct window_mode_entry *wme, int scroll_only)
 		{
 			window_copy_update_cursor(wme, px, data->cy);
 			if (window_copy_update_selection(wme, 1, 0))
-				window_copy_redraw_lines(wme, data->cy, 1);
+				window_copy_redraw_lines(wme, data->cy, 1, 1);
 		}
 	}
 
@@ -6192,13 +6214,13 @@ window_copy_cursor_up(struct window_mode_entry *wme, int scroll_only)
 			px = window_copy_find_length(wme, py);
 		window_copy_update_cursor(wme, px, data->cy);
 		if (window_copy_update_selection(wme, 1, 0))
-			window_copy_redraw_lines(wme, data->cy, 1);
+			window_copy_redraw_lines(wme, data->cy, 1, 1);
 	}
 	else if (data->lineflag == LINE_SEL_RIGHT_LEFT)
 	{
 		window_copy_update_cursor(wme, 0, data->cy);
 		if (window_copy_update_selection(wme, 1, 0))
-			window_copy_redraw_lines(wme, data->cy, 1);
+			window_copy_redraw_lines(wme, data->cy, 1, 1);
 	}
 }
 
@@ -6232,7 +6254,7 @@ window_copy_cursor_down(struct window_mode_entry *wme, int scroll_only)
 			data->cx = data->lastcx;
 		window_copy_scroll_up(wme, 1);
 		if (scroll_only && data->cy > 0)
-			window_copy_redraw_lines(wme, data->cy - 1, 2);
+			window_copy_redraw_lines(wme, data->cy - 1, 2, 0);
 	} else {
 		if (norectsel) {
 			window_copy_update_cursor(wme, data->lastcx,
@@ -6240,7 +6262,7 @@ window_copy_cursor_down(struct window_mode_entry *wme, int scroll_only)
 		} else
 			window_copy_update_cursor(wme, data->cx, data->cy + 1);
 		if (window_copy_update_selection(wme, 1, 0))
-			window_copy_redraw_lines(wme, data->cy - 1, 2);
+			window_copy_redraw_lines(wme, data->cy - 1, 2, 1);
 	}
 
 	if (norectsel) {
@@ -6251,7 +6273,7 @@ window_copy_cursor_down(struct window_mode_entry *wme, int scroll_only)
 		{
 			window_copy_update_cursor(wme, px, data->cy);
 			if (window_copy_update_selection(wme, 1, 0))
-				window_copy_redraw_lines(wme, data->cy, 1);
+				window_copy_redraw_lines(wme, data->cy, 1, 1);
 		}
 	}
 
@@ -6264,13 +6286,13 @@ window_copy_cursor_down(struct window_mode_entry *wme, int scroll_only)
 			px = window_copy_find_length(wme, py);
 		window_copy_update_cursor(wme, px, data->cy);
 		if (window_copy_update_selection(wme, 1, 0))
-			window_copy_redraw_lines(wme, data->cy, 1);
+			window_copy_redraw_lines(wme, data->cy, 1, 1);
 	}
 	else if (data->lineflag == LINE_SEL_RIGHT_LEFT)
 	{
 		window_copy_update_cursor(wme, 0, data->cy);
 		if (window_copy_update_selection(wme, 1, 0))
-			window_copy_redraw_lines(wme, data->cy, 1);
+			window_copy_redraw_lines(wme, data->cy, 1, 1);
 	}
 }
 
@@ -6540,7 +6562,7 @@ window_copy_cursor_prompt(struct window_mode_entry *wme, int direction,
 	}
 
 	window_copy_update_selection(wme, 1, 0);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static void
@@ -6564,21 +6586,22 @@ window_copy_scroll_up(struct window_mode_entry *wme, u_int ny)
 	if (window_copy_line_numbers_active(wme)) {
 		if (window_copy_line_number_mode(wme) !=
 		    WINDOW_COPY_LINE_NUMBERS_ABSOLUTE) {
-			window_copy_redraw_screen(wme);
+			window_copy_redraw_screen(wme, 0);
 			return;
 		}
 		screen_write_start(&ctx, &data->screen);
 		screen_write_cursormove(&ctx, 0, 0, 0);
 		screen_write_deleteline(&ctx, ny, 8);
 		window_copy_write_lines(wme, &ctx, screen_size_y(s) - ny, ny);
-		window_copy_write_line(wme, &ctx, 0);
+		window_copy_write_line(wme, &ctx, 0, 0);
 		if (screen_size_y(s) > 1)
-			window_copy_write_line(wme, &ctx, 1);
+			window_copy_write_line(wme, &ctx, 1, 0);
 		if (screen_size_y(s) > 3)
-			window_copy_write_line(wme, &ctx, screen_size_y(s) - 2);
+			window_copy_write_line(wme, &ctx,
+			    screen_size_y(s) - 2, 0);
 		if (s->sel != NULL && screen_size_y(s) > ny) {
 			window_copy_write_line(wme, &ctx,
-			    screen_size_y(s) - ny - 1);
+			    screen_size_y(s) - ny - 1, 0);
 		}
 		screen_write_cursormove(&ctx,
 		    window_copy_cursor_offset(wme, data->cx, screen_size_x(s)),
@@ -6595,13 +6618,14 @@ window_copy_scroll_up(struct window_mode_entry *wme, u_int ny)
 	screen_write_cursormove(&ctx, 0, 0, 0);
 	screen_write_deleteline(&ctx, ny, 8);
 	window_copy_write_lines(wme, &ctx, screen_size_y(s) - ny, ny);
-	window_copy_write_line(wme, &ctx, 0);
+	window_copy_write_line(wme, &ctx, 0, 0);
 	if (screen_size_y(s) > 1)
-		window_copy_write_line(wme, &ctx, 1);
+		window_copy_write_line(wme, &ctx, 1, 0);
 	if (screen_size_y(s) > 3)
-		window_copy_write_line(wme, &ctx, screen_size_y(s) - 2);
+		window_copy_write_line(wme, &ctx, screen_size_y(s) - 2, 0);
 	if (s->sel != NULL && screen_size_y(s) > ny)
-		window_copy_write_line(wme, &ctx, screen_size_y(s) - ny - 1);
+		window_copy_write_line(wme, &ctx, screen_size_y(s) - ny - 1,
+		    0);
 	screen_write_cursormove(&ctx,
 	    window_copy_cursor_offset(wme, data->cx, screen_size_x(s)), data->cy,
 	    0);
@@ -6633,7 +6657,7 @@ window_copy_scroll_down(struct window_mode_entry *wme, u_int ny)
 	if (window_copy_line_numbers_active(wme)) {
 		if (window_copy_line_number_mode(wme) !=
 		    WINDOW_COPY_LINE_NUMBERS_ABSOLUTE) {
-			window_copy_redraw_screen(wme);
+			window_copy_redraw_screen(wme, 0);
 			return;
 		}
 		screen_write_start(&ctx, &data->screen);
@@ -6641,9 +6665,9 @@ window_copy_scroll_down(struct window_mode_entry *wme, u_int ny)
 		screen_write_insertline(&ctx, ny, 8);
 		window_copy_write_lines(wme, &ctx, 0, ny);
 		if (s->sel != NULL && screen_size_y(s) > ny)
-			window_copy_write_line(wme, &ctx, ny);
+			window_copy_write_line(wme, &ctx, ny, 0);
 		else if (ny == 1)
-			window_copy_write_line(wme, &ctx, 1);
+			window_copy_write_line(wme, &ctx, 1, 0);
 		screen_write_cursormove(&ctx,
 		    window_copy_cursor_offset(wme, data->cx, screen_size_x(s)),
 		    data->cy, 0);
@@ -6660,9 +6684,9 @@ window_copy_scroll_down(struct window_mode_entry *wme, u_int ny)
 	screen_write_insertline(&ctx, ny, 8);
 	window_copy_write_lines(wme, &ctx, 0, ny);
 	if (s->sel != NULL && screen_size_y(s) > ny)
-		window_copy_write_line(wme, &ctx, ny);
+		window_copy_write_line(wme, &ctx, ny, 0);
 	else if (ny == 1) /* nuke position */
-		window_copy_write_line(wme, &ctx, 1);
+		window_copy_write_line(wme, &ctx, 1, 0);
 	screen_write_cursormove(&ctx, window_copy_cursor_offset(wme, data->cx,
 	    screen_size_x(s)), data->cy, 0);
 	screen_write_stop(&ctx);
@@ -6683,7 +6707,7 @@ window_copy_rectangle_set(struct window_mode_entry *wme, int rectflag)
 		window_copy_update_cursor(wme, px, data->cy);
 
 	window_copy_update_selection(wme, 1, 0);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 static void
@@ -6761,7 +6785,7 @@ window_copy_start_drag(struct client *c, struct mouse_event *m)
 		break;
 	}
 
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 	window_copy_drag_update(c, m);
 }
 
@@ -6856,7 +6880,7 @@ window_copy_jump_to_mark(struct window_mode_entry *wme)
 	data->my = tmy;
 	data->showmark = 1;
 	window_copy_update_selection(wme, 0, 0);
-	window_copy_redraw_screen(wme);
+	window_copy_redraw_screen(wme, 1);
 }
 
 /* Scroll up if the cursor went off the visible screen. */
@@ -6882,7 +6906,7 @@ window_copy_acquire_cursor_up(struct window_mode_entry *wme, u_int hsize,
 	}
 	window_copy_update_cursor(wme, px, cy);
 	if (window_copy_update_selection(wme, 1, 0))
-		window_copy_redraw_lines(wme, cy, nd);
+		window_copy_redraw_lines(wme, cy, nd, 1);
 }
 
 /* Scroll down if the cursor went off the visible screen. */
@@ -6911,5 +6935,5 @@ window_copy_acquire_cursor_down(struct window_mode_entry *wme, u_int hsize,
 	else
 		window_copy_update_cursor(wme, px, cy);
 	if (window_copy_update_selection(wme, 1, no_reset))
-		window_copy_redraw_lines(wme, oldy, nd);
+		window_copy_redraw_lines(wme, oldy, nd, 1);
 }


### PR DESCRIPTION
1. Fix flickering when at the top in copy-mode and scrolling up with mousewheel
2. Similarly fix flickering when at the bottom and scrolling down with mousewheel
3. Fix flickering when the copy-mode cursor moved or the selectionn changed, it was redrawing the line that the cursor was on over and over.
4. Flickering was caused by excessive clearing and redrawing where only redrawing was necessary to change the selection.