### PR TITLE
Do not let a stuck client prevent the server from exiting

### DIFF
--- a/control.c
+++ b/control.c
@@ -878,6 +878,24 @@ control_discard(struct client *c)
 	bufferevent_disable(cs->read_event, EV_READ);
 }
 
+/*
+ * Discard all output for a client, including output which has already been
+ * queued to be written. Used when the client has stopped accepting output so
+ * it is never going to be delivered.
+ */
+void
+control_discard_all(struct client *c)
+{
+	struct control_state	*cs = c->control_state;
+	struct control_block	*cb, *cb1;
+
+	control_discard(c);
+	TAILQ_FOREACH_SAFE(cb, &cs->all_blocks, all_entry, cb1)
+		control_free_block(cs, cb);
+	evbuffer_drain(cs->write_event->output,
+	    EVBUFFER_LENGTH(cs->write_event->output));
+}
+
 /* Stop control mode. */
 void
 control_stop(struct client *c)

--- a/regress/control-client-exit-stalled.sh
+++ b/regress/control-client-exit-stalled.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+# A control client whose terminal has stopped accepting output (for example
+# its ssh connection or terminal emulator died) never drains the output that
+# server_client_check_exit waits on before sending MSG_EXIT, and may then
+# never close its socket either. This must not prevent the server from
+# exiting: after kill-server the server previously stayed alive forever with
+# server_exit set, closing every new connection immediately, so every new
+# client failed with "server exited unexpectedly" until the server was killed
+# by hand. The server now bounds the exit handshake: it discards output it
+# can never deliver and drops the client if it still does not close.
+#
+# The stalled terminal is simulated by a fifo whose read end is held open but
+# never read.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+DIR=$(mktemp -d)
+FIFO=$DIR/fifo
+SERVER=
+
+mkfifo "$FIFO" || exit 1
+
+cleanup() {
+	[ -n "$SERVER" ] && kill -9 "$SERVER" 2>/dev/null
+	$TMUX kill-server 2>/dev/null
+	exec 8<&- 2>/dev/null
+	rm -rf "$DIR"
+}
+trap cleanup 0 1 15
+
+# A detached session whose pane floods printable output forever.
+$TMUX -f/dev/null new -d -x 80 -y 24 -s rt 'cat /dev/zero | tr "\000" x' || exit 1
+SERVER=$($TMUX display -pt rt '#{pid}')
+
+# Attach a control client with output down the fifo; stdin held open by sleep
+# so it stays attached. The fifo fills and is never read, so a backlog forms
+# in the server that can never be delivered.
+( sleep 60 ) | $TMUX -f/dev/null -C attach -t rt >"$FIFO" 2>&1 &
+exec 8<"$FIFO"
+
+n=0
+while [ $n -lt 50 ]; do
+	$TMUX lsc -F '#{client_name}' 2>/dev/null | grep -q . && break
+	sleep 0.1
+	n=$((n + 1))
+done
+$TMUX lsc -F '#{client_name}' 2>/dev/null | grep -q . ||
+	{ echo "control client did not attach"; exit 1; }
+
+# Let the pane flood fill the fifo so the client's output is stuck.
+sleep 2
+
+# Ask the server to exit. This sets CLIENT_EXIT on the stalled client, whose
+# output can never drain.
+$TMUX kill-server 2>/dev/null
+
+# The server must exit within the exit timeout (10 seconds) plus slack,
+# rather than staying in limbo forever rejecting new clients.
+n=0
+while [ $n -lt 100 ]; do
+	if ! kill -0 "$SERVER" 2>/dev/null; then
+		SERVER=
+		exit 0
+	fi
+	sleep 0.2
+	n=$((n + 1))
+done
+
+echo "server did not exit after kill-server; new clients see:"
+$TMUX ls 2>&1
+exit 1

--- a/server-client.c
+++ b/server-client.c
@@ -37,6 +37,7 @@ static key_code	server_client_check_mouse(struct client *, struct key_event *);
 static void	server_client_repeat_timer(int, short, void *);
 static void	server_client_click_timer(int, short, void *);
 static void	server_client_check_exit(struct client *);
+static void	server_client_exit_timer(int, short, void *);
 static void	server_client_check_redraw(struct client *);
 static void	server_client_check_modes(struct client *);
 static void	server_client_set_title(struct client *);
@@ -309,6 +310,7 @@ server_client_create(int fd)
 
 	evtimer_set(&c->repeat_timer, server_client_repeat_timer, c);
 	evtimer_set(&c->click_timer, server_client_click_timer, c);
+	evtimer_set(&c->exit_timer, server_client_exit_timer, c);
 
 	c->click_wp = -1;
 
@@ -525,6 +527,7 @@ server_client_lost(struct client *c)
 
 	evtimer_del(&c->repeat_timer);
 	evtimer_del(&c->click_timer);
+	evtimer_del(&c->exit_timer);
 	if (event_initialized(&c->cycle_timer))
 		evtimer_del(&c->cycle_timer);
 
@@ -2285,6 +2288,61 @@ server_client_click_timer(__unused int fd, __unused short events, void *data)
 	c->flags &= ~(CLIENT_DOUBLECLICK|CLIENT_TRIPLECLICK);
 }
 
