### PR TITLE
fix(input): return to ground state when input buffer overflows

### DIFF
--- a/input.c
+++ b/input.c
@@ -1016,6 +1016,13 @@ input_parse(struct input_ctx *ictx, const u_char *buf, size_t len)
 		if (itr->handler != NULL && itr->handler(ictx) != 0)
 			continue;
 
+		if ((ictx->flags & INPUT_DISCARD) &&
+		    ictx->state != &input_state_ground) {
+			input_clear(ictx);
+			ictx->state = &input_state_ground;
+			continue;
+		}
+
 		/* And switch state, if necessary. */
 		if (itr->state != NULL)
 			input_set_state(ictx, itr);


### PR DESCRIPTION
When an OSC, DCS, or CSI sequence exceeds the input buffer size, INPUT_DISCARD is set but the state machine stays in its current non-ground state, stalling all further input processing until the sequence terminator arrives.

Force a return to ground state when INPUT_DISCARD is detected outside ground, so subsequent input can be processed immediately.