### PR TITLE
fix(file): add O_NOFOLLOW to file operations

### DIFF
--- a/client.c
+++ b/client.c
@@ -81,8 +81,10 @@ client_get_lock(char *lockfile)
 
 	log_debug("lock file is %s", lockfile);
 
-	if ((lockfd = open(lockfile, O_WRONLY|O_CREAT, 0600)) == -1) {
+	if ((lockfd = open(lockfile, O_WRONLY|O_CREAT|O_NOFOLLOW, 0600)) == -1) {
 		log_debug("open failed: %s", strerror(errno));
+		if (errno == ELOOP)
+			return (-1);
 		return (-1);
 	}
 

--- a/file.c
+++ b/file.c
@@ -56,6 +56,14 @@ file_get_path(struct client *c, const char *file)
 		return (path);
 	xasprintf(&full_path, "%s/%s", server_client_get_cwd(c, NULL), path);
 	free(path);
+	{
+		char *resolved = realpath(full_path, NULL);
+		if (resolved != NULL && strcmp(resolved, full_path) != 0) {
+			free(full_path);
+			return (resolved);
+		}
+		free(resolved);
+	}
 	return (full_path);
 }
 
@@ -599,7 +607,7 @@ file_write_open(struct client_files *files, struct tmuxpeer *peer,
 
 	cf->fd = -1;
 	if (msg->fd == -1)
-		cf->fd = open(path, msg->flags|flags, 0644);
+		cf->fd = open(path, msg->flags|flags|O_NOFOLLOW, 0644);
 	else if (allow_streams) {
 		if (msg->fd != STDOUT_FILENO && msg->fd != STDERR_FILENO)
 			errno = EBADF;
@@ -760,7 +768,7 @@ file_read_open(struct client_files *files, struct tmuxpeer *peer,
 
 	cf->fd = -1;
 	if (msg->fd == -1)
-		cf->fd = open(path, flags);
+		cf->fd = open(path, flags|O_NOFOLLOW);
 	else if (allow_streams) {
 		if (msg->fd != STDIN_FILENO)
 			errno = EBADF;


### PR DESCRIPTION
File operations in client.c and file.c followed symlinks without protection.  Add O_NOFOLLOW to open() calls for lock files, file write, and file read paths.  Resolve path traversal via realpath() in file_get_path.