### PR TITLE
configure.ac: don't enable jemalloc if ASAN enabled on macOS, error if both enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -635,13 +635,20 @@ AC_ARG_ENABLE(
 )
 try_jemalloc=no
 require_jemalloc=no
+if test "x$enable_asan" = xyes && test "x$enable_jemalloc" = xyes; then
+	AC_MSG_ERROR([--enable-asan and --enable-jemalloc cannot be used together])
+fi
 if test "x$enable_jemalloc" = xyes; then
 	try_jemalloc=yes
 elif test "x$enable_jemalloc" = x; then
 	case "$host_os" in
 		*darwin*)
-			try_jemalloc=yes
-			require_jemalloc=yes
+			if test "x$enable_asan" = xyes; then
+				enable_jemalloc=no
+			else
+				try_jemalloc=yes
+				require_jemalloc=yes
+			fi
 			;;
 	esac
 fi


### PR DESCRIPTION
ASAN and jemalloc both replace `malloc` with their version.

Previously, configuring with `--enable-asan` on macOS would enable both jemalloc and ASAN. I'm not sure which one won, but seemed undesired.