### PR TITLE
minor tmux.1 update/fix (run-shell)

### DIFF
--- a/tmux.1
+++ b/tmux.1
@@ -8752,7 +8752,7 @@ values are given, they are available as
 and so on.
 For example:
 .Bd -literal -offset indent
-run-shell 'myscript.sh #1 #2' foo bar
+run-shell 'myscript.sh #{1} #{2}' foo bar
 .Ed
 .Pp
 With


### PR DESCRIPTION
Related to #5121, minor inconsistency in tmux.1.

I updated to tmux3.7_b-1 on archlinux and checked the man-page regarding run-shell with args. I noticed the example:

`run-shell 'myscript.sh #1 #2' foo bar`.

As I recall you reverted the `#1 #2` support due to conflict with some theming configuration. The correct example should be:

`run-shell 'myscript.sh #{1} #{2}' foo bar`.