### PR TITLE
Keep the background when a wide character or a tab is broken up

### DIFF
--- a/grid-view.c
+++ b/grid-view.c
@@ -47,9 +47,9 @@ grid_view_set_cell(struct grid *gd, u_int px, u_int py,
 
 /* Set padding. */
 void
-grid_view_set_padding(struct grid *gd, u_int px, u_int py)
+grid_view_set_padding(struct grid *gd, u_int px, u_int py, int bg)
 {
-	grid_set_padding(gd, grid_view_x(gd, px), grid_view_y(gd, py));
+	grid_set_padding(gd, grid_view_x(gd, px), grid_view_y(gd, py), bg);
 }
 
 /* Set cells. */

--- a/grid.c
+++ b/grid.c
@@ -682,9 +682,13 @@ grid_set_cell(struct grid *gd, u_int px, u_int py, const struct grid_cell *gc)
 
 /* Set padding at position. */
 void
-grid_set_padding(struct grid *gd, u_int px, u_int py)
+grid_set_padding(struct grid *gd, u_int px, u_int py, int bg)
 {
-	grid_set_cell(gd, px, py, &grid_padding_cell);
+	struct grid_cell	gc;
+
+	memcpy(&gc, &grid_padding_cell, sizeof gc);
+	gc.bg = bg;
+	grid_set_cell(gd, px, py, &gc);
 }
 
 /* Set cells at position. */

--- a/regress/tab-cell-background.sh
+++ b/regress/tab-cell-background.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# When a write breaks up a wide character or a tab, the columns it covered must
+# keep the background colour, both in the grid and on the terminal. The second
+# server is attached to the first so that what is actually sent is checked, not
+# just what tmux has stored.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+TMUX2="$TEST_TMUX -LtestB$$ -f/dev/null"
+$TMUX2 kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap "rm -f $TMP" 0 1 15
+
+# 1. Write inside a tab. 2. Overwrite the right half of a wide character.
+# 3. Two tabs of different colours, the first partly deleted so that padding
+#    from both ends up next to each other, then written over.
+# The sleep is so that the client is attached before anything is written and
+# the changes are sent as they happen rather than as one redraw.
+$TMUX2 -f/dev/null new -d -x24 -y3 "
+	sleep 2
+	printf '\033[44m\033[K\t\033[4GX'
+	printf '\033[2;1H\033[44m\033[K\344\270\226\033[2GX'
+	printf '\033[3;1H\033[42m\033[K\t\033[43m\033[K\t\033[0m\033[4G\033[8P\rx'
+	cat" || exit 1
+$TMUX2 set -g status off || exit 1
+
+$TMUX -f/dev/null new -x24 -y4 -d "$TMUX2 attach" || exit 1
+sleep 4
+
+$TMUX capturep -pe -S0 -E2 >$TMP || exit 1
+$TMUX kill-server 2>/dev/null
+$TMUX2 kill-server 2>/dev/null
+
+printf '\033[44m   X\n X\n\033[49mx\033[42m  \033[43m             \033[49m\n' |
+	cmp - $TMP || exit 1
+
+exit 0

--- a/screen-write.c
+++ b/screen-write.c
@@ -2480,15 +2480,63 @@ screen_write_collect_insert_clear(struct screen_write_ctx *ctx, u_int px,
 	}
 }
 
+/*
+ * Clear a cell that is being broken up by a write over part of it, keeping the
+ * background so the columns it covered do not lose their colour.
+ */
+static void
+screen_write_clear_cell(struct grid *gd, u_int px, u_int py)
+{
+	struct grid_cell	 gc;
+	int			 bg;
+
+	grid_view_get_cell(gd, px, py, &gc);
+	bg = gc.bg;
+
+	memcpy(&gc, &grid_default_cell, sizeof gc);
+	gc.bg = bg;
+	grid_view_set_cell(gd, px, py, &gc);
+}
+
+/*
+ * Queue clears for a range of cells already cleared in the grid. Adjacent
+ * cells may have come from different characters and so have different
+ * backgrounds, so this is done in runs of the same colour.
+ */
+static void
+screen_write_clear_runs(struct screen_write_ctx *ctx, u_int px, u_int nx)
+{
+	struct screen		*s = ctx->s;
+	struct grid_cell	 gc;
+	u_int			 xx, start = px;
+	int			 bg = 8;
+
+	for (xx = px; xx < px + nx; xx++) {
+		grid_view_get_cell(s->grid, xx, s->cy, &gc);
+		if (xx == start)
+			bg = gc.bg;
+		else if (gc.bg != bg) {
+			log_debug("%s: from %u, size %u", __func__, start,
+			    xx - start);
+			screen_write_collect_insert_clear(ctx, start,
+			    xx - start, bg);
+			start = xx;
+			bg = gc.bg;
+		}
+	}
+	log_debug("%s: from %u, size %u", __func__, start, xx - start);
+	screen_write_collect_insert_clear(ctx, start, xx - start, bg);
+}
+
 /* Finish and store collected cells. */
 void
 screen_write_collect_end(struct screen_write_ctx *ctx)
 {
 	struct screen			*s = ctx->s;
-	struct screen_write_citem	*ci = ctx->item, *bci = NULL, *aci;
+	struct screen_write_citem	*ci = ctx->item;
 	struct screen_write_cline	*cl = &s->write_list[s->cy];
 	struct grid_cell		 gc;
-	u_int				 xx;
+	u_int				 xx, bx = 0, bnx = 0;
 
 	if (ci->used == 0)
 		return;
@@ -2504,8 +2552,7 @@ screen_write_collect_end(struct screen_write_ctx *ctx)
 			grid_view_get_cell(s->grid, xx, s->cy, &gc);
 			if (~gc.flags & GRID_FLAG_PADDING)
 				break;
-			grid_view_set_cell(s->grid, xx, s->cy,
-			    &grid_default_cell);
+			screen_write_clear_cell(s->grid, xx, s->cy);
 			log_debug("%s: padding erased (before) at %u (cx %u)",
 			    __func__, xx, s->cx);
 		}
