### PR TITLE
fix(server): use fstat/fchmod to avoid TOCTOU race on server socket

### DIFF
--- a/server.c
+++ b/server.c
@@ -348,7 +348,7 @@ server_update_socket(void)
 	if (n != last) {
 		last = n;
 
-		if (stat(socket_path, &sb) != 0)
+		if (server_fd == -1 || fstat(server_fd, &sb) != 0)
 			return;
 		mode = sb.st_mode & ACCESSPERMS;
 		if (n != 0) {
@@ -360,7 +360,7 @@ server_update_socket(void)
 				mode |= S_IXOTH;
 		} else
 			mode &= ~(S_IXUSR|S_IXGRP|S_IXOTH);
-		chmod(socket_path, mode);
+		fchmod(server_fd, mode);
 	}
 }
 

--- a/tmux.c
+++ b/tmux.c
@@ -375,7 +375,8 @@ int
 main(int argc, char **argv)
 {
 	char					*path = NULL, *label = NULL;
-	char					*cause, **var;
+	char					*cause, *parent, *parent_dir, **var;
+	char					 resolved[PATH_MAX];
 	const char				*s, *cwd;
 	int					 opt, keys, feat = 0, fflag = 0;
 	uint64_t				 flags = 0;
@@ -452,7 +453,16 @@ main(int argc, char **argv)
 			break;
 		case 'S':
 			free(path);
-			path = xstrdup(optarg);
+			if ((parent = xstrdup(optarg)) != NULL) {
+				parent_dir = dirname(parent);
+				if (realpath(parent_dir, resolved) != NULL)
+					xasprintf(&path, "%s/%s", resolved,
+					    basename(optarg));
+				else
+					path = xstrdup(optarg);
+				free(parent);
+			} else
+				path = xstrdup(optarg);
 			break;
 		case 'T':
 			tty_add_features(&feat, optarg, ":,");


### PR DESCRIPTION
server_update_socket used stat() then chmod() on socket_path, creating a TOCTOU race. Use fstat()/fchmod() on the already-open server fd instead. Also resolve the -S flag path's parent directory with realpath() to prevent symlink-based socket hijacking.