### PR TITLE
Do not loop forever in tty_draw_line on zero-width cells not marked as padding (#5024 follow-up)

### DIFF
--- a/tools/tty-draw-zero-width-livelock-repro.sh
+++ b/tools/tty-draw-zero-width-livelock-repro.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ══════════════════════════════════════════════════════════════════════════════
+# Deterministic reproducer for the tty_draw_line livelock caused by a
+# non-padding, zero-width grid cell.
+#
+# Context
+#   Upstream tmux commit 281e8ff7 (2026-05-13) fixed the #5024 livelock but
+#   only for GRID_FLAG_PADDING (orphan padding) cells: those now return
+#   empty=1 from tty_draw_line_get_empty() and the draw loop advances by 1.
+#
+#   A *non-padding* cell with utf8_data.width == 0 (e.g. a stray variation
+#   selector U+FE0F, a combining mark, or any zero-width code point that the
+#   grid did not fold into the preceding cell) is NOT classified empty: it
+#   falls through every clause in tty_draw_line_get_empty() and the draw loop
+#   then executes `i += gcp->data.width;` with width == 0. i never advances,
+#   the for(;;) never terminates, and the tmux server livelocks on one core
+#   (state Rs). The only recovery is kill -9 on the server PID.
+#
+#   This reproducer plants that exact pathological cell directly into the live
+#   server grid via gdb, then forces a redraw. There is no timing window: an
+#   unpatched server livelocks every run; a patched server survives every run.
+#
+# Requirements
+#   gdb, passwordless sudo (ptrace attach), the tmux source tree (for struct
+#   offsets, auto-computed below), a built ./tmux binary.
+#
+# Safety
+#   Runs on a private throwaway socket (-L repro-$$). The real 'default'
+#   server is never touched. On livelock the server can only be recovered
+#   with kill -9 — we apply that only to the private PID.
+#
+# Usage
+#   tools/tty-draw-zero-width-livelock-repro.sh ./tmux        # RED or GREEN
+#   tools/tty-draw-zero-width-livelock-repro.sh /path/to/tmux
+# ══════════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+TMUX_BIN="${1:-./tmux}"
+[ -x "$TMUX_BIN" ] || { echo "not executable: $TMUX_BIN" >&2; exit 2; }
+
+# Resolve the tmux source tree (for offsetof probe) relative to this script.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SRC_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+[ -f "$SRC_DIR/tmux.h" ] || { echo "tmux.h not found in $SRC_DIR" >&2; exit 2; }
+
+SOCK="repro-$$"
+log() { printf '\033[1;34m[repro]\033[0m %s\n' "$*" >&2; }
+
+command -v gdb >/dev/null || { echo "gdb required" >&2; exit 2; }
+
+log "target binary: $TMUX_BIN ($("$TMUX_BIN" -V 2>&1))"
+log "source tree:   $SRC_DIR"
+log "private socket: $SOCK  (your 'default' server is NOT touched)"
+
+# ── Auto-compute struct offsets for this exact build ──────────────────────────
+OFFSETS_PROBE="$(mktemp -d)/offsets.c"
+cat > "$OFFSETS_PROBE" <<'EOF'
+#include <stddef.h>
+#include <stdio.h>
+#define TMUX_H_INSIDE 1
+#define TMUX_NAME "__probe__"
+#include "tmux.h"
+int main(void) {
+    printf("WP_BASE=%zu\n", offsetof(struct window_pane, base));
+    printf("SCREEN_GRID=%zu\n", offsetof(struct screen, grid));
+    printf("GC_SIZE=%zu\n", sizeof(struct grid_cell));
+    printf("GC_DATA=%zu\n", offsetof(struct grid_cell, data.data));
+    printf("GC_USIZE=%zu\n", offsetof(struct grid_cell, data.size));
+    printf("GC_UWIDTH=%zu\n", offsetof(struct grid_cell, data.width));
+    printf("GC_BG=%zu\n", offsetof(struct grid_cell, bg));
+    return 0;
+}
+EOF
+OFFSETS_BIN="${OFFSETS_PROBE%.c}"
+if ! gcc -I"$SRC_DIR" -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 \
+        -DTMUX_VERSION='"probe"' -DTMUX_TERM='"xterm"' -DTMUX_MOUSE=1 \
+        -std=gnu99 -O0 "$OFFSETS_PROBE" -o "$OFFSETS_BIN" 2>/dev/null; then
+    echo "failed to compile offsets probe against $SRC_DIR" >&2
+    rm -rf "$(dirname "$OFFSETS_PROBE")"
+    exit 2
+fi
+eval "$("$OFFSETS_BIN")"
+rm -rf "$(dirname "$OFFSETS_PROBE")"
+log "offsets: WP_BASE=$WP_BASE SCREEN_GRID=$SCREEN_GRID GC_SIZE=$GC_SIZE GC_UWIDTH=$GC_UWIDTH GC_BG=$GC_BG"
+
+# ── 1. Fresh isolated server + attached real pty client (redraw needs a client)
+"$TMUX_BIN" -L"$SOCK" -f /dev/null new-session -d -s repro -x 120 -y 30 'sleep 600'
+SRVPID=$("$TMUX_BIN" -L"$SOCK" display -p '#{pid}')
+script -qfc "$TMUX_BIN -L$SOCK attach -t repro" /dev/null </dev/null >/dev/null 2>&1 &
+CLIENTPID=$!
+sleep 2
+PTS=$("$TMUX_BIN" -L"$SOCK" list-clients -F '#{client_name}' | head -1)
+log "server pid=$SRVPID  client pts=$PTS"
+
+cleanup() {
+    # Livelocked server ignores tmux cmds and SIGTERM — kill -9 the private pid.
+    kill -9 "$SRVPID" "$CLIENTPID" 2>/dev/null
+    pkill -9 -f "$SOCK" 2>/dev/null
+    rm -f "/tmp/tmux-$(id -u)/$SOCK" 2>/dev/null
+}
+trap cleanup EXIT
+
+# ── 2. Plant the pathological cell at column 5, row 0:
+#       U+FE0F (EF B8 8F), size=3, width=0, NON-PADDING, non-default bg.
+#    This is the grid state pi/hermes/codex create by chance when a variation
+#    selector is emitted standalone into a colored cell.
+cat > "/tmp/repro-inject-$$.gdb" <<GDB
+set confirm off
+set pagination off
+set var \$wp = ((void*(*)(unsigned int))window_pane_find_by_id)(0)
+set var \$gd = *(void**)((char*)\$wp + $WP_BASE + $SCREEN_GRID)
+set var \$gc = (char*)((void*(*)(unsigned long))malloc)($GC_SIZE)
+call ((void*(*)(void*,void*,unsigned long))memcpy)(\$gc, &grid_default_cell, $GC_SIZE)
+set var *(unsigned char*)(\$gc + $GC_DATA + 0) = 0xef
+set var *(unsigned char*)(\$gc + $GC_DATA + 1) = 0xb8
+set var *(unsigned char*)(\$gc + $GC_DATA + 2) = 0x8f
+set var *(unsigned char*)(\$gc + $GC_USIZE)  = 3
+set var *(unsigned char*)(\$gc + $GC_UWIDTH) = 0
+set var *(int*)(\$gc + $GC_BG) = 2
+call ((void(*)(void*,unsigned,unsigned,void*))grid_view_set_cell)(\$gd, 5, 0, \$gc)
+printf "INJECTED width0 non-padding cell into gd=%p\n", \$gd
+detach
+quit
+GDB
+log "injecting width==0 non-padding cell via gdb (sudo)..."
+sudo gdb -batch -x "/tmp/repro-inject-$$.gdb" -p "$SRVPID" 2>&1 | grep -E "INJECTED|error|Cannot|warning" | head -3
+rm -f "/tmp/repro-inject-$$.gdb"
+
+# ── 3. Force a full redraw and measure.
+read -r _ _ _ _ _ _ _ _ _ _ _ _ _ ut st _ < "/proc/$SRVPID/stat"; t0=$((ut+st))
+timeout 3 "$TMUX_BIN" -L"$SOCK" refresh-client -t "$PTS" >/dev/null 2>&1
+refresh_rc=$?
+sleep 3
+if [ -r "/proc/$SRVPID/stat" ]; then
+    read -r _ _ _ _ _ _ _ _ _ _ _ _ _ ut st _ < "/proc/$SRVPID/stat"; t1=$((ut+st))
+    ticks=$((t1-t0))
+else
+    ticks="server-gone"
+fi
+timeout 3 "$TMUX_BIN" -L"$SOCK" display -p ok >/dev/null 2>&1
+display_rc=$?
+state=$(ps -o stat= -p "$SRVPID" 2>/dev/null | tr -d ' ')
+
+echo
+log "── RESULT ──────────────────────────────────────────"
+log "refresh-client rc = $refresh_rc   (124 = timed out = LIVELOCK)"
+log "CPU ticks in 3s   = $ticks        (>250 = pegged core = LIVELOCK)"
+log "display-message rc= $display_rc   (0 = responsive)"
+log "server state      = ${state:-gone} (Rs = spinning = LIVELOCK; Ss = idle = OK)"
+if [ "$display_rc" -eq 0 ] && { [ "$ticks" = "server-gone" ] || [ "$ticks" -lt 100 ]; }; then
+    log "VERDICT: ✅ SURVIVED — non-padding zero-width cell does not livelock"
+    exit 0
+else
+    log "VERDICT: ❌ LIVELOCKED — non-padding zero-width cell livelocks the server"
+    exit 1
+fi

--- a/tty-draw.c
+++ b/tty-draw.c
@@ -100,6 +100,8 @@ tty_draw_line_get_empty(const struct grid_cell *gc,
 		empty = nx;
 	else if (gc->flags & GRID_FLAG_PADDING)
 		empty = 1;
+	else if (gc->data.width == 0)
+		empty = 1;
 	else if (gc->flags & GRID_FLAG_SELECTED)
 		empty = 0;
 	else if (gc->bg == last->bg && gc->attr == 0 && gc->link == 0) {


### PR DESCRIPTION
## Summary

Commit `281e8ff7` (2026-05-13) closed #5024 by making `tty_draw_line_get_empty()` return `1` for orphan `GRID_FLAG_PADDING` cells, so the draw loop advances instead of spinning on `i += gcp->data.width` (which is `0` for padding).

That fix only covers the padding case. A **non-padding** cell whose `utf8_data.width == 0` still falls through every clause of `tty_draw_line_get_empty()`, returns `empty == 0`, and the loop then executes:

```c
if (empty != 0)
    i += empty;
else
    i += gcp->data.width;   /* width == 0 -> i never advances -> livelock */
```

`i` never moves, the `for (;;)` in `tty_draw_line()` never terminates, one core pegs at 100% (state `Rs`), every socket command hangs, and the only recovery is `kill -9` on the server.

Such cells appear in practice when a **variation selector (U+FE0F), a combining mark, or other zero-width code point** is emitted standalone into a coloured cell and is not folded into the preceding base character — exactly the output pattern of the animated, emoji-bearing status lines produced by several AI CLI TUIs (pi, hermes, codex) and the control-mode pollers described in #5024.

## Fix

Treat a zero-width cell as a one-cell empty advance, mirroring the existing padding clause:

```c
if (gc->data.width > nx)
    empty = nx;
else if (gc->flags & GRID_FLAG_PADDING)
    empty = 1;
else if (gc->data.width == 0)        /* new */
    empty = 1;
else if (gc->flags & GRID_FLAG_SELECTED)
    empty = 0;
...
```

The cell is visually dropped (one column redrawn as space-equivalent) and the next full redraw self-corrects it. This matches how padding is already handled and avoids changing the loop's structure.

## Reproducer

`tools/tty-draw-zero-width-livelock-repro.sh` is a deterministic reproducer. It starts a throwaway server on a private socket (`-L repro-\$\$`, the real server is never touched), injects the exact pathological cell (UTF-8 `EF B8 8F`, `size = 3`, `width = 0`, non-padding, `bg = 2`) via gdb, forces a redraw, and measures. Struct offsets are auto-computed from the source tree so it tracks ABI changes.

## Verification (master HEAD `15746a1b`, 2026-07-15)

Back-to-back, same script, same injected cell:

| binary | `refresh-client` rc | CPU ticks / 3s | `display` rc | `ps` state | verdict |
|--------|---------------------|----------------|--------------|------------|---------|
| master unpatched | **124 (timeout)** | **569** | **124 (timeout)** | **`Rs`** | livelocked |
| with this patch | 0 | 0 | 0 | `Ss` | survives |

Only the private test server was affected (killed on exit); the real server was untouched.

Reproducer requirements: `gdb`, passwordless `sudo` (ptrace attach), the tmux source tree (for the offsetof probe).

## Notes

- This is a residual gap left by #5024's fix, not a regression of it.
- I can drop the `tools/` reproducer commit if you would rather not carry a gdb-based diagnostic in the tree; happy to keep just the one-line fix.
- I have not attempted to address the underlying question of how a zero-width code point ends up as a standalone, non-padding cell in the grid — only the immediate livelock, consistent with how the padding case was handled.