### PR TITLE
Do not refresh copy mode during synchronized output

### DIFF
--- a/regress/copy-mode-refresh-sync.sh
+++ b/regress/copy-mode-refresh-sync.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+cleanup()
+{
+	$TMUX kill-server 2>/dev/null
+	rm -rf "$TMP"
+}
+fail()
+{
+	echo "$1"
+	cleanup
+	exit 1
+}
+wait_done()
+{
+	i=0
+	while [ $i -lt 50 ]; do
+		[ -f "$DONE" ] && return
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "pane command did not finish"
+}
+wait_sync()
+{
+	i=0
+	while [ $i -lt 50 ]; do
+		state=$($TMUX display-message -p -t "$PANE" '#{synchronized_output_flag}')
+		[ "$state" = "1" ] && return
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "pane did not enter synchronized output"
+}
+wait_state()
+{
+	expected=$1
+	i=0
+	while [ $i -lt 50 ]; do
+		state=$($TMUX display-message -p -t "$PANE" '#{synchronized_output_flag} #{pane_unseen_changes} #{refresh_active}')
+		[ "$state" = "$expected" ] && return
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "unexpected state: $state"
+}
+trap cleanup 0
+trap 'exit 1' 1 2 3 15
+
+TMP=$(mktemp -d) || exit 1
+GO="$TMP/go"
+DONE="$TMP/done"
+SCRIPT="$TMP/pane.sh"
+
+cat >"$SCRIPT" <<EOF
+#!/bin/sh
+while [ ! -f "$GO" ]; do sleep 0.01; done
+printf '\033[?2026h'
+printf 'one\n'
+sleep 0.5
+printf '\033[?2026h'
+sleep 0.5
+printf '\033[?2026l'
+printf 'two\n'
+touch "$DONE"
+sleep 1
+EOF
+chmod +x "$SCRIPT" || exit 1
+
+PANE=$($TMUX new -d -x40 -y10 -P -F '#{pane_id}' "$SCRIPT") || exit 1
+$TMUX set -g window-size manual || exit 1
+$TMUX copy-mode -t "$PANE" || exit 1
+$TMUX send-keys -t "$PANE" -X refresh-on || exit 1
+
+touch "$GO"
+wait_sync
+sleep 0.2
+wait_state "1 1 1"
+
+wait_done
+wait_state "0 0 1"
+
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -2319,7 +2319,7 @@ Cycles the current line between centre, top, and bottom.
 Turn on automatic refresh of the content from the pane, so that new output
 appears while in copy mode.
 Automatic refresh is off by default; it will scroll only while the cursor is at
-the bottom and is paused while a selection is in progress.
+the bottom and is paused while a selection or synchronized output is in progress.
 .It Xo
 .Ic refresh\-off
 .Xc

--- a/window-copy.c
+++ b/window-copy.c
@@ -3046,8 +3046,8 @@ window_copy_refresh_timer(__unused int fd, __unused short events, void *arg)
 	 * Skip the refresh while a selection is being made, otherwise it would
 	 * move; only follow new output if the cursor is still at the bottom.
 	 */
-	if ((wp->flags & PANE_UNSEENCHANGES) && data->screen.sel == NULL &&
-	    data->cursordrag == CURSORDRAG_NONE) {
+	if ((wp->flags & PANE_UNSEENCHANGES) && (~wp->base.mode & MODE_SYNC) &&
+	    data->screen.sel == NULL && data->cursordrag == CURSORDRAG_NONE) {
 		follow = (data->oy == 0 &&
 		    data->cy == screen_size_y(&data->screen) - 1);
 		window_copy_do_refresh(wme, follow);


### PR DESCRIPTION
## Problem

copy-mode auto refresh can redraw in the middle of DEC synchronized output, exposing an incomplete application frame as flicker.

## Solution
defer automatic refresh while synchronized output is active, leaving the pending update to refresh normally after the synchronized frame ends.

related #5165

@grothesque LMK if this helps