### PR TITLE
Query the outer terminal cursor colour

### DIFF
--- a/input.c
+++ b/input.c
@@ -3163,6 +3163,8 @@ static void
 input_osc_12(struct input_ctx *ictx, const char *p)
 {
 	struct window_pane	*wp = ictx->wp;
+	struct window		*w;
+	struct client		*loop;
 	int			 c;
 
 	if (strcmp(p, "?") == 0) {
@@ -3170,6 +3172,20 @@ input_osc_12(struct input_ctx *ictx, const char *p)
 			c = ictx->ctx.s->ccolour;
 			if (c == -1)
 				c = ictx->ctx.s->default_ccolour;
+			if (c == -1 || COLOUR_DEFAULT(c)) {
+				w = wp->window;
+				TAILQ_FOREACH(loop, &clients, entry) {
+					if (loop->flags & CLIENT_UNATTACHEDFLAGS)
+						continue;
+					if (loop->session == NULL ||
+					    !session_has(loop->session, w))
+						continue;
+					if (loop->tty.default_ccolour == -1)
+						continue;
+					c = loop->tty.default_ccolour;
+					break;
+				}
+			}
 			input_osc_colour_reply(ictx, 1, 12, 0, c,
 			    ictx->input_end);
 		}

--- a/regress/input-requests.sh
+++ b/regress/input-requests.sh
@@ -82,6 +82,20 @@ pid, fd = attach()
 try:
     time.sleep(0.5)
 
+    read_until(fd, b"\033]12;?\033\\")
+    os.write(fd, b"\033]12;rgb:1212/3434/5656\033\\")
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        cursor_out = f.name
+    respawn("stty raw -echo min 1 time 50; "
+        "printf '\\033]12;?\\033\\\\'; "
+        "dd bs=1 count=25 2>/dev/null | cat -v >%s; sleep 1" %
+        cursor_out)
+    got = wait_file(cursor_out)
+    expected = b"^[]12;rgb:1212/3434/5656^[\\"
+    if got != expected:
+        raise AssertionError("cursor reply: expected %r got %r" %
+            (expected, got))
+
     with tempfile.NamedTemporaryFile(delete=False) as f:
         palette_out = f.name
     respawn("stty raw -echo min 1 time 50; "

--- a/tmux.h
+++ b/tmux.h
@@ -1762,6 +1762,7 @@ struct tty {
 	u_int		 cy;
 	enum screen_cursor_style cstyle;
 	int		 ccolour;
+	int		 default_ccolour;
 
         /* Properties of the area being drawn on. */
         /* When true, the drawing area is bigger than the terminal. */
@@ -1810,6 +1811,7 @@ struct tty {
 #define TTY_WAITFG 0x2000
 #define TTY_WAITBG 0x4000
 #define TTY_BRACKETPASTE 0x8000
+#define TTY_WAITCCOLOUR 0x10000
 #define TTY_ALL_REQUEST_FLAGS \
 	(TTY_HAVEDA|TTY_HAVEDA2|TTY_HAVEXDA)
 	int		 flags;

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -977,7 +977,7 @@ partial_key:
 		if (delay < 500)
 			delay = 500;
 	}
-	if (tty->flags & (TTY_WAITFG|TTY_WAITBG) ||
+	if (tty->flags & (TTY_WAITFG|TTY_WAITBG|TTY_WAITCCOLOUR) ||
 	    tty->flags & (TTY_OSC52QUERY|TTY_WINSIZEQUERY) ||
 	    (tty->flags & TTY_ALL_REQUEST_FLAGS) != TTY_ALL_REQUEST_FLAGS ||
 	    !TAILQ_EMPTY(&c->input_requests)) {
@@ -1679,8 +1679,8 @@ tty_keys_extended_device_attributes(struct tty *tty, const char *buf,
 }
 
 /*
- * Handle foreground or background input. Returns 0 for success, -1 for
- * failure, 1 for partial.
+ * Handle foreground, background or cursor colour input. Returns 0 for success,
+ * -1 for failure, 1 for partial.
  */
 int
 tty_keys_colours(struct tty *tty, const char *buf, size_t len, size_t *size,
@@ -1693,7 +1693,7 @@ tty_keys_colours(struct tty *tty, const char *buf, size_t len, size_t *size,
 
 	*size = 0;
 
-	/* First four bytes are always \033]1 and 0 or 1 and ;. */
+	/* First four bytes are always \033]1 and 0, 1 or 2 and ;. */
 	if (buf[0] != '\033')
 		return (-1);
 	if (len == 1)
@@ -1706,7 +1706,7 @@ tty_keys_colours(struct tty *tty, const char *buf, size_t len, size_t *size,
 		return (-1);
 	if (len == 3)
 		return (1);
-	if (buf[3] != '0' && buf[3] != '1')
+	if (buf[3] != '0' && buf[3] != '1' && buf[3] != '2')
 		return (-1);
 	if (len == 4)
 		return (1);
@@ -1744,13 +1744,21 @@ tty_keys_colours(struct tty *tty, const char *buf, size_t len, size_t *size,
 			log_debug("fg is %s", colour_tostring(n));
 		*fg = n;
 		tty->flags &= ~TTY_WAITFG;
-	} else if (n != -1) {
+	} else if (n != -1 && buf[3] == '1') {
 		if (c != NULL)
 			log_debug("%s bg is %s", c->name, colour_tostring(n));
 		else
 			log_debug("bg is %s", colour_tostring(n));
 		*bg = n;
 		tty->flags &= ~TTY_WAITBG;
+	} else if (n != -1) {
+		if (c != NULL) {
+			log_debug("%s cursor colour is %s", c->name,
+			    colour_tostring(n));
+		} else
+			log_debug("cursor colour is %s", colour_tostring(n));
+		tty->default_ccolour = n;
+		tty->flags &= ~TTY_WAITCCOLOUR;
 	}
 
 	return (0);

--- a/tty.c
+++ b/tty.c
@@ -111,7 +111,7 @@ tty_init(struct tty *tty, struct client *c)
 	tty->client = c;
 
 	tty->cstyle = SCREEN_CURSOR_DEFAULT;
-	tty->ccolour = -1;
+	tty->ccolour = tty->default_ccolour = -1;
 	tty->fg = tty->bg = -1;
 	tty->mouse_last_pane = -1;
 
@@ -319,7 +319,7 @@ tty_start_timer_callback(__unused int fd, __unused short events, void *data)
 		tty_update_features(tty);
 	tty->flags |= TTY_ALL_REQUEST_FLAGS;
 
-	tty->flags &= ~(TTY_WAITBG|TTY_WAITFG);
+	tty->flags &= ~(TTY_WAITBG|TTY_WAITFG|TTY_WAITCCOLOUR);
 }
 
 static void
@@ -403,8 +403,8 @@ tty_send_requests(struct tty *tty)
 			tty_puts(tty, "\033[>c");
 		if (~tty->flags & TTY_HAVEXDA)
 			tty_puts(tty, "\033[>q");
-		tty_puts(tty, "\033]10;?\033\\\033]11;?\033\\");
-		tty->flags |= (TTY_WAITBG|TTY_WAITFG);
+		tty_puts(tty, "\033]10;?\033\\\033]11;?\033\\\033]12;?\033\\");
+		tty->flags |= (TTY_WAITBG|TTY_WAITFG|TTY_WAITCCOLOUR);
 	} else
 		tty->flags |= TTY_ALL_REQUEST_FLAGS;
 	tty->last_requests = time(NULL);
@@ -430,8 +430,8 @@ tty_repeat_requests(struct tty *tty, int force)
 	tty->last_requests = t;
 
 	if (tty->term->flags & TERM_VT100LIKE) {
-		tty_puts(tty, "\033]10;?\033\\\033]11;?\033\\");
-		tty->flags |= (TTY_WAITBG|TTY_WAITFG);
+		tty_puts(tty, "\033]10;?\033\\\033]11;?\033\\\033]12;?\033\\");
+		tty->flags |= (TTY_WAITBG|TTY_WAITFG|TTY_WAITCCOLOUR);
 	}
 	tty_start_start_timer(tty);
 }


### PR DESCRIPTION
## Summary

- request the outer terminal cursor colour with OSC 12 alongside the existing OSC 10 and 11 queries
- store the reported colour separately from cursor colours applied by tmux
- answer an inner OSC 12 query with the outer colour when no explicit tmux cursor colour is configured

Addresses #4127.

## Testing

- `make -j4`
- `regress/input-requests.sh` (new outer-terminal to inner-application round-trip)
- `regress/input-osc.sh`
- `regress/theme-report.sh`
- `regress/format-variables.sh`
- full regression run: all related tests pass; the same three unrelated existing macOS/timing failures remain in `copy-mode-selection-scroll.sh`, `format-mouse.sh`, and the `menu-over-split` golden

Prepared with OpenAI Codex assistance; I reviewed and tested the changes.