### PR TITLE
RFC: resynchronise control mode clients that fall behind, instead of pausing or killing them

### DIFF
--- a/control.c
+++ b/control.c
@@ -30,27 +30,44 @@
 #include "tmux.h"
 
 /*
- * Block of data to output. Each client has one "all" queue of blocks and
- * another queue for each pane (in struct client_offset). %output blocks are
- * added to both queues and other output lines (notifications) added only to
- * the client queue.
- *
- * When a client becomes writeable, data from blocks on the pane queue are sent
- * up to the maximum size (CLIENT_BUFFER_HIGH). If a block is entirely written,
- * it is removed from both pane and client queues and if this means non-%output
- * blocks are now at the head of the client queue, they are written.
- *
- * This means a %output block holds up any subsequent non-%output blocks until
- * it is written which enforces ordering even if the client cannot accept the
- * entire block in one go.
+ * A queued block of output. Each client has one "all" queue and a per-pane
+ * queue; a block on both holds up any later block until it is written, which
+ * keeps output ordered against notifications. LINE is a verbatim notification
+ * line; PANE is pane output of size bytes read at cp->offset; REPAINT is a
+ * resync repaint, rendered lazily into its own buffer when the drain loop first
+ * reaches it and escaped from there.
  */
+enum control_block_type {
+	CONTROL_BLOCK_LINE,
+	CONTROL_BLOCK_PANE,
+	CONTROL_BLOCK_REPAINT
+};
 struct control_block {
-	size_t				 size;
-	char				*line;
+	enum control_block_type		 type;
 	uint64_t			 t;
+
+	size_t				 size;		/* PANE */
+	char				*line;		/* LINE */
+	struct evbuffer			*repaint;	/* REPAINT */
+
+	/* History sequence when a PANE block was created (resync watermark). */
+	struct grid_history_state	 history;
 
 	TAILQ_ENTRY(control_block)	 entry;
 	TAILQ_ENTRY(control_block)	 all_entry;
+};
+
+/*
+ * Exclusive pane state. ON streams normally; OFF is disabled and holds the
+ * pane read gate; PAUSED has been paused with %pause; RESYNC has discarded its
+ * backlog and owes a repaint (queued as a REPAINT block) while it keeps running
+ * with its output discarded.
+ */
+enum control_pane_state {
+	CONTROL_PANE_ON,
+	CONTROL_PANE_OFF,
+	CONTROL_PANE_PAUSED,
+	CONTROL_PANE_RESYNC
 };
 
 /* Control client pane. */
@@ -65,9 +82,15 @@ struct control_pane {
 	struct window_pane_offset	 offset;
 	struct window_pane_offset	 queued;
 
-	int				 flags;
-#define CONTROL_PANE_OFF 0x1
-#define CONTROL_PANE_PAUSED 0x2
+	enum control_pane_state		 state;
+
+	/*
+	 * History sequence and pane width when the client fell behind, used to
+	 * bound the RESYNC scrollback replay; a discontinuity or width change
+	 * degrades it to a repaint only.
+	 */
+	struct grid_history_state	 resync_state;
+	u_int				 resync_sx;
 
 	int				 pending_flag;
 	TAILQ_ENTRY(control_pane)	 pending_entry;
@@ -91,6 +114,15 @@ struct control_state {
 	struct bufferevent		*write_event;
 
 	struct monitor_set		*subs;
+
+	/*
+	 * Output watchdog. resync_last_progress is stamped whenever the write
+	 * buffer actually drains; the timer recovers panes that make no progress
+	 * for too long, the case where both the pane-read and socket-write paths
+	 * are stalled and no other callback fires. See control_client_stalled.
+	 */
+	struct event			 output_timer;
+	uint64_t			 resync_last_progress;
 };
 
 /* Low and high watermarks. */
@@ -103,10 +135,66 @@ struct control_state {
 /* Maximum age for clients that are not using pause mode. */
 #define CONTROL_MAXIMUM_AGE 300000
 
+/* No-drain-progress window before a stalled client's panes are resynced. */
+#define CONTROL_RESYNC_TIMEOUT 5000
+
+/*
+ * Byte backstop for output that never scrolls into history: alt-screen and
+ * cursor-addressed redraws (progress bars, curses apps) accumulate bytes with
+ * zero scrolled lines, so the line trigger never fires, yet the backlog grows
+ * without bound. A repaint of such a pane is lossless of its final state - only
+ * ephemeral intermediate frames are dropped - so resync eagerly once the
+ * backlog passes this. Memory protection only; the primary trigger is missed
+ * lines against the history limit. Sized at one full scrollback of typical
+ * output (~64 bytes/line * ~2000 lines * some slack), not a tunable.
+ */
+#define CONTROL_RESYNC_BACKLOG 262144
+
 /* Flags to ignore client. */
 #define CONTROL_IGNORE_FLAGS \
 	(CLIENT_CONTROL_NOOUTPUT| \
 	 CLIENT_UNATTACHEDFLAGS)
+
+static void	control_pane_resync(struct client *, struct window_pane *,
+		    struct control_pane *);
+static void	control_update_resyncs(struct client *);
+static void	control_arm_output_timer(struct control_state *);
+static struct evbuffer *control_build_repaint(struct window_pane *,
+		    struct control_pane *);
+
+/*
+ * The control-resync choice: off (0) keeps the legacy kill; on (1) resyncs
+ * everything, preempting pause mode; keep-pause (2) resyncs plain clients but
+ * pauses pause-after clients with %pause.
+ */
+#define CONTROL_RESYNC_OFF 0
+#define CONTROL_RESYNC_ON 1
+#define CONTROL_RESYNC_KEEP_PAUSE 2
+
+/* Is resync enabled for this server (any non-off value)? */
+static int
+control_resync_enabled(void)
+{
+	return (options_get_number(global_options, "control-resync") !=
+	    CONTROL_RESYNC_OFF);
+}
+
+/*
+ * Does this client recover with a resync rather than a pause? Plain clients
+ * always do when resync is enabled; a pause-after client does too unless the
+ * option is keep-pause, in which case it stays on the %pause path.
+ */
+static int
+control_client_uses_resync(struct client *c)
+{
+	int	mode = options_get_number(global_options, "control-resync");
+
+	if (mode == CONTROL_RESYNC_OFF)
+		return (0);
+	if (c->flags & CLIENT_CONTROL_PAUSEAFTER)
+		return (mode == CONTROL_RESYNC_ON);
+	return (1);
+}
 
 /* Compare client panes. */
 static int
@@ -124,7 +212,10 @@ RB_GENERATE_STATIC(control_panes, control_pane, entry, control_pane_cmp);
 static void
 control_free_block(struct control_state *cs, struct control_block *cb)
 {
-	free(cb->line);
+	if (cb->type == CONTROL_BLOCK_LINE)
+		free(cb->line);
+	else if (cb->type == CONTROL_BLOCK_REPAINT && cb->repaint != NULL)
+		evbuffer_free(cb->repaint);
 	TAILQ_REMOVE(&cs->all_blocks, cb, all_entry);
 	free(cb);
 }
@@ -217,6 +308,24 @@ control_reset_offsets(struct client *c)
 	cs->pending_count = 0;
 }
 
+/*
+ * A client is stalled when it has made no drain progress for the timeout while
+ * output is still buffered. This is derived rather than latched, so updating
+ * resync_last_progress on the next write clears it. A stalled client abstains
+ * from the pane read gate for panes with nothing queued, which is what
+ * re-enables the pty in the deadlock where the backlog is entirely in the write
+ * buffer and there is nothing left to act on per pane.
+ */
+static int
+control_client_stalled(struct control_state *cs)
+{
+	uint64_t	now = get_timer();
+
+	if (EVBUFFER_LENGTH(cs->write_event->output) == 0)
+		return (0);
+	return (now - cs->resync_last_progress >= CONTROL_RESYNC_TIMEOUT);
+}
+
 /* Get offsets for client. */
 struct window_pane_offset *
 control_pane_offset(struct client *c, struct window_pane *wp, int *off)
@@ -230,12 +339,29 @@ control_pane_offset(struct client *c, struct window_pane *wp, int *off)
 	}
 
 	cp = control_get_pane(c, wp);
