### PR TITLE
Redraw only dirty lines when synchronized update ends

### DIFF
--- a/input.c
+++ b/input.c
@@ -1955,8 +1955,6 @@ input_csi_dispatch_rm_private(struct input_ctx *ictx)
 			break;
 		case 2026:
 			screen_write_stop_sync(ictx->wp);
-			if (ictx->wp != NULL)
-				ictx->wp->flags |= PANE_REDRAW;
 			break;
 		case 2031:
 			screen_write_mode_clear(sctx, MODE_THEME_UPDATES);

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1324,6 +1324,7 @@ screen_redraw_draw_pane(struct screen_redraw_ctx *ctx, struct window_pane *wp)
 
 	if (wp->base.mode & MODE_SYNC)
 		screen_write_stop_sync(wp);
+	screen_write_clear_dirty(wp);
 
 	log_debug("%s: %s @%u %%%u", __func__, c->name, w->id, wp->id);
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -38,6 +38,8 @@ static int	screen_write_overwrite(struct screen_write_ctx *,
 		    struct grid_cell *, u_int);
 static int	screen_write_combine(struct screen_write_ctx *,
 		    const struct grid_cell *);
+static void	screen_write_redraw_line(struct screen_write_ctx *,
+		    struct tty_ctx *, u_int);
 
 struct screen_write_citem {
 	u_int				x;
@@ -958,6 +960,73 @@ screen_write_mode_clear(struct screen_write_ctx *ctx, int mode)
 		log_debug("%s: %s", __func__, screen_mode_to_string(mode));
 }
 
+/* Mark lines dirty during sync mode so they can be redrawn when it ends. */
+static void
+screen_write_sync_dirty_lines(struct screen_write_ctx *ctx, u_int y, u_int ny)
+{
+	struct window_pane	*wp = ctx->wp;
+	struct screen		*s = ctx->s;
+	u_int			 sy = screen_size_y(s);
+	bitstr_t		*bs;
+
+	if (wp == NULL || y >= sy || ny == 0)
+		return;
+	bs = wp->sync_dirty;
+	if (ny > sy - y)
+		ny = sy - y;
+	if (bs == NULL || wp->sync_dirty_size != sy) {
+		if (bs != NULL && wp->sync_dirty_size != sy) {
+			y = 0;
+			ny = sy;
+		}
+		free(bs);
+
+		bs = wp->sync_dirty = bit_alloc(sy);
+		if (bs == NULL)
+			fatal("bit_alloc failed");
+		wp->sync_dirty_size = sy;
+	}
+	bit_nset(bs, y, y + ny - 1);
+}
+
+/* Redraw dirty lines. */
+static void
+screen_write_flush_dirty(struct window_pane *wp)
+{
+	struct screen_write_ctx	 ctx;
+	struct tty_ctx		 ttyctx;
+	struct screen		*s = &wp->base;
+	u_int			 y, sy = screen_size_y(s), lines = 0;
+
+	if (wp->sync_dirty == NULL)
+		return;
+
+	screen_write_start_pane(&ctx, wp, s);
+	screen_write_initctx(&ctx, &ttyctx, 1, 1);
+
+	for (y = 0; y < sy; y++) {
+		if (y < wp->sync_dirty_size && bit_test(wp->sync_dirty, y)) {
+			screen_write_redraw_line(&ctx, &ttyctx, y);
+			lines++;
+		}
+	}
+	log_debug("%s: %%%u had %u dirty lines", __func__, wp->id, lines);
+
+	screen_write_stop(&ctx);
+	screen_write_clear_dirty(wp);
+}
+
+/* Clear any dirty lines. */
+void
+screen_write_clear_dirty(struct window_pane *wp)
+{
+	if (wp != NULL && wp->sync_dirty != NULL) {
+		free(wp->sync_dirty);
+		wp->sync_dirty = NULL;
+		wp->sync_dirty_size = 0;
+	}
+}
+
 /* Sync timeout callback. */
 static void
 screen_write_sync_callback(__unused int fd, __unused short events, void *arg)
@@ -969,7 +1038,7 @@ screen_write_sync_callback(__unused int fd, __unused short events, void *arg)
 
 	if (wp->base.mode & MODE_SYNC) {
 		wp->base.mode &= ~MODE_SYNC;
-		wp->flags |= PANE_REDRAW;
+		screen_write_flush_dirty(wp);
 	}
 }
 
@@ -1000,6 +1069,8 @@ screen_write_stop_sync(struct window_pane *wp)
 	if (event_initialized(&wp->sync_timer))
 		evtimer_del(&wp->sync_timer);
 	wp->base.mode &= ~MODE_SYNC;
+
+	screen_write_flush_dirty(wp);
 
 	log_debug("%s: %%%u stopped sync mode", __func__, wp->id);
 }
