### PR TITLE
fix(cmd): guard realloc size arithmetic against overflow

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -845,7 +845,7 @@ cmd_template_replace(const char *template, const char *s, int idx)
 	char		 ch, *buf;
 	const char	*ptr, *cp, quote[] = "\"\\$;~";
 	int		 replaced, quoted;
-	size_t		 len;
+	size_t		 len, slen;
 
 	if (strchr(template, '%') == NULL)
 		return (xstrdup(template));
@@ -870,7 +870,10 @@ cmd_template_replace(const char *template, const char *s, int idx)
 			if (quoted)
 				ptr++;
 
-			buf = xrealloc(buf, len + (strlen(s) * 3) + 1);
+			slen = strlen(s);
+			if (slen >= SIZE_MAX / 3 || len > SIZE_MAX - (slen * 3) - 1)
+				fatalx("argument too long");
+			buf = xrealloc(buf, len + (slen * 3) + 1);
 			for (cp = s; *cp != '\0'; cp++) {
 				if (quoted && strchr(quote, *cp) != NULL)
 					buf[len++] = '\\';
@@ -879,6 +882,8 @@ cmd_template_replace(const char *template, const char *s, int idx)
 			buf[len] = '\0';
 			continue;
 		}
+		if (len > SIZE_MAX - 2)
+			fatalx("argument too long");
 		buf = xrealloc(buf, len + 2);
 		buf[len++] = ch;
 		buf[len] = '\0';


### PR DESCRIPTION
In cmd_template_replace(), the size passed to xrealloc(), len + strlen(s) * 3 + 1, can overflow before the allocation. Add a SIZE_MAX guard before it.

Dropped the format.c hunks after review: those sites use xreallocarray(), which already guards the multiplication.