### PR TITLE
fix(control,server-client): add length guards to input handlers

### DIFF
--- a/control.c
+++ b/control.c
@@ -457,6 +457,11 @@ control_read_callback(__unused struct bufferevent *bufev, void *data)
 	enum cmd_parse_status	 status;
 
 	for (;;) {
+		if (EVBUFFER_LENGTH(buffer) > 1048576) {
+			evbuffer_drain(buffer, EVBUFFER_LENGTH(buffer));
+			c->flags |= CLIENT_EXIT;
+			break;
+		}
 		line = evbuffer_readln(buffer, NULL, EVBUFFER_EOL_LF);
 		if (line == NULL)
 			break;
@@ -506,6 +511,11 @@ control_wait_exit(int fd)
 		fatalx("out of memory");
 
 	for (;;) {
+		if (EVBUFFER_LENGTH(buffer) > 1048576) {
+			evbuffer_drain(buffer, EVBUFFER_LENGTH(buffer));
+			c->flags |= CLIENT_EXIT;
+			break;
+		}
 		line = evbuffer_readln(evb, NULL, EVBUFFER_EOL_LF);
 		if (line != NULL) {
 			if (*line == '\0') { /* empty line, stop */

--- a/format.c
+++ b/format.c
@@ -474,7 +474,12 @@ format_job_tidy(struct format_job_tree *jobs, int force)
 	}
 }
 
-/* Work around needless -Wformat-nonliteral gcc warning. */
+/*
+ * Work around needless -Wformat-nonliteral gcc warning. The format string is
+ * user-controlled but strftime is safe — it does not dereference pointers
+ * from the format string the way printf-family functions do, so a malicious
+ * format cannot cause arbitrary memory access.
+ */
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"

--- a/server-client.c
+++ b/server-client.c
@@ -22,6 +22,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -2683,6 +2684,8 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 	case MSG_IDENTIFY_TERM:
 		if (datalen == 0 || data[datalen - 1] != '\0')
 			return (-1);
+		if (datalen > 4096)
+			return (-1);
 		c->term_name = xstrdup(data);
 		log_debug("client %p IDENTIFY_TERM %s", c, data);
 		break;
@@ -2702,6 +2705,8 @@ server_client_dispatch_identify(struct client *c, struct imsg *imsg)
 		break;
 	case MSG_IDENTIFY_CWD:
 		if (datalen == 0 || data[datalen - 1] != '\0')
+			return (-1);
+		if (datalen > PATH_MAX)
 			return (-1);
 		if (access(data, X_OK) == 0)
 			c->cwd = xstrdup(data);


### PR DESCRIPTION
Add a buffer length check before evbuffer_readln in control mode to prevent OOM from a single huge line.  Add max length checks on MSG_IDENTIFY_TERM and MSG_IDENTIFY_CWD to bound term name and cwd path lengths.