-	if (cp == NULL || (cp->flags & CONTROL_PANE_PAUSED)) {
+	if (cp == NULL) {
 		*off = 0;
 		return (NULL);
 	}
-	if (cp->flags & CONTROL_PANE_OFF) {
+
+	switch (cp->state) {
+	case CONTROL_PANE_OFF:
 		*off = 1;
+		return (NULL);
+	case CONTROL_PANE_PAUSED:
+	case CONTROL_PANE_RESYNC:
+		*off = 0;
+		return (NULL);
+	case CONTROL_PANE_ON:
+		break;
+	}
+
+	/*
+	 * A caught-up pane (nothing queued) of a stalled client abstains too, so
+	 * the pty is not held shut by output that will never drain.
+	 */
+	if (TAILQ_EMPTY(&cp->blocks) && control_client_stalled(cs)) {
+		*off = 0;
 		return (NULL);
 	}
 	*off = (EVBUFFER_LENGTH(cs->write_event->output) >= CONTROL_BUFFER_LOW);
@@ -249,8 +375,8 @@ control_set_pane_on(struct client *c, struct window_pane *wp)
 	struct control_pane	*cp;
 
 	cp = control_get_pane(c, wp);
-	if (cp != NULL && (cp->flags & CONTROL_PANE_OFF)) {
-		cp->flags &= ~CONTROL_PANE_OFF;
+	if (cp != NULL && cp->state == CONTROL_PANE_OFF) {
+		cp->state = CONTROL_PANE_ON;
 		memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
 		memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
 	}
@@ -266,7 +392,7 @@ control_set_pane_off(struct client *c, struct window_pane *wp)
 	control_discard_pane(c, cp);
 	memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
 	memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
-	cp->flags |= CONTROL_PANE_OFF;
+	cp->state = CONTROL_PANE_OFF;
 }
 
 /* Continue a paused pane. */
@@ -276,8 +402,8 @@ control_continue_pane(struct client *c, struct window_pane *wp)
 	struct control_pane	*cp;
 
 	cp = control_get_pane(c, wp);
-	if (cp != NULL && (cp->flags & CONTROL_PANE_PAUSED)) {
-		cp->flags &= ~CONTROL_PANE_PAUSED;
+	if (cp != NULL && cp->state == CONTROL_PANE_PAUSED) {
+		cp->state = CONTROL_PANE_ON;
 		memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
 		memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
 		control_write(c, "%%continue %%%u", wp->id);
@@ -291,11 +417,65 @@ control_pause_pane(struct client *c, struct window_pane *wp)
 	struct control_pane	*cp;
 
 	cp = control_add_pane(c, wp);
-	if (~cp->flags & CONTROL_PANE_PAUSED) {
-		cp->flags |= CONTROL_PANE_PAUSED;
+	if (cp->state != CONTROL_PANE_PAUSED) {
+		cp->state = CONTROL_PANE_PAUSED;
 		control_discard_pane(c, cp);
 		control_write(c, "%%pause %%%u", wp->id);
 	}
+}
+
+/*
+ * Enter resync for a pane: discard the backlog, fast-forward the offsets to the
+ * parser position, and queue a repaint block owed to the client (rendered
+ * lazily when the drain loop reaches it). The pane keeps running with its
+ * output discarded until the repaint has drained and a writable callback
+ * resumes it (control_update_resyncs). A pause-after client is preempted here
+ * rather than paused.
+ */
+static void
+control_pane_resync(struct client *c, struct window_pane *wp,
+    struct control_pane *cp)
+{
+	struct control_state	*cs = c->control_state;
+	struct control_block	*cb, *first;
+
+	if (cp->state == CONTROL_PANE_RESYNC)
+		return;
+
+	/*
+	 * Tag with the oldest queued block's history if there is one: it is the
+	 * first output the client has not seen, so replaying from it can only
+	 * under-replay, never duplicate.
+	 */
+	first = TAILQ_FIRST(&cp->blocks);
+	if (first != NULL && first->type == CONTROL_BLOCK_PANE)
+		cp->resync_state = first->history;
+	else
+		grid_history_get_state(wp->base.grid, &cp->resync_state);
+	cp->resync_sx = screen_size_x(&wp->base);
+
+	if (c->flags & CLIENT_CONTROL_PAUSEAFTER)
+		log_debug("%s: %s: preempting pause-after on %%%u", __func__,
+		    c->name, wp->id);
+	log_debug("%s: %s: resync %%%u", __func__, c->name, wp->id);
+
+	cp->state = CONTROL_PANE_RESYNC;
+	control_discard_pane(c, cp);
+	control_pane_clear_pending(cs, cp);
+	memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
+	memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
+
+	cb = xcalloc(1, sizeof *cb);
+	cb->type = CONTROL_BLOCK_REPAINT;
+	cb->t = get_timer();
+	TAILQ_INSERT_TAIL(&cs->all_blocks, cb, all_entry);
+	TAILQ_INSERT_TAIL(&cp->blocks, cb, entry);
+	TAILQ_INSERT_TAIL(&cs->pending_list, cp, pending_entry);
+	cp->pending_flag = 1;
+	cs->pending_count++;
+
+	bufferevent_enable(cs->write_event, EV_WRITE);
+	control_arm_output_timer(cs);
 }
 
 /* Write a line. */
@@ -312,6 +492,7 @@ control_vwrite(struct client *c, const char *fmt, va_list ap)
 	bufferevent_write(cs->write_event, "\n", 1);
 
 	bufferevent_enable(cs->write_event, EV_WRITE);
+	control_arm_output_timer(cs);
 	free(s);
 }
 
@@ -332,49 +513,47 @@ control_write(struct client *c, const char *fmt, ...)
 	}
 
 	cb = xcalloc(1, sizeof *cb);
+	cb->type = CONTROL_BLOCK_LINE;
 	xvasprintf(&cb->line, fmt, ap);
 	TAILQ_INSERT_TAIL(&cs->all_blocks, cb, all_entry);
 	cb->t = get_timer();
 
 	log_debug("%s: %s: storing line: %s", __func__, c->name, cb->line);
 	bufferevent_enable(cs->write_event, EV_WRITE);
+	control_arm_output_timer(cs);
 
 	va_end(ap);
 }
 
-/* Check age for this pane. */
+/*
+ * Whether a pane has fallen far enough behind for a resync. The trigger is
+ * missed scrolled lines, not buffered bytes: while the client has missed no
+ * more lines than the history keeps, a repaint reconstructs everything it
+ * missed, so a resync is lossless and buffering buys nothing; once it has
+ * missed more, the history no longer covers those lines and only a wholly
+ * buffered client keeps growing. The floor keeps a tiny or empty history from
+ * resyncing once per scrolled line - a resync should stand for at least a
+ * couple of screenfuls. CONTROL_RESYNC_BACKLOG is the byte backstop for output
+ * that never scrolls into history.
+ */
 static int
-control_check_age(struct client *c, struct window_pane *wp,
-    struct control_pane *cp)
+control_pane_behind(struct control_pane *cp, struct window_pane *wp,
+    size_t backlog)
 {
-	struct control_block	*cb;
-	uint64_t		 t, age;
+	struct grid		*gd = wp->base.grid;
+	struct control_block	*first;
+	u_int			 missed, threshold, sy = screen_size_y(&wp->base);
 
-	cb = TAILQ_FIRST(&cp->blocks);
-	if (cb == NULL)
+	if (backlog > CONTROL_RESYNC_BACKLOG)
+		return (1);
+
+	first = TAILQ_FIRST(&cp->blocks);
+	if (first == NULL || first->type != CONTROL_BLOCK_PANE)
 		return (0);
-	t = get_timer();
-	if (cb->t >= t)
-		return (0);
 
-	age = t - cb->t;
-	log_debug("%s: %s: %%%u is %llu behind", __func__, c->name, wp->id,
-	    (unsigned long long)age);
-
-	if (c->flags & CLIENT_CONTROL_PAUSEAFTER) {
-		if (age < c->pause_age)
-			return (0);
-		cp->flags |= CONTROL_PANE_PAUSED;
-		control_discard_pane(c, cp);
-		control_write(c, "%%pause %%%u", wp->id);
-	} else {
-		if (age < CONTROL_MAXIMUM_AGE)
-			return (0);
-		c->exit_message = xstrdup("too far behind");
-		c->flags |= CLIENT_EXIT;
-		control_discard(c);
-	}
-	return (1);
+	missed = grid_history_missed(gd, &first->history);
+	threshold = (gd->hlimit > 2 * sy) ? gd->hlimit : 2 * sy;
+	return (missed >= threshold);
 }
 
 /* Write output from a pane. */
@@ -396,10 +575,30 @@ control_write_output(struct client *c, struct window_pane *wp)
 		return;
 	}
 	cp = control_add_pane(c, wp);
-	if (cp->flags & (CONTROL_PANE_OFF|CONTROL_PANE_PAUSED))
+	if (cp->state != CONTROL_PANE_ON)
 		goto ignore;
-	if (control_check_age(c, wp, cp))
-		return;
+
+	/*
+	 * While the client is stalled do not queue this batch: it would be
+	 * trimmed while the client abstains from the buffer minimum. Enter resync
+	 * so the pane owes a repaint and keeps fast-forwarding instead. Otherwise
+	 * enter resync once the client has fallen behind the history frontier (or
+	 * the byte backstop), rather than letting the pane buffer grow without
+	 * bound.
+	 */
+	if (control_client_uses_resync(c)) {
+		window_pane_get_new_data(wp, &cp->offset, &new_size);
+		if (control_client_stalled(cs)) {
+			control_pane_resync(c, wp, cp);
+			goto ignore;
+		}
+		if (control_pane_behind(cp, wp, new_size)) {
+			log_debug("%s: %s: %%%u behind, backlog %zu", __func__,
+			    c->name, wp->id, new_size);
+			control_pane_resync(c, wp, cp);
+			goto ignore;
+		}
+	}
 
 	window_pane_get_new_data(wp, &cp->queued, &new_size);
 	if (new_size == 0)
@@ -407,7 +606,9 @@ control_write_output(struct client *c, struct window_pane *wp)
 	window_pane_update_used_data(wp, &cp->queued, new_size);
 
 	cb = xcalloc(1, sizeof *cb);
+	cb->type = CONTROL_BLOCK_PANE;
 	cb->size = new_size;
+	grid_history_get_state(wp->base.grid, &cb->history);
 	TAILQ_INSERT_TAIL(&cs->all_blocks, cb, all_entry);
 	cb->t = get_timer();
 
@@ -423,6 +624,7 @@ control_write_output(struct client *c, struct window_pane *wp)
 		cs->pending_count++;
 	}
 	bufferevent_enable(cs->write_event, EV_WRITE);
+	control_arm_output_timer(cs);
 	return;
 
 ignore:
@@ -554,7 +756,7 @@ control_flush_all_blocks(struct client *c)
 	struct control_block	*cb, *cb1;
 
 	TAILQ_FOREACH_SAFE(cb, &cs->all_blocks, all_entry, cb1) {
-		if (cb->size != 0)
+		if (cb->type != CONTROL_BLOCK_LINE)
 			break;
 		log_debug("%s: %s: flushing line: %s", __func__, c->name,
 		    cb->line);
@@ -643,9 +845,10 @@ control_write_pending(struct client *c, struct control_pane *cp, size_t limit)
 	struct control_state	*cs = c->control_state;
 	struct window_pane	*wp = NULL;
 	struct evbuffer		*message = NULL;
-	size_t			 used = 0, size;
+	size_t			 used = 0, size, remaining;
 	struct control_block	*cb, *cb1;
 	uint64_t		 age, t = get_timer();
+	int			 done;
 
 	wp = control_window_pane(c, cp->pane);
 	if (wp == NULL || wp->fd == -1) {
@@ -658,40 +861,43 @@ control_write_pending(struct client *c, struct control_pane *cp, size_t limit)
 	}
 
 	while (used != limit && !TAILQ_EMPTY(&cp->blocks)) {
-		if (control_check_age(c, wp, cp)) {
-			if (message != NULL)
-				evbuffer_free(message);
-			message = NULL;
-			break;
-		}
-
 		cb = TAILQ_FIRST(&cp->blocks);
-		if (cb->t < t)
-			age = t - cb->t;
-		else
-			age = 0;
-		log_debug("%s: %s: output block %zu (age %llu) for %%%u "
-		    "(used %zu/%zu)", __func__, c->name, cb->size,
-		    (unsigned long long)age, cp->pane, used, limit);
+		age = (cb->t < t) ? t - cb->t : 0;
 
-		size = cb->size;
+		/* Render a repaint the first time the drain loop reaches it. */
+		if (cb->type == CONTROL_BLOCK_REPAINT) {
+			if (cb->repaint == NULL)
+				cb->repaint = control_build_repaint(wp, cp);
+			remaining = EVBUFFER_LENGTH(cb->repaint);
+		} else
+			remaining = cb->size;
+
+		size = remaining;
 		if (size > limit - used)
 			size = limit - used;
 		used += size;
 
-		message = control_append_data(c, cp, age, message, wp, size);
+		if (message == NULL)
+			message = control_message_start(c, wp, age);
+		if (cb->type == CONTROL_BLOCK_REPAINT) {
+			control_append_escaped(message, EVBUFFER_DATA(cb->repaint),
+			    size);
+			evbuffer_drain(cb->repaint, size);
+			done = (EVBUFFER_LENGTH(cb->repaint) == 0);
+		} else {
+			control_append_data(c, cp, age, message, wp, size);
+			cb->size -= size;
+			done = (cb->size == 0);
+		}
 
-		cb->size -= size;
-		if (cb->size == 0) {
+		if (done) {
 			TAILQ_REMOVE(&cp->blocks, cb, entry);
 			control_free_block(cs, cb);
 
 			cb = TAILQ_FIRST(&cs->all_blocks);
-			if (cb != NULL && cb->size == 0) {
-				if (wp != NULL && message != NULL) {
-					control_write_data(c, message);
-					message = NULL;
-				}
+			if (cb != NULL && cb->type == CONTROL_BLOCK_LINE) {
+				control_write_data(c, message);
+				message = NULL;
 				control_flush_all_blocks(c);
 			}
 		}
@@ -711,7 +917,16 @@ control_write_callback(__unused struct bufferevent *bufev, void *data)
 	struct evbuffer		*evb = cs->write_event->output;
 	size_t			 space, limit;
 
+	/*
+	 * This callback only fires when the socket accepted data, so reaching
+	 * it means output drained: stamp progress (which is what makes
+	 * control_client_stalled false again) and finish any resync whose
+	 * repaint has now gone out.
+	 */
+	cs->resync_last_progress = get_timer();
+
 	control_flush_all_blocks(c);
+	control_update_resyncs(c);
 
 	while (EVBUFFER_LENGTH(evb) < CONTROL_BUFFER_HIGH) {
 		if (cs->pending_count == 0)
@@ -732,8 +947,162 @@ control_write_callback(__unused struct bufferevent *bufev, void *data)
 			control_pane_clear_pending(cs, cp);
 		}
 	}
+
 	if (EVBUFFER_LENGTH(evb) == 0)
 		bufferevent_disable(cs->write_event, EV_WRITE);
+}
+
+/* Is there output outstanding that the resync watchdog should watch? */
+static int
+control_output_pending(struct control_state *cs)
+{
+	struct control_pane	*cp;
+
+	if (!TAILQ_EMPTY(&cs->all_blocks) ||
+	    cs->pending_count != 0 ||
+	    EVBUFFER_LENGTH(cs->write_event->output) != 0)
+		return (1);
+
+	/*
+	 * A pane in resync is owed a repaint or waiting for room to resume; keep
+	 * watching so the last-resort age kill still fires for a client that has
+	 * gone quiet after its repaint drained.
+	 */
+	RB_FOREACH(cp, control_panes, &cs->panes) {
+		if (cp->state == CONTROL_PANE_RESYNC)
+			return (1);
+	}
+	return (0);
+}
+
+/*
+ * Arm the watchdog for one second while there is output to watch. Called when
+ * output is first queued and re-called from the timer itself, so an idle client
+ * has no periodic wakeup.
+ */
+static void
+control_arm_output_timer(struct control_state *cs)
+{
+	struct timeval	tv = { .tv_sec = 1 };
+
+	if (evtimer_initialized(&cs->output_timer) &&
+	    control_output_pending(cs) &&
+	    !evtimer_pending(&cs->output_timer, NULL))
+		evtimer_add(&cs->output_timer, &tv);
+}
+
+/*
+ * Watchdog for a client that makes no progress draining its output. Both the
+ * pane-read and socket-write callbacks are dead when the sole consumer is a
+ * stalled client, so this is the only path that can recover the pane. It closes
+ * a client that drains nothing for the maximum age; otherwise, per pane, it
+ * resyncs a resync client that has fallen behind the history frontier (or byte
+ * backstop) or that still holds queued blocks once stalled, and pauses a
+ * pause-after client kept on the %pause path once its output has aged past
+ * pause-after. Panes with nothing queued recover through the stalled abstention
+ * in control_pane_offset.
+ */
+static void
+control_output_timer(__unused int fd, __unused short events, void *data)
+{
+	struct client		*c = data;
+	struct control_state	*cs = c->control_state;
+	struct control_pane	*cp;
+	struct control_block	*cb;
+	struct window_pane	*wp;
+	uint64_t		 now = get_timer(), age;
+	size_t			 lag;
+	int			 uses_resync, stalled;
+
+	if (!control_output_pending(cs))
+		return;
+
+	age = (now > cs->resync_last_progress) ?
+	    now - cs->resync_last_progress : 0;
+	if (age >= CONTROL_MAXIMUM_AGE) {
+		log_debug("%s: %s: no progress for maximum age, exiting",
+		    __func__, c->name);
+		c->exit_message = xstrdup("too far behind");
+		c->flags |= CLIENT_EXIT;
+		control_discard(c);
+		return;
+	}
+	if (!control_resync_enabled()) {
+		control_arm_output_timer(cs);
+		return;
+	}
+
+	uses_resync = control_client_uses_resync(c);
+	stalled = control_client_stalled(cs);
+
+	RB_FOREACH(cp, control_panes, &cs->panes) {
+		if (cp->state != CONTROL_PANE_ON)
+			continue;
+		wp = control_window_pane(c, cp->pane);
+		if (wp == NULL || wp->fd == -1)
+			continue;
+		if (uses_resync) {
+			window_pane_get_new_data(wp, &cp->offset, &lag);
+			if (control_pane_behind(cp, wp, lag)) {
+				log_debug("%s: %s: %%%u behind, backlog %zu",
+				    __func__, c->name, cp->pane, lag);
+				control_pane_resync(c, wp, cp);
+			} else if (stalled && !TAILQ_EMPTY(&cp->blocks))
+				control_pane_resync(c, wp, cp);
+		} else {
+			cb = TAILQ_FIRST(&cp->blocks);
+			if (age >= (uint64_t)c->pause_age ||
+			    (cb != NULL && now > cb->t &&
+			    now - cb->t >= (uint64_t)c->pause_age))
+				control_pause_pane(c, wp);
+		}
+	}
+
+	control_arm_output_timer(cs);
+}
+
+/* Build the repaint byte stream owed to a resynced pane. */
+static struct evbuffer *
+control_build_repaint(struct window_pane *wp, struct control_pane *cp)
+{
+	struct evbuffer	*msg;
+
+	msg = evbuffer_new();
+	if (msg == NULL)
+		fatalx("out of memory");
+	screen_repaint(&wp->base, &cp->resync_state, cp->resync_sx, msg);
+	return (msg);
+}
+
+/*
+ * Finish any resync whose repaint has fully drained. Reaching this on a
+ * writable callback means the client has room again, so resume normal streaming
+ * from the current parser position; output produced while discarding is skipped
+ * (a gap, never a duplicate). A pane whose repaint is still queued stays in
+ * resync.
+ */
+static void
+control_update_resyncs(struct client *c)
+{
+	struct control_state	*cs = c->control_state;
+	struct control_pane	*cp;
+	struct window_pane	*wp;
+
+	RB_FOREACH(cp, control_panes, &cs->panes) {
+		if (cp->state != CONTROL_PANE_RESYNC || !TAILQ_EMPTY(&cp->blocks))
+			continue;
+		wp = control_window_pane(c, cp->pane);
+		if (wp != NULL && wp->fd != -1) {
+			log_debug("%s: %s: resync of %%%u delivered", __func__,
+			    c->name, cp->pane);
+			memcpy(&cp->offset, &wp->offset, sizeof cp->offset);
+			memcpy(&cp->queued, &wp->offset, sizeof cp->queued);
+		} else {
+			log_debug("%s: %s: %%%u gone, ending resync", __func__,
+			    c->name, cp->pane);
+		}
+		cp->state = CONTROL_PANE_ON;
+	}
 }
 
 /* Write a subscription change. */
@@ -778,6 +1147,9 @@ control_start(struct client *c)
 	TAILQ_INIT(&cs->pending_list);
 	TAILQ_INIT(&cs->all_blocks);
 	cs->subs = monitor_create_client(c, control_sub_change, NULL);
+
+	evtimer_set(&cs->output_timer, control_output_timer, c);
+	cs->resync_last_progress = get_timer();
 
 	cs->read_event = bufferevent_new(c->fd, control_read_callback,
 	    control_write_callback, control_error_callback, c);
@@ -831,6 +1203,9 @@ control_stop(struct client *c)
 		return;
 
 	monitor_destroy(cs->subs);
+
+	if (evtimer_initialized(&cs->output_timer))
+		evtimer_del(&cs->output_timer);
 
 	if (~c->flags & CLIENT_CONTROLCONTROL)
 		bufferevent_free(cs->write_event);

--- a/control.c
+++ b/control.c
@@ -174,6 +174,17 @@ control_discard_pane(struct client *c, struct control_pane *cp)
 	}
 }
 
