### PR TITLE
Do not hide cursor during synchronized redraw

### DIFF
--- a/regress/sync-cursor-redraw.sh
+++ b/regress/sync-cursor-redraw.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+
+# A synchronized pane update must not gain cursor visibility changes when tmux
+# redraws it for a client that supports synchronized output.
+
+PATH=/bin:/usr/bin
+TERM=screen
+LC_ALL=C.UTF-8
+export TERM LC_ALL
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+DIR=$(mktemp -d) || exit 1
+TMUX_TMPDIR=$DIR
+export TMUX_TMPDIR
+
+INNER="$TEST_TMUX -Lsync-cursor-inner-$$ -f/dev/null"
+OUTER="$TEST_TMUX -Lsync-cursor-outer-$$ -f/dev/null"
+APP_BYTES=$DIR/app-bytes
+CLIENT_BYTES=$DIR/client-bytes
+EXPECTED=$DIR/expected
+CONTROL=$DIR/control
+
+MARKER=SYNC_CURSOR_MARKER
+SYNC_ON=$(printf '\033[?2026h')
+SYNC_OFF=$(printf '\033[?2026l')
+CIVIS=$(printf '\033[?25l')
+CNORM=$(printf '\033[?25h')
+
+fail()
+{
+	echo "$*" >&2
+	exit 1
+}
+
+cleanup()
+{
+	$OUTER kill-server 2>/dev/null
+	$INNER kill-server 2>/dev/null
+	rm -rf "$DIR"
+}
+trap cleanup 0 1 15
+
+wait_for_bytes()
+{
+	file=$1
+	needle=$2
+	i=0
+	while [ "$i" -lt 50 ]; do
+		grep -F -q "$needle" "$file" 2>/dev/null && return 0
+		sleep 0.1
+		i=$((i + 1))
+	done
+	fail "timed out waiting for bytes in $file"
+}
+
+wait_for_inner_client()
+{
+	i=0
+	while [ "$i" -lt 50 ]; do
+		$INNER list-clients -F '#{client_session}' 2>/dev/null |
+		    grep -Fx -q inner && return 0
+		sleep 0.1
+		i=$((i + 1))
+	done
+	fail "inner client did not attach"
+}
+
+check_geometry()
+{
+	tmux=$1
+	target=$2
+	actual=$($tmux display-message -p -t "$target" \
+	    '#{window_width}x#{window_height} #{pane_width}x#{pane_height}') ||
+	    fail "cannot read geometry for $target"
+	[ "$actual" = "80x24 80x24" ] ||
+	    fail "$target geometry is $actual, expected 80x24 80x24"
+}
+
+wait_for_stable_bytes()
+{
+	file=$1
+	previous=-1
+	stable=0
+	i=0
+	while [ "$i" -lt 50 ]; do
+		current=$(wc -c <"$file" 2>/dev/null) || current=0
+		if [ "$current" -gt 0 ] && [ "$current" -eq "$previous" ]; then
+			stable=$((stable + 1))
+			[ "$stable" -eq 3 ] && return 0
+		else
+			stable=0
+		fi
+		previous=$current
+		sleep 0.1
+		i=$((i + 1))
+	done
+	fail "client byte stream did not become stable"
+}
+
+mkfifo "$CONTROL" || exit 1
+$INNER new-session -d -s inner -x 80 -y 24 \
+    "read signal <'$CONTROL'; printf '\033[?2026h%s\033[?2026l' '$MARKER'; exec sleep 30" ||
+    exit 1
+$INNER set-option -g status off || exit 1
+$INNER set-option -g window-size manual || exit 1
+$INNER set-option -as terminal-features '*:sync' || exit 1
+$INNER pipe-pane -O -t inner:0.0 "cat >'$APP_BYTES'" || exit 1
+
+$OUTER new-session -d -s outer -x 80 -y 24 \
+    "$TEST_TMUX -Lsync-cursor-inner-$$ -f/dev/null attach-session -t inner" ||
+    exit 1
+$OUTER set-option -g status off || exit 1
+$OUTER set-option -g window-size manual || exit 1
+
+wait_for_inner_client
+check_geometry "$INNER" inner:0.0
+check_geometry "$OUTER" outer:0.0
+
+client_geometry=$($INNER list-clients -F '#{client_width}x#{client_height}') ||
+    exit 1
+[ "$client_geometry" = "80x24" ] ||
+    fail "unexpected inner client geometry: $client_geometry"
+client_features=$($INNER list-clients -F '#{client_termfeatures}') || exit 1
+case ,$client_features, in
+*,sync,*) ;;
+*) fail "inner client does not advertise Sync: $client_features" ;;
+esac
+
+$OUTER pipe-pane -O -t outer:0.0 "cat >'$CLIENT_BYTES'" || exit 1
+sleep 0.2
+
+printf '%s%s%s' "$SYNC_ON" "$MARKER" "$SYNC_OFF" >"$EXPECTED"
+printf 'go\n' >"$CONTROL" || exit 1
+
+wait_for_bytes "$APP_BYTES" "$SYNC_OFF"
+wait_for_bytes "$CLIENT_BYTES" "$MARKER"
+wait_for_stable_bytes "$CLIENT_BYTES"
+$OUTER pipe-pane -t outer:0.0 || exit 1
+: >"$CLIENT_BYTES"
+$OUTER pipe-pane -O -t outer:0.0 "cat >'$CLIENT_BYTES'" || exit 1
+$INNER refresh-client || exit 1
+wait_for_bytes "$CLIENT_BYTES" "$MARKER"
+wait_for_bytes "$CLIENT_BYTES" "$SYNC_ON"
+wait_for_bytes "$CLIENT_BYTES" "$SYNC_OFF"
+wait_for_stable_bytes "$CLIENT_BYTES"
+
+cmp -s "$EXPECTED" "$APP_BYTES" ||
+    fail "application byte stream differs from the synchronized test frame"
+grep -F -q "$CIVIS" "$APP_BYTES" &&
+    fail "application unexpectedly emitted civis"
+grep -F -q "$CNORM" "$APP_BYTES" &&
+    fail "application unexpectedly emitted cnorm"
+failed=0
+if grep -F -q "$CIVIS" "$CLIENT_BYTES"; then
+	echo "inner client emitted civis before synchronized output was committed" >&2
+	failed=1
+fi
+if grep -F -q "$CNORM" "$CLIENT_BYTES"; then
+	echo "inner client emitted cnorm after synchronized output was committed" >&2
+	failed=1
+fi
+exit "$failed"

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -1763,8 +1763,8 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 			}
 		}
 	}
