### PR TITLE
feat(master): Added `hide-pane` and `show-pane`.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ dist_tmux_SOURCES = \
 	cmd-display-message.c \
 	cmd-find-window.c \
 	cmd-find.c \
+	cmd-hide-pane.c \
 	cmd-if-shell.c \
 	cmd-join-pane.c \
 	cmd-kill-pane.c \

--- a/cmd-hide-pane.c
+++ b/cmd-hide-pane.c
@@ -1,0 +1,242 @@
+/* $OpenBSD$ */
+
+/*
+ * Copyright (c) 2026 Michael Grant <mgrant@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+ * IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "tmux.h"
+
+/*
+ * Hide or show panes.
+ */
+
+static enum cmd_retval cmd_hide_pane_exec(struct cmd *, struct cmdq_item *);
+static enum cmd_retval cmd_show_pane_exec(struct cmd *, struct cmdq_item *);
+
+const struct cmd_entry cmd_hide_pane_entry = {
+	.name = "hide-pane",
+	.alias = "hidep",
+
+	.args = { "at:", 0, 1, NULL },
+	.usage = "[-a] " CMD_TARGET_PANE_USAGE,
+
+	.target = { 't', CMD_FIND_PANE, 0 },
+
+	.flags = CMD_AFTERHOOK,
+	.exec = cmd_hide_pane_exec
+};
+
+const struct cmd_entry cmd_show_pane_entry = {
+	.name = "show-pane",
+	.alias = "showp",
+
+	.args = { "at:", 0, 1, NULL },
+	.usage = "[-a] " CMD_TARGET_PANE_USAGE,
+
+	.target = { 't', CMD_FIND_PANE, 0 },
+
+	.flags = CMD_AFTERHOOK,
+	.exec = cmd_show_pane_exec
+};
+
+static int
+cmd_hide_pane_count_visible(struct window *w)
+{
+	struct window_pane	*wp;
+	u_int			 n = 0;
+
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (window_pane_is_visible(wp))
+			n++;
+	}
+	return (n);
+}
+
+static enum cmd_retval
+cmd_hide_pane_hide(struct cmdq_item *item, struct window *w,
+    struct window_pane *wp)
+{
+	struct window_pane	*wpp = NULL;
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (window_pane_is_hidden(wp))
+		return (CMD_RETURN_NORMAL);
+	if (wp == w->active && cmd_hide_pane_count_visible(w) == 1) {
+		cmdq_error(item, "can't hide the last visible pane");
+		return (CMD_RETURN_ERROR);
+	}
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't hide a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+	if (wp == w->active) {
+		/* Find previous active pane. */
+		TAILQ_FOREACH(wpp, &w->last_panes, sentry) {
+			if (wpp != wp && window_pane_is_visible(wpp))
+				break;
+		}
+		if (wpp == NULL) {
+			TAILQ_FOREACH(wpp, &w->z_index, zentry) {
+				if (wpp != wp &&
+				    window_pane_is_visible(wpp))
+					break;
+			}
+		}
+	}
+
+	lc->flags |= LAYOUT_CELL_HIDDEN;
+
+	layout_remove_tile(w, lc);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	redraw_invalidate_scene(w);
+
+	window_pane_stack_remove(&w->last_panes, wp);
+	if (wpp != NULL) {
+		window_set_active_pane(w, wpp, 1);
+	} else if (wp == w->active) {
+		/* No visible previous active pane; null active pane
+		 * to show dots background. */
+		w->active = NULL;
+		if (options_get_number(global_options, "focus-events"))
+			window_pane_update_focus(wp);
+		events_fire_window("window-layout-changed", w);
+		server_redraw_window(w);
+	} else {
+		events_fire_window("window-layout-changed", w);
+		server_redraw_window(w);
+	}
+
+	return (CMD_RETURN_NORMAL);
+}
+
+static enum cmd_retval
+cmd_hide_pane_exec(struct cmd *self, struct cmdq_item *item)
+{
+	struct args		*args = cmd_get_args(self);
+	struct cmd_find_state	*target = cmdq_get_target(item);
+	struct winlink		*wl = target->wl;
+	struct window		*w = wl->window;
+	struct window_pane	*wp, *active_pane = w->active;
+	u_int			 id;
+	char			*cause = NULL;
+	enum cmd_retval		 rv;
+
+	window_unzoom(w, 1);
+
+	if (args_has(args, 'a')) {
+		TAILQ_FOREACH(wp, &w->z_index, zentry) {
+			if (!window_pane_is_visible(wp) || wp == active_pane)
+				continue;
+			rv = cmd_hide_pane_hide(item, w, wp);
+			if (rv != CMD_RETURN_NORMAL)
+				return (rv);
+		}
+		return (CMD_RETURN_NORMAL);
+	} else {
+		wp = target->wp;
+		if (wp == NULL) {
+			id = args_strtonum_and_expand(args, 't', 0, INT_MAX,
+			    item, &cause);
+			if (cause != NULL) {
+				cmdq_error(item, "%s target pane", cause);
+				return (CMD_RETURN_ERROR);
+			}
+			wp = window_pane_find_by_id(id);
+		}
+		if (wp == NULL) {
+			cmdq_error(item, "No target pane to hide.");
+			return (CMD_RETURN_ERROR);
+		}
+		return (cmd_hide_pane_hide(item, w, wp));
+	}
+}
+
+static enum cmd_retval
+cmd_hide_pane_show(struct cmdq_item *item, struct window *w,
+    struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (!window_pane_is_hidden(wp))
+		return (CMD_RETURN_NORMAL);
+
+	if (w->flags & WINDOW_ZOOMED) {
+		cmdq_error(item, "can't show a pane while window is zoomed");
+		return (CMD_RETURN_ERROR);
+	}
+
+	if (!window_pane_is_floating(wp) && layout_insert_tile(w, lc) != 0) {
+		cmdq_error(item, "no space for a new pane");
+		return (CMD_RETURN_ERROR);
+	}
+	lc->flags &= ~LAYOUT_CELL_HIDDEN;
+
+	window_set_active_pane(w, wp, 1);
+	layout_fix_offsets(w);
+	layout_fix_panes(w, NULL);
+	events_fire_window("window-layout-changed", w);
+	redraw_invalidate_scene(w);
+	server_redraw_window(w);
+
+	return (CMD_RETURN_NORMAL);
+}
+
+static enum cmd_retval
+cmd_show_pane_exec(struct cmd *self, struct cmdq_item *item)
+{
+	struct args		*args = cmd_get_args(self);
+	struct cmd_find_state	*target = cmdq_get_target(item);
+	struct winlink		*wl = target->wl;
+	struct window		*w = wl->window;
+	struct window_pane	*wp;
+	u_int			 id;
+	char			*cause = NULL;
+	enum cmd_retval		 rv;
+
+	window_unzoom(w, 1);
+
+	if (args_has(args, 'a')) {
+		TAILQ_FOREACH(wp, &w->z_index, zentry) {
+			if (!window_pane_is_visible(wp))
+				continue;
+			rv = cmd_hide_pane_show(item, w, wp);
+			if (rv != CMD_RETURN_NORMAL)
+				return (rv);
+		}
+		return (CMD_RETURN_NORMAL);
+	} else {
+		wp = target->wp;
+		if (wp == NULL) {
+			id = args_strtonum_and_expand(args, 't', 0, INT_MAX,
+			    item, &cause);
+			if (cause != NULL) {
+				cmdq_error(item, "%s target pane", cause);
+				return (CMD_RETURN_ERROR);
+			}
+			wp = window_pane_find_by_id(id);
+		}
+		if (wp == NULL) {
+			cmdq_error(item, "No target pane to show.");
+			return (CMD_RETURN_ERROR);
+		}
+		return (cmd_hide_pane_show(item, w, wp));
+	}
+}

