### PR TITLE
control: stop queueing output and notifications to exiting clients

### DIFF
--- a/control-notify.c
+++ b/control-notify.c
@@ -25,6 +25,7 @@
 
 #define CONTROL_SHOULD_NOTIFY_CLIENT(c) \
 	((c) != NULL && ((c)->flags & CLIENT_CONTROL) && \
+	 (~(c)->flags & CLIENT_EXIT) && \
 	 (c)->control_state != NULL)
 
 void

--- a/control.c
+++ b/control.c
@@ -481,7 +481,7 @@ control_write_output(struct client *c, struct window_pane *wp)
 	if (winlink_find_by_window(&c->session->windows, wp->window) == NULL)
 		return;
 
-	if (c->flags & CONTROL_IGNORE_FLAGS) {
+	if (c->flags & (CONTROL_IGNORE_FLAGS|CLIENT_EXIT)) {
 		cp = control_get_pane(c, wp);
 		if (cp != NULL)
 			goto ignore;


### PR DESCRIPTION
## TL;DR

Once a control (`-CC`) client is marked `CLIENT_EXIT` — evicted as `"too far behind"` by `control_check_age()`, or told to go by `detach-client` — the server still queues **new** work for it:

- `CONTROL_SHOULD_NOTIFY_CLIENT()` checks only `CLIENT_CONTROL` and `control_state`, so every notification keeps being formatted and queued for a client that is already being evicted for not consuming data;
- `control_write_output()` keeps creating `%output` blocks for it until the exit handshake completes.

None of it is ever meaningfully consumed: the exit handshake only waits for blocks that were *already* queued (`control_all_done()`), and after `CLIENT_EXITED` is set, `server_client_check_exit()` returns early so even `control_discard()` never runs again.

Queueing that data is not just pointless work — it is what the server later `writev()`s to the dying client's tty. In the incident behind #5356, that tty's file description had been switched to blocking under the server's feet, and the write of exactly these queued notification bytes parked the single-threaded server inside the kernel (`n_tty_write`) forever, hanging every session and every future tmux command.

This PR stops queueing for exiting clients: pane output takes the existing `ignore` path (consuming pane offsets the way `no-output` clients do), and the notify macro excludes `CLIENT_EXIT`. Two lines. Either this or #5356 alone prevents the wedge — both were verified independently with the reproducer below — but each stands on its own.

## Why a client can linger long after CLIENT_EXIT

The exit handshake is asynchronous and the window can be arbitrarily long:

- `server_client_check_exit()` sends `MSG_EXIT` only after already-queued output drains to the tty (`control_all_done()`) — on a slow terminal that alone takes a while;
- after `MSG_EXIT`, a `wait-exit` client deliberately lingers (reading stdin until EOF) with its socket open, so the server keeps the `struct client` and its tty fds;
- if the client's terminal is dead (the scenario that triggers `"too far behind"` eviction in the first place), the client can additionally block forever in its final `%exit` write. In the production incident behind #5356 we found such zombie clients 22 and 30 days old.

During that entire window, master keeps formatting and queueing notifications for the doomed client.

## Evidence

Reproducer (script below), `--mode age`, on the full wedge scenario from #5356. This PR does **not** touch client.c, so the client-side O_NONBLOCK flip on the shared tty file description still happens — the difference is purely whether the server has queued bytes to write afterwards:

| binary | outcome |
|---|---|
| master (next-3.7) | **WEDGED** — after the flip, `%window-renamed` notifications queue for the zombie; on the next partial tty writability the server `writev()`s them to the blocking fd and parks in `n_tty_write` (t=337 s). Every tmux command hangs. |
| master + this PR | **NOT WEDGED** — the flip still occurs, but nothing new is queued for the exiting client, the server never writes to the blocking fd, and it stays responsive throughout (verified for 20 notification-burst rounds). |

The park in the vanilla run happens *during the notification bursts*, on the zombie's tty fd — the queued notifications are demonstrably the ammunition:

<details><summary>vanilla master: wedge log (excerpt)</summary>

```
[ 307.40]   aging... 300s, client wchan=do_sys_poll, server wchan=do_sys_poll
[ 326.61] *** FLIP: client fd0 O_NONBLOCK cleared (client.c:411-413 epilogue ran); drained 6144b total
[ 326.61] tty tail: ...'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n%output %0 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
[ 326.61]   server fd 5 O_NONBLOCK=False  <- shared description
[ 326.61] client wchan=wait_woken syscall=0 0x0 0x5140e0 0x400 0x800000 0x0 0x0 0x7fff27294e88 0x7f445
[ 326.61] parking phase: notification bursts + 64-byte trickles
[ 334.15] outside command TIMEOUT at round 15 — server unresponsive
[ 337.16] server wchan=wait_woken
[ 337.16] server syscall=20 0x5 0x7fff27294400 0x1 0x7f44526c9080 0x1 0x0 0x7fff272943f8 0x7f4452304f17
[ 337.16] probe 'tmux -L wedgevan ls' -> rc=TIMEOUT
[ 337.17] server kernel stack:
[<0>] wait_woken+0x33/0x50
[<0>] n_tty_write+0x402/0x460
[<0>] file_tty_write+0x11e/0x330
[<0>] do_iter_readv_writev+0x7a/0x1c0
[<0>] vfs_writev+0xc9/0x230
[<0>] do_writev+0x5e/0xe0
[<0>] do_syscall_64+0x68/0x130
[<0>] entry_SYSCALL_64_after_hwframe+0x4b/0x53

[ 337.17] VERDICT: WEDGE REPRODUCED — server parked in n_tty_write, all commands hang
```
</details>

<details><summary>master + this PR: same scenario, no wedge (excerpt)</summary>

```
[ 307.50]   aging... 300s, client wchan=do_sys_poll, server wchan=do_sys_poll
[ 326.61] *** FLIP: client fd0 O_NONBLOCK cleared (client.c:411-413 epilogue ran); drained 4096b total
[ 326.61] tty tail: ...'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\r\n%output %0 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
[ 326.61]   server fd 5 O_NONBLOCK=False  <- shared description
[ 326.61] client wchan=wait_woken syscall=0 0x0 0x514280 0x400 0x1000000 0x0 0x0 0x7fffebeae3b8 0x7fc9
[ 326.61] parking phase: notification bursts + 64-byte trickles
[ 334.04] server wchan=do_sys_poll
[ 334.04] server syscall=7 0x529340 0x4 0x2b4b 0x7fc9193b1c20 0x7fffebeae280 0x7fc9196cad20 0x7fffebeae20
[ 334.04] probe 'tmux -L wcontrolfix ls' -> rc=0
[ 334.05] server kernel stack:
[<0>] do_sys_poll+0x4b9/0x890
[<0>] __se_sys_poll+0x2d/0x120
[<0>] do_syscall_64+0x68/0x130
[<0>] entry_SYSCALL_64_after_hwframe+0x4b/0x53

[ 334.05] VERDICT: NOT WEDGED — O_NONBLOCK flip occurred but the server never parked and stayed responsive (probe rc=0)
```
</details>

<details><summary>rig.py (full reproducer)</summary>

```python
#!/usr/bin/env python3
"""Reproduce the tmux -CC server wedge (server parked in n_tty_write).

Simulates a dying EternalTerminal: holds the pty master open, reads on a
controllable schedule, stalls, then lets tmux's own client-exit path flip
O_NONBLOCK off on the shared tty file description and park the server.

Usage: rig.py [--mode detach|age] [--tmux /path/to/tmux]
  detach: trigger client exit via detach-client (fast, seconds)
  age:    wait for control_check_age "too far behind" (authentic, ~5.5 min)
"""
import argparse
import os
import pty
import select
import signal
import subprocess
import sys
import time

SOCK = "wedgetest"  # overridden by --sock

t0 = time.time()
def log(msg):
    print(f"[{time.time()-t0:7.2f}] {msg}", flush=True)

def outside(tmux, *args, timeout=3):
    """Run a tmux command from outside against the test server."""
    try:
        r = subprocess.run([tmux, "-L", SOCK, *args],
                           capture_output=True, text=True, timeout=timeout)
        return r.returncode, r.stdout.strip(), r.stderr.strip()
    except subprocess.TimeoutExpired:
        return "TIMEOUT", "", ""

def fd_flags(pid, fd):
    try:
        with open(f"/proc/{pid}/fdinfo/{fd}") as f:
            for line in f:
                if line.startswith("flags"):
                    return line.split()[1]
    except OSError:
        return None

def nonblock(pid, fd):
    fl = fd_flags(pid, fd)
    return None if fl is None else bool(int(fl, 8) & 0o4000)

def rss_kb(pid):
    try:
        with open(f"/proc/{pid}/status") as f:
            for line in f:
                if line.startswith("VmRSS"):
                    return int(line.split()[1])
    except OSError:
        return -1

def wchan(pid):
    try:
        with open(f"/proc/{pid}/wchan") as f:
            return f.read().strip()
    except OSError:
        return "?"

def syscall_of(pid):
    try:
        with open(f"/proc/{pid}/syscall") as f:
            return f.read().strip()
    except OSError:
        return "?"

def pts_fds(pid, pts):
    fds = []
    try:
        for fd in os.listdir(f"/proc/{pid}/fd"):
            try:
                if os.readlink(f"/proc/{pid}/fd/{fd}") == pts:
                    fds.append(int(fd))
            except OSError:
                pass
    except OSError:
        pass
    return sorted(fds)

def find_server_pid(tmux):
    # The server is the process listening on the socket; ask ss.
    out = subprocess.run(["ss", "-xlp"], capture_output=True, text=True).stdout
    for line in out.splitlines():
        if f"tmux-{os.getuid()}/{SOCK}" in line and "pid=" in line:
            return int(line.split("pid=")[1].split(",")[0])
    return None

def drain(master, seconds, chunk=65536, label="drain"):
    end = time.time() + seconds
    total = 0
    while time.time() < end:
        r, _, _ = select.select([master], [], [], 0.1)
        if r:
            try:
                total += len(os.read(master, chunk))
            except OSError:
                break
    log(f"{label}: read {total} bytes over {seconds}s")
    return total

def trickle(master, nbytes):
    """Read a tiny amount: frees partial tty-buffer room, like a dying reader."""
    r, _, _ = select.select([master], [], [], 0.1)
    if not r:
        return 0
    try:
        return len(os.read(master, nbytes))
    except OSError:
        return 0

def pump(master, cap=4 * 1024 * 1024):
    """Drain everything currently available (a healthy, keeping-up reader)."""
    total = 0
    while total < cap:
        r, _, _ = select.select([master], [], [], 0)
        if not r:
            break
        try:
            data = os.read(master, 65536)
        except OSError:
            break
        if not data:
            break
        total += len(data)
    return total

def main():
    global SOCK
    ap = argparse.ArgumentParser()
    ap.add_argument("--mode", choices=["detach", "age", "leak"], default="detach")
    ap.add_argument("--tmux", default="/usr/bin/tmux")
    ap.add_argument("--sock", default="wedgetest")
    args = ap.parse_args()
    tmux = args.tmux
    SOCK = args.sock

    outside(tmux, "kill-server", timeout=5)  # clean slate on the test socket

    master, slave = pty.openpty()
    pts = os.ttyname(slave)
    log(f"pty: master fd {master}, slave {pts}")

    client = subprocess.Popen(
        [tmux, "-f", "/dev/null", "-L", SOCK, "-CC", "new", "-A", "-s", "wedge"],
        stdin=slave, stdout=slave, stderr=slave, start_new_session=True)
    os.close(slave)
    log(f"client pid {client.pid}")

    # Healthy phase: drain the control stream, find the server.
    drain(master, 1.5, label="healthy drain")
    server = find_server_pid(tmux)
    if server is None:
        log("FATAL: no server found"); sys.exit(1)
    sfds = pts_fds(server, pts)
    log(f"server pid {server}, fds on {pts}: {sfds}")
    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}")
    log(f"client fd0 O_NONBLOCK={nonblock(client.pid, 0)}")

    # Ask for wait-exit like ET does (via the control client's own stdin).
    os.write(master, b"refresh-client -f wait-exit\n")
    drain(master, 0.5, label="post-refresh drain")
    rc, out, err = outside(tmux, "list-clients", "-F",
                           "#{client_name} [#{client_flags}]")
    log(f"clients: {out or err} (rc={rc})")
    client_name = out.split()[0] if out else None

    # Leak mode adds a second, healthy control client B on the same session.
    # It keeps pane reads enabled while zombie A pins the drain offset.
    masterB = None
    clientB = None
    if args.mode == "leak":
        masterB, slaveB = pty.openpty()
        clientB = subprocess.Popen(
            [tmux, "-f", "/dev/null", "-L", SOCK, "-CC", "new", "-A",
             "-s", "wedge"],
            stdin=slaveB, stdout=slaveB, stderr=slaveB, start_new_session=True)
        os.close(slaveB)
        drain(masterB, 1.0, label="observer B initial drain")
        # no-output: B keeps pane reads enabled but tracks no pane offsets,
        # so the only offset that can pin the pane buffer is zombie A's.
        os.write(masterB, b"refresh-client -f no-output\n")
        drain(masterB, 0.5, label="observer B post-refresh drain")
        log(f"healthy no-output observer client B pid {clientB.pid}")

    # Flood: pane output builds control %output volume. Full speed for the
    # fast detach mode; throttled (~10KB/s) for age mode so 300s of backlog
    # stays small while blocks still age past CONTROL_MAXIMUM_AGE.
    if args.mode == "detach":
        flood = "yes wedge-payload"
    else:  # age and leak both need the slow flood during the aging window
        flood = 'while :; do head -c 2000 /dev/zero | tr "\\0" x; sleep 0.2; done'
    outside(tmux, "send-keys", "-t", "wedge", flood, "Enter")
    drain(master, 1.0, label="flood drain")

    # STALL: stop reading. Kernel tty buffer fills, server backlog grows.
    log("STALL: reader stops (ET link dead)")
    time.sleep(3)
    log(f"server wchan={wchan(server)} (expect healthy poll)")
    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}")

    if args.mode == "detach":
        log(f"trigger: detach-client -t {client_name}")
        rc, out, err = outside(tmux, "detach-client", "-t", client_name)
        log(f"detach rc={rc} {err}")
    else:
        log("trigger: aging blocks past CONTROL_MAXIMUM_AGE (300s), "
            "no reads from A" + (", B kept drained" if masterB else ""))
        for i in range(320):
            time.sleep(1)
            if masterB is not None:
                pump(masterB)
            if nonblock(client.pid, 0) is False:
                log(f"  flip already observed during aging at {i}s")
                break
            if i % 30 == 0:
                log(f"  aging... {i}s, client wchan={wchan(client.pid)}, "
                    f"server wchan={wchan(server)}")
            if wchan(server) == "wait_woken":
                log(f"  server parked during aging at {i}s")
                break

    # Watch for the O_NONBLOCK flip on the shared description. Drain at a
    # moderate rate (a dying-but-not-dead reader) so control_all_done can
    # complete and MSG_EXIT can reach the client.
    flipped = None
    drained = 0
    tail = bytearray()
    deadline = time.time() + 120
    last_report = time.time()
    while time.time() < deadline:
        r, _, _ = select.select([master], [], [], 0.1)
        if r:
            try:
                chunk = os.read(master, 2048)
                drained += len(chunk)
                tail.extend(chunk)
                del tail[:-300]
            except OSError:
                pass
        if masterB is not None:
            pump(masterB)
        nb = nonblock(client.pid, 0)
        if nb is False:
            flipped = time.time()
            log(f"*** FLIP: client fd0 O_NONBLOCK cleared "
                f"(client.c:411-413 epilogue ran); drained {drained}b total")
            break
        if time.time() - last_report > 5:
            log(f"  waiting for flip... drained {drained}b, "
                f"client wchan={wchan(client.pid)}")
            last_report = time.time()
        time.sleep(0.1)
    # A little more drain so the client's %exit line reaches us.
    drained += trickle(master, 4096)
    tail_txt = bytes(tail[-300:]).decode("utf-8", "replace")
    log(f"tty tail: ...{tail_txt[-160:]!r}")
    if flipped is None:
        rc, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"no flip observed; server wchan={wchan(server)}, probe rc={rc}")
        # End the wait-exit linger and let the (fixed) epilogue finish.
        try:
            os.write(master, b"\n")
        except OSError:
            pass
        drain(master, 2.0, label="post-linger drain")
        time.sleep(1)
        rc2, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"after ending linger: client alive={client.poll() is None}, "
            f"server wchan={wchan(server)}, probe rc={rc2}")
        if rc == 0 and rc2 == 0:
            log("VERDICT: NO FLIP while server in use, server healthy "
                "(expected outcome for fixed client)")
            cleanup(tmux, server, client)
            sys.exit(2)
        log("VERDICT: no flip but server unhealthy — investigate")
        cleanup(tmux, server, client)
        sys.exit(4)

    for fd in sfds:
        log(f"  server fd {fd} O_NONBLOCK={nonblock(server, fd)}  <- shared description")
    log(f"client wchan={wchan(client.pid)} syscall={syscall_of(client.pid)[:60]}")

    if args.mode == "leak":
        # Zombie A is now CLIENT_EXITED, session-attached, socket open. Its
        # frozen pane offset pins server_client_check_pane_buffer's
        # `minimum`, so the pane input evbuffer cannot be drained past it —
        # while healthy observer B keeps pane reads ENABLED. Run the pane
        # at ~1MB/s, keep draining B, and watch the server's RSS.
        outside(tmux, "send-keys", "-t", "wedge", "C-c")
        time.sleep(0.5)
        outside(tmux, "send-keys", "-t", "wedge",
                'while :; do head -c 100000 /dev/zero | tr "\\0" x; '
                'sleep 0.1; done', "Enter")
        rss0 = rss_kb(server)
        b_bytes = 0
        log(f"leak phase: ~1MB/s pane output; zombie A pins the buffer, "
            f"B drained continuously; server RSS start {rss0} kB")
        for i in range(70):
            time.sleep(0.5)
            b_bytes += pump(masterB)
            if i % 10 == 9:
                log(f"  t+{(i+1)//2:2d}s server RSS={rss_kb(server)} kB, "
                    f"B received {b_bytes//1024} kB total")
        outside(tmux, "send-keys", "-t", "wedge", "C-c", timeout=5)
        delta = rss_kb(server) - rss0
        rc, _, _ = outside(tmux, "list-sessions", timeout=3)
        log(f"VERDICT: server RSS delta {delta} kB over 35s of ~1MB/s pane "
            f"output with a healthy observer attached (B got "
            f"{b_bytes//1024} kB, probe rc={rc}) — "
            + ("UNBOUNDED GROWTH (zombie pins pane buffer)"
               if delta > 15000 else "bounded"))
        cleanup(tmux, server, client)
        if clientB is not None:
            try:
                os.kill(clientB.pid, signal.SIGKILL)
            except OSError:
                pass
        sys.exit(0)

    # Park the server: queue a BURST of notification bytes to the zombie
    # control client while the tty is full, then free a sliver of room so
    # poll fires with chunk > room on the now-blocking fd.
    log("parking phase: notification bursts + 64-byte trickles")
    parked = False
    for rnd in range(20):
        rc = 0
        for i in range(40):
            rc, _, _ = outside(tmux, "rename-window", "-t", "wedge:0",
                               f"w{rnd}x{i}", timeout=2)
            if rc == "TIMEOUT":
                break
        if rc == "TIMEOUT":
            log(f"outside command TIMEOUT at round {rnd} — server unresponsive")
            parked = True
            break
        trickle(master, 64)
        time.sleep(0.3)
        w = wchan(server)
        if w == "wait_woken":
            log(f"*** PARKED at round {rnd}: server wchan=wait_woken")
            parked = True
            break

    # Verdict.
    w = wchan(server)
    sc = syscall_of(server)
    rc, _, _ = outside(tmux, "list-sessions", timeout=3)
    log(f"server wchan={w}")
    log(f"server syscall={sc[:80]}")
    log(f"probe 'tmux -L {SOCK} ls' -> rc={rc}")
    stack = subprocess.run(["sudo", "-n", "cat", f"/proc/{server}/stack"],
                           capture_output=True, text=True).stdout
    log("server kernel stack:\n" + stack)
    if w == "wait_woken" and "n_tty_write" in stack and rc == "TIMEOUT":
        log("VERDICT: WEDGE REPRODUCED — server parked in n_tty_write, "
            "all commands hang")
        code = 0
    else:
        log(f"VERDICT: NOT WEDGED — O_NONBLOCK flip occurred but the server "
            f"never parked and stayed responsive (probe rc={rc})")
        code = 3

    cleanup(tmux, server, client)
    sys.exit(code)

def cleanup(tmux, server, client):
    log("cleanup: killing test server and client")
    for pid in (server, client.pid):
        try:
            os.kill(pid, signal.SIGKILL)
        except (OSError, TypeError):
            pass
    # Reap pane shells left behind (children of the dead server die with it).

if __name__ == "__main__":
    main()
```
</details>

## Relationship to #5356

Two halves of the same production incident, fixed independently. That PR removes the *cause* of the blocking write — the client's mid-exit `O_NONBLOCK` flip reaching the server through the shared file description. This PR removes the *ammunition* — bytes queued for a client that is already leaving. Defense in depth: the flip can in principle come from other sources too (anything sharing the description can change its flags), and with this PR the server has nothing pending to write to such a client once it is on the way out.
