### PR TITLE
fix(signal): use volatile sig_atomic_t for signal flags

### DIFF
--- a/client.c
+++ b/client.c
@@ -35,7 +35,7 @@
 static struct tmuxproc	*client_proc;
 static struct tmuxpeer	*client_peer;
 static uint64_t		 client_flags;
-static int		 client_suspended;
+static volatile sig_atomic_t	 client_suspended;
 static enum {
 	CLIENT_EXIT_NONE,
 	CLIENT_EXIT_DETACHED,
@@ -47,14 +47,14 @@ static enum {
 	CLIENT_EXIT_SERVER_EXITED,
 	CLIENT_EXIT_MESSAGE_PROVIDED
 } client_exitreason = CLIENT_EXIT_NONE;
-static int		 client_exitflag;
+static volatile sig_atomic_t	 client_exitflag;
 static int		 client_exitval;
 static enum msgtype	 client_exittype;
 static const char	*client_exitsession;
 static char		*client_exitmessage;
 static const char	*client_execshell;
 static const char	*client_execcmd;
-static int		 client_attached;
+static volatile sig_atomic_t	 client_attached;
 static struct client_files client_files = RB_INITIALIZER(&client_files);
 
 static __dead void	 client_exec(const char *,const char *);
@@ -519,7 +519,7 @@ client_signal(int sig)
 	log_debug("%s: %s", __func__, strsignal(sig));
 	if (sig == SIGCHLD) {
 		for (;;) {
-			pid = waitpid(WAIT_ANY, &status, WNOHANG);
+			pid = waitpid(WAIT_ANY, &status, WNOHANG|WUNTRACED);
 			if (pid == 0)
 				break;
 			if (pid == -1) {

--- a/server.c
+++ b/server.c
@@ -44,7 +44,7 @@ struct clients		 clients;
 struct tmuxproc		*server_proc;
 static int		 server_fd = -1;
 static uint64_t		 server_client_flags;
-static int		 server_exit;
+static volatile sig_atomic_t	 server_exit;
 static struct event	 server_ev_accept;
 static struct event	 server_ev_tidy;
 


### PR DESCRIPTION
Signal-state flags in server.c and client.c were plain int instead of volatile sig_atomic_t.  Also add WUNTRACED to the client waitpid loop to match the server handler.