### PR TITLE
fix(job): use _exit instead of exit in child process after fork

### DIFF
--- a/job.c
+++ b/job.c
@@ -147,7 +147,7 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e,
 			else if (chdir("/") == 0)
 				environ_set(env, "PWD", 0, "/");
 			else
-				fatal("chdir failed");
+				_exit(1);
 		}
 
 		environ_push(env);
@@ -155,21 +155,21 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e,
 
 		if (~flags & JOB_PTY) {
 			if (dup2(out[1], STDIN_FILENO) == -1)
-				fatal("dup2 failed");
+				_exit(1);
 			do_close = do_close && out[1] != STDIN_FILENO;
 			if (dup2(out[1], STDOUT_FILENO) == -1)
-				fatal("dup2 failed");
+				_exit(1);
 			do_close = do_close && out[1] != STDOUT_FILENO;
 			if (flags & JOB_SHOWSTDERR) {
 				if (dup2(out[1], STDERR_FILENO) == -1)
-					fatal("dup2 failed");
+					_exit(1);
 				do_close = do_close && out[1] != STDERR_FILENO;
 			} else {
 				nullfd = open(_PATH_DEVNULL, O_RDWR);
 				if (nullfd == -1)
-					fatal("open failed");
+					_exit(1);
 				if (dup2(nullfd, STDERR_FILENO) == -1)
-					fatal("dup2 failed");
+					_exit(1);
 				if (nullfd != STDERR_FILENO)
 					close(nullfd);
 			}
@@ -183,11 +183,11 @@ job_run(const char *cmd, int argc, char **argv, struct environ *e,
 			if (flags & JOB_DEFAULTSHELL)
 				setenv("SHELL", shell, 1);
 			execl(shell, argv0, "-c", cmd, (char *)NULL);
-			fatal("execl failed");
+			_exit(1);
 		} else {
 			argvp = cmd_copy_argv(argc, argv);
 			execvp(argvp[0], argvp);
-			fatal("execvp failed");
+			_exit(1);
 		}
 	}
 


### PR DESCRIPTION
In the child process path after fork(), fatal() calls exit() which invokes atexit handlers and flushes inherited stdio buffers.  Use _exit() instead, matching the pattern already used by spawn.c and cmd-pipe-pane.c.