+/*
+ * Number of seconds to wait for an exiting client to flush its remaining
+ * output and then to close its connection. A client whose terminal has gone
+ * away (for example a control client whose ssh or terminal emulator has died)
+ * may never do either and must not be allowed to prevent the server exiting.
+ */
+#define CLIENT_EXIT_TIMEOUT 10
+
+/* Bound how long an exiting client may take, if not already bounded. */
+static void
+server_client_exit_deadline(struct client *c)
+{
+	struct timeval	tv = { .tv_sec = CLIENT_EXIT_TIMEOUT };
+
+	if (!evtimer_pending(&c->exit_timer, NULL))
+		evtimer_add(&c->exit_timer, &tv);
+}
+
+/* Exit timer has expired: stop waiting for the client to exit gracefully. */
+static void
+server_client_exit_timer(__unused int fd, __unused short events, void *data)
+{
+	struct client		*c = data;
+	struct client_file	*cf;
+
+	if (c->flags & (CLIENT_DEAD|CLIENT_SUSPENDED))
+		return;
+	if (c->flags & CLIENT_EXITED) {
+		/*
+		 * MSG_EXIT was sent but the client has not closed its
+		 * connection, perhaps because it is stuck writing to a dead
+		 * terminal. Drop it or it will prevent the server exiting.
+		 */
+		log_debug("%s: %s took too long to exit, dropping", __func__,
+		    c->name);
+		server_client_lost(c);
+		return;
+	}
+	if (~c->flags & CLIENT_EXIT)
+		return;
+
+	/*
+	 * The client has stopped accepting the output that must be flushed
+	 * before MSG_EXIT can be sent. It is never going to be delivered, so
+	 * discard it and let the exit continue.
+	 */
+	log_debug("%s: %s took too long to flush, discarding output", __func__,
+	    c->name);
+	if (c->flags & CLIENT_CONTROL)
+		control_discard_all(c);
+	RB_FOREACH(cf, client_files, &c->files)
+		evbuffer_drain(cf->buffer, EVBUFFER_LENGTH(cf->buffer));
+	server_client_check_exit(c);
+}
+
 /* Check if client should be exited. */
 static void
 server_client_check_exit(struct client *c)
@@ -2301,14 +2359,22 @@ server_client_check_exit(struct client *c)
 
 	if (c->flags & CLIENT_CONTROL) {
 		control_discard(c);
-		if (!control_all_done(c))
+		if (!control_all_done(c)) {
+			server_client_exit_deadline(c);
 			return;
+		}
 	}
 	RB_FOREACH(cf, client_files, &c->files) {
-		if (EVBUFFER_LENGTH(cf->buffer) != 0)
+		if (EVBUFFER_LENGTH(cf->buffer) != 0) {
+			server_client_exit_deadline(c);
 			return;
+		}
 	}
 	c->flags |= CLIENT_EXITED;
+
+	/* Now wait (bounded) for the client to process MSG_EXIT and close. */
+	evtimer_del(&c->exit_timer);
+	server_client_exit_deadline(c);
 
 	switch (c->exit_type) {
 	case CLIENT_EXIT_RETURN:

--- a/tmux.h
+++ b/tmux.h
@@ -2243,6 +2243,8 @@ struct client {
 	struct event		 click_timer;
 	int			 click_loc;
 	int			 click_wp;
+
+	struct event		 exit_timer;
 	u_int			 click_button;
 	struct mouse_event	 click_event;
 
@@ -4020,6 +4022,7 @@ time_t	monitor_get_fire_time(struct monitor_set *, const char *);
 
 /* control.c */
 void	control_discard(struct client *);
+void	control_discard_all(struct client *);
 void	control_start(struct client *);
 void	control_ready(struct client *);
 void	control_stop(struct client *);


### PR DESCRIPTION
### Problem

If a control client's terminal has stopped accepting output (for example its ssh connection or terminal emulator has died), the server can never finish exiting. After `kill-server` or SIGTERM the server stays alive forever with `server_exit` set, and `server_accept()` then accepts and immediately closes every new connection — so every subsequent tmux command on that socket fails with `server exited unexpectedly` until the server is killed by hand.

Observed in the wild: a 3.7b server on a dev machine sat in this state for over a week, rejecting every attach, after the EternalTerminal connection under its `-CC` client died.

### Cause

Two unbounded waits in the exit handshake:

1. `server_client_check_exit()` will not send `MSG_EXIT` until `control_all_done()` — i.e. until the write bufferevent to the client's terminal has fully drained. A terminal nobody reads never drains, so the client is never told to exit and never leaves the clients list. (`control_discard()` only drops not-yet-queued pane blocks; bytes already in the write buffer, and non-pane blocks, remain.) The "too far behind" eviction in `control_check_age()` funnels into this same gate, so it does not help.
2. Even once `MSG_EXIT` is sent, the client is only removed when it closes its socket, which a client stuck writing to a dead tty may never do.

This completes the scenario from #5356 / #5357: those stopped the server from wedging on, and queueing new output to, a control client whose terminal reader died; this stops the server waiting forever on such a client at exit.

### Fix

Bound both waits with a per-client timer (`CLIENT_EXIT_TIMEOUT`, 10 seconds):

- If the output an exiting client must flush has not drained in time, discard it — it can never be delivered — via a new `control_discard_all()`, and let the exit continue.
- If the client has still not closed its connection 10 seconds after `MSG_EXIT`, drop it with `server_client_lost()`.

Suspended clients are exempted so a stopped (ctrl-Z) client is not penalized. Healthy exits are unaffected: the timer is deleted when the client closes normally, and a normal `kill-server` still completes in milliseconds.

### Reproduction / test

`regress/control-client-exit-stalled.sh` (included): attach a `-C` client with stdout on a fifo whose read end is held open but never read, flood a pane, then `kill-server`. On master the server is still alive 20+ seconds later and any new client gets `server exited unexpectedly`; with this change the server exits ~10 seconds after `kill-server`.

Existing control regress tests (`control-client-exit.sh`, `control-client-wait-exit.sh`, `control-client-sanity.sh`, `control-client-size.sh`, `control-notify-events.sh`, `control-subscriptions.sh`) pass, and the build is warning-free.

As with my previous PRs, AI assistance was used to investigate and prepare this change; I have reviewed and verified it.