@@ -1154,8 +1225,10 @@ screen_write_redraw_line(struct screen_write_ctx *ctx, struct tty_ctx *ttyctx,
 	struct visible_ranges	*r;
 	struct visible_range	*ri;
 
-	if (s->mode & MODE_SYNC)
+	if (s->mode & MODE_SYNC) {
+		screen_write_sync_dirty_lines(ctx, yy, 1);
 		return;
+	}
 
 	r = screen_redraw_get_visible_ranges(wp, xoff, yoff + yy, sx, NULL);
 	for (i = 0; i < r->used; i++) {
@@ -2265,8 +2338,18 @@ screen_write_collect_flush(struct screen_write_ctx *ctx, int scroll_only,
 	struct screen_write_citem	*ci, *tmp;
 	struct screen_write_cline	*cl;
 
-	if (s->mode & MODE_SYNC)
+	if (s->mode & MODE_SYNC) {
+		if (ctx->scrolled != 0) {
+			screen_write_sync_dirty_lines(ctx, s->rupper,
+			    s->rlower + 1 - s->rupper);
+		}
+		for (y = 0; y < screen_size_y(s); y++) {
+			cl = &s->write_list[y];
+			if (!TAILQ_EMPTY(&cl->items))
+				screen_write_sync_dirty_lines(ctx, y, 1);
+		}
 		goto discard;
+	}
 
 	if (ctx->scrolled != 0) {
 		if (!screen_write_collect_flush_scrolled(ctx))
@@ -2609,8 +2692,12 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	}
 
 	/* If not writing, done now. */
-	if (skip || s->mode & MODE_SYNC)
+	if (skip)
 		return;
+	if (s->mode & MODE_SYNC) {
+		screen_write_sync_dirty_lines(ctx, s->cy, 1);
+		return;
+	}
 
 	/* Do a full line redraw if needed. */
 	if (redraw && wp != NULL) {

--- a/tmux.h
+++ b/tmux.h
@@ -1305,6 +1305,9 @@ struct window_pane {
 	struct event	 resize_timer;
 	struct event	 sync_timer;
 
+	bitstr_t	*sync_dirty;
+	u_int		 sync_dirty_size;
+
 	struct input_ctx *ictx;
 
 	struct grid_cell cached_gc;
@@ -3321,6 +3324,7 @@ void	 screen_write_mode_set(struct screen_write_ctx *, int);
 void	 screen_write_mode_clear(struct screen_write_ctx *, int);
 void	 screen_write_start_sync(struct window_pane *);
 void	 screen_write_stop_sync(struct window_pane *);
+void	 screen_write_clear_dirty(struct window_pane *);
 void	 screen_write_cursorup(struct screen_write_ctx *, u_int);
 void	 screen_write_cursordown(struct screen_write_ctx *, u_int);
 void	 screen_write_cursorright(struct screen_write_ctx *, u_int);

--- a/window.c
+++ b/window.c
@@ -1093,6 +1093,7 @@ window_pane_destroy(struct window_pane *wp)
 	struct window_pane_resize	*r1;
 
 	window_pane_reset_mode_all(wp);
+	screen_write_clear_dirty(wp);
 	free(wp->searchstr);
 
 	if (wp->fd != -1) {


### PR DESCRIPTION
### Problem

On the `release_3.7c` branch (and released 3.7b), ending a synchronized update (`DECRST 2026`) sets `PANE_REDRAW`, repainting the whole pane (added in e802909d as the fix for #5304). The full repaint erases any passthrough content drawn over the pane: with `allow-passthrough on`, a sixel image sent by yazi appears for a fraction of a second and is then wiped by the repaint. This is the "image flashes and disappears" behaviour mentioned as a side note in #5126.

Bisect on my machine confirms 3.7a works and 3.7b does not, and the regressing change is exactly the `PANE_REDRAW` added in the 2026 case of `input_csi_dispatch_rm_private()`.

Simply reverting those two lines is not enough: that brings back the #5304 corruption (verified with `nvim --clean` + scrolling - output stays stale because tty output is suppressed while `MODE_SYNC` is set).

### Fix

Port the approach from master (565db46a and d33d5b7d) to this branch: while a pane is in sync mode, record which lines are actually written at the three places that suppress tty output during `MODE_SYNC` (`screen_write_redraw_line`, `screen_write_collect_flush`, `screen_write_cell`), plus the whole scroll region if there was any scrolling. When sync ends, redraw only those dirty lines instead of the entire pane. Lines never touched during the sync block - such as those covered by a passthrough image - are left alone.

### Testing

Built with `--enable-sixel`, tested on foot 1.27 / Arch Linux:

* yazi image preview inside tmux: image now persists (before: flashed once and disappeared)
* `nvim --clean cfg.c` + `C-d` scrolling (the #5304 reproduction): renders correctly, no stale content
* smoke: scrollback, horizontal split, alternate screen enter/exit all behave as before

Refs #5126, #5304.
