### PR TITLE
client: do not restore blocking mode while the server may still write to the tty

### DIFF
--- a/client.c
+++ b/client.c
@@ -239,9 +239,8 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 	pid_t			 ppid;
 	enum msgtype		 msg;
 	struct termios		 tio, saved_tio;
-	size_t			 size, linesize = 0;
-	ssize_t			 linelen;
-	char			*line = NULL, **caps = NULL, *cause;
+	size_t			 size;
+	char			**caps = NULL, *cause;
 	u_int			 ncaps = 0;
 	struct args_value	*values;
 
@@ -407,11 +406,6 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 		client_exec(client_execshell, client_execcmd);
 	}
 
-	/* Restore streams to blocking. */
-	setblocking(STDIN_FILENO, 1);
-	setblocking(STDOUT_FILENO, 1);
-	setblocking(STDERR_FILENO, 1);
-
 	/* Print the exit message, if any, and exit. */
 	if (client_attached) {
 		if (client_exitreason != CLIENT_EXIT_NONE)
@@ -426,15 +420,8 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 		else
 			printf("%%exit\n");
 		fflush(stdout);
-		if (client_flags & CLIENT_CONTROL_WAITEXIT) {
-			setvbuf(stdin, NULL, _IOLBF, 0);
-			for (;;) {
-				linelen = getline(&line, &linesize, stdin);
-				if (linelen <= 1)
-					break;
-			}
-			free(line);
-		}
+		if (client_flags & CLIENT_CONTROL_WAITEXIT)
+			control_wait_exit(STDIN_FILENO);
 		if (client_flags & CLIENT_CONTROLCONTROL) {
 			printf("\033\\");
 			fflush(stdout);
@@ -442,6 +429,17 @@ client_main(struct event_base *base, int argc, char **argv, uint64_t flags,
 		}
 	} else if (client_exitreason != CLIENT_EXIT_NONE)
 		fprintf(stderr, "%s\n", client_exit_message());
+
+	/*
+	 * Restore the streams to blocking for whatever uses the terminal
+	 * next. O_NONBLOCK is a property of the open file description, shared
+	 * with the descriptors passed to the server with MSG_IDENTIFY, so
+	 * restoring it any earlier can leave the single-threaded server
+	 * blocked in write(2) to a slow or dead terminal.
+	 */
+	setblocking(STDIN_FILENO, 1);
+	setblocking(STDOUT_FILENO, 1);
+	setblocking(STDERR_FILENO, 1);
 	return (client_exitval);
 }
 

--- a/control.c
+++ b/control.c
@@ -19,6 +19,8 @@
 
 #include <sys/types.h>
 
+#include <errno.h>
+#include <poll.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -483,6 +485,56 @@ control_all_done(struct client *c)
 	if (!TAILQ_EMPTY(&cs->all_blocks))
 		return (0);
 	return (EVBUFFER_LENGTH(cs->write_event->output) == 0);
