### PR TITLE
fire after-swap-window hook in swap-window

### DIFF
--- a/cmd-swap-window.c
+++ b/cmd-swap-window.c
@@ -38,7 +38,7 @@ const struct cmd_entry cmd_swap_window_entry = {
 	.source = { 's', CMD_FIND_WINDOW, CMD_FIND_DEFAULT_MARKED },
 	.target = { 't', CMD_FIND_WINDOW, 0 },
 
-	.flags = 0,
+	.flags = CMD_AFTERHOOK,
 	.exec = cmd_swap_window_exec
 };
 

--- a/options-table.c
+++ b/options-table.c
@@ -1944,6 +1944,7 @@ const struct options_table_entry options_table[] = {
 	OPTIONS_TABLE_AFTER_HOOK("show-messages"),
 	OPTIONS_TABLE_AFTER_HOOK("show-options"),
 	OPTIONS_TABLE_AFTER_HOOK("split-window"),
+	OPTIONS_TABLE_AFTER_HOOK("swap-window"),
 	OPTIONS_TABLE_AFTER_HOOK("unbind-key"),
 	OPTIONS_TABLE_HOOK("alert-activity", "",
 	    "Run when a window has activity."),


### PR DESCRIPTION
Swap-window wasn't triggering an after-hook,unlike nearly every other window/pane command (like new-window, split-window, select-pane, and the others). Its hook name also wasn't entered in the options-table so:

set-hook -g after-swap-window 'some-command'

would result in an invalid option: after-swap-window error.

This pulls in CMD_AFTERHOOK to the swap-window command entry and adds "after-swap-window" to options-table.c mirroring the existing convention applied to other commands.

Manual tests:

set-hook -g after-swap-window 'run-shell "echo fired >> /tmp/log"'

swap-window -s test:0 -t test:1

/tmp/log then contains "fired"; previously set-hook returned invalid option.