### PR TITLE
Remove padding from borderless menus

### DIFF
--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -482,7 +482,7 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	enum box_lines		 lines = BOX_LINES_DEFAULT;
 	char			*title, *cause = NULL;
 	int			 flags = 0, starting_choice = 0;
-	u_int			 px, py, i, count = args_count(args);
+	u_int			 px, py, sx, sy, i, count = args_count(args);
 	struct options		*o = target->s->curw->window->options;
 	struct options_entry	*oe;
 
@@ -531,9 +531,6 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	if (menu->count == 0)
 		goto out;
-	if (!cmd_display_menu_get_menu_pos(tc, item, args, &px, &py,
-	    menu->width + 4, menu->count + 2))
-		goto out;
 
 	value = args_get(args, 'b');
 	if (value != NULL) {
@@ -544,7 +541,12 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 			cmdq_error(item, "menu-border-lines %s", cause);
 			goto fail;
 		}
-	}
+	} else
+		lines = options_get_number(o, "menu-border-lines");
+
+	menu_dimensions(menu, lines, &sx, &sy);
+	if (!cmd_display_menu_get_menu_pos(tc, item, args, &px, &py, sx, sy))
+		goto out;
 
 	if (args_has(args, 'O'))
 		flags |= MENU_STAYOPEN;

--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -483,7 +483,7 @@ cmd_display_menu_exec(struct cmd *self, struct cmdq_item *item)
 	char			*title, *cause = NULL;
 	int			 flags = 0, starting_choice = 0;
 	u_int			 px, py, sx, sy, i, count = args_count(args);
