### PR TITLE
Avoid unsigned underflow in window_visible_ranges for off-screen panes

### DIFF
--- a/window-visible.c
+++ b/window-visible.c
@@ -83,6 +83,8 @@ window_visible_ranges(struct window_pane *base_wp, int px, int py, u_int width,
 	w = base_wp->window;
 	if ((u_int)py >= w->sy)
 		goto empty;
+	if ((u_int)px >= w->sx)
+		goto empty;
 	if (px + width > w->sx)
 		width = w->sx - px;
 


### PR DESCRIPTION
### Problem

The server can enter a livelock — one CPU pinned at 100% in user mode, never
returning to the event loop. `tmux ls`, `has-session`, `info` and new
`attach-session` all block on the command socket and never return; existing
clients freeze. `kill-server` and `SIGTERM` are not serviced — only `SIGKILL`
recovers the server.

First hit in normal use via tmux-resurrect / tmux-continuum (`@continuum-restore
on`): auto-restore recreates panes and resizes on attach, and one restored pane
was in copy mode. Backtrace (macOS `sample`; captured on 3.7b, the same path
exists on current master):

```
server_client_loop -> resize_window -> layout_fix_panes -> window_copy_resize
  -> window_copy_redraw_lines -> screen_write_stop -> screen_write_collect_flush
    -> window_visible_ranges -> server_client_ensure_ranges
      -> xrecallocarray -> recallocarray        (~100% of samples)
```

### Cause

In `window_visible_ranges()` (window-visible.c):

```c
if ((u_int)py >= w->sy)
        goto empty;
if (px + width > w->sx)
        width = w->sx - px;   /* width is u_int; px > w->sx wraps to ~UINT_MAX */
```

`px < 0`, `py >= w->sy` and `width == 0` are guarded, but `px >= w->sx` is not.
During a resize a pane's x offset (a pane scrollbar, or a floating pane) can
momentarily exceed the shrunk window width, so `width` wraps to a huge value and
then drives the range-splitting loop and
`server_client_ensure_ranges(r, r->used + 1)` / `xrecallocarray()` into the
livelock.

### Fix

Guard `px` against `w->sx` exactly like `py` against `w->sy` just above — a pane
starting at or past the right edge has nothing visible, so return empty.

### Reproduction / verification (built from master, HEAD cad1c81)

Isolated socket, built with `./configure --disable-utf8proc`:

```sh
TM=./tmux
$TM -Ltest -f/dev/null new-session -d -x200 -y50 sh
$TM -Ltest set -g pane-scrollbars on
$TM -Ltest set -g window-size manual
$TM -Ltest send-keys -t s:0.0 'for i in $(seq 1 20000); do printf "L%05d\n" $i; done' Enter
sleep 1
$TM -Ltest split-window -h ; $TM -Ltest split-window -h
$TM -Ltest select-pane -t 0 ; $TM -Ltest copy-mode -t 0 ; $TM -Ltest send-keys -X -t 0 history-top
$TM -Ltest new-pane -O -X 100 -Y 20 -x 40 -y 12      # x offset (100) ends up past the right edge
for W in 200 30 10 5 8 3 60 4 6 2 40 5; do for H in 50 8 3 20; do
  $TM -Ltest resize-window -x $W -y $H; $TM -Ltest refresh-client
done; done
```

- **Unpatched:** within a few seconds the server pins a CPU at 100% and a
  `resize-window` never returns; `tmux -Ltest ls` hangs; recover with `kill -9`.
- **Patched:** the same scenario completes cleanly across repeated runs, the
  server stays responsive (`tmux -Ltest ls` returns immediately), CPU returns to
  idle, and panes still render.

### Related

- #5024 / #4969 / #5397 — same "server livelock in the redraw path, only SIGKILL
  recovers" family, different function (`tty_draw_line`).
- #4938 / #4958 / #4956 — unsigned underflow during copy-mode resize in
  `window-copy.c` (same bug class, adjacent file).
