### PR TITLE
Do not repaint an open overlay on background redraws or option changes (#5336)

### DIFF
--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1858,9 +1858,20 @@ redraw_screen(struct client *c)
 {
 	int	flags = 0;
 
-	if (c->flags & CLIENT_REDRAWWINDOW)
-		redraw_draw(c, NULL, REDRAW_ALL);
-	else {
+	if (c->flags & CLIENT_REDRAWWINDOW) {
+		/*
+		 * A full window redraw draws every pane around the overlay
+		 * without touching its cells, so repainting the overlay is only
+		 * needed when it is explicitly flagged (its content changed, or
+		 * the screen was cleared by a resize or refresh, which set the
+		 * flag via server_redraw_client). Otherwise a background pane
+		 * redraw would make an open popup flicker (GitHub issue 5336).
+		 */
+		if (c->flags & CLIENT_REDRAWOVERLAY)
+			redraw_draw(c, NULL, REDRAW_ALL);
+		else
+			redraw_draw(c, NULL, REDRAW_ALL & ~REDRAW_OVERLAY);
+	} else {
 		if (c->flags & CLIENT_REDRAWBORDERS)
 			flags |= (REDRAW_PANE_BORDER|REDRAW_PANE_STATUS);
 		if (c->flags & CLIENT_REDRAWSTATUS)


### PR DESCRIPTION
Follow-up to #5350. After that fix (and the `visible_ranges` pane clipping), background draws no longer overwrite an open `display-popup`, so the overlay only needs repainting when its *own* content changes. Two paths still repaint it unconditionally — this is the flicker in #5336:

1. **Option changes** — `options_push_changes()` calls `server_redraw_client()`, which sets `CLIENT_ALLREDRAWFLAGS` (including `CLIENT_REDRAWOVERLAY`). Tooling that updates the status line by setting options many times a second then repaints any open popup on each change. Adds `server_redraw_client_no_overlay()` and uses it there.

2. **Background full redraws** — when a redraw is deferred because the tty output buffer is backed up (`server-client.c`), `CLIENT_REDRAWWINDOW` is set and `redraw_screen()` repaints the overlay too. So a pane scrolling behind the popup repaints it on every deferred redraw. Skips the overlay unless `CLIENT_REDRAWOVERLAY` is explicitly set.

Note on repro: the background path only triggers when the tty output buffer actually backs up, so the visible flicker is environment-dependent — it shows on slower/remote terminals and under load, but can be invisible on a fast local terminal. I filed #5336 and @ibehnam confirmed it on 3.7.
