### PR TITLE
Add manual-or-smallest window sizing

### DIFF
--- a/cmd-resize-window.c
+++ b/cmd-resize-window.c
@@ -110,6 +110,7 @@ cmd_resize_window_exec(struct cmd *self, struct cmdq_item *item)
 	    WINDOW_SIZE_MANUAL_OR_SMALLEST) {
 		options_set_number(w->options, "window-size", WINDOW_SIZE_MANUAL);
 	}
+	w->manual_size_set = 1;
 	w->manual_sx = sx;
 	w->manual_sy = sy;
 	recalculate_size(w, 1);

--- a/cmd-resize-window.c
+++ b/cmd-resize-window.c
@@ -106,7 +106,10 @@ cmd_resize_window_exec(struct cmd *self, struct cmdq_item *item)
 		    WINDOW_SIZE_SMALLEST);
 	}
 
-	options_set_number(w->options, "window-size", WINDOW_SIZE_MANUAL);
+	if (options_get_number(w->options, "window-size") !=
+	    WINDOW_SIZE_MANUAL_OR_SMALLEST) {
+		options_set_number(w->options, "window-size", WINDOW_SIZE_MANUAL);
+	}
 	w->manual_sx = sx;
 	w->manual_sy = sy;
 	recalculate_size(w, 1);

--- a/cmd-set-option.c
+++ b/cmd-set-option.c
@@ -236,6 +236,7 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 	char				*expanded = NULL, *array_key = NULL;
 	const char			*value;
 	int				 window, already, error, ambiguous;
+	int				 old_window_size = -1;
 	int				 scope;
 
 	window = (cmd_get_entry(self) == &cmd_set_window_option_entry);
@@ -290,6 +291,8 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	o = options_get_only(oo, name);
 	parent = options_get(oo, name);
+	if (strcmp(name, "window-size") == 0)
+		old_window_size = options_get_number(oo, name);
 
 	/* Check that array options and keys match up. */
 	if (array_key != NULL && (*name == '@' || !options_is_array(parent))) {
@@ -379,6 +382,8 @@ cmd_set_option_exec(struct cmd *self, struct cmdq_item *item)
 		}
 	}
 
+	if (strcmp(name, "window-size") == 0)
+		resize_window_update_manual_size(target, oo, old_window_size);
 	options_push_changes(name);
 
 out:

--- a/format.c
+++ b/format.c
@@ -3098,10 +3098,13 @@ static void *
 format_cb_window_manual_height(struct format_tree *ft)
 {
 	struct window	*w = ft->w;
+	int		 type;
 
 	if (w == NULL)
 		return (NULL);
-	if (options_get_number(w->options, "window-size") != WINDOW_SIZE_MANUAL)
+	type = options_get_number(w->options, "window-size");
+	if (type != WINDOW_SIZE_MANUAL &&
+	    type != WINDOW_SIZE_MANUAL_OR_SMALLEST)
 		return (xstrdup(""));
 	return (format_printf("%u", w->manual_sy));
 }
@@ -3300,10 +3303,13 @@ static void *
 format_cb_window_manual_width(struct format_tree *ft)
 {
 	struct window	*w = ft->w;
+	int		 type;
 
 	if (w == NULL)
 		return (NULL);
-	if (options_get_number(w->options, "window-size") != WINDOW_SIZE_MANUAL)
+	type = options_get_number(w->options, "window-size");
+	if (type != WINDOW_SIZE_MANUAL &&
+	    type != WINDOW_SIZE_MANUAL_OR_SMALLEST)
 		return (xstrdup(""));
 	return (format_printf("%u", w->manual_sx));
 }

