### PR TITLE
fix(xmalloc): add overflow check to xcalloc

### DIFF
--- a/xmalloc.c
+++ b/xmalloc.c
@@ -44,6 +44,8 @@ xcalloc(size_t nmemb, size_t size)
 
 	if (size == 0 || nmemb == 0)
 		fatalx("xcalloc: zero size");
+	if (nmemb > SIZE_MAX / size)
+		fatalx("xcalloc: overflow: %zu * %zu", nmemb, size);
 	ptr = calloc(nmemb, size);
 	if (ptr == NULL)
 		fatalx("xcalloc: allocating %zu * %zu bytes: %s",


### PR DESCRIPTION
xcalloc() wraps calloc() but does not validate that nmemb * size fits in size_t before calling calloc().  Every other allocation wrapper in xmalloc.c already performs this check (xreallocarray delegates to reallocarray which checks internally).

Add nmemb > SIZE_MAX / size before calloc(), matching the pattern used by the compat reallocarray and recallocarray implementations.