+/* Remove a pane from the pending list if it is on it. */
+static void
+control_pane_clear_pending(struct control_state *cs, struct control_pane *cp)
+{
+	if (!cp->pending_flag)
+		return;
+	TAILQ_REMOVE(&cs->pending_list, cp, pending_entry);
+	cp->pending_flag = 0;
+	cs->pending_count--;
+}
+
 /* Get actual pane for this client. */
 static struct window_pane *
 control_window_pane(struct client *c, u_int pane)
@@ -554,42 +565,59 @@ control_flush_all_blocks(struct client *c)
 	}
 }
 
+/* Append escaped bytes to a message, as expected in a %output line. */
+static void
+control_append_escaped(struct evbuffer *message, const u_char *data,
+    size_t size)
+{
+	size_t	i, start;
+
+	for (i = 0; i < size; i++) {
+		if (data[i] < ' ' || data[i] == '\\') {
+			evbuffer_add_printf(message, "\\%03o", data[i]);
+		} else {
+			start = i;
+			while (i + 1 < size &&
+			    data[i + 1] >= ' ' &&
+			    data[i + 1] != '\\')
+				i++;
+			evbuffer_add(message, data + start, i - start + 1);
+		}
+	}
+}
+
+/* Start a new %output (or %extended-output) message. */
+static struct evbuffer *
+control_message_start(struct client *c, struct window_pane *wp, uint64_t age)
+{
+	struct evbuffer	*message;
+
+	message = evbuffer_new();
+	if (message == NULL)
+		fatalx("out of memory");
+	if (c->flags & CLIENT_CONTROL_PAUSEAFTER) {
+		evbuffer_add_printf(message, "%%extended-output %%%u %llu : ",
+		    wp->id, (unsigned long long)age);
+	} else
+		evbuffer_add_printf(message, "%%output %%%u ", wp->id);
+	return (message);
+}
+
 /* Append data to buffer. */
 static struct evbuffer *
 control_append_data(struct client *c, struct control_pane *cp, uint64_t age,
     struct evbuffer *message, struct window_pane *wp, size_t size)
 {
 	u_char	*new_data;
-	size_t	 new_size, start;
-	u_int	 i;
+	size_t	 new_size;
 
-	if (message == NULL) {
-		message = evbuffer_new();
-		if (message == NULL)
-			fatalx("out of memory");
-		if (c->flags & CLIENT_CONTROL_PAUSEAFTER) {
-			evbuffer_add_printf(message,
-			    "%%extended-output %%%u %llu : ", wp->id,
-			    (unsigned long long)age);
-		} else
-			evbuffer_add_printf(message, "%%output %%%u ", wp->id);
-	}
+	if (message == NULL)
+		message = control_message_start(c, wp, age);
 
 	new_data = window_pane_get_new_data(wp, &cp->offset, &new_size);
 	if (new_size < size)
 		fatalx("not enough data: %zu < %zu", new_size, size);
-	for (i = 0; i < size; i++) {
-		if (new_data[i] < ' ' || new_data[i] == '\\') {
-			evbuffer_add_printf(message, "\\%03o", new_data[i]);
-		} else {
-			start = i;
-			while (i + 1 < size &&
-			    new_data[i + 1] >= ' ' &&
-			    new_data[i + 1] != '\\')
-				i++;
-			evbuffer_add(message, new_data + start, i - start + 1);
-		}
-	}
+	control_append_escaped(message, new_data, size);
 	window_pane_update_used_data(wp, &cp->offset, size);
 	return (message);
 }
@@ -701,9 +729,7 @@ control_write_callback(__unused struct bufferevent *bufev, void *data)
 				break;
 			if (control_write_pending(c, cp, limit))
 				continue;
-			TAILQ_REMOVE(&cs->pending_list, cp, pending_entry);
-			cp->pending_flag = 0;
-			cs->pending_count--;
+			control_pane_clear_pending(cs, cp);
 		}
 	}
 	if (EVBUFFER_LENGTH(evb) == 0)

--- a/grid.c
+++ b/grid.c
@@ -537,6 +537,53 @@ grid_scroll_history_region(struct grid *gd, u_int upper, u_int lower, u_int bg)
 	gd->scroll_added++;
 }
 
+/* Snapshot the history sequence state. */
+void
+grid_history_get_state(struct grid *gd, struct grid_history_state *state)
+{
+	state->added = gd->scroll_added;
+	state->generation = gd->scroll_generation;
+}
+
+/*
+ * Return the number of history lines added since a snapshot that are still
+ * present, or zero if the history was reset discontinuously (cleared or
+ * reflowed) in the meantime, in which case the snapshot no longer locates a
+ * position in the current history.
+ */
+u_int
+grid_history_delta(struct grid *gd, const struct grid_history_state *state)
+{
+	u_int	added;
+
+	if (gd->scroll_generation != state->generation ||
+	    gd->scroll_added < state->added)
+		return (0);
+	added = gd->scroll_added - state->added;
+	if (added > gd->hsize)
+		added = gd->hsize;
+	return (added);
+}
+
+/*
+ * Return the number of lines scrolled into history since a snapshot, unclamped
+ * by what history still holds. grid_history_delta caps its result at hsize
+ * because it answers "how much can I replay"; this answers "how far behind has
+ * this position fallen", which the control mode resync trigger compares against
+ * the history limit to decide when a client has fallen past what a fresh
+ * attacher would keep. Zero if the history was reset discontinuously, since the
+ * snapshot no longer locates a position - that case is left to the byte
+ * backstop and the stall watchdog.
+ */
+u_int
+grid_history_missed(struct grid *gd, const struct grid_history_state *state)
+{
+	if (gd->scroll_generation != state->generation ||
+	    gd->scroll_added < state->added)
+		return (0);
+	return (gd->scroll_added - state->added);
+}
+
 /* Expand line to fit to cell. */
 static void
 grid_expand_line(struct grid *gd, u_int py, u_int sx, u_int bg)

--- a/options-table.c
+++ b/options-table.c
@@ -35,6 +35,9 @@
 static const char *options_table_mode_keys_list[] = {
 	"emacs", "vi", NULL
 };
+static const char *options_table_control_resync_list[] = {
+	"off", "on", "keep-pause", NULL
+};
 static const char *options_table_clock_mode_style_list[] = {
 	"12", "24", "12-with-seconds", "24-with-seconds", NULL
 };