+}
+
+/*
+ * Wait for the terminal to send an empty line or close, used by a control
+ * client after printing %exit so a wrapping terminal (such as iTerm2) can
+ * finish reading. There is no event loop here and the descriptor may be
+ * non-blocking, so read into an evbuffer rather than with stdio: a stdio
+ * stream, even a line-buffered one, can pull several lines into its buffer in
+ * a single read, leaving a line that poll(2) never reports and that would
+ * therefore never be consumed.
+ */
+void
+control_wait_exit(int fd)
+{
+	struct pollfd	 pfd;
+	struct evbuffer	*evb;
+	char		*line;
+	int		 n;
+
+	evb = evbuffer_new();
+	if (evb == NULL)
+		fatalx("out of memory");
+
+	for (;;) {
+		line = evbuffer_readln(evb, NULL, EVBUFFER_EOL_LF);
+		if (line != NULL) {
+			if (*line == '\0') {	/* empty line, stop */
+				free(line);
+				break;
+			}
+			free(line);
+			continue;		/* drain buffered lines first */
+		}
+
+		pfd.fd = fd;
+		pfd.events = POLLIN;
+		if (poll(&pfd, 1, -1) == -1) {
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+
+		n = evbuffer_read(evb, fd, -1);
+		if (n == 0)			/* EOF */
+			break;
+		if (n == -1 && errno != EAGAIN && errno != EINTR)
+			break;
+	}
+
+	evbuffer_free(evb);
 }
 
 /* Flush all blocks until output. */

--- a/regress/control-client-wait-exit.sh
+++ b/regress/control-client-wait-exit.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# A control client with the wait-exit flag lingers after %exit until its input
+# sends an empty line or closes. The terminating empty line must be honoured
+# even when several lines arrive in a single read (as from a pipe or a raw
+# terminal): reading input with stdio would pull them all into the FILE buffer
+# and leave the empty line where poll never sees it, hanging the client.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+FIFO=$(mktemp -u)
+OUT=$(mktemp)
+mkfifo "$FIFO" || exit 1
+trap "$TMUX kill-server 2>/dev/null; rm -f $FIFO $OUT" 0 1 15
+
+# Start a control client that reads its input from the fifo. Keep the write
+# end open (fd 3) so the client never sees EOF: it must exit on the empty
+# line, not on the pipe closing.
+$TMUX -f/dev/null -C new -s wait-exit <"$FIFO" >"$OUT" 2>&1 &
+CLIENT=$!
+exec 3>"$FIFO"
+sleep 1
+
+# Ask to linger after exit, then detach so the client prints %exit and enters
+# the wait-exit loop.
+printf 'refresh-client -f wait-exit\n' >&3
+sleep 1
+$TMUX detach-client -s wait-exit
+
+# Wait for the client to print %exit and enter the wait-exit loop.
+i=0
+while [ $i -lt 5 ]; do
+	grep -q '^%exit' "$OUT" && break
+	sleep 1
+	i=$((i + 1))
+done
+grep -q '^%exit' "$OUT" || exit 1
+
+# Deliver the terminating empty line in one write, after a non-empty line, so
+# a single read returns "a\n" and "\n" together. The empty line must still end
+# the wait.
+printf 'a\n\n' >&3
+
+# The client should exit promptly. If it is still alive after the timeout the
+# empty line was lost in a buffer and the client has hung.
+i=0
+while [ $i -lt 10 ]; do
+	kill -0 $CLIENT 2>/dev/null || break
+	sleep 1
+	i=$((i + 1))
+done
+if kill -0 $CLIENT 2>/dev/null; then
+	kill $CLIENT 2>/dev/null
+	exit 1
+fi
+exec 3>&-
+
+exit 0

--- a/tmux.h
+++ b/tmux.h
@@ -3890,6 +3890,7 @@ void	control_discard(struct client *);
 void	control_start(struct client *);
 void	control_ready(struct client *);
 void	control_stop(struct client *);
+void	control_wait_exit(int);
 void	control_set_pane_on(struct client *, struct window_pane *);
 void	control_set_pane_off(struct client *, struct window_pane *);
 void	control_continue_pane(struct client *, struct window_pane *);


### PR DESCRIPTION
## TL;DR

When a control-mode (`-CC`) client exits, `client_main()` restores blocking mode on stdin/stdout/stderr **before** printing `%exit`. `O_NONBLOCK` is a property of the open file *description*, and the fds the client passed to the server with `MSG_IDENTIFY_STDIN`/`MSG_IDENTIFY_STDOUT` are `dup(2)`s of that same description — so the dying client quietly switches the **server's** `c->fd`/`c->out_fd` to blocking while the server is still writing control output to them.

If the terminal side of that tty has stalled (a dead ssh/EternalTerminal-style wrapper that keeps the pty master open but stops reading), the server's next `writev()` to the tty blocks forever inside the kernel (`n_tty_write`, waiting for buffer space that never comes). The server is single-threaded, so **every session freezes and every subsequent tmux command hangs**.

This PR moves the restore to the very end of the client exit sequence — for **all** client types — when the server is done with the fds. The restore itself has to stay: the flag is shared with the shell and whatever uses the terminal next, and the client-side restore is the only one that runs when the server has died and cannot restore it via its own dup.

It is also the answer to the question that closed #5087 — *"Who is going around changing the slave side of the pty to blocking behind our back and why?"* It's tmux's own client, in the exit epilogue. (#5087's per-write `fcntl()` was rightly rejected as a sledgehammer; this PR removes the actual cause instead.)

## The failure chain (no third party, no signals, no user action)

1. **A terminal-side reader stalls.** In our production case a terminal multiplexer daemon's network link died; it kept the pty master open but stopped reading. Any slow/hung terminal that holds the master works.
2. **The server evicts the client.** Pane output blocks age past `CONTROL_MAXIMUM_AGE` (300s) and `control_check_age()` sets `exit_message = "too far behind"` + `CLIENT_EXIT`. The server itself starts the fatal sequence — nobody touches anything.
3. **Exit handshake.** `server_client_check_exit()` waits for `control_all_done()` (the remaining buffered output drains to the tty as the dying reader trickles), then sends `MSG_EXIT`.
4. **The flip.** The client leaves `proc_loop()` and runs the epilogue: `setblocking(STDIN/STDOUT/STDERR, 1)` — *the server's fds are now blocking too*. The client then blocks in its own `printf("%%exit ...")` on the full tty, or survives it and sits in the `wait-exit` `getline()`. Either way it **never closes its socket**, so the server never runs `server_client_lost()` and never closes the flipped fds.
5. **The park.** Notifications keep queueing for the zombie client. The moment the stalling reader frees a little tty buffer space, `poll()` reports writable and the server `writev()`s a chunk larger than the free space **on a now-blocking fd**. The kernel writes what fits, then sleeps in `n_tty_write` until more space appears. It never does. The event loop is dead; every client and session hangs.

## Evidence from a production wedge (tmux 3.5a)

The wedged server, from `/proc` (identical stack later reproduced on `master`):

```
$ cat /proc/<server>/syscall
20 0x11 ...                     # writev, fd 17 -> /dev/pts/11 (a -CC client tty)
$ sudo cat /proc/<server>/stack
[<0>] wait_woken+0x33/0x50
[<0>] n_tty_write+0x402/0x460
[<0>] file_tty_write+0x11e/0x330
[<0>] do_iter_readv_writev+0x7a/0x1c0
[<0>] vfs_writev+0xc9/0x230
```

The O_NONBLOCK flip is directly visible in `/proc/<pid>/fdinfo` (0o4000 = O_NONBLOCK):

- healthy, attached `-CC` client and the server's dup of its tty: `flags: 04002`
- every leaked zombie client from past incidents (we found six, 1.7 to 30 days old): `flags: 02`

Core dumps of two zombies (with distro debuginfo) catch both parking spots from step 4:

- one blocked in `write()` ← `printf()` ← `client_main()` at the `%exit` line, with `"%exit server exited unexpectedly\n"` still sitting undelivered in its stdio buffer — it had been there for 22 days;
- one blocked in `getline()` in the `wait-exit` loop — for 30 days.

As a bonus, un-wedging such a server (signal or EIO) makes it burst-process everything that queued up meanwhile, which is how the `control_write()` NULL dereference fixed in #4980 was originally triggered.

## Reproducer

The script below fakes the dying terminal: it holds the pty master of a `tmux -CC new -A -s wedge` client, drains, then stalls; floods pane output; waits for the *authentic* 300s `control_check_age` eviction; then trickles tiny reads (freeing a sliver of tty buffer at a time) while notifications queue — and watches `/proc` for the O_NONBLOCK flip and the server parking in `n_tty_write`.

```
python3 rig.py --mode age --tmux /path/to/tmux --sock wedgetest
```

Results:

| binary | outcome |
|---|---|
| 3.5a (distro) | **WEDGED** — flip at t=326s, server parked in `n_tty_write` at t=337s, every command hangs |
| master (next-3.7) | **WEDGED** — same timeline |
| master + this PR | **HEALTHY** — no flip while the server holds the fds; `%exit too far behind` was actually delivered; the client exited cleanly when its stdin closed; the server stayed responsive throughout |

<details><summary>wedge log: vanilla master (excerpt)</summary>

```
[ 307.40]   aging... 300s, client wchan=do_sys_poll, server wchan=do_sys_poll
[ 326.61] *** FLIP: client fd0 O_NONBLOCK cleared (client.c:411-413 epilogue ran); drained 6144b total
[ 326.61] tty tail: ...'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n%output %0 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
[ 326.61]   server fd 5 O_NONBLOCK=False  <- shared description
[ 326.61] client wchan=wait_woken syscall=0 0x0 0x5140e0 0x400 0x800000 0x0 0x0 0x7fff27294e88 0x7f445
[ 326.61] parking phase: notification bursts + 64-byte trickles
[ 334.15] outside command TIMEOUT at round 15 — server unresponsive
[ 337.16] server wchan=wait_woken
[ 337.16] server syscall=20 0x5 0x7fff27294400 0x1 0x7f44526c9080 0x1 0x0 0x7fff272943f8 0x7f4452304f17
[ 337.16] probe 'tmux -L wedgevan ls' -> rc=TIMEOUT
[ 337.17] server kernel stack:
[<0>] wait_woken+0x33/0x50
[<0>] n_tty_write+0x402/0x460
[<0>] file_tty_write+0x11e/0x330
[<0>] do_iter_readv_writev+0x7a/0x1c0
[<0>] vfs_writev+0xc9/0x230
[<0>] do_writev+0x5e/0xe0
[<0>] do_syscall_64+0x68/0x130
[<0>] entry_SYSCALL_64_after_hwframe+0x4b/0x53

[ 337.17] VERDICT: WEDGE REPRODUCED — server parked in n_tty_write, all commands hang
```
</details>

<details><summary>healthy log: master + this PR (excerpt)</summary>

```
[ 307.43]   aging... 300s, client wchan=do_sys_poll, server wchan=do_sys_poll
[ 331.55]   waiting for flip... drained 14521b, client wchan=do_sys_poll
[ 336.56]   waiting for flip... drained 14521b, client wchan=do_sys_poll
[ 341.65]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 346.66]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 351.67]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 356.68]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 361.69]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 366.70]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 371.71]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 376.72]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 381.74]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 386.75]   waiting for flip... drained 14572b, client wchan=do_sys_poll
[ 391.83]   waiting for flip... drained 14623b, client wchan=do_sys_poll
[ 396.84]   waiting for flip... drained 14623b, client wchan=do_sys_poll
[ 401.85]   waiting for flip... drained 14623b, client wchan=do_sys_poll
[ 406.96]   waiting for flip... drained 14674b, client wchan=do_sys_poll
[ 411.97]   waiting for flip... drained 14725b, client wchan=do_sys_poll
[ 417.06]   waiting for flip... drained 14776b, client wchan=do_sys_poll
[ 422.07]   waiting for flip... drained 14776b, client wchan=do_sys_poll
[ 427.08]   waiting for flip... drained 14776b, client wchan=do_sys_poll
[ 432.10]   waiting for flip... drained 14827b, client wchan=do_sys_poll
[ 437.11]   waiting for flip... drained 14827b, client wchan=do_sys_poll
[ 442.20]   waiting for flip... drained 14878b, client wchan=do_sys_poll
[ 446.61] tty tail: ...'sleep\r\n%window-renamed @0 bash\r\n%window-renamed @0 sleep\r\n%window-renamed @0 bash\r\n%window-renamed @0 sleep\r\n%window-renamed @0 bash\r\n%window-renamed @0 sleep\r\n'
[ 446.61] no flip observed; server wchan=do_sys_poll, probe rc=0
[ 446.61] post-linger drain: read 2 bytes over 2.0s
[ 447.61] after ending linger: client alive=False, server wchan=do_sys_poll, probe rc=0
[ 447.61] VERDICT: NO FLIP while server in use, server healthy (expected outcome for fixed client)
```
</details>

<details><summary>rig.py (full reproducer)</summary>

```python
#!/usr/bin/env python3
"""Reproduce the tmux -CC server wedge (server parked in n_tty_write).

Simulates a dying EternalTerminal: holds the pty master open, reads on a
controllable schedule, stalls, then lets tmux's own client-exit path flip
O_NONBLOCK off on the shared tty file description and park the server.

Usage: rig.py [--mode detach|age] [--tmux /path/to/tmux]
  detach: trigger client exit via detach-client (fast, seconds)
  age:    wait for control_check_age "too far behind" (authentic, ~5.5 min)
"""
import argparse
import os
import pty
import select
import signal
import subprocess
import sys
import time

SOCK = "wedgetest"  # overridden by --sock

t0 = time.time()
def log(msg):
    print(f"[{time.time()-t0:7.2f}] {msg}", flush=True)

def outside(tmux, *args, timeout=3):
    """Run a tmux command from outside against the test server."""
    try:
        r = subprocess.run([tmux, "-L", SOCK, *args],
                           capture_output=True, text=True, timeout=timeout)
        return r.returncode, r.stdout.strip(), r.stderr.strip()
    except subprocess.TimeoutExpired:
        return "TIMEOUT", "", ""

def fd_flags(pid, fd):
    try:
        with open(f"/proc/{pid}/fdinfo/{fd}") as f:
            for line in f:
                if line.startswith("flags"):
                    return line.split()[1]
    except OSError:
        return None

def nonblock(pid, fd):
    fl = fd_flags(pid, fd)
    return None if fl is None else bool(int(fl, 8) & 0o4000)

def rss_kb(pid):
    try:
        with open(f"/proc/{pid}/status") as f:
            for line in f:
                if line.startswith("VmRSS"):
                    return int(line.split()[1])
    except OSError:
        return -1

def wchan(pid):
    try:
        with open(f"/proc/{pid}/wchan") as f:
            return f.read().strip()
    except OSError:
        return "?"

def syscall_of(pid):
    try:
        with open(f"/proc/{pid}/syscall") as f:
            return f.read().strip()
    except OSError:
        return "?"

def pts_fds(pid, pts):
    fds = []
    try:
        for fd in os.listdir(f"/proc/{pid}/fd"):
            try:
                if os.readlink(f"/proc/{pid}/fd/{fd}") == pts:
                    fds.append(int(fd))
            except OSError:
                pass
    except OSError:
        pass
    return sorted(fds)

def find_server_pid(tmux):
    # The server is the process listening on the socket; ask ss.
    out = subprocess.run(["ss", "-xlp"], capture_output=True, text=True).stdout
    for line in out.splitlines():
        if f"tmux-{os.getuid()}/{SOCK}" in line and "pid=" in line:
            return int(line.split("pid=")[1].split(",")[0])
    return None

def drain(master, seconds, chunk=65536, label="drain"):
    end = time.time() + seconds
    total = 0
    while time.time() < end:
        r, _, _ = select.select([master], [], [], 0.1)
        if r:
            try:
                total += len(os.read(master, chunk))
            except OSError:
                break
    log(f"{label}: read {total} bytes over {seconds}s")
    return total

def trickle(master, nbytes):
    """Read a tiny amount: frees partial tty-buffer room, like a dying reader."""
    r, _, _ = select.select([master], [], [], 0.1)
    if not r:
        return 0
    try:
        return len(os.read(master, nbytes))
    except OSError:
        return 0

def pump(master, cap=4 * 1024 * 1024):
    """Drain everything currently available (a healthy, keeping-up reader)."""
    total = 0
    while total < cap:
        r, _, _ = select.select([master], [], [], 0)
        if not r:
            break
        try:
            data = os.read(master, 65536)
        except OSError:
            break
        if not data:
            break
        total += len(data)
    return total

def main():
    global SOCK
    ap = argparse.ArgumentParser()
    ap.add_argument("--mode", choices=["detach", "age", "leak"], default="detach")
    ap.add_argument("--tmux", default="/usr/bin/tmux")
    ap.add_argument("--sock", default="wedgetest")
    args = ap.parse_args()
    tmux = args.tmux
    SOCK = args.sock

    outside(tmux, "kill-server", timeout=5)  # clean slate on the test socket

    master, slave = pty.openpty()
    pts = os.ttyname(slave)
    log(f"pty: master fd {master}, slave {pts}")

    client = subprocess.Popen(
        [tmux, "-f", "/dev/null", "-L", SOCK, "-CC", "new", "-A", "-s", "wedge"],
        stdin=slave, stdout=slave, stderr=slave, start_new_session=True)
    os.close(slave)
    log(f"client pid {client.pid}")

    # Healthy phase: drain the control stream, find the server.
    drain(master, 1.5, label="healthy drain")
    server = find_server_pid(tmux)
    if server is None:
        log("FATAL: no server found"); sys.exit(1)
    sfds = pts_fds(server, pts)
    log(f"server pid {server}, fds on {pts}: {sfds}")
    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}")
    log(f"client fd0 O_NONBLOCK={nonblock(client.pid, 0)}")

    # Ask for wait-exit like ET does (via the control client's own stdin).
    os.write(master, b"refresh-client -f wait-exit\n")
    drain(master, 0.5, label="post-refresh drain")
    rc, out, err = outside(tmux, "list-clients", "-F",
                           "#{client_name} [#{client_flags}]")
    log(f"clients: {out or err} (rc={rc})")
    client_name = out.split()[0] if out else None

    # Leak mode adds a second, healthy control client B on the same session.
    # It keeps pane reads enabled while zombie A pins the drain offset.
    masterB = None
    clientB = None
    if args.mode == "leak":
        masterB, slaveB = pty.openpty()
        clientB = subprocess.Popen(
            [tmux, "-f", "/dev/null", "-L", SOCK, "-CC", "new", "-A",
             "-s", "wedge"],
            stdin=slaveB, stdout=slaveB, stderr=slaveB, start_new_session=True)
        os.close(slaveB)
        drain(masterB, 1.0, label="observer B initial drain")
        # no-output: B keeps pane reads enabled but tracks no pane offsets,
        # so the only offset that can pin the pane buffer is zombie A's.
        os.write(masterB, b"refresh-client -f no-output\n")
        drain(masterB, 0.5, label="observer B post-refresh drain")
        log(f"healthy no-output observer client B pid {clientB.pid}")

    # Flood: pane output builds control %output volume. Full speed for the
    # fast detach mode; throttled (~10KB/s) for age mode so 300s of backlog
    # stays small while blocks still age past CONTROL_MAXIMUM_AGE.
    if args.mode == "detach":
        flood = "yes wedge-payload"
    else:  # age and leak both need the slow flood during the aging window
        flood = 'while :; do head -c 2000 /dev/zero | tr "\\0" x; sleep 0.2; done'
    outside(tmux, "send-keys", "-t", "wedge", flood, "Enter")
    drain(master, 1.0, label="flood drain")

    # STALL: stop reading. Kernel tty buffer fills, server backlog grows.
    log("STALL: reader stops (ET link dead)")
    time.sleep(3)
    log(f"server wchan={wchan(server)} (expect healthy poll)")
    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}")

    if args.mode == "detach":
        log(f"trigger: detach-client -t {client_name}")
        rc, out, err = outside(tmux, "detach-client", "-t", client_name)
        log(f"detach rc={rc} {err}")
    else:
        log("trigger: aging blocks past CONTROL_MAXIMUM_AGE (300s), "
            "no reads from A" + (", B kept drained" if masterB else ""))
        for i in range(320):
            time.sleep(1)
            if masterB is not None:
                pump(masterB)
            if nonblock(client.pid, 0) is False:
                log(f"  flip already observed during aging at {i}s")
                break
            if i % 30 == 0:
                log(f"  aging... {i}s, client wchan={wchan(client.pid)}, "
                    f"server wchan={wchan(server)}")
            if wchan(server) == "wait_woken":
                log(f"  server parked during aging at {i}s")
                break

    # Watch for the O_NONBLOCK flip on the shared description. Drain at a
    # moderate rate (a dying-but-not-dead reader) so control_all_done can
    # complete and MSG_EXIT can reach the client.
    flipped = None
    drained = 0
    tail = bytearray()
    deadline = time.time() + 120
    last_report = time.time()
    while time.time() < deadline:
        r, _, _ = select.select([master], [], [], 0.1)
        if r:
            try:
                chunk = os.read(master, 2048)
                drained += len(chunk)
                tail.extend(chunk)
                del tail[:-300]
            except OSError:
                pass
        if masterB is not None:
            pump(masterB)
        nb = nonblock(client.pid, 0)
        if nb is False:
            flipped = time.time()
            log(f"*** FLIP: client fd0 O_NONBLOCK cleared "
                f"(client.c:411-413 epilogue ran); drained {drained}b total")
            break
        if time.time() - last_report > 5:
            log(f"  waiting for flip... drained {drained}b, "
                f"client wchan={wchan(client.pid)}")
            last_report = time.time()
        time.sleep(0.1)
    # A little more drain so the client's %exit line reaches us.
    drained += trickle(master, 4096)
    tail_txt = bytes(tail[-300:]).decode("utf-8", "replace")
    log(f"tty tail: ...{tail_txt[-160:]!r}")
    if flipped is None:
        rc, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"no flip observed; server wchan={wchan(server)}, probe rc={rc}")
        # End the wait-exit linger and let the (fixed) epilogue finish.
        try:
            os.write(master, b"\n")
        except OSError:
            pass
        drain(master, 2.0, label="post-linger drain")
        time.sleep(1)
        rc2, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"after ending linger: client alive={client.poll() is None}, "
            f"server wchan={wchan(server)}, probe rc={rc2}")
        if rc == 0 and rc2 == 0:
            log("VERDICT: NO FLIP while server in use, server healthy "
                "(expected outcome for fixed client)")
            cleanup(tmux, server, client)
            sys.exit(2)
        log("VERDICT: no flip but server unhealthy — investigate")
        cleanup(tmux, server, client)
        sys.exit(4)

    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}  <- shared description")
    log(f"client wchan={wchan(client.pid)} syscall={syscall_of(client.pid)[:60]}")

    if args.mode == "leak":
        # Zombie A is now CLIENT_EXITED, session-attached, socket open. Its
        # frozen pane offset pins server_client_check_pane_buffer's
        # `minimum`, so the pane input evbuffer cannot be drained past it —
        # while healthy observer B keeps pane reads ENABLED. Run the pane
        # at ~1MB/s, keep draining B, and watch the server's RSS.
        outside(tmux, "send-keys", "-t", "wedge", "C-c")
        time.sleep(0.5)
        outside(tmux, "send-keys", "-t", "wedge",
                'while :; do head -c 100000 /dev/zero | tr "\\0" x; '
                'sleep 0.1; done', "Enter")
        rss0 = rss_kb(server)
        b_bytes = 0
        log(f"leak phase: ~1MB/s pane output; zombie A pins the buffer, "
            f"B drained continuously; server RSS start {rss0} kB")
        for i in range(70):
            time.sleep(0.5)
            b_bytes += pump(masterB)
            if i % 10 == 9:
                log(f"  t+{(i+1)//2:2d}s server RSS={rss_kb(server)} kB, "
                    f"B received {b_bytes//1024} kB total")
        outside(tmux, "send-keys", "-t", "wedge", "C-c", timeout=5)
        delta = rss_kb(server) - rss0
        rc, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"VERDICT: server RSS delta {delta} kB over 35s of ~1MB/s pane "
            f"output with a healthy observer attached (B got "
            f"{b_bytes//1024} kB, probe rc={rc}) — "
            + ("UNBOUNDED GROWTH (zombie pins pane buffer)"
               if delta > 15000 else "bounded"))
        cleanup(tmux, server, client)
        if clientB is not None:
            try:
                os.kill(clientB.pid, signal.SIGKILL)
            except OSError:
                pass
        sys.exit(0)

    # Park the server: queue a BURST of notification bytes to the zombie
    # control client while the tty is full, then free a sliver of room so
    # poll fires with chunk > room on the now-blocking fd.
    log("parking phase: notification bursts + 64-byte trickles")
    parked = False
    for rnd in range(20):
        rc = 0
        for i in range(40):
            rc, _, _ = outside(tmux, "rename-window", "-t", "wedge:0",
                               f"w{rnd}x{i}", timeout=2)
            if rc == "TIMEOUT":
                break
        if rc == "TIMEOUT":
            log(f"outside command TIMEOUT at round {rnd} — server unresponsive")
            parked = True
            break
        trickle(master, 64)
        time.sleep(0.3)
        w = wchan(server)
        if w == "wait_woken":
            log(f"*** PARKED at round {rnd}: server wchan=wait_woken")
            parked = True
            break

    # Verdict.
    w = wchan(server)
    sc = syscall_of(server)
    rc, _, _ = outside(tmux, "list-sessions", timeout=3)
    log(f"server wchan={w}")
    log(f"server syscall={sc[:80]}")
    log(f"probe 'tmux -L {SOCK} ls' -> rc={rc}")
    stack = subprocess.run(["sudo", "-n", "cat", f"/proc/{server}/stack"],
                           capture_output=True, text=True).stdout
    log("server kernel stack:\n" + stack)
    if w == "wait_woken" and "n_tty_write" in stack and rc == "TIMEOUT":
        log("VERDICT: WEDGE REPRODUCED — server parked in n_tty_write, "
            "all commands hang")
        code = 0
    else:
        log(f"VERDICT: NOT WEDGED — O_NONBLOCK flip occurred but the server "
            f"never parked and stayed responsive (probe rc={rc})")
        code = 3

    cleanup(tmux, server, client)
    sys.exit(code)

def cleanup(tmux, server, client):
    log("cleanup: killing test server and client")
    for pid in (server, client.pid):
        try:
            os.kill(pid, signal.SIGKILL)
        except (OSError, TypeError):
            pass
    # Reap pane shells left behind (children of the dead server die with it).

if __name__ == "__main__":
    main()
```
</details>

## What the patch changes

- stdin/stdout/stderr stay non-blocking through the whole exit sequence (exit message, `%exit`, `wait-exit`, final `ESC \`) and blocking is restored **once, as the last thing** before `client_main()` returns, for all client types.
- In the normal attached flow nothing changes: the server has already restored blocking via its own dup in `tty_stop_tty()` before sending `MSG_EXITED`, so the `[detached]` message is printed on a blocking fd exactly as today (verified). What changes is asynchronous exits — a client leaving while the server may still be writing (SIGTERM, dead server, the control eviction above) can no longer flip the description mid-write, for control and non-control clients alike.
- The `wait-exit` linger lives in a new `control_wait_exit()` helper in control.c using `poll()` + `evbuffer_read`/`evbuffer_readln` on the raw fd (no stdio — see review discussion below), draining every buffered line before polling again. A regress test (`regress/control-client-wait-exit.sh`) pins the buffered-line case.
- Final messages written on a non-blocking fd are indistinguishable on a healthy terminal (verified for `[detached]` and `[server exited unexpectedly]`); on a dead, full tty the client now drops the message and exits instead of blocking for weeks (we found clients parked in this printf for 22 days, and in the wait-exit `getline()` for 30).

## Related

- #4980 — the crash that fires when a wedged server is later un-wedged (same incident).
- #5357 hardens the server side of the same incident: stop queueing output/notifications to clients already marked `CLIENT_EXIT`. Either change alone prevents the wedge (both verified with the reproducer); this one removes the cause — the flip — and that one removes the ammunition.
