### PR TITLE
feat: Add WINDOW_MODE_HIDE_SCROLLBARS (and FILL_WINDOW) for display-panes

### DIFF
--- a/tmux.h
+++ b/tmux.h
@@ -1194,6 +1194,8 @@ struct window_mode {
 	int		 flags;
 #define WINDOW_MODE_HIDE_PANE_STATUS 0x1
 #define WINDOW_MODE_NO_STACK 0x2
+#define WINDOW_MODE_FILL_WINDOW 0x4
+#define WINDOW_MODE_HIDE_SCROLLBARS 0x8
 
 	struct screen	*(*init)(struct window_mode_entry *,
 			     struct cmdq_item *, struct cmd_find_state *,

--- a/window-panes.c
+++ b/window-panes.c
@@ -35,7 +35,8 @@ static void		 window_panes_key(struct window_mode_entry *,
 
 const struct window_mode window_panes_mode = {
 	.name = "panes-mode",
-	.flags = WINDOW_MODE_HIDE_PANE_STATUS|WINDOW_MODE_NO_STACK,
+	.flags = WINDOW_MODE_HIDE_PANE_STATUS|WINDOW_MODE_NO_STACK|
+	    WINDOW_MODE_FILL_WINDOW|WINDOW_MODE_HIDE_SCROLLBARS,
 
 	.init = window_panes_init,
 	.free = window_panes_free,

--- a/window.c
+++ b/window.c
@@ -2460,11 +2460,21 @@ window_pane_mode(struct window_pane *wp)
 int
 window_pane_show_scrollbar(struct window_pane *wp)
 {
+	struct window			*w = wp->window;
+	struct window_mode_entry	*wme;
+
 	if (SCREEN_IS_ALTERNATE(&wp->base))
 		return (0);
-	if (wp->window->sb == PANE_SCROLLBARS_ALWAYS ||
-	    wp->window->sb == PANE_SCROLLBARS_AUTOHIDE ||
-	    (wp->window->sb == PANE_SCROLLBARS_MODAL &&
+	if ((w->flags & WINDOW_ZOOMED) && w->active != NULL) {
+		wme = TAILQ_FIRST(&w->active->modes);
+		if (wme != NULL &&
+		    (wme->mode->flags & WINDOW_MODE_HIDE_SCROLLBARS)) {
+			return (0);
+		}
+	}
+	if (w->sb == PANE_SCROLLBARS_ALWAYS ||
+	    w->sb == PANE_SCROLLBARS_AUTOHIDE ||
+	    (w->sb == PANE_SCROLLBARS_MODAL &&
 	    window_pane_mode(wp) != WINDOW_PANE_NO_MODE))
 		return (1);
 	return (0);


### PR DESCRIPTION
## Summary
- Add `WINDOW_MODE_HIDE_SCROLLBARS` so modes can hide scrollbars while zoomed.
- Set it on `window_panes_mode` so `display-panes` does not leave scrollbars shifting the overlay.
- Also add `WINDOW_MODE_FILL_WINDOW` on the same mode for later use (unused here).

This is a split from #5433 so this plumbing can land on its own.

## Test plan
- [x] `set -g pane-scrollbars on`, split panes, generate scrollable content
- [x] Run `display-panes` (`q`) and confirm scrollbars disappear while the overlay is active
- [x] Confirm scrollbars return after display-panes exits