-	tty_sync_start(tty);
-	tty_update_mode(tty, tty->mode & ~CURSOR_MODES, NULL);
+	if (!tty_sync_start(tty))
+		tty_update_mode(tty, tty->mode & ~CURSOR_MODES, NULL);
 
 	if (wp != NULL)
 		redraw_draw_pane_lines(&dctx, wp, flags);
@@ -1808,7 +1808,6 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 		c->overlay_draw(c, c->overlay_data);
 
 	tty_reset(tty);
-	tty_sync_end(tty);
 
 #ifdef ENABLE_SIXEL
 	if (wp != NULL)

--- a/server-client.c
+++ b/server-client.c
@@ -2435,10 +2435,12 @@ server_client_check_redraw(struct client *c)
 		return;
 	}
 
-	/* Unfreeze the tty and turn off the cursor. */
+	/* Unfreeze the tty and turn off the cursor if not synchronized. */
 	log_debug("%s: redraw needed", c->name);
 	tflags = tty->flags & (TTY_BLOCK|TTY_FREEZE|TTY_NOCURSOR);
-	tty->flags = (tty->flags & ~(TTY_BLOCK|TTY_FREEZE))|TTY_NOCURSOR;
+	tty->flags &= ~(TTY_BLOCK|TTY_FREEZE);
+	if (!tty_sync_start(tty))
+		tty->flags |= TTY_NOCURSOR;
 
 	/*
 	 * If not redrawing the entire window, check whether each pane needs to

--- a/tmux.h
+++ b/tmux.h
@@ -2943,7 +2943,7 @@ const struct grid_cell *tty_check_codeset(struct tty *,
 	    const struct grid_cell *);
 struct visible_ranges *tty_check_overlay_range(struct tty *, u_int, u_int,
 	    u_int);
-void	tty_sync_start(struct tty *);
+int	tty_sync_start(struct tty *);
 void	tty_sync_end(struct tty *);
 int	tty_open(struct tty *, char **);
 void	tty_close(struct tty *);

--- a/tty-draw.c
+++ b/tty-draw.c
@@ -124,7 +124,7 @@ tty_draw_line(struct tty *tty, struct screen *s, u_int px, u_int py, u_int nx,
 	struct grid_line	*gl;
 	u_int			 i, j, last_i, cx, ex, width;
 	u_int			 cellsize, bg;
-	int			 flags, empty, wrapped = 0;
+	int			 flags, empty, sync, wrapped = 0;
 	char			 buf[1000];
 	size_t			 len;
 	enum tty_draw_line_state current_state, next_state;
@@ -166,10 +166,16 @@ tty_draw_line(struct tty *tty, struct screen *s, u_int px, u_int py, u_int nx,
 	    "bg=%d", __func__, px, px + nx, py, ex, atx, aty, defaults->fg,
 	    defaults->bg);
 
-	/* Turn off cursor while redrawing and reset region and margins. */
+	/* Turn off cursor while redrawing unless output is synchronized. */
 	flags = (tty->flags & TTY_NOCURSOR);
