### PR TITLE
fix(screen): free alternate-screen images on screen destroy

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -152,6 +152,10 @@ screen_reset_hyperlinks(struct screen *s)
 void
 screen_free(struct screen *s)
 {
+#ifdef ENABLE_SIXEL
+	struct image	*im;
+#endif
+
 	free(s->sel);
 	free(s->tabs);
 	free(s->path);
@@ -169,6 +173,14 @@ screen_free(struct screen *s)
 	screen_free_titles(s);
 
 #ifdef ENABLE_SIXEL
+	/*
+	 * Images saved when entering the alternate screen stay linked in the
+	 * global list; move them back so they are freed and unlinked here, or
+	 * a later eviction would write through this freed screen.
+	 */
+	TAILQ_CONCAT(&s->images, &s->saved_images, entry);
+	TAILQ_FOREACH(im, &s->images, entry)
+		im->list = &s->images;
 	image_free_all(s);
 #endif
 }


### PR DESCRIPTION
If a pane is destroyed while still in the alternate screen, its sixel images can
be left dangling and cause a use-after-free.

screen_alternate_on() moves the images from s->images to s->saved_images and
repoints im->list, but they stay in the global all_images list. screen_free()
only frees s->images (via image_free_all), not s->saved_images, so the saved
images remain in all_images with im->list pointing into the freed screen. Once
all_images fills up, image_store() evicts the stale entry and image_free() does
TAILQ_REMOVE(im->list, ...) into freed memory.

I reproduced it with --enable-sixel under ASan: emit a sixel, enter the
alternate screen (CSI ? 1049 h), kill the pane, then emit enough sixels
elsewhere to reach MAX_IMAGE_COUNT. On unpatched master:

    heap-use-after-free WRITE in image_free (image.c:61)
      image_free <- image_store <- screen_write_sixelimage <- input_dcs_dispatch
      freed by window_pane_free <- window_pane_destroy <- window_destroy

and the server dies. Freeing the saved images in screen_free() too fixes it:
clean under ASan afterwards, and normal sixel use and alternate-screen switching
still work.
