### PR TITLE
Fix infinite loop in tty_draw_line on standalone zero-width cells

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -2875,7 +2875,7 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 
 	/* Check if this combined character would be too long. */
 	if (last.data.size + ud->size > sizeof last.data.data)
-		return (0);
+		return (zero_width);
 
 	/* Combining; flush any pending output. */
 	screen_write_collect_flush(ctx, 0, __func__);

--- a/tty-draw.c
+++ b/tty-draw.c
@@ -100,7 +100,10 @@ tty_draw_line_get_empty(const struct grid_cell *gc,
 		empty = nx;
 	else if (gc->flags & GRID_FLAG_PADDING)
 		empty = 1;
-	else if (gc->flags & GRID_FLAG_SELECTED)
+	else if (gc->data.width == 0) {
+		/* The loop advances by width so this would never finish. */
+		empty = 1;
+	} else if (gc->flags & GRID_FLAG_SELECTED)
 		empty = 0;
 	else if (gc->bg == last->bg && gc->attr == 0 && gc->link == 0) {
 		if (gc->flags & GRID_FLAG_CLEARED)


### PR DESCRIPTION
Printing text with many combining characters stacked on one base character can hang the tmux server: it spins at 100% CPU and stops responding to everything, including `kill-server`. Only `kill -9` gets rid of it.

Try it yourself:

```sh
tmux -f /dev/null -L test new -s demo
```

Inside the new session, print one character with 16 combining marks on it:

```sh
printf 'u\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\u0325\n'
```

Now switch away and back — `C-b c` (new window), then `C-b l` (last window). The client freezes and the server pegs one core. Clean up from another terminal with `pkill -9 -f 'tmux.*-L ?test'`.

**What happens:** a grid cell holds `UTF8_SIZE` (32) bytes — the base character plus 15 two-byte combining marks. The 16th mark doesn't fit, `screen_write_combine()` returns 0 ("write normally"), and the mark is stored as its own width-0 cell while the cursor stays put. The next full redraw of that row then never finishes, because the loop in `tty_draw_line` advances by each cell's width — which is zero. Since the cursor doesn't advance, the next printed character normally overwrites the bad cell and hides the problem; it only survives when the marks end the line, sit at a wrap boundary, or a program moves the cursor after printing them (a curses app displaying such a filename is how I hit it).

Through 3.5a this terminated because the loop advanced one cell per iteration; the state-machine version advances by width. It is the zero-width sibling of the orphan-padding loop fixed in 281e8ff7 (#5024).

**The fix:** discard a combining mark that cannot be combined because the cell is full (`screen-write.c`), and treat width-0 cells as empty in `tty_draw_line` so the loop always advances (`tty-draw.c`). Either change alone stops the hang. Verified on macOS against current master (utf8proc build): unpatched spins, patched redraws normally, and a full screen of 15-mark cells (the legitimate maximum) still renders fine.

Credit where due: the bug was found thanks to [Four Tet](https://en.wikipedia.org/wiki/Four_Tet), whose album [⣎⡇ꉺლ༽இ•̛)ྀ◞ ༎ຶ ༽ৣৢ؞ৢ؞ؖ ꉺლ](https://00000ooooo.bandcamp.com/album/--5) has track titles that hung my tmux session the moment I printed them.
