### PR TITLE
fix(server): log waitpid errors instead of killing the server

### DIFF
--- a/server.c
+++ b/server.c
@@ -470,7 +470,8 @@ server_child_signal(void)
 		case -1:
 			if (errno == ECHILD)
 				return;
-			fatal("waitpid failed");
+			log_debug("waitpid failed: %s", strerror(errno));
+			return;
 		case 0:
 			return;
 		}


### PR DESCRIPTION
fatal() kills the entire tmux server on an unexpected waitpid() error, taking down all sessions.  Log the error and return instead, matching the graceful handling of ECHILD.