@@ -320,6 +323,18 @@ const struct options_table_entry options_table[] = {
 	  .default_str = "",
 	  .separator = ",",
 	  .text = "Array of override widths for Unicode codepoints."
+	},
+
+	{ .name = "control-resync",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .choices = options_table_control_resync_list,
+	  .default_num = 1,
+	  .text = "How a control mode client that falls too far behind is handled. "
+		  "'on' resynchronises it with a screen repaint (including clients "
+		  "in pause mode, which are not paused); 'keep-pause' resynchronises "
+		  "plain clients but pauses 'pause-after' clients with '%pause'; "
+		  "'off' uses the legacy behaviour and kills the client."
 	},
 
 	{ .name = "copy-command",

--- a/regress/control-resync-options.sh
+++ b/regress/control-resync-options.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# Option surface for the control-mode resync feature. No timing: every check is
+# the exit status of a set-option/show-options.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap "$TMUX kill-server 2>/dev/null; rm -f $TMP" 0 1 15
+
+$TMUX -f/dev/null new -d || exit 1
+sleep 1
+
+# control-resync defaults to on.
+$TMUX show-options -g control-resync >$TMP || exit 1
+echo "control-resync on" | cmp -s $TMP - || exit 1
+
+# All three choices are settable; a bogus value is rejected.
+$TMUX set -g control-resync off || exit 1
+$TMUX set -g control-resync on || exit 1
+$TMUX set -g control-resync keep-pause || exit 1
+$TMUX set -g control-resync bogus 2>/dev/null && exit 1
+
+# control-resync-size is gone: the trigger is measured against history-limit,
+# not a byte option, so set and show both fail.
+$TMUX set -g control-resync-size 65536 2>/dev/null && exit 1
+$TMUX show-options -g control-resync-size 2>/dev/null && exit 1
+
+# The rest of the old option surface is gone too: set and show both fail on
+# every removed name.
+$TMUX set -g control-resync-bytes 1 2>/dev/null && exit 1
+$TMUX set -g control-resync-seconds 1 2>/dev/null && exit 1
+$TMUX set -g control-resync-marker x 2>/dev/null && exit 1
+$TMUX set -g control-resync-pause-after 1 2>/dev/null && exit 1
+$TMUX show-options -g control-resync-bytes 2>/dev/null && exit 1
+
+$TMUX kill-server 2>/dev/null
+
+exit 0

--- a/regress/control-resync-pause.sh
+++ b/regress/control-resync-pause.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# pause-after policy under resync. A pause-after control client that stalls is
+# handled per the control-resync option: 'on' preempts it with a resync and does
+# NOT pause it, while 'keep-pause' keeps it on the %pause path.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+MARK="control_resync_pause_producer_$$"
+WDA=$(mktemp -d)
+WDB=$(mktemp -d)
+trap 'pkill -f "$MARK" 2>/dev/null; $TMUX kill-server 2>/dev/null; rm -rf "$WDA" "$WDB"' 0 1 15
+
+CMD="i=0; while :; do i=\$((i+1)); dd if=/dev/zero bs=262144 count=1 2>/dev/null | tr '\\0' x; done # $MARK"
+
+# A pause-after control client that stalls: set pause-after=1s, read ~1s, stop
+# reading ~8s (past the watchdog timeout), then resume ~4s.
+run_client() {
+	python3 - "$TEST_TMUX" test <<'PYEOF'
+import sys, os, select, subprocess, time
+tmux, label = sys.argv[1], sys.argv[2]
+p = subprocess.Popen([tmux, "-L", label, "-C", "attach"],
+                     stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     stderr=subprocess.DEVNULL)
+fd = p.stdout.fileno()
+try:
+    p.stdin.write(b"refresh-client -f pause-after=1\n")
+    p.stdin.flush()
+    def drain(dur):
+        end = time.time() + dur
+        while time.time() < end:
+            r, _, _ = select.select([fd], [], [], 0.1)
+            if r and not os.read(fd, 65536):
+                break
+    drain(1.0)
+    time.sleep(8.0)
+    drain(4.0)
+finally:
+    try: p.stdin.close()
+    except Exception: pass
+    try: p.terminate()
+    except Exception: pass
+    try: p.wait(timeout=3)
+    except Exception:
+        try: p.kill()
+        except Exception: pass
+PYEOF
+}
+
+# (a) control-resync on: the pause-after client is preempted with a resync, so
+# the log shows the resync and no %pause is ever written for the pane.
+cd "$WDA" || exit 1
+$TMUX -vv -f/dev/null new -d -x80 -y24 "$CMD" || exit 1
+$TMUX set -g control-resync on || exit 1
+sleep 1
+run_client || exit 1
+$TMUX kill-server 2>/dev/null
+pkill -f "$MARK" 2>/dev/null
+sleep 1
+grep -aq "control_pane_resync:" "$WDA"/tmux-server-*.log || exit 1
+grep -aq "%pause %" "$WDA"/tmux-server-*.log && exit 1
+
+# (b) control-resync keep-pause: the same client stays on the %pause path, so a
+# %pause is written for the pane.
+cd "$WDB" || exit 1
+$TMUX kill-server 2>/dev/null
+sleep 1
+$TMUX -vv -f/dev/null new -d -x80 -y24 "$CMD" || exit 1
+$TMUX set -g control-resync keep-pause || exit 1
+sleep 1
+run_client || exit 1
+$TMUX kill-server 2>/dev/null
+pkill -f "$MARK" 2>/dev/null
+sleep 1
+grep -aq "%pause %" "$WDB"/tmux-server-*.log || exit 1
+
+exit 0

--- a/regress/control-resync-recover.sh
+++ b/regress/control-resync-recover.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Zero-block watchdog. A pane keeps producing while its sole control client is
+# wedged (stdout blocked). With control-resync on, the watchdog resyncs the pane
+# so it keeps running; a frozen pane would not advance its counter at all.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+MARK="control_resync_recover_producer_$$"
+CTR=$(mktemp)
+FIFO=$(mktemp -u)
+trap 'kill $CPID 2>/dev/null; exec 7<&- 2>/dev/null; pkill -f "$MARK" 2>/dev/null; $TMUX kill-server 2>/dev/null; rm -f "$CTR" "$CTR.w" "$FIFO"' 0 1 15
+
+echo 0 >"$CTR" || exit 1
+mkfifo "$FIFO" || exit 1
+
+# Pane producer: bump a counter file (written atomically via rename so a reader
+# never sees a truncated value) and blast 256k of output each iteration. The
+# unique MARK lives in the command line so pkill can find the loop.
+CMD="i=0; while :; do i=\$((i+1)); echo \$i >$CTR.w; mv $CTR.w $CTR; dd if=/dev/zero bs=262144 count=1 2>/dev/null | tr '\\0' x; done # $MARK"
+$TMUX -f/dev/null new -d -x80 -y24 "$CMD" || exit 1
+$TMUX set -g control-resync on || exit 1
+sleep 1
+
+# Hold the FIFO read end open on fd 7 but never read it (opening read+write
+# never blocks and needs no helper process), then attach the sole control client
+# with its stdout going into that FIFO. Once the pipe fills the client's writes
+# block, it makes no drain progress and stalls.
+exec 7<>"$FIFO" || exit 1
+$TMUX -C attach >"$FIFO" 2>/dev/null &
+CPID=$!
+sleep 1
+
+START=$(cat "$CTR") || exit 1
+sleep 12
+END=$(cat "$CTR") || exit 1
+
+kill $CPID 2>/dev/null
+exec 7<&-
+pkill -f "$MARK" 2>/dev/null
+$TMUX kill-server 2>/dev/null
+
+# A frozen pane advances by 0; the resync watchdog keeps it running (baseline
+# observed well over a thousand in this window). Require a conservative floor.
+case "$START" in ''|*[!0-9]*) exit 1;; esac
+case "$END" in ''|*[!0-9]*) exit 1;; esac
+[ "$((END - START))" -ge 20 ] || exit 1
+
+exit 0

--- a/regress/control-resync-repaint.sh
+++ b/regress/control-resync-repaint.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+# A resynced pane is repainted. A control client reads briefly, stalls (stops
+# reading long enough to trigger the watchdog), then resumes. The delivered
+# repaint arrives as a %output line beginning a DEC 2026 synchronized update,
+# and the server log records entering and completing the resync.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+MARK="control_resync_repaint_producer_$$"
+WD=$(mktemp -d)
+OUT=$(mktemp)
+trap 'pkill -f "$MARK" 2>/dev/null; $TMUX kill-server 2>/dev/null; rm -rf "$WD"; rm -f "$OUT"' 0 1 15
+
+CMD="i=0; while :; do i=\$((i+1)); dd if=/dev/zero bs=262144 count=1 2>/dev/null | tr '\\0' x; done # $MARK"
+
+# Run the server with logging from its own directory so tmux-server-*.log is
+# isolated and trivial to clean.
+cd "$WD" || exit 1
+# A small history-limit makes the pane's history the resync frontier: the
+# producer scrolls far more than this almost at once, so once the client stops
+# reading it trips the missed-lines trigger quickly (the byte backstop and the
+# no-progress watchdog would catch it too). Set it in the config so the pane's
+# grid is created with it.
+echo "set -g history-limit 50" >conf || exit 1
+$TMUX -vv -fconf new -d -x80 -y24 "$CMD" || exit 1
+$TMUX set -g control-resync on || exit 1
+sleep 1
+
+# Read ~1s, stop reading ~8s (forcing a stall and hence a resync), then resume
+# ~4s to collect the delivered repaint. python3 gives a deterministic
+# read/stop/resume that plain shell redirection cannot.
+python3 - "$TEST_TMUX" test "$OUT" <<'PYEOF' || exit 1
+import sys, os, select, subprocess, time
+tmux, label, outf = sys.argv[1], sys.argv[2], sys.argv[3]
+p = subprocess.Popen([tmux, "-L", label, "-C", "attach"],
+                     stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     stderr=subprocess.DEVNULL)
+fd = p.stdout.fileno()
+buf = bytearray()
+def drain(dur):
+    end = time.time() + dur
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if r:
+            d = os.read(fd, 65536)
+            if not d:
+                break
+            buf.extend(d)
+try:
+    drain(1.0)
+    time.sleep(8.0)
+    drain(4.0)
+    with open(outf, "wb") as f:
+        f.write(buf)
+finally:
+    try: p.stdin.close()
+    except Exception: pass
+    try: p.terminate()
+    except Exception: pass
+    try: p.wait(timeout=3)
+    except Exception:
+        try: p.kill()
+        except Exception: pass
+PYEOF
+
+# The repaint begins a DEC 2026 synchronized update, so the raw %output stream
+# contains the literal 2026h.
+grep -aq "2026h" "$OUT" || exit 1
+# The server log records the pane entering resync and the repaint being
+# delivered.
+grep -aq "control_pane_resync:" "$WD"/tmux-server-*.log || exit 1
+grep -aq "resync of %.* delivered" "$WD"/tmux-server-*.log || exit 1
+
+pkill -f "$MARK" 2>/dev/null
+$TMUX kill-server 2>/dev/null
+
+exit 0