@@ -2514,20 +2561,12 @@ screen_write_collect_end(struct screen_write_ctx *ctx)
 				grid_view_get_cell(s->grid, 0, s->cy, &gc);
 			if (gc.data.width > 1 ||
 			    (gc.flags & GRID_FLAG_PADDING)) {
-				grid_view_set_cell(s->grid, xx, s->cy,
-				    &grid_default_cell);
+				screen_write_clear_cell(s->grid, xx, s->cy);
 				log_debug("%s: padding erased (before) at %u "
 				    "(cx %u)", __func__, xx, s->cx);
 			}
-		}
-		if (xx != s->cx) {
-			bci = ctx->item;
-			bci->type = CLEAR;
-			bci->x = xx;
-			bci->bg = 8;
-			bci->used = s->cx - xx;
-			log_debug("%s: padding erased (before): from %u, "
-			    "size %u", __func__, bci->x, bci->used);
+			bx = xx;
+			bnx = s->cx - xx;
 		}
 	}
 
@@ -2538,28 +2577,20 @@ screen_write_collect_end(struct screen_write_ctx *ctx)
 
 	grid_view_set_cells(s->grid, s->cx, s->cy, &ci->gc, cl->data + ci->x,
 	    ci->used);
-	if (bci != NULL)
-		screen_write_collect_insert(ctx, bci);
+	if (bnx != 0)
+		screen_write_clear_runs(ctx, bx, bnx);
 	screen_write_set_cursor(ctx, s->cx + ci->used, -1);
 
 	for (xx = s->cx; xx < screen_size_x(s); xx++) {
 		grid_view_get_cell(s->grid, xx, s->cy, &gc);
 		if (~gc.flags & GRID_FLAG_PADDING)
 			break;
-		grid_view_set_cell(s->grid, xx, s->cy, &grid_default_cell);
+		screen_write_clear_cell(s->grid, xx, s->cy);
 		log_debug("%s: padding erased (after) at %u (cx %u)",
 		    __func__, xx, s->cx);
 	}
-	if (xx != s->cx) {
-		aci = ctx->item;
-		aci->type = CLEAR;
-		aci->x = s->cx;
-		aci->bg = 8;
-		aci->used = xx - s->cx;
-		log_debug("%s: padding erased (after): from %u, size %u",
-		    __func__, aci->x, aci->used);
-		screen_write_collect_insert(ctx, aci);
-	}
+	if (xx != s->cx)
+		screen_write_clear_runs(ctx, s->cx, xx - s->cx);
 }
 
 /* Write cell data, collecting if necessary. */
@@ -2687,7 +2718,7 @@ screen_write_cell(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	 */
 	for (xx = s->cx + 1; xx < s->cx + width; xx++) {
 		log_debug("%s: new padding at %u,%u", __func__, xx, s->cy);
-		grid_view_set_padding(gd, xx, s->cy);
+		grid_view_set_padding(gd, xx, s->cy, gc->bg);
 		skip = 0;
 	}
 
@@ -2899,7 +2930,7 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	/* Set the new cell. */
 	grid_view_set_cell(gd, cx - n, cy, &last);
 	if (force_wide)
-		grid_view_set_padding(gd, cx - 1, cy);
+		grid_view_set_padding(gd, cx - 1, cy, last.bg);
 
 	/*
 	 * Check if all of this character is visible. No character will be
@@ -2968,12 +2999,12 @@ screen_write_overwrite(struct screen_write_ctx *ctx, struct grid_cell *gc,
 			if (~tmp_gc.flags & GRID_FLAG_PADDING)
 				break;
 			log_debug("%s: padding at %u,%u", __func__, xx, s->cy);
-			grid_view_set_cell(gd, xx, s->cy, &grid_default_cell);
+			screen_write_clear_cell(gd, xx, s->cy);
 		}
 
 		/* Overwrite the character at the start of this padding. */
 		log_debug("%s: character at %u,%u", __func__, xx, s->cy);
-		grid_view_set_cell(gd, xx, s->cy, &grid_default_cell);
+		screen_write_clear_cell(gd, xx, s->cy);
 		done = 1;
 	}
 
