### PR TITLE
Escape newline and tab in format_quote_shell()

### DIFF
--- a/format.c
+++ b/format.c
@@ -4325,7 +4325,7 @@ format_quote_shell(const char *s)
 
 	at = out = xmalloc(strlen(s) * 2 + 1);
 	for (cp = s; *cp != '\0'; cp++) {
-		if (strchr("|&;<>()$`\\\"'*?[# =%", *cp) != NULL)
+		if (strchr("|&;<>()$`\\\"'*?[# =%\n\t", *cp) != NULL)
 			*at++ = '\\';
 		*at++ = *cp;
 	}


### PR DESCRIPTION
`format_quote_shell()` escapes shell metacharacters for the `#{q:}`
format modifier but omits newline (0x0a) and tab (0x09).

In POSIX sh, newline is a command separator and tab is a "blank" token
delimiter (Section 2.10.2). When `#{q:pane_current_path}` is
interpolated into `run-shell` and the path contains these bytes, the
shell splits the expanded string into multiple commands — achieving
command injection despite the quoting.

This is reachable via `pane_current_path` because `osdep_get_cwd()`
returns raw filesystem bytes (both Linux `readlink(/proc/pid/cwd)` and
macOS `proc_pidinfo` are byte-transparent), and
`format_cb_current_path()` passes them through with bare `xstrdup`.

The fix adds both bytes to the existing `strchr` charset:
- `\<newline>` = POSIX line continuation (consumed as whitespace)
- `\<tab>` = literal tab (no longer a token delimiter)

Tested on tmux 3.7b (macOS) and tmux 3.4 (Ubuntu 24.04).

Related: #5425 (documents that `#{q:}` should be used for
application-settable variables — this fix makes that recommendation
complete).