--- a/regress/control-resync-replay.sh
+++ b/regress/control-resync-replay.sh
@@ -1,0 +1,771 @@
+#!/bin/sh
+
+# Serialization-fidelity test for the control-mode resync REPAINT/REPLAY path.
+#
+# Uses tmux itself as the reference emulator (an "oracle" round-trip): a screen
+# is constructed on an ORIGINAL server, a resync is induced on an attached -C
+# client, the delivered repaint %output byte stream is extracted, and those raw
+# bytes are fed into a fresh pane on a SECOND (ORACLE) server. Because the same
+# tmux emulator parses the repaint, comparing oracle-vs-original is a true
+# fidelity check with no reference-emulator gap: any divergence is a real
+# screen_repaint / control.c serialiser bug.
+#
+# One numbered case per screen construction: SGR spectrum, UTF-8 wide+combining,
+# custom tab stops, scroll region, alt screen, origin mode, cursor style/colour,
+# hidden cursor, insert mode, application keypad/cursor-keys, bracketed paste,
+# wrap off, mouse modes, empty and full screens, wrapped-line scrollback replay,
+# scrollback ordering, width-change degrade and history-trim degrade.
+#
+# Silent on pass; on failure the diverging cases are printed to stderr and the
+# script exits 1. The heavy lifting is a python3 driver (the four existing
+# control-resync regress tests likewise embed python3 to drive a -C client).
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+command -v python3 >/dev/null 2>&1 || {
+	echo "control-resync-replay: python3 required" >&2
+	exit 1
+}
+
+OSOCK="resyncreplayo$$"
+RSOCK="resyncreplayr$$"
+WD=$(mktemp -d)
+
+trap '$TEST_TMUX -L "$OSOCK" kill-server 2>/dev/null;
+      $TEST_TMUX -L "$RSOCK" kill-server 2>/dev/null;
+      rm -rf "$WD"' 0 1 15
+
+python3 - "$TEST_TMUX" "$OSOCK" "$RSOCK" "$WD" <<'PYEOF' || exit 1
+"""Dev driver for the tmux-as-oracle resync fidelity test.
+
+Round-trip: build a screen on an ORIGINAL tmux server, induce a control-mode
+resync, extract the client's repaint %output byte stream, feed it into a fresh
+pane on a second (ORACLE) tmux server, and compare oracle-vs-original. Because
+the same tmux emulator parses the repaint, there is no reference-emulator
+fidelity gap: any divergence is a real serialiser bug.
+
+argv: <tmux> <orig-sock> <orac-sock> <workdir>
+"""
+import glob
+import os
+import pty
+import re
+import select
+import subprocess
+import sys
+import termios
+import time
+
+TMUX, OSOCK, RSOCK, WD = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+REPAINT_SIG = b"\x18\x1b\\"                    # CAN + ST begins every repaint
+OCT = re.compile(rb"\\([0-7]{3})")
+FAIL = []
+
+
+def unescape(b):
+    return OCT.sub(lambda m: bytes([int(m.group(1), 8)]), b)
+
+
+def run(*a, **kw):
+    return subprocess.run([str(x) for x in a], capture_output=True,
+                          timeout=25, **kw)
+
+
+def tmux(sock, *a):
+    r = run(TMUX, "-L", sock, *a)
+    return r.returncode, r.stdout.decode("utf-8", "replace"), r.stderr.decode()
+
+
+def logcount(needle):
+    g = sorted(glob.glob(os.path.join(WD, "tmux-server-*.log")))
+    if not g:
+        return 0
+    r = run("grep", "-cF", needle, g[-1])
+    try:
+        return int(r.stdout.strip() or b"0")
+    except ValueError:
+        return 0
+
+
+# --------------------------------------------------------------------------- victim
+class Victim:
+    """A real `tmux -C` client over a pty (small buffer => the repaint defers
+    behind the pre-gap backlog until we resume, so it is rendered from the final
+    grid, not an intermediate one)."""
+
+    def __init__(self, sock, session):
+        mfd, sfd = pty.openpty()
+        a = termios.tcgetattr(sfd)
+        a[3] &= ~(termios.ECHO | termios.ECHONL)
+        termios.tcsetattr(sfd, termios.TCSANOW, a)
+        self.proc = subprocess.Popen(
+            [TMUX, "-L", sock, "-C", "attach", "-t", session],
+            stdin=sfd, stdout=sfd, stderr=sfd, start_new_session=True, cwd=WD)
+        os.close(sfd)
+        self.fd = mfd
+        os.set_blocking(self.fd, False)
+        self.buf = bytearray()
+
+    def drain(self, dur):
+        end = time.time() + dur
+        while time.time() < end:
+            r, _, _ = select.select([self.fd], [], [], 0.1)
+            if r:
+                try:
+                    d = os.read(self.fd, 65536)
+                except OSError:
+                    break
+                if d:
+                    self.buf.extend(d)
+
+    def clear(self):
+        self.buf = bytearray()
+
+    def pane_output(self, pane):
+        prefix = b"%output %" + pane.lstrip("%").encode() + b" "
+        out = bytearray()
+        for line in bytes(self.buf).split(b"\n"):
+            if line.endswith(b"\r"):
+                line = line[:-1]
+            if line.startswith(prefix):
+                out += unescape(line[len(prefix):])
+        return bytes(out)
+
+    def close(self):
+        try:
+            self.proc.terminate()
+        except Exception:
+            pass
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------- oracle
+_ORAC_SEQ = [0]
+
+
+# A glyph the test content never emits, so any cell left showing it after the
+# repaint is a cell the repaint failed to write (a write omission).
+DIRTY = b"@"
+
+
+def _dirty_fill(sx, sy):
+    """Bytes that paint every visible cell with the sentinel, then home. Feeding
+    this BEFORE the repaint models a real client repainting over its stale
+    pre-gap screen: any cell the repaint never writes keeps the sentinel, so
+    write OMISSION (e.g. cells a tab glides over) becomes visible, not just
+    wrong writes."""
+    out = bytearray(b"\x1b[m")
+    for r in range(1, sy + 1):
+        out += b"\x1b[%d;1H" % r
+        out += DIRTY * sx
+    out += b"\x1b[H"
+    return bytes(out)
+
+
+def oracle_feed(repaint, sx, sy, history_limit, dirty=False):
+    """Feed `repaint` into a fresh oracle pane sized sx*sy; return pane id. When
+    `dirty`, pre-fill every cell with the sentinel first so unwritten cells show.
+
+    The pane blocks on a FIFO so we can resize BEFORE the bytes are parsed."""
+    _ORAC_SEQ[0] += 1
+    name = "o%d" % _ORAC_SEQ[0]
+    fifo = os.path.join(WD, "fifo_%s" % name)
+    try:
+        os.remove(fifo)
+    except OSError:
+        pass
+    os.mkfifo(fifo)
+    tmux(RSOCK, "set-option", "-g", "history-limit", str(history_limit))
+    tmux(RSOCK, "set-option", "-g", "window-size", "manual")
+    tmux(RSOCK, "new-window", "-t", "orac:", "-n", name,
+         "sh -c 'cat %s; exec sleep 3600'" % fifo)
+    tmux(RSOCK, "resize-window", "-t", "orac:" + name, "-x", str(sx),
+         "-y", str(sy))
+    time.sleep(0.4)
+    payload = (_dirty_fill(sx, sy) if dirty else b"") + repaint
+    with open(fifo, "wb") as f:
+        f.write(payload)
+    time.sleep(1.0 + len(repaint) / 60000.0)      # large repaints parse slower
+    _, out, _ = tmux(RSOCK, "display-message", "-p", "-t", "orac:" + name,
+                     "#{pane_id}")
+    return out.strip()
+
+
+def cap_e(sock, pane):
+    _, out, _ = tmux(sock, "capture-pane", "-p", "-e", "-C", "-t", pane)
+    lines = out.split("\n")
+    while lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def cap_plain(sock, pane):
+    _, out, _ = tmux(sock, "capture-pane", "-p", "-C", "-t", pane)
+    lines = [ln.rstrip() for ln in out.split("\n")]
+    while lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def cap_join(sock, pane, n):
+    _, out, _ = tmux(sock, "capture-pane", "-p", "-J", "-S", "-%d" % n,
+                     "-t", pane)
+    return [ln.rstrip() for ln in out.split("\n")]
+
+
+def cursor(sock, pane):
+    _, out, _ = tmux(sock, "display-message", "-p", "-t", pane,
+                     "#{cursor_x},#{cursor_y},#{cursor_flag}")
+    return out.strip()
+
+
+def flag(sock, pane, name):
+    _, out, _ = tmux(sock, "display-message", "-p", "-t", pane, "#{%s}" % name)
+    return out.strip()
+
+
+# --------------------------------------------------------------------------- flow
+def new_pane(win):
+    tmux(OSOCK, "new-window", "-t", "m:", "-n", win)
+    _, out, _ = tmux(OSOCK, "display-message", "-p", "-t", "m:" + win,
+                     "#{pane_id}")
+    return "m:" + win, out.strip()
+
+
+def send(target, s):
+    tmux(OSOCK, "send-keys", "-t", target, s, "Enter")
+
+
+def _await_resync(base, timeout=14):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        time.sleep(0.3)
+        if logcount("resync %") > base:
+            return True
+    return False
+
+
+# Resync trigger mode -- THE single migration switch (mirrors replay_oracle.py).
+# "bytecap": legacy control-resync-size (a byte cap set above the socket so the
+# repaint defers). "linelimit": the new trigger -- no control-resync-size; the
+# resync fires on missed scrolled lines >= max(history-limit, ~2 screenfuls), so
+# a small history-limit set before pane creation induces (and speeds up) the
+# gap. history-limit then serves double duty (trigger threshold + replay depth);
+# TRIGGER_HLIMIT is the deferral-safe floor. Values tuned against the new binary.
+RESYNC_TRIGGER = "linelimit"
+TRIGGER_HLIMIT = 250
+LINELIMIT_FILL_LINE = "F" * 78     # wide (>=65 B) discrete filler row (deferral)
+
+
+def arm_resync_trigger(cap, history_limit):
+    if RESYNC_TRIGGER == "bytecap":
+        tmux(OSOCK, "set-option", "-g", "control-resync-size", str(cap))
+        tmux(OSOCK, "set-option", "-g", "history-limit", str(history_limit))
+    else:                                               # linelimit
+        hl = history_limit if history_limit < 100000 else TRIGGER_HLIMIT
+        tmux(OSOCK, "set-option", "-g", "history-limit", str(hl))
+
+
+def resync_redraw(victim, target, pane, draw, cap, resize, history_limit,
+                  filler=90000):
+    """Byte-cap resync, THEN draw the final screen while resyncing, resume,
+    return (repaint_bytes, fired)."""
+    arm_resync_trigger(cap, history_limit)
+    victim.drain(0.8)
+    victim.clear()
+    base = logcount("resync %")
+    send(target, "head -c %d /dev/zero | tr '\\0' Z; echo _F_" % filler)
+    fired = _await_resync(base)
+    time.sleep(0.6)
+    if resize is not None:
+        tmux(OSOCK, "refresh-client", "-C", "%dx%d" % resize)
+        time.sleep(0.8)
+    for d in draw:
+        send(target, d)
+        time.sleep(0.35)
+    time.sleep(1.0)
+    victim.clear()
+    victim.drain(3.0)
+    raw = victim.pane_output(pane)
+    sig = raw.find(REPAINT_SIG)
+    return (raw[sig:] if sig >= 0 else b""), fired
+
+
+def resync_then_produce(victim, target, pane, produce_cmd, sentinel,
+                        cap=40000, filler=80000, history_limit=100000):
+    """A byte filler fires the resync with the socket full (so the repaint
+    defers). Content is then produced during the resync; it scrolls into
+    history within the post-resync replay window. Wait for `sentinel` to reach
+    the pane, then resume. Return (repaint_bytes, fired)."""
+    arm_resync_trigger(cap, history_limit)
+    victim.drain(0.8)
+    victim.clear()
+    base = logcount("resync %")
+    # Newline-terminated filler (discrete lines, NOT one giant wrapped line)
+    # so the scrollback replay stays line-structured and the lines under test
+    # are not absorbed into a single logical line.
+    # Wide discrete filler rows so the line trigger fires only after the socket
+    # is full (deferral); ZFILLER's ~8 B rows would trip it before saturation.
+    send(target, "yes %s | head -c %d; echo _F_" % (LINELIMIT_FILL_LINE, filler))
+    fired = _await_resync(base)
+    time.sleep(0.6)
+    send(target, "%s; echo %s" % (produce_cmd, sentinel))
+    t0 = time.time()
+    while time.time() - t0 < 10:
+        _, out, _ = tmux(OSOCK, "capture-pane", "-p", "-t", pane)
+        if sentinel in out:
+            break
+        time.sleep(0.3)
+    time.sleep(0.6)
+    victim.clear()
+    victim.drain(3.0)
+    raw = victim.pane_output(pane)
+    sig = raw.find(REPAINT_SIG)
+    return (raw[sig:] if sig >= 0 else b""), fired
+
+
+def check(cond, case, msg):
+    if not cond:
+        FAIL.append("%s: %s" % (case, msg))
+    return bool(cond)
+
+
+def progress(name):
+    if os.environ.get("REPLAY_DEBUG"):
+        sys.stderr.write("[%6.1f] case %s\n" % (time.time() - T0, name))
+        sys.stderr.flush()
+
+
+T0 = time.time()
+
+
+# =========================================================================== cases
+ONLY = set(x for x in os.environ.get("REPLAY_ONLY", "").split(",") if x)
+
+
+def visible_case(victim, name, draw, cap=40000, sx=80, sy=24, resize=None,
+                 history_limit=100000, greps=(), nogreps=(),
+                 oracle_flags=(), check_cursor=True, check_visible=True,
+                 dirty=True):
+    if ONLY and name not in ONLY:
+        return
+    progress(name)
+    target, pane = new_pane(name)
+    time.sleep(0.4)
+    repaint, fired = resync_redraw(victim, target, pane, draw, cap, resize,
+                                   history_limit)
+    ok = check(fired, name, "resync did not fire")
+    ok = check(bool(repaint), name, "no repaint extracted") and ok
+    if not ok:
+        tmux(OSOCK, "kill-window", "-t", target)
+        return
+    osx, osy = (resize if resize else (sx, sy))
+    opane = oracle_feed(repaint, osx, osy, history_limit, dirty=dirty)
+    if check_visible:
+        # Content (plain text) and cursor are HARD: a surviving dirty-fill
+        # sentinel or wrong glyph shows up here. The -e SGR representation is
+        # HARD on a clean oracle (attribute fidelity) but SOFT under a
+        # dirty-fill, where background-on-blank (BCE) cells legitimately differ
+        # in representation while the plain text still matches -- distinguishing
+        # "sentinel survived / content wrong" from "SGR representation differs".
+        o_txt, r_txt = cap_plain(OSOCK, pane), cap_plain(RSOCK, opane)
+        check(o_txt == r_txt, name,
+              "content mismatch\n      orig=%r\n      orac=%r"
+              % (o_txt[:8], r_txt[:8]))
+        o_e, r_e = cap_e(OSOCK, pane), cap_e(RSOCK, opane)
+        if o_e != r_e and o_txt == r_txt:
+            if dirty:
+                if os.environ.get("REPLAY_DEBUG"):
+                    sys.stderr.write("  %s: attributes-only diff (soft)\n"
+                                     % name)
+            else:
+                check(False, name,
+                      "attribute mismatch\n      orig=%r\n      orac=%r"
+                      % (o_e[:8], r_e[:8]))
+    if check_cursor:
+        oc, rc = cursor(OSOCK, pane), cursor(RSOCK, opane)
+        check(oc == rc, name, "cursor mismatch orig=%s orac=%s" % (oc, rc))
+    for g in greps:
+        check(g in repaint, name, "repaint missing %r" % g)
+    for g in nogreps:
+        check(g not in repaint, name, "repaint unexpectedly has %r" % g)
+    for fname, want in oracle_flags:
+        got = flag(RSOCK, opane, fname)
+        check(got == want, name,
+              "oracle #{%s}=%s want %s" % (fname, got, want))
+    tmux(OSOCK, "kill-window", "-t", target)
+
+
+def scrollback_case(victim, name, produce_cmd, prefix, sentinel, cap=24000,
+                    filler=55000, history_limit=100000, want_intact=None):
+    if ONLY and name not in ONLY:
+        return
+    progress(name)
+    target, pane = new_pane(name)
+    time.sleep(0.4)
+    repaint, fired = resync_then_produce(victim, target, pane, produce_cmd,
+                                         sentinel, cap=cap, filler=filler,
+                                         history_limit=history_limit)
+    ok = check(fired, name, "resync did not fire")
+    ok = check(bool(repaint), name, "no repaint extracted") and ok
+    if not ok:
+        tmux(OSOCK, "kill-window", "-t", target)
+        return
+    opane = oracle_feed(repaint, 80, 24, history_limit)
+    orig = [ln for ln in cap_join(OSOCK, pane, 100000) if prefix in ln]
+    orac = [ln for ln in cap_join(RSOCK, opane, 100000) if prefix in ln]
+    if os.environ.get("DEBUG"):
+        with open(os.path.join(WD, "last_repaint_%s.bin" % name), "wb") as f:
+            f.write(repaint)
+        ridx = repaint.find(prefix.encode() if isinstance(prefix, str)
+                            else prefix)
+        sys.stderr.write("DEBUG %s repaint@%d len=%d\n" % (name, ridx,
+                                                           len(repaint)))
+        sys.stderr.write("  repaint slice: %r\n" % repaint[max(0, ridx-40):ridx+340])
+        sys.stderr.write("  orig(%d): %r\n" % (len(orig), [len(x) for x in orig]))
+        sys.stderr.write("  orac(%d): %r\n" % (len(orac), [len(x) for x in orac]))
+    # ordered subsequence, no duplicates
+    it = iter(orig)
+    subseq = all(any(x == y for y in it) for x in orac)
+    seen, dup = set(), None
+    for ln in orac:
+        if ln in seen:
+            dup = ln
+            break
+        seen.add(ln)
+    check(bool(orac), name, "oracle replayed 0 %r lines" % prefix)
+    check(subseq, name, "oracle not an ordered subsequence of original")
+    check(dup is None, name, "oracle has duplicate line %r" % dup)
+    if want_intact is not None:
+        check(any(want_intact in ln for ln in orac), name,
+              "wrapped logical line not intact in replay")
+    tmux(OSOCK, "kill-window", "-t", target)
+
+
+def wrapped_case(victim, name):
+    """A logical line far wider than the pane, scrolled into history, must be
+    replayed WITHOUT artificial hard breaks: the scrollback-replay joins the
+    wrapped rows into one continuous run (SGR resets between the 80-col row
+    boundaries, but no CR/LF), so the client re-wraps it as one logical line.
+    Asserted directly on the repaint bytes -- the precise invariant -- since a
+    hard break would insert \\r\\n between the row segments."""
+    if ONLY and name not in ONLY:
+        return
+    progress(name)
+    target, pane = new_pane(name)
+    time.sleep(0.4)
+    repaint, fired = resync_then_produce(
+        victim, target, pane,
+        "printf 'W%.0s' $(seq 1 300); printf '\\n'; "
+        "for i in $(seq 1 30); do echo post-$i; done",
+        "WDONE_SENTINEL", cap=24000, filler=55000)
+    ok = check(fired, name, "resync did not fire")
+    ok = check(bool(repaint), name, "no repaint extracted") and ok
+    if not ok:
+        tmux(OSOCK, "kill-window", "-t", target)
+        return
+    wi = repaint.find(b"W" * 10)
+    ok = check(wi >= 0, name, "wide line not present in replay")
+    if ok:
+        # The wide line occupies a contiguous region of the replay. Strip the
+        # per-row SGR resets; the W run must stay whole (>= 240 of the 300),
+        # proving the 80-col rows were joined with no \r\n hard break. A hard
+        # break would cap the run near 80.
+        region = repaint[wi:wi + 700]
+        end = region.find(b"\r")            # first CR ends the logical line
+        wline = region[:end] if end >= 0 else region
+        stripped = wline.replace(b"\x1b[m", b"")
+        run = 0
+        best = 0
+        for ch in stripped:
+            if ch == ord("W"):
+                run += 1
+                best = max(best, run)
+            else:
+                run = 0
+        check(best >= 240, name,
+              "wide line hard-broken in replay (max contiguous W run %d, "
+              "expected ~300)" % best)
+        check(b"\r" not in wline and b"\n" not in wline, name,
+              "artificial line break inside the wrapped logical line")
+    tmux(OSOCK, "kill-window", "-t", target)
+
+
+def _noscroll(k):
+    # k rows of "<79 X>\r": overwrites one physical line (scrolls nothing) while
+    # streaming ~80*k bytes, used to fill the socket / trip the byte backstop.
+    return "yes %s | head -n %d | tr '\\n' '\\r'" % ("X" * 79, k)
+
+
+def frontier_case(victim, name, prefix, produce, N, L, sentinel, mode):
+    """Lossless-frontier of the line trigger. The missed-line counter only
+    accrues once the client socket is full, so a non-scrolling prefill saturates
+    it first; then exactly N numbered lines scroll (all missed). Asserted on the
+    REPAINT's replayed numbers -- what the client receives -- since the oracle's
+    kept history depth is a separate emulator property.
+      complete (N<L): the repaint replays 1..N contiguous, no loss, no dup.
+      degrade (N>>L): a bounded recent contiguous window, oldest dropped (min>1,
+      a gap not a duplicate), reaching the latest, no dup."""
+    if ONLY and name not in ONLY:
+        return
+    progress(name)
+    target, pane = new_pane(name)
+    time.sleep(0.4)
+    tmux(OSOCK, "set-option", "-g", "history-limit", str(L))
+    victim.drain(0.8)
+    victim.clear()
+    base = logcount("resync %")
+    send(target, produce + "; echo " + sentinel)
+    fired = _await_resync(base, timeout=18)
+    t0 = time.time()
+    while time.time() - t0 < 12:
+        _, out, _ = tmux(OSOCK, "capture-pane", "-p", "-t", pane)
+        if sentinel in out:
+            break
+        time.sleep(0.3)
+    time.sleep(0.6)
+    victim.clear()
+    victim.drain(3.0)
+    raw = victim.pane_output(pane)
+    sig = raw.find(REPAINT_SIG)
+    repaint = raw[sig:] if sig >= 0 else b""
+    ok = check(fired, name, "resync did not fire")
+    ok = check(bool(repaint), name, "no repaint extracted") and ok
+    if not ok:
+        tmux(OSOCK, "kill-window", "-t", target)
+        return
+    rep = [int(m) for m in re.findall(prefix.encode() + rb"(\d+)", repaint)]
+    contiguous = bool(rep) and (max(rep) - min(rep) + 1 == len(set(rep)))
+    nodup = len(rep) == len(set(rep))
+    info = ("count=%d min=%s max=%s contig=%s dup=%s"
+            % (len(rep), rep[0] if rep else None, max(rep) if rep else None,
+               contiguous, not nodup))
+    if mode == "complete":
+        check(bool(rep) and min(rep) == 1 and max(rep) == N and len(rep) == N
+              and contiguous and nodup, name,
+              "N<L replay not lossless (%s, want 1..%d)" % (info, N))
+    else:
+        check(bool(rep) and min(rep) > 1 and max(rep) == N and len(rep) < N
+              and len(rep) <= 3 * L and contiguous and nodup
+              and rep == sorted(rep), name,
+              "N>>L replay not a graceful bounded gap (%s)" % info)
+    tmux(OSOCK, "kill-window", "-t", target)
+
+
+def main():
+    tmux(OSOCK, "kill-server")
+    tmux(RSOCK, "kill-server")
+    subprocess.run([TMUX, "-vv", "-L", OSOCK, "-f/dev/null", "new-session",
+                    "-d", "-s", "m", "-x", "80", "-y", "24"], cwd=WD, check=True)
+    subprocess.run([TMUX, "-L", RSOCK, "-f/dev/null", "new-session",
+                    "-d", "-s", "orac", "-x", "80", "-y", "24"], cwd=WD,
+                   check=True)
+    time.sleep(0.5)
+    tmux(OSOCK, "set-option", "-g", "history-limit", "100000")
+    tmux(OSOCK, "set-option", "-g", "control-resync", "on")
+    obs = subprocess.Popen([TMUX, "-L", OSOCK, "-C", "attach", "-t", "m"],
+                           stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                           stderr=subprocess.DEVNULL, cwd=WD)
+    obs.stdin.write(b"refresh-client -f no-output\n")
+    obs.stdin.flush()
+    time.sleep(0.5)
+    victim = Victim(OSOCK, "m")
+    victim.drain(1.0)
+
+    try:
+        # 1. SGR spectrum -- kept on a CLEAN oracle (dirty=False) so the -e
+        #    attribute representation is checked strictly (this is the one case
+        #    whose whole point is SGR fidelity; a dirty-fill would soften it).
+        visible_case(victim, "sgr", [
+            "printf '\\033c\\033[1mB\\033[0m\\033[3mI\\033[0m\\033[4mU\\033[0m"
+            "\\033[9mS\\033[0m\\033[7mR\\033[0m \\033[4:3mCUL\\033[0m "
+            "\\033[31mr\\033[32mg\\033[34mb\\033[0m \\033[38;5;208m256\\033[0m "
+            "\\033[48;5;22mBG\\033[0m "
+            "\\033[38;2;10;20;30m\\033[48;2;200;100;50mRGB\\033[0m\\n"
+            "\\033[5;10H'; sleep 30"], dirty=False)
+
+        # 2. UTF-8 wide + combining + wide char straddling the right margin
+        visible_case(victim, "utf8", [
+            "printf '\\033c\\346\\227\\245\\346\\234\\254 "        # CJK wide
+            "cafe\\314\\201 e\\314\\201x "                          # combining
+            "\\033[1;80H\\344\\270\\200TAIL\\n\\033[4;1H'; sleep 30"])
+
+        # 4. custom tab stops (clear all, set via HTS). The repaint must restore
+        #    the custom stops (clear-all DECST + HTS at each) AND leave the cells
+        #    a TAB jumps over blank: screen_repaint serialises tab-gap cells as a
+        #    literal TAB, so it must clear each line before painting or stale
+        #    content survives under the gap. Checked over a dirty-filled oracle
+        #    so a gap the repaint fails to clear shows the sentinel.
+        visible_case(victim, "tabs", [
+            "printf '\\033c\\033[3g\\033[1;4H\\033H\\033[1;20H\\033H"
+            "\\033[1;40H\\033H\\033[2;1Ha\\tb\\tc\\td\\033[6;1H'; sleep 30"],
+            greps=[b"\x1b[3g", b"\x1b[1;4H\x1bH", b"\x1b[1;20H\x1bH",
+                   b"\x1b[1;40H\x1bH"],
+            dirty=True)
+
+        # 5. scroll region (DECSTBM) with cursor inside it
+        visible_case(victim, "scroll_region", [
+            "printf '\\033c\\033[5;15r\\033[8;1Hinside-region line\\n"
+            "second\\033[10;3H'; sleep 30"],
+            greps=[b"\x1b[5;15r"])
+
+        # 6. alt screen active at gap time -> repaint-only, lands in alt
+        visible_case(victim, "altscreen", [
+            "printf '\\033c\\033[?1049h\\033[2J\\033[HALT-CONTENT here"
+            "\\033[3;5H'; sleep 30"],
+            greps=[b"\x1b[?1049h"])
+
+        # 7. origin mode (DECOM): the cursor address the repaint emits is taken
+        #    relative to the scroll region, so an absolute row would land the
+        #    cursor in the wrong place. Check the exact cursor here.
+        visible_case(victim, "origin", [
+            "printf '\\033c\\033[5;15r\\033[?6h\\033[2;1Horigin-inside"
+            "\\033[3;1H'; sleep 30"],
+            greps=[b"\x1b[?6h"], oracle_flags=[("origin_flag", "1")],
+            check_visible=False)
+
+        # 8. cursor styles (DECSCUSR) -- no capture format, grep the repaint
+        visible_case(victim, "cursor_style", [
+            "printf '\\033c\\033[4 qsteady-underline-cursor\\033[2;1H'; "
+            "sleep 30"], greps=[b"\x1b[4 q"])
+
+        # 9. cursor colour (OSC 12)
+        visible_case(victim, "cursor_colour", [
+            "printf '\\033c\\033]12;#ff8800\\033\\\\colour-cursor"
+            "\\033[2;1H'; sleep 30"], greps=[b"\x1b]12;"])
+
+        # 10. hidden cursor
+        visible_case(victim, "hidden_cursor", [
+            "printf '\\033chidden\\033[?25l\\033[2;1H'; sleep 30"],
+            oracle_flags=[("cursor_flag", "0")], check_cursor=False)
+
+        # 11. insert mode
+        visible_case(victim, "insert", [
+            "printf '\\033cinsert-mode\\033[4h\\033[3;1H'; sleep 30"],
+            greps=[b"\x1b[4h"], oracle_flags=[("insert_flag", "1")])
+
+        # 12. application keypad
+        visible_case(victim, "app_keypad", [
+            "printf '\\033ckeypad-app\\033=\\033[2;1H'; sleep 30"],
+            greps=[b"\x1b="], oracle_flags=[("keypad_flag", "1")])
+
+        # 13. application cursor keys
+        visible_case(victim, "app_cursor_keys", [
+            "printf '\\033ccursor-keys\\033[?1h\\033[2;1H'; sleep 30"],
+            greps=[b"\x1b[?1h"], oracle_flags=[("keypad_cursor_flag", "1")])
+
+        # 14. bracketed paste (no capture format)
+        visible_case(victim, "bracketed_paste", [
+            "printf '\\033cbracket\\033[?2004h\\033[2;1H'; sleep 30"],
+            greps=[b"\x1b[?2004h"])
+
+        # 15a. autowrap OFF
+        visible_case(victim, "wrap_off", [
+            "printf '\\033cnowrap\\033[?7l\\033[2;1H'; sleep 30"],
+            greps=[b"\x1b[?7l"], oracle_flags=[("wrap_flag", "0")])
+
+        # 15b. mouse modes (button tracking + SGR extended)
+        visible_case(victim, "mouse", [
+            "printf '\\033cmouse\\033[?1000h\\033[?1006h\\033[2;1H'; sleep 30"],
+            greps=[b"\x1b[?1000h", b"\x1b[?1006h"],
+            oracle_flags=[("mouse_standard_flag", "1")])
+
+        # 19. empty screen
+        visible_case(victim, "empty", ["printf '\\033c\\033[H'; sleep 30"])
+
+        # 20. full screen exactly at pane size (24 rows filled)
+        visible_case(victim, "full_screen", [
+            "printf '\\033c'; for i in $(seq 1 24); do "
+            "printf 'row-%02d-###############################################"
+            "###############\\n' $i; done; printf '\\033[12;40H'; sleep 30"])
+
+        # 3. wrapped logical line wider than the pane -> the scrollback replay
+        #    must join it back into one logical line (no artificial hard break).
+        #    The W line is produced first, then enough pad lines to scroll it
+        #    into history and saturate the socket (so the repaint defers).
+        # A byte filler fires the resync (repaint deferred behind the full
+        # socket); the W line + pads are then produced during the resync, so
+        # they scroll into history within the post-resync replay window. The
+        # replay must join the wrapped rows back into one logical line.
+        wrapped_case(victim, "wrapped")
+
+        # 16. scrollback replay: numbered lines, ordered subsequence, no dups
+        scrollback_case(victim, "scrollback",
+                        "for i in $(seq 1 300); do echo SBLINE-$i; done",
+                        prefix="SBLINE-", sentinel="SBDONE_SENTINEL")
+
+        # 17. width change during gap -> repaint-only at the new width
+        visible_case(victim, "width_change", [
+            "printf '\\033cwidth-change-line\\033[3;50Hmark\\033[5;1H'; "
+            "sleep 30"], resize=(100, 30))
+
+        # 18. history trimmed (tiny limit) -> degrade to repaint-only, no crash
+        visible_case(victim, "history_trim", [
+            "printf '\\033ctrimmed-history\\033[2;1H'; sleep 30"],
+            history_limit=2)
+        alive = flag(OSOCK, "m:", "pid")
+        check(bool(alive), "history_trim", "server not alive after degrade")
+
+        # 23. tab-gap stale cells over pre-existing content. Custom tab stops
+        #     with a<TAB>b<TAB>c<TAB>d leave gaps grid_string_cells serialises
+        #     as literal TABs, which advance the cursor without clearing the
+        #     cells under them, so the repaint must erase each line before
+        #     painting. A width change skips the scrollback replay, so the
+        #     dirty-filled oracle is the only content under the gaps and the
+        #     check is deterministic: pre-fix the sentinel survives there.
+        visible_case(victim, "tab_gap", [
+            "printf '\\033c\\033[3g\\033[1;4H\\033H\\033[1;20H\\033H"
+            "\\033[1;40H\\033H\\033[2;1Ha\\tb\\tc\\td\\033[6;1H'; sleep 30"],
+            greps=[b"\x1b[3g"], resize=(100, 30), dirty=True)
+
+        # 24. resize + scroll region + origin mode (deterministic seed-40 case).
+        #     The pane is resized during the gap with a scroll region and origin
+        #     mode active; the repaint re-enables origin mode before addressing
+        #     the cursor, so an absolute row lands it one row off. The address
+        #     must be region-relative. Checks the exact restored cursor.
+        visible_case(victim, "resize_scroll_region", [
+            "printf '\\033c\\033[9;12r\\033[?6h\\033[3;5Hregion-origin"
+            "\\033[2;4H'; sleep 30"],
+            resize=(100, 30), greps=[b"\x1b[9;12r", b"\x1b[?6h"],
+            check_visible=False)
+
+        # 25a. Lossless frontier -- COMPLETE: fewer scrolled lines than the
+        #      history limit (N<L). Prefill the socket (non-scroll), scroll N,
+        #      then a non-scroll blast to trip the byte backstop. The repaint
+        #      must replay all N missed lines (1..N), no loss, no off-by-one.
+        frontier_case(victim, "frontier_complete", "FL-",
+                      "%s; for i in $(seq 1 40); do echo FL-$i; done; %s"
+                      % (_noscroll(2500), _noscroll(1200)),
+                      40, 80, "FCDONE", "complete")
+        # 25b. Lossless frontier -- DEGRADE: far more scrolled lines than the
+        #      history limit (N>>L). The line trigger fires; the replay is a
+        #      bounded recent window with the oldest lines dropped (graceful
+        #      gap, never a duplicate), still reaching the latest line.
+        frontier_case(victim, "frontier_degrade", "DL-",
+                      "%s; for i in $(seq 1 300); do echo DL-$i; done"
+                      % _noscroll(2500),
+                      300, 80, "FDDONE", "degrade")
+    finally:
+        victim.close()
+        obs.terminate()
+
+    if FAIL:
+        sys.stderr.write("REPLAY FIDELITY FAILURES (%d):\n" % len(FAIL))
+        for f in FAIL:
+            sys.stderr.write("  - %s\n" % f)
+        sys.exit(1)
+    if os.environ.get("REPLAY_DEBUG"):
+        sys.stderr.write("all replay cases passed\n")
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+
+exit 0