-	struct options		*o = target->s->curw->window->options;
+	struct options		*o = target->w->options;
 	struct options_entry	*oe;
 
 	if (args_has(args, 'C')) {

--- a/menu.c
+++ b/menu.c
@@ -52,6 +52,18 @@ struct menu_data {
 };
 
 void
+menu_dimensions(struct menu *menu, enum box_lines lines, u_int *sx, u_int *sy)
+{
+	if (lines == BOX_LINES_NONE)
+		*sx = menu->item_width + 2;
+	else
+		*sx = menu->width + 4;
+	*sy = menu->count;
+	if (lines != BOX_LINES_NONE)
+		*sy += 2;
+}
+
+void
 menu_add_items(struct menu *menu, const struct menu_item *items,
     struct cmdq_item *qitem, struct client *c, struct cmd_find_state *fs)
 {
@@ -142,6 +154,8 @@ menu_add_item(struct menu *menu, const struct menu_item *item,
 	width = format_width(new_item->name);
 	if (*new_item->name == '-')
 		width--;
+	if (width > menu->item_width)
+		menu->item_width = width;
 	if (width > menu->width)
 		menu->width = width;
 }
@@ -238,7 +252,7 @@ menu_update(struct menu_data *md)
 	screen_write_clearscreen(&ctx, 8);
 
 	if (md->border_lines != BOX_LINES_NONE) {
-		screen_write_box(&ctx, menu->width + 4, menu->count + 2,
+		screen_write_box(&ctx, menu_width(md), menu_height(md),
 		    md->border_lines, &md->border_style_gc, menu->title);
 	}
 
@@ -286,11 +300,13 @@ menu_destroy(struct window *w)
 void
 menu_get_cursor(struct menu_data *md, u_int *cx, u_int *cy)
 {
-	*cx = md->px + 2;
+	u_int	border = (md->border_lines != BOX_LINES_NONE);
+
+	*cx = md->px + 1 + border;
 	if (md->choice == -1)
 		*cy = md->py;
 	else
-		*cy = md->py + 1 + md->choice;
+		*cy = md->py + border + md->choice;
 }
 
 struct screen *
@@ -302,13 +318,19 @@ menu_screen(struct menu_data *md)
 u_int
 menu_width(struct menu_data *md)
 {
-	return (md->menu->width + 4);
+	u_int	sx, sy;
+
+	menu_dimensions(md->menu, md->border_lines, &sx, &sy);
+	return (sx);
 }
 
 u_int
 menu_height(struct menu_data *md)
 {
-	return (md->menu->count + 2);
+	u_int	sx, sy;
+
+	menu_dimensions(md->menu, md->border_lines, &sx, &sy);
+	return (sy);
 }
 
 u_int
@@ -338,6 +360,9 @@ menu_key(struct client *c, struct menu_data *md, struct key_event *event)
 	enum cmd_parse_status		 status;
 	char				*error;
 	key_code			 key;
+	u_int				 border;
+
+	border = (md->border_lines != BOX_LINES_NONE);
 
 	if (KEYC_IS_MOUSE(event->key)) {
 		/*
@@ -353,10 +378,9 @@ menu_key(struct client *c, struct menu_data *md, struct key_event *event)
 				return (1);
 			return (0);
 		}
-		if (m->x < md->px ||
-		    m->x > md->px + 4 + menu->width ||
-		    m->y < md->py + 1 ||
-		    m->y > md->py + 1 + n - 1) {
+		if (m->x < md->px || m->x >= md->px + menu_width(md) ||
+		    m->y < md->py + border ||
+		    m->y >= md->py + border + n) {
 			if (~md->flags & MENU_STAYOPEN) {
 				if (!move && MOUSE_RELEASE(m->b))
 					return (1);
@@ -379,7 +403,7 @@ menu_key(struct client *c, struct menu_data *md, struct key_event *event)
 			if (!MOUSE_WHEEL(m->b) && !MOUSE_DRAG(m->b))
 				goto chosen;
 		}
-		md->choice = m->y - (md->py + 1);
+		md->choice = m->y - (md->py + border);
 		if (md->choice != old)
 			server_redraw_window_menu(md->w);
 		return (0);
@@ -550,8 +574,7 @@ menu_resize(struct menu_data *md, struct window *w)
 	nx = md->px;
 	ny = md->py;
 
-	sx = md->menu->width + 4;
-	sy = md->menu->count + 2;
+	menu_dimensions(md->menu, md->border_lines, &sx, &sy);
 
 	if (nx + sx > w->sx) {
 		if (w->sx <= sx)
@@ -591,8 +614,9 @@ menu_display(struct menu *menu, int flags, int starting_choice,
 		w = fs->w;
 	o = w->options;
 
-	sx = menu->width + 4;
-	sy = menu->count + 2;
+	if (lines == BOX_LINES_DEFAULT)
+		lines = options_get_number(o, "menu-border-lines");
+	menu_dimensions(menu, lines, &sx, &sy);
 	if (sx >= w->sx)
 		px = 0;
 	else if (px + sx > w->sx)
@@ -603,9 +627,6 @@ menu_display(struct menu *menu, int flags, int starting_choice,
 		py = w->sy - sy;
 	w->menu_last_px = px;
 	w->menu_last_py = py;
-
-	if (lines == BOX_LINES_DEFAULT)
-		lines = options_get_number(o, "menu-border-lines");
 
 	md = xcalloc(1, sizeof *md);
 	md->w = w;

--- a/regress/screen-redraw-menus.sh
+++ b/regress/screen-redraw-menus.sh
@@ -115,6 +115,19 @@ $TMUX2 display-menu -T "This title must not reserve width" -C 1 \
 sleep 1
 compare menu-noborder
 
+# Menu border style follows the explicitly targeted window, not the current
+# window when a different pane is selected.
+setup 40 14
+$TMUX2 set menu-border-lines none || exit 1
+$TMUX2 neww || exit 1
+$TMUX2 display-menu -t%0 -T "Menu" -C 1 \
+    "Alpha item" a "" \
+    "Beta item" b "" \
+    "" "" "" \
+    "Gamma item" g "" || exit 1
+$TMUX2 selectw -t%0 || exit 1
+compare menu-target-window-noborder
+
 # Menu with double border lines.
 setup 40 14
 menu -b double -x6 -y8

--- a/regress/screen-redraw-menus.sh
+++ b/regress/screen-redraw-menus.sh
@@ -106,7 +106,13 @@ compare menu-over-split
 
 # Menu with no border lines.
 setup 40 14
-menu -b none -x6 -y8
+$TMUX2 display-menu -T "This title must not reserve width" -C 1 \
+    -b none -x6 -y8 \
+    "Alpha item" a "" \
+    "Beta item" b "" \
+    "" "" "" \
+    "Gamma item" g "" || exit 1
+sleep 1
 compare menu-noborder
 
 # Menu with double border lines.

--- a/regress/screen-redraw-results/menu-noborder.result
+++ b/regress/screen-redraw-results/menu-noborder.result
@@ -1,11 +1,11 @@
 MENU00 abcdefghij
 MENU01 abcdefghij
-MENU02[38;5;45m[48;5;235m  Menu            [39m[49m
-MENU03[38;5;45m[48;5;235m [38;5;250m Alpha item (a) [38;5;45m [39m[49m
-MENU04[38;5;45m[48;5;235m [38;5;16m[48;5;220m Beta item  (b) [38;5;45m[48;5;235m [39m[49m
-MENU05[38;5;45m[48;5;235m                  [39m[49m
-MENU06[38;5;45m[48;5;235m [38;5;250m Gamma item (g) [38;5;45m [39m[49m
-MENU07[38;5;45m[48;5;235m                  [39m[49m
+MENU02 abcdefghij
+MENU03 abcdefghij
+MENU04[38;5;250m[48;5;235m Alpha item (a) [39m[49m
+MENU05[38;5;16m[48;5;220m Beta item  (b) [39m[49m
+MENU06[38;5;45m[48;5;235m                [39m[49m
+MENU07[38;5;250m[48;5;235m Gamma item (g) [39m[49m
 MENU08 abcdefghij
 MENU09 abcdefghij
 MENU10 abcdefghij

--- a/regress/screen-redraw-results/menu-target-window-noborder.result
+++ b/regress/screen-redraw-results/menu-target-window-noborder.result
@@ -1,0 +1,13 @@
+MENU00 abcdefghij
+MENU01 abcdefghij
+MENU02 abcdefghij
+MENU03 abcdefghij
+MENU04 abcd[38;5;250m[48;5;235m Alpha item (a) [39m[49m
+MENU05 abcd[38;5;16m[48;5;220m Beta item  (b) [39m[49m
+MENU06 abcd[38;5;45m[48;5;235m                [39m[49m
+MENU07 abcd[38;5;250m[48;5;235m Gamma item (g) [39m[49m
+MENU08 abcdefghij
+MENU09 abcdefghij
+MENU10 abcdefghij
+MENU11 abcdefghij
+MENU12 abcdefghij

--- a/screen-write.c
+++ b/screen-write.c
@@ -828,7 +828,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu, int choice,
 	struct screen		*s = ctx->s;
 	struct grid_cell	 default_gc;
 	const struct grid_cell	*gc = &default_gc;
-	u_int			 cx, cy, i, j, width = menu->width;
+	u_int			 border, cx, cy, i, j, width;
 	const char		*name;
 
 	cx = s->cx;
@@ -836,26 +836,34 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu, int choice,
 
 	memcpy(&default_gc, menu_gc, sizeof default_gc);
 
-	screen_write_box(ctx, menu->width + 4, menu->count + 2, lines,
-	    border_gc, menu->title);
+	border = (lines != BOX_LINES_NONE);
+	if (border)
+		width = menu->width;
+	else
+		width = menu->item_width;
+	if (border) {
+		screen_write_box(ctx, width + 4, menu->count + 2, lines,
+		    border_gc, menu->title);
+	}
 
 	for (i = 0; i < menu->count; i++) {
 		name = menu->items[i].name;
 		if (name == NULL) {
-			screen_write_cursormove(ctx, cx, cy + 1 + i, 0);
-			screen_write_hline(ctx, width + 4, 1, 1, lines,
-			    border_gc);
+			screen_write_cursormove(ctx, cx, cy + border + i, 0);
+			screen_write_hline(ctx, width + 2 + (2 * border), 1,
+			    1, lines, border_gc);
 			continue;
 		}
 
 		if (choice >= 0 && i == (u_int)choice && *name != '-')
 			gc = choice_gc;
 
-		screen_write_cursormove(ctx, cx + 1, cy + 1 + i, 0);
+		screen_write_cursormove(ctx, cx + border, cy + border + i, 0);
 		for (j = 0; j < width + 2; j++)
 			screen_write_putc(ctx, gc, ' ');
 
-		screen_write_cursormove(ctx, cx + 2, cy + 1 + i, 0);
+		screen_write_cursormove(ctx, cx + border + 1,
+		    cy + border + i, 0);
 		if (*name == '-') {
 			default_gc.attr |= GRID_ATTR_DIM;
 			format_draw(ctx, gc, width, name + 1, NULL, 0);

--- a/screen-write.c
+++ b/screen-write.c
@@ -838,7 +838,7 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu, int choice,
 	struct screen		*s = ctx->s;
 	struct grid_cell	 default_gc;
 	const struct grid_cell	*gc = &default_gc;
-	u_int			 cx, cy, i, j, width = menu->width;
+	u_int			 border, cx, cy, i, j, width;
 	const char		*name;
 
 	cx = s->cx;
@@ -846,26 +846,34 @@ screen_write_menu(struct screen_write_ctx *ctx, struct menu *menu, int choice,
 
 	memcpy(&default_gc, menu_gc, sizeof default_gc);
 
-	screen_write_box(ctx, menu->width + 4, menu->count + 2, lines,
-	    border_gc, menu->title);
+	border = (lines != BOX_LINES_NONE);
+	if (border)
+		width = menu->width;
+	else
+		width = menu->item_width;
+	if (border) {
+		screen_write_box(ctx, width + 4, menu->count + 2, lines,
+		    border_gc, menu->title);
+	}
 
 	for (i = 0; i < menu->count; i++) {
 		name = menu->items[i].name;
 		if (name == NULL) {
-			screen_write_cursormove(ctx, cx, cy + 1 + i, 0);
-			screen_write_hline(ctx, width + 4, 1, 1, lines,
-			    border_gc);
+			screen_write_cursormove(ctx, cx, cy + border + i, 0);
+			screen_write_hline(ctx, width + 2 + (2 * border), 1,
+			    1, lines, border_gc);
 			continue;
 		}
 
 		if (choice >= 0 && i == (u_int)choice && *name != '-')
 			gc = choice_gc;
 
-		screen_write_cursormove(ctx, cx + 1, cy + 1 + i, 0);
+		screen_write_cursormove(ctx, cx + border, cy + border + i, 0);
 		for (j = 0; j < width + 2; j++)
 			screen_write_putc(ctx, gc, ' ');
 
-		screen_write_cursormove(ctx, cx + 2, cy + 1 + i, 0);
+		screen_write_cursormove(ctx, cx + border + 1,
+		    cy + border + i, 0);
 		if (*name == '-') {
 			default_gc.attr |= GRID_ATTR_DIM;
 			format_draw(ctx, gc, width, name + 1, NULL, 0);

--- a/tmux.h
+++ b/tmux.h
@@ -1179,6 +1179,7 @@ struct menu {
 	struct menu_item	*items;
 	u_int			 count;
 	u_int			 width;
+	u_int			 item_width;
 };
 typedef void (*menu_choice_cb)(struct menu *, u_int, key_code, void *);
 
@@ -4159,6 +4160,7 @@ void		 menu_add_item(struct menu *, const struct menu_item *,
 		    struct cmdq_item *, struct client *,
 		    struct cmd_find_state *);
 void		 menu_free(struct menu *);
+void		 menu_dimensions(struct menu *, enum box_lines, u_int *, u_int *);
 int		 menu_display(struct menu *, int, int, struct cmdq_item *,
 		    u_int, u_int, struct client *, enum box_lines, const char *,
 		    const char *, const char *, struct cmd_find_state *,

--- a/tmux.h
+++ b/tmux.h
@@ -1181,6 +1181,7 @@ struct menu {
 	struct menu_item	*items;
 	u_int			 count;
 	u_int			 width;
+	u_int			 item_width;
 };
 typedef void (*menu_choice_cb)(struct menu *, u_int, key_code, void *);
 
@@ -4172,6 +4173,7 @@ void		 menu_add_item(struct menu *, const struct menu_item *,
 		    struct cmdq_item *, struct client *,
 		    struct cmd_find_state *);
 void		 menu_free(struct menu *);
+void		 menu_dimensions(struct menu *, enum box_lines, u_int *, u_int *);
 int		 menu_display(struct menu *, int, int, struct cmdq_item *,
 		    u_int, u_int, struct client *, enum box_lines, const char *,
 		    const char *, const char *, struct cmd_find_state *,


### PR DESCRIPTION
## Summary

- size and position menus without frame rows or columns when `menu-border-lines` is `none`
- keep hidden titles from reserving width in borderless menus
- use the same geometry for rendering, cursor placement, resize, and mouse hit testing

Addresses #4897.

## Testing

- `make -j4`
- focused `screen-redraw-menus.sh` no-border regression
- `regress/menu-mouse.sh`
- full regression run: related tests pass; three unrelated existing macOS/timing failures remain in `copy-mode-selection-scroll.sh`, `format-mouse.sh`, and the `menu-over-split` golden

Prepared with OpenAI Codex assistance; I reviewed and tested the changes.