@@ -2991,17 +3022,7 @@ screen_write_overwrite(struct screen_write_ctx *ctx, struct grid_cell *gc,
 				break;
 			log_debug("%s: overwrite at %u,%u", __func__, xx,
 			    s->cy);
-			if (gc->flags & GRID_FLAG_TAB) {
-				memcpy(&tmp_gc, gc, sizeof tmp_gc);
-				memset(tmp_gc.data.data, 0,
-				    sizeof tmp_gc.data.data);
-				*tmp_gc.data.data = ' ';
-				tmp_gc.data.width = tmp_gc.data.size =
-				    tmp_gc.data.have = 1;
-				grid_view_set_cell(gd, xx, s->cy, &tmp_gc);
-			} else
-				grid_view_set_cell(gd, xx, s->cy,
-				    &grid_default_cell);
+			screen_write_clear_cell(gd, xx, s->cy);
 			done = 1;
 		}
 	}

--- a/tmux.h
+++ b/tmux.h
@@ -3493,7 +3493,7 @@ void	 grid_clear_history(struct grid *);
 const struct grid_line *grid_peek_line(struct grid *, u_int);
 void	 grid_get_cell(struct grid *, u_int, u_int, struct grid_cell *);
 void	 grid_set_cell(struct grid *, u_int, u_int, const struct grid_cell *);
-void	 grid_set_padding(struct grid *, u_int, u_int);
+void	 grid_set_padding(struct grid *, u_int, u_int, int);
 void	 grid_set_cells(struct grid *, u_int, u_int, const struct grid_cell *,
 	     const char *, size_t);
 struct grid_line *grid_get_line(struct grid *, u_int);
@@ -3538,7 +3538,7 @@ void	 grid_reader_cursor_back_to_indentation(struct grid_reader *);
 void	 grid_view_get_cell(struct grid *, u_int, u_int, struct grid_cell *);
 void	 grid_view_set_cell(struct grid *, u_int, u_int,
 	     const struct grid_cell *);
-void	 grid_view_set_padding(struct grid *, u_int, u_int);
+void	 grid_view_set_padding(struct grid *, u_int, u_int, int);
 void	 grid_view_set_cells(struct grid *, u_int, u_int,
 	     const struct grid_cell *, const char *, size_t);
 void	 grid_view_clear_history(struct grid *, u_int);


### PR DESCRIPTION
## Summary
- Padding cells now carry a background colour, so the columns covered by a wide character or a tab keep their background when a write breaks it up.
- The terminal is cleared in runs of the same background, since adjacent padding can come from different characters.
- Add `regress/tab-cell-background.sh`.

## Problem
A tab is stored as a single multiple-column cell (`GRID_FLAG_TAB`), and a wide character as a cell plus padding. Padding carries no attributes of its own — `grid_padding_cell` is default fg/bg.

When a write lands *inside* one of those spans the leftover columns are cleared to `grid_default_cell`, and the terminal is sent the matching clear with `bg = 8`, so the background colour underneath is silently lost.

Minimal reproductions, in a 24 column pane:

```sh
printf '\033[44m\033[K\t\033[4GX'		# write inside a tab
printf '\033[44m\033[K\344\270\226\033[2GX'	# overwrite half a wide character
```

`capture-pane -pe` for the first, before:

```
   \033[44mX\033[49m    \033[44m
```

Columns 0-2 and 4-7 have dropped back to the default background. After:

```
\033[44m   X
```

I hit this from a TUI that uses tabs for cursor motion while horizontally scrolling a syntax highlighted diff: whitespace runs kept losing their row background a frame later. It only reproduced under tmux.

## Fix
`grid_set_padding()` and `grid_view_set_padding()` take a background, and the two callers pass the background of the cell the padding belongs to.

`screen_write_clear_cell()` clears a cell keeping its background, and is used by both places that clear padding — `screen_write_collect_end()`, which is where plain ASCII goes, and `screen_write_overwrite()`, which handles wide characters and redraws the line from the grid afterwards.

Padding cells next to each other can come from different characters, for example when a tab is partly deleted and padding from two tabs of different colours ends up together:

```sh
printf '\033[42m\033[K\t\033[43m\033[K\t\033[0m\033[4G\033[8P\rx'
```

So `screen_write_collect_end()` queues one clear per run of the same background instead of a single one with the hardcoded 8.

This also lets the `GRID_FLAG_TAB` special case in `screen_write_overwrite()` go away, as it only covered trailing padding.

## Test plan
- [x] `regress/tab-cell-background.sh` covers all three cases and fails on master
- [x] The test attaches a second server to the first, like `am-terminal.sh`, so what is sent is checked and not just what is stored — capturing the same server only shows the grid, which was already correct in the third case
- [x] Full `regress` suite: no new failures (`check-names`, `display-panes` and `screen-redraw-menus` already fail here on macOS)
- [x] Verified end to end against the original TUI: drift before, clean after