--- a/cmd.c
+++ b/cmd.c
@@ -49,6 +49,7 @@ extern const struct cmd_entry cmd_display_popup_entry;
 extern const struct cmd_entry cmd_display_panes_entry;
 extern const struct cmd_entry cmd_find_window_entry;
 extern const struct cmd_entry cmd_has_session_entry;
+extern const struct cmd_entry cmd_hide_pane_entry;
 extern const struct cmd_entry cmd_if_shell_entry;
 extern const struct cmd_entry cmd_join_pane_entry;
 extern const struct cmd_entry cmd_kill_pane_entry;
@@ -106,6 +107,7 @@ extern const struct cmd_entry cmd_show_environment_entry;
 extern const struct cmd_entry cmd_show_hooks_entry;
 extern const struct cmd_entry cmd_show_messages_entry;
 extern const struct cmd_entry cmd_show_options_entry;
+extern const struct cmd_entry cmd_show_pane_entry;
 extern const struct cmd_entry cmd_show_prompt_history_entry;
 extern const struct cmd_entry cmd_show_window_options_entry;
 extern const struct cmd_entry cmd_source_file_entry;
@@ -143,6 +145,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_display_panes_entry,
 	&cmd_find_window_entry,
 	&cmd_has_session_entry,
+	&cmd_hide_pane_entry,
 	&cmd_if_shell_entry,
 	&cmd_join_pane_entry,
 	&cmd_kill_pane_entry,