--- a/options-table.c
+++ b/options-table.c
@@ -88,7 +88,7 @@ static const char *options_table_get_clipboard_list[] = {
 	"off", "buffer", "request", "both", NULL
 };
 static const char *options_table_window_size_list[] = {
-	"largest", "smallest", "manual", "latest", NULL
+	"largest", "smallest", "manual", "latest", "manual-or-smallest", NULL
 };
 static const char *options_table_remain_on_exit_list[] = {
 	"off", "on", "failed", "key", NULL
@@ -1811,7 +1811,8 @@ const struct options_table_entry options_table[] = {
 		  "'latest' uses the size of the most recently used client, "
 		  "'largest' the largest client, 'smallest' the smallest "
 		  "client and 'manual' a size set by the 'resize-window' "
-		  "command."
+		  "command. 'manual-or-smallest' uses the manual size or "
+		  "the smallest client if it is smaller."
 	},
 
 	{ .name = "window-style",

--- a/regress/window-size-manual-smallest.sh
+++ b/regress/window-size-manual-smallest.sh
@@ -32,9 +32,14 @@ wait_size()
 	fail "expected size $expected, got $actual"
 }
 
-$TMUX new-session -d -s test -x 100 -y 40 || exit 1
-$TMUX resize-window -t test: -x 100 -y 40 || exit 1
-$TMUX set-option -w -t test: window-size manual-or-smallest || exit 1
+$TMUX new-session -d -s test || exit 1
+$TMUX new-session -d -s local || exit 1
+$TMUX set -g default-size 100x40 || exit 1
+$TMUX set-window-option -t local: window-size manual-or-smallest || exit 1
+local_manual=$($TMUX display -t local: -p \
+    '#{window_manual_width}x#{window_manual_height}')
+[ "$local_manual" = "100x40" ] || fail "unexpected local manual size: $local_manual"
+$TMUX set -g window-size manual-or-smallest || exit 1
 
 manual=$($TMUX display -t test: -p \
     '#{window_manual_width}x#{window_manual_height}')
@@ -48,7 +53,7 @@ wait_size 80x24
 
 # A manual resize keeps the mode and changes the size cap.
 $TMUX resize-window -t test: -x 70 -y 20 || exit 1
-mode=$($TMUX show-option -wv -t test: window-size)
+mode=$($TMUX show -wAv -t test: window-size)
 [ "$mode" = "manual-or-smallest" ] || fail "unexpected mode: $mode"
 wait_size 70x20
 
@@ -62,5 +67,15 @@ client=$($TMUX list-clients -F '#{client_name}')
 exec 3>&-
 wait "$client_pid" 2>/dev/null || true
 wait_size 100x40
+
+# Preserve an explicitly resized cap when changing the global mode.
+$TMUX set -g window-size smallest || exit 1
+$TMUX resize-window -t test: -x 70 -y 20 || exit 1
+$TMUX set-window-option -t test: window-size manual-or-smallest || exit 1
+manual=$($TMUX display -t test: -p \
+    '#{window_manual_width}x#{window_manual_height}')
+[ "$manual" = "70x20" ] || fail "unexpected resized manual size: $manual"
+$TMUX set -g window-size manual-or-smallest || exit 1
+wait_size 70x20
 
 exit 0

--- a/regress/window-size-manual-smallest.sh
+++ b/regress/window-size-manual-smallest.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Lmanualsmallest$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp)
+FIFO="$TMP.fifo"
+mkfifo "$FIFO"
+trap '$TMUX kill-server 2>/dev/null; rm -f "$TMP" "$FIFO"' 0 1 15
+
+fail()
+{
+	echo "$1"
+	exit 1
+}
+
+wait_size()
+{
+	expected=$1
+	n=0
+	while [ $n -lt 50 ]; do
+		actual=$($TMUX display -t test: -p \
+		    '#{window_width}x#{window_height}' 2>/dev/null)
+		[ "$actual" = "$expected" ] && return 0
+		sleep 0.1
+		n=$((n + 1))
+	done
+	fail "expected size $expected, got $actual"
+}
+
+$TMUX new-session -d -s test -x 100 -y 40 || exit 1
+$TMUX resize-window -t test: -x 100 -y 40 || exit 1
+$TMUX set-option -w -t test: window-size manual-or-smallest || exit 1
+
+manual=$($TMUX display -t test: -p \
+    '#{window_manual_width}x#{window_manual_height}')
+[ "$manual" = "100x40" ] || fail "unexpected manual size: $manual"
+
+$TMUX -C attach -t test <"$FIFO" >"$TMP" 2>&1 &
+client_pid=$!
+exec 3>"$FIFO"
+echo 'refresh-client -C 80,24' >&3
+wait_size 80x24
+
+# A manual resize keeps the mode and changes the size cap.
+$TMUX resize-window -t test: -x 70 -y 20 || exit 1
+mode=$($TMUX show-option -wv -t test: window-size)
+[ "$mode" = "manual-or-smallest" ] || fail "unexpected mode: $mode"
+wait_size 70x20
+
+# A larger manual size remains capped by the attached client.
+$TMUX resize-window -t test: -x 100 -y 40 || exit 1
+wait_size 80x24
+
+# With no attached client, the window returns to its manual size.
+client=$($TMUX list-clients -F '#{client_name}')
+[ -n "$client" ] || fail "control client did not attach"
+exec 3>&-
+wait "$client_pid" 2>/dev/null || true
+wait_size 100x40
+
+exit 0