--- a/screen.c
+++ b/screen.c
@@ -913,3 +913,193 @@ out:
 	buf[last] = '\0';
 	return (buf);
 }
+
+/* Append a fixed string (no formatting) to a buffer. */
+static void
+screen_repaint_add(struct evbuffer *msg, const char *s)
+{
+	evbuffer_add(msg, s, strlen(s));
+}
+
+/* Reset attributes and serialise one grid row. */
+static void
+screen_repaint_row(struct evbuffer *msg, struct screen *s, u_int py, u_int sx)
+{
+	struct grid_cell	*gc = NULL;
+	char			*line;
+
+	screen_repaint_add(msg, "\033[m");
+	line = grid_string_cells(s->grid, 0, py, sx, &gc,
+	    GRID_STRING_WITH_SEQUENCES, s);
+	screen_repaint_add(msg, line);
+	free(line);
+}
+
+/* Restore custom tab stops (clear all, then set one at each stop). */
+static void
+screen_repaint_tabs(struct evbuffer *msg, struct screen *s, u_int sx)
+{
+	u_int	i;
+
+	if (s->tabs == NULL)
+		return;
+	screen_repaint_add(msg, "\033[3g");
+	for (i = 0; i < sx; i++) {
+		if (bit_test(s->tabs, i))
+			evbuffer_add_printf(msg, "\033[1;%uH\033H", i + 1);
+	}
+}
+
+/*
+ * Restore the terminal modes, scroll region and cursor from the screen. This is
+ * the counterpart to the state input.c parses and tty_update_mode emits, so it
+ * must be kept in step with them; transient and negotiation-only bits (the
+ * synchronised update flag, cursor-blinking-set, extended keys) are masked out.
+ */
+static void
+screen_repaint_state(struct evbuffer *msg, struct screen *s)
+{
+	int	mode = s->mode &
+		    ~(MODE_SYNC|MODE_CURSOR_BLINKING_SET|EXTENDED_KEY_MODES);
+	u_int	n;
+	u_char	r, g, b;
+
+	/* Autowrap, cursor keys, keypad, insert. */
+	screen_repaint_add(msg, (mode & MODE_WRAP) ? "\033[?7h" : "\033[?7l");
+	screen_repaint_add(msg, (mode & MODE_KCURSOR) ? "\033[?1h" : "\033[?1l");
+	screen_repaint_add(msg, (mode & MODE_KKEYPAD) ? "\033=" : "\033>");
+	screen_repaint_add(msg, (mode & MODE_INSERT) ? "\033[4h" : "\033[4l");
+
+	/* Bracketed paste and focus reporting. */
+	screen_repaint_add(msg, (mode & MODE_BRACKETPASTE) ? "\033[?2004h" :
+	    "\033[?2004l");
+	screen_repaint_add(msg, (mode & MODE_FOCUSON) ? "\033[?1004h" :
+	    "\033[?1004l");
+
+	/* Mouse modes: clear all then re-apply, as tty_update_mode does. */
+	screen_repaint_add(msg, "\033[?1006l\033[?1000l\033[?1002l\033[?1003l");
+	if (mode & ALL_MOUSE_MODES)
+		screen_repaint_add(msg, "\033[?1006h");
+	if (mode & MODE_MOUSE_ALL)
+		screen_repaint_add(msg, "\033[?1000h\033[?1002h\033[?1003h");
+	else if (mode & MODE_MOUSE_BUTTON)
+		screen_repaint_add(msg, "\033[?1000h\033[?1002h");
+	else if (mode & MODE_MOUSE_STANDARD)
+		screen_repaint_add(msg, "\033[?1000h");
+
+	/* Scroll region (DECSTBM); this homes the cursor. */
+	evbuffer_add_printf(msg, "\033[%u;%ur", s->rupper + 1, s->rlower + 1);
+
+	/* Cursor style (DECSCUSR). */
+	n = 0;
+	switch (s->cstyle) {
+	case SCREEN_CURSOR_DEFAULT:
+		break;
+	case SCREEN_CURSOR_BLOCK:
+		n = (s->mode & MODE_CURSOR_BLINKING) ? 1 : 2;
+		break;
+	case SCREEN_CURSOR_UNDERLINE:
+		n = (s->mode & MODE_CURSOR_BLINKING) ? 3 : 4;
+		break;
+	case SCREEN_CURSOR_BAR:
+		n = (s->mode & MODE_CURSOR_BLINKING) ? 5 : 6;
+		break;
+	}
+	evbuffer_add_printf(msg, "\033[%u q", n);
+
+	/* Cursor colour (OSC 12). */
+	if (s->ccolour != -1) {
+		colour_split_rgb(colour_force_rgb(s->ccolour), &r, &g, &b);
+		evbuffer_add_printf(msg, "\033]12;rgb:%02hhx/%02hhx/%02hhx\033\\",
+		    r, g, b);
+	}
+
+	/* Origin mode last, since it homes the cursor. */
+	screen_repaint_add(msg, (mode & MODE_ORIGIN) ? "\033[?6h" : "\033[?6l");
+}
+
+/*
+ * Replay history lines [from, to) so they feed the client's own scrollback.
+ * Lines are written at the bottom row so each true line end scrolls one line
+ * up; wrapped logical lines are joined and re-wrapped by the client, with
+ * autowrap forced on for the replay.
+ */
+static void
+screen_repaint_replay(struct evbuffer *msg, struct screen *s, u_int sx,
+    u_int sy, u_int from, u_int to)
+{
+	struct grid		*gd = s->grid;
+	const struct grid_line	*gl;
+	u_int			 py;
+
+	evbuffer_add_printf(msg, "\033[?7h\033[%u;1H", sy);
+	for (py = from; py < to; py++) {
+		screen_repaint_row(msg, s, py, sx);
+		gl = grid_peek_line(gd, py);
+		if (gl == NULL || (~gl->flags & GRID_LINE_WRAPPED))
+			screen_repaint_add(msg, "\033[m\r\n");
+	}
+}
+
+/*
+ * Build a byte stream that reconstructs the screen on a fresh terminal, for a
+ * control mode client that must be repainted after its output was discarded.
+ * If from and owidth locate a usable position in the current primary-screen
+ * history, recent scrollback is replayed first (best effort, never duplicating
+ * lines); otherwise only the visible screen is painted.
+ */
+void
+screen_repaint(struct screen *s, const struct grid_history_state *from,
+    u_int owidth, struct evbuffer *msg)
+{
+	struct grid	*gd = s->grid;
+	u_int		 sx = screen_size_x(s), sy = screen_size_y(s), ry, gap = 0;
+	int		 alt = SCREEN_IS_ALTERNATE(s);
+	int		 cursor = (s->mode & MODE_CURSOR);
+
+	/* Cancel any partial escape sequence the gap may have cut mid-stream. */
+	screen_repaint_add(msg, "\030\033\\"); /* CAN, ST */
+
+	/* Paint atomically where supported; hide the cursor as a fallback. */
+	screen_repaint_add(msg, "\033[?2026h\033[?25l");
+
+	if (!alt && gd->hsize != 0 && sx == owidth)
+		gap = grid_history_delta(gd, from);
+	screen_repaint_tabs(msg, s, sx);
+	if (gap != 0)
+		screen_repaint_replay(msg, s, sx, sy, gd->hsize - gap, gd->hsize);
+
+	/* Enter the alternate screen before painting its contents. */
+	if (alt)
+		screen_repaint_add(msg, "\033[?1049h");
+
+	/*
+	 * Repaint each visible row. Erase the whole line first, as tty_draw_line
+	 * clears a row before drawing it: grid_string_cells emits a literal tab
+	 * for GRID_FLAG_TAB cells, which advances the cursor without clearing the
+	 * cells it glides over, so stale content under a tab gap would otherwise
+	 * survive a paint that only clears from the cursor to the end of line.
+	 */
+	screen_repaint_add(msg, "\033[m");
+	for (ry = 0; ry < sy; ry++) {
+		evbuffer_add_printf(msg, "\033[%u;1H\033[2K", ry + 1);
+		screen_repaint_row(msg, s, gd->hsize + ry, sx);
+		screen_repaint_add(msg, "\033[m");
+	}
+
+	/*
+	 * Restore state, then reposition the cursor. screen_repaint_state has by
+	 * now re-enabled origin mode if it was set, which makes cursor addressing
+	 * relative to the scroll region, so the absolute row must be converted to
+	 * a region-relative one before it is emitted.
+	 */
+	screen_repaint_state(msg, s);
+	if (s->mode & MODE_ORIGIN) {
+		u_int	crow = (s->cy > s->rupper) ? s->cy - s->rupper : 0;
+		evbuffer_add_printf(msg, "\033[%u;%uH", crow + 1, s->cx + 1);
+	} else
+		evbuffer_add_printf(msg, "\033[%u;%uH", s->cy + 1, s->cx + 1);
+	screen_repaint_add(msg, "\033[?2026l");
+	if (cursor)
+		screen_repaint_add(msg, "\033[?25h");
+}