@@ -200,6 +203,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_show_hooks_entry,
 	&cmd_show_messages_entry,
 	&cmd_show_options_entry,
+	&cmd_show_pane_entry,
 	&cmd_show_prompt_history_entry,
 	&cmd_show_window_options_entry,
 	&cmd_source_file_entry,

--- a/format.c
+++ b/format.c
@@ -2319,6 +2319,21 @@ format_cb_pane_height(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for pane_hidden_flag. */
+static void *
+format_cb_pane_hidden_flag(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL) {
+		if (window_pane_is_hidden(wp))
+			return (xstrdup("1"));
+		return (xstrdup("0"));
+	}
+	return (NULL);
+}
+
+
 /* Callback for pane_id. */
 static void *
 format_cb_pane_id(struct format_tree *ft)
@@ -3673,6 +3688,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_height", FORMAT_TABLE_STRING,
 	  format_cb_pane_height
+	},
+	{ "pane_hidden_flag", FORMAT_TABLE_STRING,
+	  format_cb_pane_hidden_flag
 	},
 	{ "pane_id", FORMAT_TABLE_STRING,
 	  format_cb_pane_id

--- a/layout.c
+++ b/layout.c
@@ -261,8 +261,9 @@ layout_cell_is_tiled(struct layout_cell *lc)
 {
 	int	is_leaf = lc->type == LAYOUT_WINDOWPANE;
 	int	is_floating = lc->flags & LAYOUT_CELL_FLOATING;
+	int	is_hidden = lc->flags & LAYOUT_CELL_HIDDEN;
 
-	return is_leaf && !is_floating;
+	return is_leaf && !(is_floating || is_hidden);
 }
 
 static int

--- a/tmux.h
+++ b/tmux.h
@@ -1547,7 +1547,8 @@ struct layout_cell {
 	enum layout_type	 type;
 
 	int			 flags;
-#define LAYOUT_CELL_FLOATING 0x1
+#define LAYOUT_CELL_FLOATING	0x1
+#define LAYOUT_CELL_HIDDEN	0x2
 
 	struct layout_cell	*parent;
 
@@ -3801,6 +3802,7 @@ int		 window_pane_get_pane_status(struct window_pane *);
 struct style_range *window_pane_status_get_range(struct window_pane *, u_int,
 		     u_int);
 int		 window_pane_is_floating(struct window_pane *);
+int		 window_pane_is_hidden(struct window_pane *);
 
 /* window-border.c */
 void		 window_get_border_cell(struct window *, struct window_pane *,

--- a/window.c
+++ b/window.c
@@ -728,6 +728,11 @@ window_set_active_pane(struct window *w, struct window_pane *wp, int notify)
 	window_pane_stack_remove(&w->last_panes, wp);
 	window_pane_stack_push(&w->last_panes, lastwp);
 
+	if (window_pane_is_floating(wp)) {
+		TAILQ_REMOVE(&w->z_index, wp, zentry);
+		TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
+	}
+
 	w->active = wp;
 	w->active->active_point = next_active_point++;
 	w->active->flags |= PANE_CHANGED;
@@ -842,7 +847,7 @@ window_get_active_at(struct window *w, u_int x, u_int y)
 		if (!window_pane_is_visible(wp))
 			continue;
 		window_pane_full_size_offset(wp, &xoff, &yoff, &sx, &sy);
-		if (!window_pane_is_floating(wp)) {
+		if (layout_cell_is_tiled(wp->layout_cell)) {
 			/*
 			 * Tiled - to and including the right border, excluding
 			 * the bottom border.
@@ -1060,7 +1065,7 @@ window_add_pane(struct window *w, struct window_pane *other, u_int hlimit,
 void
 window_lost_pane(struct window *w, struct window_pane *wp)
 {
-	struct window_pane	*lastwp;
+	struct window_pane	*wpp, *lastwp = NULL;
 
 	log_debug("%s: @%u pane %%%u", __func__, w->id, wp->id);
 
@@ -1073,21 +1078,31 @@ window_lost_pane(struct window *w, struct window_pane *wp)
 
 	window_pane_stack_remove(&w->last_panes, wp);
 	if (wp == w->active) {
-		lastwp = NULL;
 		if (wp == w->modal) {
 			lastwp = w->modal_last;
 			w->modal = NULL;
 			w->modal_last = NULL;
 		}
 		if (lastwp != NULL && window_has_pane(w, lastwp))
-			w->active = lastwp;
+			wpp = lastwp;
 		else
-			w->active = TAILQ_FIRST(&w->last_panes);
-		if (w->active == NULL) {
-			w->active = TAILQ_PREV(wp, window_panes, entry);
-			if (w->active == NULL)
-				w->active = TAILQ_NEXT(wp, entry);
+			wpp = TAILQ_FIRST(&w->last_panes);
+		/* Try to find a good fit. */
+		if (wpp == NULL || window_pane_is_hidden(wpp)) {
+			wpp = TAILQ_PREV(wp, window_panes, entry);
+			if (wpp == NULL || window_pane_is_hidden(wpp))
+				wpp = TAILQ_NEXT(wp, entry);
 		}
+		/* Try to find any fit. */
+		if (wpp == NULL || window_pane_is_hidden(wpp)) {
+			TAILQ_FOREACH(wpp, &w->panes, entry) {
+				if (wpp != wp && !window_pane_is_hidden(wpp))
+					break;
+			}
+		}
+		if (wpp != NULL && window_pane_is_hidden(wpp))
+			wpp = NULL;
+		w->active = wpp;
 		if (w->active != NULL) {
 			window_pane_stack_remove(&w->last_panes, w->active);
 			w->active->flags |= PANE_CHANGED;
@@ -1266,6 +1281,8 @@ window_pane_printable_flags(struct window_pane *wp)
 		flags[pos++] = 'Z';
 	if (window_pane_is_floating(wp))
 		flags[pos++] = 'F';
+	if (window_pane_is_hidden(wp))
+		flags[pos++] = 'H';
 	if (wp == w->modal)
 		flags[pos++] = 'O';
 	flags[pos] = '\0';
@@ -1970,8 +1987,11 @@ window_pane_key(struct window_pane *wp, struct client *c, struct session *s,
 int
 window_pane_is_visible(struct window_pane *wp)
 {
-	if (~wp->window->flags & WINDOW_ZOOMED)
+	if (~wp->window->flags & WINDOW_ZOOMED) {
+		if (window_pane_is_hidden(wp))
+			return (0);
 		return (1);
+	}
 	return (wp == wp->window->active);
 }
 
@@ -2828,6 +2848,16 @@ window_pane_is_floating(struct window_pane *wp)
 	struct layout_cell	*lc = wp->layout_cell;
 
 	if (lc == NULL || (lc->flags & LAYOUT_CELL_FLOATING) == 0)
+		return (0);
+	return (1);
+}
+
+int
+window_pane_is_hidden(struct window_pane *wp)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (lc == NULL || (lc->flags & LAYOUT_CELL_HIDDEN) == 0)
 		return (0);
 	return (1);
 }


### PR DESCRIPTION
There are two small annoyances with the current implementation.
1. #5223. I want to fix this before merging if possible.
2. The last visible pane cannot be hidden. This would result in the active pane being NULL. This can be fixed, but it would require a scope of change beyond this PR. A non-NULL active pane invariant is enforced on `cmd-find.c:1004`. I believe allowing a NULL active pane would require NULL checks in all the consumers of `cmd_find_target`.