### PR TITLE
doc: warn about application-controlled format variables in shell-consuming commands

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -7036,6 +7036,19 @@ escape
 command arguments; with
 .Ql s
 use single quotes.
+.Pp
+Some variables such as
+.Ic pane_title
+and
+.Ic pane_path
+are set by escape sequences from processes in the pane and may contain
+arbitrary content including shell metacharacters.
+.Ql q:\&
+should be used to escape these when interpolating into commands passed to
+.Ic run\-shell ,
+.Ic if\-shell ,
+or
+.Ic pipe\-pane .
 .Ql E:\&
 will expand the format twice, for example
 .Ql #{E:status\-left}


### PR DESCRIPTION
Format variables such as `pane_title` and `pane_path` are set by terminal
escape sequences from processes running in the pane, so they can contain
arbitrary content including shell metacharacters. When one of these is
interpolated into `run-shell`, `if-shell`, or `pipe-pane` without `#{q:...}`,
the expanded string is evaluated by `/bin/sh`. Default key bindings are
unaffected — this only concerns user-written hooks or plugin commands that
build a shell command out of these variables.

The manual already documents that `pane_title` is application-settable and that
the `q:` modifier escapes `sh(1)` special characters, but neither fact is stated
at the `run-shell`/`if-shell`/`pipe-pane` entries, which is where the unsafe
pattern actually gets written. This adds a short note to each of those three
entries pointing at `#{q:variable}`.

<details>
<summary>Why it matters — minimal reproduction (isolated, self-cleaning)</summary>

```bash
SOCKET="verify-$$"
PROOF=$(mktemp /tmp/tmux-proof.XXXXXX)
rm -f "$PROOF"

tmux -L "$SOCKET" -f /dev/null new-session -d -s test -x 80 -y 24

# Install an unsafe hook (the non-default configuration required)
tmux -L "$SOCKET" set-hook -g pane-title-changed \
  "run-shell \"echo #{pane_title} >> $PROOF\""

# The pane process emits an OSC 2 escape, setting pane_title
tmux -L "$SOCKET" send-keys -t test "printf '\\033]2;\$(id > $PROOF)\\007'" Enter
sleep 2

cat "$PROOF"
# → uid=501(user) gid=20(staff) ...

# Control: #{q:pane_title} prevents it
tmux -L "$SOCKET" set-hook -g pane-title-changed \
  "run-shell \"echo #{q:pane_title} >> ${PROOF}.safe\""
tmux -L "$SOCKET" send-keys -t test "printf '\\033]2;\$(id > ${PROOF}.control)\\007'" Enter
sleep 2
# ${PROOF}.control does not exist — #{q:} neutralized the payload

tmux -L "$SOCKET" kill-server
rm -f "$PROOF" "${PROOF}.safe" "${PROOF}.control"
```
</details>

Applies cleanly to current master; verified on tmux 3.7b (macOS Darwin 25.5.0).