--- a/screen.c
+++ b/screen.c
@@ -438,6 +438,12 @@ screen_resize_y(struct screen *s, u_int sy, int eat_empty, u_int *cy)
 		if (gd->flags & GRID_HISTORY) {
 			gd->hscrolled += needed;
 			gd->hsize += needed;
+			/*
+			 * These lines enter history without going through
+			 * grid_scroll_history, so mark a history discontinuity.
+			 */
+			if (needed != 0)
+				gd->scroll_generation++;
 		} else if (needed > 0 && available > 0) {
 			if (available > needed)
 				available = needed;

--- a/tmux.1
+++ b/tmux.1
@@ -4719,6 +4719,30 @@ where codepoint may be a UTF\-8 character, an identifier of the form
 .Ql U+number
 where the number is a hexadecimal number, or a range of the form
 .Ql U+number\-U+number .
+.It Xo Ic control\-resync
+.Op Ic off | on | keep\-pause
+.Xc
+How a control mode client that falls too far behind is recovered (see
+.Sx CONTROL MODE ) .
+A client is too far behind once it has missed more scrolled lines for a pane
+than
+.Ic history\-limit
+keeps: up to that point a repaint reconstructs everything it missed, so nothing
+is lost by waiting, but past it
+.Nm
+is already discarding lines the client never saw.
+With
+.Ic on
+(the default) it is resynchronised with a repaint, including a client in pause
+mode, which is not paused.
+With
+.Ic keep\-pause
+a pause mode client is paused with
+.Ic %pause
+instead.
+With
+.Ic off
+such a client is killed.
 .It Ic copy\-command Ar shell\-command
 Give the command to pipe to if the
 .Ic copy\-pipe
@@ -8858,7 +8882,10 @@ has been deleted.
 .It Ic %pause Ar pane\-id
 The pane has been paused (if the
 .Ar pause\-after
-flag is set).
+flag is set and
+.Ic control\-resync
+is
+.Ic keep\-pause ) .
 .It Ic %session\-changed Ar session\-id Ar name
 The client is now attached to the session with ID
 .Ar session\-id ,