--- a/resize.c
+++ b/resize.c
@@ -138,13 +138,14 @@ clients_calculate_size(int type, int current, struct client *c,
 	u_int		 cx, cy, n = 0;
 
 	/*
-	 * Start comparing with 0 for largest and UINT_MAX for smallest or
-	 * latest.
+	 * Start comparing with 0 for largest, the manual size for manual
+	 * choices and UINT_MAX for smallest or latest.
 	 */
 	if (type == WINDOW_SIZE_LARGEST) {
 		*sx = 0;
 		*sy = 0;
-	} else if (w != NULL && type == WINDOW_SIZE_MANUAL) {
+	} else if (w != NULL && (type == WINDOW_SIZE_MANUAL ||
+	    type == WINDOW_SIZE_MANUAL_OR_SMALLEST)) {
 		*sx = w->manual_sx;
 		*sy = w->manual_sy;
 		log_debug("%s: manual size %ux%u", __func__, *sx, *sy);
@@ -264,6 +265,8 @@ skip:
 	}
 	if (type == WINDOW_SIZE_LATEST)
 		log_debug("%s: type is latest", __func__);
+	else if (type == WINDOW_SIZE_MANUAL_OR_SMALLEST)
+		log_debug("%s: type is manual-or-smallest", __func__);
 	else
 		log_debug("%s: type is smallest", __func__);
 	return (*sx != UINT_MAX && *sy != UINT_MAX);
@@ -285,6 +288,7 @@ default_window_size(struct client *c, struct session *s, struct window *w,
 	u_int *sx, u_int *sy, u_int *xpixel, u_int *ypixel, int type)
 {
 	const char	*value;
+	u_int		 manual_sx, manual_sy;
 
 	/* Get type if not provided. */
 	if (type == -1)
@@ -312,8 +316,9 @@ default_window_size(struct client *c, struct session *s, struct window *w,
 		c = NULL;
 
 	/*
-	 * Look for a client to base the size on. If none exists (or the type
-	 * is manual), use the default-size option.
+	 * Look for a client to base the size on. If none exists (or the type is
+	 * manual), use the default-size option. For manual-or-smallest, also use
+	 * default-size to cap the size of a new window.
 	 */
 	if (!clients_calculate_size(type, 0, c, s, w,
 	    default_window_size_skip_client, sx, sy, xpixel, ypixel)) {
@@ -324,6 +329,16 @@ default_window_size(struct client *c, struct session *s, struct window *w,
 		}
 		log_debug("%s: using %ux%u from default-size", __func__, *sx,
 		    *sy);
+	} else if (type == WINDOW_SIZE_MANUAL_OR_SMALLEST && w == NULL) {
+		value = options_get_string(s->options, "default-size");
+		if (sscanf(value, "%ux%u", &manual_sx, &manual_sy) != 2) {
+			manual_sx = 80;
+			manual_sy = 24;
+		}
+		if (*sx > manual_sx)
+			*sx = manual_sx;
+		if (*sy > manual_sy)
+			*sy = manual_sy;
 	}
 
 done:
@@ -370,9 +385,9 @@ recalculate_size(struct window *w, int now)
 	log_debug("%s: @%u is %ux%u", __func__, w->id, w->sx, w->sy);
 
 	/*
-	 * Type is manual, smallest, largest, latest. Current is the
-	 * aggressive-resize option (do not resize based on clients where the
-	 * window is not the current window).
+	 * Type is manual, smallest, largest, latest or manual-or-smallest.
+	 * Current is the aggressive-resize option (do not resize based on
+	 * clients where the window is not the current window).
 	 */
 	type = options_get_number(w->options, "window-size");
 	current = options_get_number(w->options, "aggressive-resize");
@@ -404,12 +419,12 @@ recalculate_size(struct window *w, int now)
 	}
 
 	/*
-	 * If the now flag is set or if the window is sized manually, change
-	 * the size immediately. Otherwise set the flag and it will be done
-	 * later.
+	 * If the now flag is set or if the window has a manual size, change the
+	 * size immediately. Otherwise set the flag and it will be done later.
 	 */
 	log_debug("%s: @%u new size %ux%u", __func__, w->id, sx, sy);
-	if (now || type == WINDOW_SIZE_MANUAL)
+	if (now || type == WINDOW_SIZE_MANUAL ||
+	    type == WINDOW_SIZE_MANUAL_OR_SMALLEST)
 		resize_window(w, sx, sy, xpixel, ypixel);
 	else {
 		w->new_sx = sx;

--- a/resize.c
+++ b/resize.c
@@ -283,6 +283,65 @@ default_window_size_skip_client(struct client *loop, __unused int type,
 	return (0);
 }
 
+static int
+resize_window_get_manual_size(struct session *s, u_int *sx, u_int *sy)
+{
+	const char	*value;
+
+	value = options_get_string(s->options, "default-size");
+	if (sscanf(value, "%ux%u", sx, sy) != 2)
+		return (0);
+	if (*sx < WINDOW_MINIMUM)
+		*sx = WINDOW_MINIMUM;
+	if (*sx > WINDOW_MAXIMUM)
+		*sx = WINDOW_MAXIMUM;
+	if (*sy < WINDOW_MINIMUM)
+		*sy = WINDOW_MINIMUM;
+	if (*sy > WINDOW_MAXIMUM)
+		*sy = WINDOW_MAXIMUM;
+	return (1);
+}
+
+void
+resize_window_update_manual_size(struct cmd_find_state *target,
+    struct options *oo, int old)
+{
+	struct session	*s;
+	struct winlink	*wl;
+	struct window	*w;
+	u_int		 sx, sy;
+
+	if (old < 0 || old == WINDOW_SIZE_MANUAL_OR_SMALLEST ||
+	    options_get_number(oo, "window-size") !=
+	    WINDOW_SIZE_MANUAL_OR_SMALLEST)
+		return;
+
+	if (oo == global_w_options) {
+		RB_FOREACH(w, windows, &windows) {
+			if (w->manual_size_set ||
+			    options_get_only(w->options, "window-size") != NULL)
+				continue;
+			TAILQ_FOREACH(wl, &w->winlinks, wentry) {
+				s = wl->session;
+				if (!resize_window_get_manual_size(s, &sx, &sy))
+					continue;
+				w->manual_sx = sx;
+				w->manual_sy = sy;
+				break;
+			}
+		}
+		return;
+	}
+
+	if (target == NULL || target->w == NULL || target->s == NULL ||
+	    target->w->manual_size_set)
+		return;
+	if (!resize_window_get_manual_size(target->s, &sx, &sy))
+		return;
+	target->w->manual_sx = sx;
+	target->w->manual_sy = sy;
+}
+
 void
 default_window_size(struct client *c, struct session *s, struct window *w,
 	u_int *sx, u_int *sy, u_int *xpixel, u_int *ypixel, int type)

--- a/tmux.1
+++ b/tmux.1
@@ -3888,7 +3888,10 @@ sets the size of the largest session containing the window;
 the size of the smallest.
 This command will automatically set
 .Ic window\-size
-to manual in the window options.
+to
+.Ar manual
+in the window options, unless it is already
+.Ar manual-or-smallest .
 .Tg respawnp
 .It Xo Ic respawn\-pane
 .Op Fl \&Ek
@@ -6192,7 +6195,7 @@ see the
 section.
 .Pp
 .It Xo Ic window\-size
-.Ar largest | Ar smallest | Ar manual | Ar latest
+.Ar largest | Ar smallest | Ar manual | Ar latest | Ar manual-or-smallest
 .Xc
 Configure how
 .Nm
@@ -6207,6 +6210,9 @@ If
 the size of a new window is set from the
 .Ic default\-size
 option and windows are resized automatically.
+If set to
+.Ar manual-or-smallest ,
+the manually set size is used unless an attached client is smaller.
 With
 .Ar latest ,
 .Nm

--- a/tmux.h
+++ b/tmux.h
@@ -1454,6 +1454,7 @@ struct window {
 	u_int			 sy;
 	u_int			 manual_sx;
 	u_int			 manual_sy;
+	int			 manual_size_set;
 	u_int			 xpixel;
 	u_int			 ypixel;
 
@@ -3410,6 +3411,8 @@ void	 prompt_save_history(void);
 
 /* resize.c */
 void	 resize_window(struct window *, u_int, u_int, int, int);
+void	 resize_window_update_manual_size(struct cmd_find_state *,
+	     struct options *, int);
 void	 default_window_size(struct client *, struct session *, struct window *,
 	     u_int *, u_int *, u_int *, u_int *, int);
 void	 recalculate_size(struct window *, int);

--- a/tmux.h
+++ b/tmux.h
@@ -1523,6 +1523,7 @@ TAILQ_HEAD(winlink_stack, winlink);
 #define WINDOW_SIZE_SMALLEST 1
 #define WINDOW_SIZE_MANUAL 2
 #define WINDOW_SIZE_LATEST 3
+#define WINDOW_SIZE_MANUAL_OR_SMALLEST 4
 
 /* Pane border status option. */
 #define PANE_STATUS_OFF 0

--- a/window-customize.c
+++ b/window-customize.c
@@ -1699,20 +1699,24 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 	struct options_entry			*o;
 	const struct options_table_entry	*oe;
 	struct options				*oo = item->oo;
+	struct cmd_find_state			 fs;
 	const char				*name = item->name;
 	const char				*array_key = item->array_key;
 	char					*cause;
 	u_int					 idx;
 	char					 keybuf[32];
+	int					 old_window_size = -1;
 
 	if (s == NULL || *s == '\0' || data->dead)
 		return (PROMPT_CLOSE);
-	if (item == NULL || !window_customize_check_item(data, item, NULL))
+	if (item == NULL || !window_customize_check_item(data, item, &fs))
 		return (PROMPT_CLOSE);
 	o = options_get(oo, name);
 	if (o == NULL)
 		return (PROMPT_CLOSE);
 	oe = options_table_entry(o);
+	if (strcmp(name, "window-size") == 0)
+		old_window_size = options_get_number(oo, name);
 
 	if (oe != NULL && (oe->flags & OPTIONS_TABLE_IS_ARRAY)) {
 		if (array_key == NULL) {
@@ -1729,6 +1733,7 @@ window_customize_set_option_callback(struct client *c, void *itemdata,
 		if (options_from_string(oo, oe, name, s, 0, &cause) != 0)
 			goto fail;
 	}
+	resize_window_update_manual_size(&fs, oo, old_window_size);
 	if (item->option_type == WINDOW_CUSTOMIZE_HOOKS && *name == '@')
 		hooks_add_event(name);
 
@@ -2131,6 +2136,7 @@ window_customize_set_option(struct client *c,
 	const char				*array_key = item->array_key;
 	char					*prompt, *value, *text;
 	struct cmd_find_state			 fs;
+	int					 old_window_size = -1;
 
 	if (item == NULL || !window_customize_check_item(data, item, &fs))
 		return;
@@ -2199,6 +2205,8 @@ window_customize_set_option(struct client *c,
 		else
 			oo = window_customize_get_tree(scope, &fs);
 	}
+	if (strcmp(name, "window-size") == 0)
+		old_window_size = options_get_number(oo, name);
 
 	if (oe != NULL && oe->type == OPTIONS_TABLE_FLAG) {
 		flag = options_get_number(oo, name);
@@ -2249,6 +2257,7 @@ window_customize_set_option(struct client *c,
 		free(prompt);
 		free(value);
 	}
+	resize_window_update_manual_size(&fs, oo, old_window_size);
 }
 
 static enum prompt_result
@@ -2348,11 +2357,15 @@ static void
 window_customize_unset_option(struct window_customize_modedata *data,
     struct window_customize_itemdata *item)
 {
+	struct cmd_find_state	 fs;
 	struct options_entry	*o;
+	int			 old_window_size = -1;
 
-	if (item == NULL || !window_customize_check_item(data, item, NULL))
+	if (item == NULL || !window_customize_check_item(data, item, &fs))
 		return;
 
+	if (strcmp(item->name, "window-size") == 0)
+		old_window_size = options_get_number(item->oo, item->name);
 	o = options_get(item->oo, item->name);
 	if (o == NULL)
 		return;
@@ -2360,20 +2373,25 @@ window_customize_unset_option(struct window_customize_modedata *data,
 	    item == mode_tree_get_current(data->data))
 		mode_tree_up(data->data, 0);
 	options_remove_or_default(o, item->array_key, NULL);
+	resize_window_update_manual_size(&fs, item->oo, old_window_size);
 }
 
 static void
 window_customize_reset_option(struct window_customize_modedata *data,
     struct window_customize_itemdata *item)
 {
+	struct cmd_find_state	 fs;
 	struct options		*oo;
 	struct options_entry	*o;
+	int			 old_window_size = -1;
 
-	if (item == NULL || !window_customize_check_item(data, item, NULL))
+	if (item == NULL || !window_customize_check_item(data, item, &fs))
 		return;
 	if (item->array_key != NULL)
 		return;
 
+	if (strcmp(item->name, "window-size") == 0)
+		old_window_size = options_get_number(item->oo, item->name);
 	oo = item->oo;
 	while (oo != NULL) {
 		o = options_get_only(oo, item->name);
@@ -2381,6 +2399,7 @@ window_customize_reset_option(struct window_customize_modedata *data,
 			options_remove_or_default(o, NULL, NULL);
 		oo = options_get_parent(oo);
 	}
+	resize_window_update_manual_size(&fs, item->oo, old_window_size);
 }
 
 static enum prompt_result


### PR DESCRIPTION
## Summary

- add the `manual-or-smallest` choice proposed in #2671
- use the manual dimensions as a cap while still shrinking for smaller attached clients
- preserve the mode across `resize-window` and expose its cap through the existing manual-size formats
- document the new choice and cover client attach, cap changes, and detach

Addresses #2671.

## Testing

- `make -j4`
- `regress/window-size-manual-smallest.sh` (fails before the implementation, passes after)
- `regress/session-group-resize.sh`
- `regress/new-session-size.sh`
- `regress/new-session-no-client.sh`
- `regress/screen-redraw-cache.sh`
- `regress/format-variables.sh`
- `regress/options-values.sh`

Prepared with OpenAI Codex assistance; I reviewed and tested the changes.