-	tty->flags |= TTY_NOCURSOR;
-	tty_update_mode(tty, tty->mode, s);
+	sync = 0;
+	if ((tty->flags & TTY_SYNCING) &&
+	    tty_term_has(tty->term, TTYC_SYNC) && flags == 0)
+		sync = 1;
+	if (!sync) {
+		tty->flags |= TTY_NOCURSOR;
+		tty_update_mode(tty, tty->mode, s);
+	}
 	tty_region_off(tty);
 	tty_margin_off(tty);
 
@@ -338,6 +344,8 @@ tty_draw_line(struct tty *tty, struct screen *s, u_int px, u_int py, u_int nx,
 	}
 
 out:
-	tty->flags = (tty->flags & ~TTY_NOCURSOR)|flags;
-	tty_update_mode(tty, tty->mode, s);
+	if (!sync) {
+		tty->flags = (tty->flags & ~TTY_NOCURSOR)|flags;
+		tty_update_mode(tty, tty->mode, s);
+	}
 }

--- a/tty.c
+++ b/tty.c
@@ -1576,19 +1576,22 @@ tty_draw_images(struct client *c, struct window_pane *wp)
 }
 #endif
 
-void
+int
 tty_sync_start(struct tty *tty)
 {
+	int	sync = tty_term_has(tty->term, TTYC_SYNC);
+
 	if (tty->flags & TTY_BLOCK)
-		return;
+		return (0);
 	if (tty->flags & TTY_SYNCING)
-		return;
+		return (sync);
 	tty->flags |= TTY_SYNCING;
 
-	if (tty_term_has(tty->term, TTYC_SYNC)) {
+	if (sync) {
 		log_debug("%s sync start", tty->client->name);
 		tty_putcode_i(tty, TTYC_SYNC, 1);
 	}
+	return (sync);
 }
 
 void


### PR DESCRIPTION
Closes #5419.

## Problem

A physical-client redraw uses synchronized output but still applies the legacy unsynchronized redraw strategy:

1. `server_client_check_redraw()` forces `TTY_NOCURSOR`;
2. `redraw_draw()` removes all cursor modes;
3. each `tty_draw_line()` temporarily hides and restores the cursor;
4. `redraw_draw()` commits synchronized output before `server_client_reset_state()` restores the final cursor position, mode, style, and visibility.

The pane can therefore require a visible cursor before and after the redraw while tmux emits `civis` before the synchronized commit and `cnorm` after it. Repeated full redraws disrupt the terminal's cursor blink lifecycle; in the issue's Windows Terminal reproduction this appears as rapid, irregular flicker.

## Fix

Treat a client redraw and its final terminal-state restoration as one physical synchronized-output transaction.

### `server-client.c`

- Add `sync` to distinguish an active physical transaction from tmux's internal `TTY_SYNCING` bookkeeping.
- Start synchronization in `server_client_check_redraw()`, after outstanding-output/blocked-client deferral and before clearing `TTY_FREEZE` or performing any pane or full-window drawing. This covers pane-only redraw paths as well as `redraw_screen()`.
- Require both `TTY_SYNCING` and `TTYC_SYNC` before relying on synchronization. `tty_sync_start()` sets the internal flag even when the terminal lacks the capability, so checking only the flag would break the unsynchronized fallback.
- Split the old combined flag assignment. Always clear `TTY_BLOCK|TTY_FREEZE`, but add temporary `TTY_NOCURSOR` only without physical synchronization.
- Do not clear a pre-existing `TTY_NOCURSOR`; explicit/semantic cursor hiding therefore remains in force.

### `screen-redraw.c`

- Keep `tty_sync_start()` in `redraw_draw()`. It is idempotent and keeps this helper safe if reached by another caller.
- Remove `CURSOR_MODES` only when `TTYC_SYNC` is unavailable. A capable terminal buffers intermediate drawing, so changing visibility/blink modes inside the transaction is unnecessary; terminals without synchronization retain the old protection.
- Remove the local `tty_sync_end()`. It committed the temporary redraw state too early. The existing `server_client_reset_state()` call immediately after `server_client_check_redraw()` restores final cursor position/mode/style/visibility and then calls `tty_sync_end()`, making that the single lifecycle endpoint.

### `tty-draw.c`

- Record whether a line is being drawn inside an active physical synchronized transaction.
- Require no pre-existing `TTY_NOCURSOR` for the fast path. A pre-existing flag is semantic state, not a temporary redraw optimization, and must remain hidden.
- Skip line-local `TTY_NOCURSOR` hide/update and restore/update only on that fast path. Otherwise execute the original pair unchanged, preserving behavior for unsynchronized terminals and explicitly hidden cursors.
- Use the same `sync` snapshot at entry and cleanup so the function cannot skip only one half of the hide/restore pair.

The resulting order is:

```text
sync start
complete client redraw
restore final cursor position, mode, style and visibility
sync end
```

instead of committing a temporarily hidden cursor and restoring it afterwards.

## Why this is safe

- `tty_sync_start()` is idempotent when `TTY_SYNCING` is already set.
- Blocked clients return before synchronization starts.
- The server loop always calls `server_client_reset_state()` immediately after `server_client_check_redraw()`, and that function already ends any active transaction after restoring final state.
- Non-sync terminals still force `TTY_NOCURSOR`, remove cursor modes during redraw, and run the original line-local hide/restore path.
- Existing `TTY_NOCURSOR` is preserved at both client-redraw and line-draw levels.
- The final mode calculation is unchanged; this patch changes only temporary redraw handling and transaction ownership.

## Regression test

`regress/sync-cursor-redraw.sh` uses two isolated tmux servers to capture both sides of the redraw:

- the application stream entering the inner pane;
- the inner tmux client's physical output entering the outer pane.

It verifies fixed 80x24 geometry, actual `sync` client capability, one exact balanced application synchronized-output frame with no cursor visibility controls, and one isolated `refresh-client` redraw. Current master deterministically emits both `civis` and `cnorm`; this branch does not.

## Validation

- Clean current master: regression fails with both cursor-transition diagnostics.
- This branch: regression passes repeatedly.
- `make -j2` passes.
- Focused redraw/mode regressions pass:
  - `tty-draw-line.sh`
  - `screen-redraw-status.sh`
  - `screen-redraw-menus.sh`
  - `screen-redraw-popups.sh`
  - `screen-redraw-cache.sh`
  - `screen-redraw-scrollbars.sh`
  - `input-modes.sh`
  - `decrqm-sync.sh`
  - `sync-cursor-redraw.sh`
- All 118 regression scripts passed: the first bounded run passed through `style-trim.sh` before its external timeout, and the remaining nine scripts all passed separately.