@@ -8925,6 +8952,20 @@ The window with ID
 was renamed to
 .Ar name .
 .El
+.Pp
+If a client cannot keep up and has missed more scrolled lines for a pane than
+.Ic history\-limit
+keeps, or it makes no progress for several seconds, that output is discarded
+rather than held indefinitely (see
+.Ic control\-resync ) .
+When the client can accept data again the pane is resynchronised by repainting
+it with
+.Ic %output :
+the visible screen, scrollback, cursor and terminal modes are reproduced, but a
+few pieces of state that are not held in the grid may be briefly wrong until the
+application redraws them, notably the saved cursor
+.Pq Ql DECSC ,
+the selected character sets and any images.
 .Sh ENVIRONMENT
 When
 .Nm

--- a/tmux.h
+++ b/tmux.h
@@ -905,6 +905,12 @@ struct grid {
 	struct grid_line	*linedata;
 };
 
+/* Snapshot of a grid's history sequence, for grid_history_delta. */
+struct grid_history_state {
+	u_int	added;
+	u_int	generation;
+};
+
 /* Virtual cursor in a grid. */
 struct grid_reader {
 	struct grid	*gd;
@@ -3374,6 +3380,9 @@ void	 grid_remove_history(struct grid *, u_int );
 void	 grid_scroll_history(struct grid *, u_int);
 void	 grid_scroll_history_region(struct grid *, u_int, u_int, u_int);
 void	 grid_clear_history(struct grid *);
+void	 grid_history_get_state(struct grid *, struct grid_history_state *);
+u_int	 grid_history_delta(struct grid *, const struct grid_history_state *);
+u_int	 grid_history_missed(struct grid *, const struct grid_history_state *);
 const struct grid_line *grid_peek_line(struct grid *, u_int);
 void	 grid_get_cell(struct grid *, u_int, u_int, struct grid_cell *);
 void	 grid_set_cell(struct grid *, u_int, u_int, const struct grid_cell *);

--- a/tmux.h
+++ b/tmux.h
@@ -3563,6 +3563,8 @@ int	 screen_select_cell(struct screen *, struct grid_cell *,
 	     const struct grid_cell *);
 int	 screen_alternate_on(struct screen *, struct grid_cell *, int);
 int	 screen_alternate_off(struct screen *, struct grid_cell *, int);
+void	 screen_repaint(struct screen *, const struct grid_history_state *,
+	     u_int, struct evbuffer *);
 const char *screen_mode_to_string(int);
 const char *screen_print(struct screen *, int);
 


### PR DESCRIPTION
This is an RFC. I'd like a read on the direction before investing more time in it.

## Motivation

The goal is to make the whole EternalTerminal <-> tmux stack behave well end to end: attach with -CC over a remote link, step away while a pane spews output, and come back to a session that is current and responsive. Today every hop handles a slow consumer badly. On the ET side, megabytes queue in kernel buffers so ^C takes a minute or more to bite (MisterTea/EternalTerminal#631, fixed with per-link flow control in MisterTea/EternalTerminal#730). On the tmux hop the only tool is pausing: iTerm2 sets pause-after, tmux emits %pause, and the user gets a "press to unpause" banner. That's bad UX — when you're looking at a buffer you want to see it; you always press the button. The defaults for clients that don't opt in are worse: the pane buffer grows until a 300 second kill, and a sole client that stops reading gets pane reads disabled, at which point the program in the pane blocks in write() with nothing to time it out.

## What this does

End-to-end flow control instead. When tmux can't write to a control client it queues locally, as now. When a client falls further behind than the pane's history keeps, tmux discards the backlog and refreshes the client's state: a repaint of the pane inside a synchronized-update bracket, plus a replay of the missed scrollback out of history. The aim is to be strictly better than pausing — up to history-limit behind, the refresh reconstructs everything the client missed, so resyncing loses nothing; past that, history is already trimming lines the client never saw, so holding the backlog only postpones the same loss. When incremental catch-up is cheaper, tmux just keeps streaming; the refresh is what an unpause would have sent anyway, minus the button.

The refresh is plain terminal control codes carried in the normal %output stream, so the client protocol doesn't change and existing clients render it as-is (unmodified iTerm2 included). By default pause-after clients are resynced too and never see %pause; `control-resync keep-pause` restores the old behaviour and `off` the legacy kill.

Three patches: a small factoring of the control output path, a grid API for tracking the history sequence, then the feature. One new server option; the thresholds derive from history-limit rather than adding knobs. The shape follows TTY_BLOCK, which already does discard-then-redraw for slow regular terminals.

## Disclosure and testing

The implementation is largely AI-generated, directed and reviewed by me. It has been tested heavily with automation: in-tree regress tests including a 26-case repaint-fidelity suite that round-trips every generated repaint through a second tmux instance as an oracle, and a coverage-guided fuzzer over the serialiser. The fuzzing caught two bugs in the new repaint code introduced by this series (stale cells under tab gaps, and a cursor restore that ignored origin mode); both are fixed in what's posted here. What it has not had is real-world end-to-end time. Before taking this further I plan to set up automated testing that runs iTerm2 -> injected proxy -> tmux, so I can reconstruct real flow-control scenarios (slow links, stalls, dead readers) against real client behaviour.

Related: #5356 / #5357 came out of the same investigation.
