### PR TITLE
Add a vertical (side) status line

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,12 @@
 CHANGES FROM 3.7b TO 3.8
 
+* Add a vertical status line at the left or right of the terminal, enabled
+  with the side-status option, sized with side-status-width and drawn from
+  the side-status-format array. Formats may produce multiple rows with the
+  new nl style, the window list is scrolled to keep the current window
+  visible, and ranges know the row they were drawn on so the mouse works as
+  on the status line.
+
 * Build with jemalloc on macOS to avoid what appears to be a bug in the system
   calloc(3) (issue 5385).
 

--- a/cmd-display-menu.c
+++ b/cmd-display-menu.c
@@ -313,7 +313,16 @@ cmd_display_menu_get_menu_pos(struct client *tc, struct cmdq_item *item,
 
 	ft = format_create_from_target(item);
 	if (event->m.valid) {
-		mouse_x = event->m.x + ox;
+		if (event->m.sideat == 0) {
+			if (event->m.x >= event->m.sidecols)
+				mouse_x = event->m.x - event->m.sidecols + ox;
+			else
+				mouse_x = ox;
+		} else if (event->m.sideat > 0 &&
+		    event->m.x >= (u_int)event->m.sideat)
+			mouse_x = ox + sx - 1;
+		else
+			mouse_x = event->m.x + ox;
 		if (event->m.statusat == 0) {
 			if (event->m.y >= event->m.statuslines)
 				mouse_y = event->m.y - event->m.statuslines + oy;

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -314,11 +314,19 @@ cmd_join_pane_mouse_move(struct client *c, struct mouse_event *m)
 		y -= m->statuslines;
 	else if (m->statusat > 0 && y >= m->statusat)
 		y = m->statusat - 1;
+	if (m->sideat == 0 && x >= (int)m->sidecols)
+		x -= m->sidecols;
+	else if (m->sideat > 0 && x >= m->sideat)
+		x = m->sideat - 1;
 	ly = m->ly + m->oy; lx = m->lx + m->ox;
 	if (m->statusat == 0 && ly >= (int)m->statuslines)
 		ly -= m->statuslines;
 	else if (m->statusat > 0 && ly >= m->statusat)
 		ly = m->statusat - 1;
+	if (m->sideat == 0 && lx >= (int)m->sidecols)
+		lx -= m->sidecols;
+	else if (m->sideat > 0 && lx >= m->sideat)
+		lx = m->sideat - 1;
 
 	if (x != lx || y != ly) {
 		lc->g.xoff += x - lx;

--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -262,11 +262,19 @@ cmd_resize_pane_mouse_resize_move_floating(struct client *c,
 		y -= m->statuslines;
 	else if (m->statusat > 0 && y >= m->statusat)
 		y = m->statusat - 1;
+	if (m->sideat == 0 && x >= (int)m->sidecols)
+		x -= m->sidecols;
+	else if (m->sideat > 0 && x >= m->sideat)
+		x = m->sideat - 1;
 	ly = m->ly + m->oy; lx = m->lx + m->ox;
 	if (m->statusat == 0 && ly >= (int)m->statuslines)
 		ly -= m->statuslines;
 	else if (m->statusat > 0 && ly >= m->statusat)
 		ly = m->statusat - 1;
+	if (m->sideat == 0 && lx >= (int)m->sidecols)
+		lx -= m->sidecols;
+	else if (m->sideat > 0 && lx >= m->sideat)
+		lx = m->sideat - 1;
 
 	if ((lx == left || lx == left + 1) && ly == wp->yoff - 1) {
 		/* Top left corner. */
@@ -376,11 +384,19 @@ cmd_resize_pane_mouse_resize_tiled(struct client *c, struct mouse_event *m)
 		y -= m->statuslines;
 	else if (m->statusat > 0 && y >= (u_int)m->statusat)
 		y = m->statusat - 1;
+	if (m->sideat == 0 && x >= m->sidecols)
+		x -= m->sidecols;
+	else if (m->sideat > 0 && x >= (u_int)m->sideat)
+		x = m->sideat - 1;
 	ly = m->ly + m->oy; lx = m->lx + m->ox;
 	if (m->statusat == 0 && ly >= m->statuslines)
 		ly -= m->statuslines;
 	else if (m->statusat > 0 && ly >= (u_int)m->statusat)
 		ly = m->statusat - 1;
+	if (m->sideat == 0 && lx >= m->sidecols)
+		lx -= m->sidecols;
+	else if (m->sideat > 0 && lx >= (u_int)m->sideat)
+		lx = m->sideat - 1;
 
 	for (i = 0; i < nitems(cells); i++) {
 		lc = layout_search_by_border(w->layout_root, lx + offsets[i][0],

--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -357,6 +357,10 @@ cmd_split_window_mouse_resize(struct client *c, struct mouse_event *m)
 		y -= m->statuslines;
 	else if (m->statusat > 0 && y >= m->statusat)
 		y = m->statusat - 1;
+	if (m->sideat == 0 && x >= (int)m->sidecols)
+		x -= m->sidecols;
+	else if (m->sideat > 0 && x >= m->sideat)
+		x = m->sideat - 1;
 
 	lines = window_pane_get_pane_lines(wp);
 	border = (lines != PANE_LINES_NONE);

--- a/cmd.c
+++ b/cmd.c
@@ -777,6 +777,8 @@ cmd_mouse_at(struct window_pane *wp, struct mouse_event *m, u_int *xp,
 
 	if (m->statusat == 0 && y >= m->statuslines)
 		y -= m->statuslines;
+	if (m->sideat == 0 && x >= m->sidecols)
+		x -= m->sidecols;
 
 	if ((int)x < wp->xoff || (int)x >= wp->xoff + (int)wp->sx)
 		return (-1);

--- a/format-draw.c
+++ b/format-draw.c
@@ -1007,6 +1007,14 @@ format_draw(struct screen_write_ctx *octx, const struct grid_cell *base,
 	 */
 	switch (list_align) {
 	case STYLE_ALIGN_DEFAULT:
+		if (s[LIST].cx != 0 || s[AFTER].cx != 0) {
+			/* A list with default alignment is part of the left. */
+			format_draw_left(octx, available, ocx, ocy, &s[LEFT],
+			    &s[CENTRE], &s[RIGHT], &s[ABSOLUTE_CENTRE],
+			    &s[LIST], &s[LIST_LEFT], &s[LIST_RIGHT], &s[AFTER],
+			    focus_start, focus_end, &frs);
+			break;
+		}
 		/* No list. */
 		format_draw_none(octx, available, ocx, ocy, &s[LEFT],
 		    &s[CENTRE], &s[RIGHT], &s[ABSOLUTE_CENTRE], &frs);

--- a/format-draw.c
+++ b/format-draw.c
@@ -1103,6 +1103,369 @@ out:
 	screen_write_cursormove(octx, ocx, ocy, 0);
 }
 
+/* A single row of a multi-row format. */
+struct format_line {
+	char	*chunk;
+	int	 in_list;
+	int	 has_focus;
+	int	 marker;	/* 0 = none, 1 = up, 2 = down */
+};
+
+/* State when splitting a format into rows. */
+struct format_lines {
+	struct format_line	*lines;
+	u_int			 nlines;
+
+	char			*prefix;
+	int			 in_list;
+	int			 has_focus;
+	int			 marker;
+};
+
+/* Add a row between start and end to the line array. */
+static void
+format_draw_lines_add(struct format_lines *fls, const char *start,
+    const char *end, const char *suffix)
+{
+	struct format_line	*fl;
+
+	fls->lines = xreallocarray(fls->lines, fls->nlines + 1,
+	    sizeof *fls->lines);
+	fl = &fls->lines[fls->nlines++];
+	xasprintf(&fl->chunk, "%s%.*s%s", fls->prefix, (int)(end - start),
+	    start, suffix);
+	fl->in_list = fls->in_list;
+	fl->has_focus = fls->has_focus;
+	fl->marker = fls->marker;
+}
+
+/*
+ * End the current row and carry the current style state over to the start of
+ * the next row. Note the default stack is flattened at a break: push-default
+ * state does not cross rows. A marker is a single row, so marker state does
+ * not carry either: it is restored to the last list state before the marker.
+ */
+static void
+format_draw_lines_break(struct format_lines *fls, struct style *sy,
+    enum style_list nomarker, const char *start, const char *end)
+{
+	struct style	 carried;
+	const char	*s;
+
+	/*
+	 * A range still open at the end of the string is discarded by
+	 * format_draw, so close any open range at the break; the carried
+	 * style reopens it at the start of the next row.
+	 */
+	if (sy->range_type != STYLE_RANGE_NONE)
+		format_draw_lines_add(fls, start, end, "#[norange]");
+	else
+		format_draw_lines_add(fls, start, end, "");
+
+	if (sy->list == STYLE_LIST_LEFT_MARKER ||
+	    sy->list == STYLE_LIST_RIGHT_MARKER)
+		sy->list = nomarker;
+
+	/*
+	 * List state is not carried into the row itself: which rows are part
+	 * of the list is tracked here, and rendering a single row does not
+	 * need the list machinery.
+	 */
+	style_copy(&carried, sy);
+	carried.list = STYLE_LIST_OFF;
+
+	free(fls->prefix);
+	s = style_tostring(&carried);
+	if (*s != '\0')
+		xasprintf(&fls->prefix, "#[%s]", s);
+	else
+		fls->prefix = xstrdup("");
+
+	fls->in_list = 0;
+	fls->has_focus = 0;
+	fls->marker = 0;
+}
+
+/*
+ * Track the flags of a row when text is seen: the row is classified by the
+ * list state its text was drawn under, not by the styles it happens to
+ * contain.
+ */
+static void
+format_draw_lines_text(struct format_lines *fls, const struct style *sy)
+{
+	switch (sy->list) {
+	case STYLE_LIST_ON:
+		fls->in_list = 1;
+		break;
+	case STYLE_LIST_FOCUS:
+		fls->in_list = 1;
+		fls->has_focus = 1;
+		break;
+	case STYLE_LIST_LEFT_MARKER:
+		if (fls->marker == 0)
+			fls->marker = 1;
+		break;
+	case STYLE_LIST_RIGHT_MARKER:
+		if (fls->marker == 0)
+			fls->marker = 2;
+		break;
+	case STYLE_LIST_OFF:
+		break;
+	}
+}
+
+/*
+ * Split an expanded format into rows at nl styles and literal newlines,
+ * walking the string and parsing styles the same way as format_draw.
+ */
+static void
+format_draw_lines_split(struct format_lines *fls, const char *expanded,
+    const struct grid_cell *base)
+{
+	struct grid_cell	 current_default, base_default;
+	struct style		 sy, saved_sy;
+	enum style_list		 nomarker = STYLE_LIST_OFF;
+	const char		*cp, *start, *end;
+	char			*tmp;
+	u_int			 n;
+
+	memcpy(&base_default, base, sizeof base_default);
+	memcpy(&current_default, base, sizeof current_default);
+	style_set(&sy, &current_default);
+
+	fls->prefix = xstrdup("");
+	cp = start = expanded;
+	while (*cp != '\0') {
+		/* Handle sequences of # in the same way as format_draw. */
+		if (cp[0] == '#' && cp[1] != '[' && cp[1] != '\0') {
+			format_draw_lines_text(fls, &sy);
+			for (n = 1; cp[n] == '#'; n++)
+				/* nothing */;
+			if (cp[n] != '[') {
+				cp += n;
+				continue;
+			}
+			if ((n % 2) == 0)
+				cp += (n + 1);
+			else
+				cp += (n - 1);
+			continue;
+		}
+
+		/* Is this not a style? */
+		if (cp[0] != '#' || cp[1] != '[' || sy.ignore) {
+			if (*cp == '\n') {
+				format_draw_lines_break(fls, &sy, nomarker,
+				    start, cp);
+				cp++;
+				start = cp;
+			} else {
+				format_draw_lines_text(fls, &sy);
+				cp++;
+			}
+			continue;
+		}
+
+		/* This is a style. Work out where the end is and parse it. */
+		end = format_skip(cp + 2, "]");
+		if (end == NULL)
+			break;
+		tmp = xstrndup(cp + 2, end - (cp + 2));
+		style_copy(&saved_sy, &sy);
+		if (style_parse(&sy, &current_default, tmp) != 0) {
+			free(tmp);
+			cp = end + 1;
+			continue;
+		}
+		free(tmp);
+
+		/* If this style pushed or popped the default, update it. */
+		if (sy.default_type == STYLE_DEFAULT_PUSH) {
+			memcpy(&current_default, &saved_sy.gc,
+			    sizeof current_default);
+			sy.default_type = STYLE_DEFAULT_BASE;
+		} else if (sy.default_type == STYLE_DEFAULT_POP) {
+			memcpy(&current_default, &base_default,
+			    sizeof current_default);
+			sy.default_type = STYLE_DEFAULT_BASE;
+		} else if (sy.default_type == STYLE_DEFAULT_SET) {
+			memcpy(&base_default, &saved_sy.gc,
+			    sizeof base_default);
+			memcpy(&current_default, &saved_sy.gc,
+			    sizeof current_default);
+			sy.default_type = STYLE_DEFAULT_BASE;
+		}
+
+		/* Track the last list state that was not a marker. */
+		if (sy.list != STYLE_LIST_LEFT_MARKER &&
+		    sy.list != STYLE_LIST_RIGHT_MARKER)
+			nomarker = sy.list;
+
+		/* End the row if the style has a line break. */
+		if (sy.nl) {
+			sy.nl = 0;
+			format_draw_lines_break(fls, &sy, nomarker, start, cp);
+			cp = end + 1;
+			start = cp;
+			continue;
+		}
+
+		cp = end + 1;
+	}
+	if (cp != start || fls->nlines == 0)
+		format_draw_lines_add(fls, start, cp, "");
+	free(fls->prefix);
+	fls->prefix = NULL;
+}
+
+/* Draw one row and give any ranges it produces the row's y position. */
+static void
+format_draw_lines_row(struct screen_write_ctx *octx,
+    const struct grid_cell *base, u_int width, u_int py, const char *chunk,
+    struct style_ranges *srs, int default_colours)
+{
+	struct style_ranges	 row_srs;
+	struct style_range	*sr, *sr1;
+
+	screen_write_cursormove(octx, 0, py, 0);
+	if (srs == NULL) {
+		format_draw(octx, base, width, chunk, NULL, default_colours);
+		return;
+	}
+	style_ranges_init(&row_srs);
+	format_draw(octx, base, width, chunk, &row_srs, default_colours);
+	TAILQ_FOREACH_SAFE(sr, &row_srs, entry, sr1) {
+		TAILQ_REMOVE(&row_srs, sr, entry);
+		sr->y = py;
+		TAILQ_INSERT_TAIL(srs, sr, entry);
+	}
+}
+
+/*
+ * Draw a multi-row format into no more than height rows starting at the
+ * cursor, with each row drawn by format_draw at the given width. Rows in the
+ * list section are scrolled to keep the focus row visible and replaced by the
+ * up and down marker rows where trimmed. Ranges are given the screen row they
+ * were drawn on. Returns the number of rows drawn.
+ */
+u_int
+format_draw_lines(struct screen_write_ctx *octx, const struct grid_cell *base,
+    u_int width, u_int height, const char *expanded, struct style_ranges *srs,
+    int default_colours)
+{
+	struct format_lines	 fls;
+	struct format_line	*fl;
+	u_int			*top, *list, *bottom;
+	u_int			 n_top = 0, n_list = 0, n_bottom = 0;
+	u_int			 vis_top, vis_list, vis_bottom, lstart, f;
+	u_int			 i, y, ocy = octx->s->cy;
+	int			 first_list = -1, last_list = -1;
+	int			 up = -1, down = -1;
+
+	if (height == 0)
+		return (0);
+
+	memset(&fls, 0, sizeof fls);
+	format_draw_lines_split(&fls, expanded, base);
+
+	/* Find the list section and the marker rows. */
+	for (i = 0; i < fls.nlines; i++) {
+		if (fls.lines[i].marker == 1) {
+			if (up == -1)
+				up = i;
+			continue;
+		}
+		if (fls.lines[i].marker == 2) {
+			if (down == -1)
+				down = i;
+			continue;
+		}
+		if (fls.lines[i].in_list) {
+			if (first_list == -1)
+				first_list = i;
+			last_list = i;
+		}
+	}
+
+	/* Partition the rows into above, inside and below the list. */
+	top = xreallocarray(NULL, fls.nlines, sizeof *top);
+	list = xreallocarray(NULL, fls.nlines, sizeof *list);
+	bottom = xreallocarray(NULL, fls.nlines, sizeof *bottom);
+	for (i = 0; i < fls.nlines; i++) {
+		if (fls.lines[i].marker != 0)
+			continue;
+		if (first_list == -1 || (int)i < first_list)
+			top[n_top++] = i;
+		else if ((int)i <= last_list)
+			list[n_list++] = i;
+		else
+			bottom[n_bottom++] = i;
+	}
+
+	/* Trim the list first, then the bottom, then the top. */
+	vis_top = n_top;
+	vis_list = n_list;
+	vis_bottom = n_bottom;
+	while (vis_top + vis_list + vis_bottom > height) {
+		if (vis_list > 0)
+			vis_list--;
+		else if (vis_bottom > 0)
+			vis_bottom--;
+		else
+			vis_top--;
+	}
+
+	/* Scroll the list to keep the focus row visible. */
+	f = 0;
+	for (i = 0; i < n_list; i++) {
+		if (fls.lines[list[i]].has_focus) {
+			f = i;
+			break;
+		}
+	}
+	if (vis_list == 0 || f < vis_list / 2)
+		lstart = 0;
+	else
+		lstart = f - vis_list / 2;
+	if (lstart + vis_list > n_list)
+		lstart = n_list - vis_list;
+
+	/* Draw the rows. */
+	y = 0;
+	for (i = 0; i < vis_top; i++) {
+		fl = &fls.lines[top[i]];
+		format_draw_lines_row(octx, base, width, ocy + y, fl->chunk,
+		    srs, default_colours);
+		y++;
+	}
+	for (i = 0; i < vis_list; i++) {
+		fl = &fls.lines[list[lstart + i]];
+		if (i == 0 && lstart > 0 && up != -1)
+			fl = &fls.lines[up];
+		else if (i == vis_list - 1 && lstart + vis_list < n_list &&
+		    down != -1)
+			fl = &fls.lines[down];
+		format_draw_lines_row(octx, base, width, ocy + y, fl->chunk,
+		    srs, default_colours);
+		y++;
+	}
+	for (i = 0; i < vis_bottom; i++) {
+		fl = &fls.lines[bottom[i]];
+		format_draw_lines_row(octx, base, width, ocy + y, fl->chunk,
+		    srs, default_colours);
+		y++;
+	}
+
+	for (i = 0; i < fls.nlines; i++)
+		free(fls.lines[i].chunk);
+	free(fls.lines);
+	free(top);
+	free(list);
+	free(bottom);
+	return (y);
+}
+
 /* Get width, taking #[] into account. */
 u_int
 format_width(const char *expanded)

--- a/format.c
+++ b/format.c
@@ -1377,6 +1377,13 @@ format_cb_mouse_status_line(struct format_tree *ft)
 		y = ft->m.y;
 	} else if (ft->m.statusat > 0 && ft->m.y >= (u_int)ft->m.statusat) {
 		y = ft->m.y - ft->m.statusat;
+	} else if (ft->m.sideat != -1 &&
+	    ft->m.x >= (u_int)ft->m.sideat &&
+	    ft->m.x < ft->m.sideat + ft->m.sidecols) {
+		if (ft->m.statusat == 0)
+			y = ft->m.y - ft->m.statuslines;
+		else
+			y = ft->m.y;
 	} else
 		return (NULL);
 	xasprintf(&value, "%u", y);
@@ -1399,13 +1406,23 @@ format_cb_mouse_status_range(struct format_tree *ft)
 	if (ft->m.statusat == 0 && ft->m.y < ft->m.statuslines) {
 		x = ft->m.x;
 		y = ft->m.y;
+		sr = status_get_range(ft->c, x, y);
 	} else if (ft->m.statusat > 0 && ft->m.y >= (u_int)ft->m.statusat) {
 		x = ft->m.x;
 		y = ft->m.y - ft->m.statusat;
+		sr = status_get_range(ft->c, x, y);
+	} else if (ft->m.sideat != -1 &&
+	    ft->m.x >= (u_int)ft->m.sideat &&
+	    ft->m.x < ft->m.sideat + ft->m.sidecols) {
+		x = ft->m.x - ft->m.sideat;
+		if (ft->m.statusat == 0)
+			y = ft->m.y - ft->m.statuslines;
+		else
+			y = ft->m.y;
+		sr = side_status_get_range(ft->c, x, y);
 	} else
 		return (NULL);
 
-	sr = status_get_range(ft->c, x, y);
 	if (sr == NULL)
 		return (NULL);
 	switch (sr->type) {
@@ -2045,6 +2062,10 @@ format_cb_mouse_x(struct format_tree *ft)
 			return (format_printf("%u", ft->m.x));
 		if (ft->m.statusat > 0 && ft->m.y >= (u_int)ft->m.statusat)
 			return (format_printf("%u", ft->m.x));
+		if (ft->m.sideat != -1 &&
+		    ft->m.x >= (u_int)ft->m.sideat &&
+		    ft->m.x < ft->m.sideat + ft->m.sidecols)
+			return (format_printf("%u", ft->m.x - ft->m.sideat));
 	}
 	return (NULL);
 }
@@ -2066,6 +2087,15 @@ format_cb_mouse_y(struct format_tree *ft)
 			return (format_printf("%u", ft->m.y));
 		if (ft->m.statusat > 0 && ft->m.y >= (u_int)ft->m.statusat)
 			return (format_printf("%u", ft->m.y - ft->m.statusat));
+		if (ft->m.sideat != -1 &&
+		    ft->m.x >= (u_int)ft->m.sideat &&
+		    ft->m.x < ft->m.sideat + ft->m.sidecols) {
+			if (ft->m.statusat == 0)
+				y = ft->m.y - ft->m.statuslines;
+			else
+				y = ft->m.y;
+			return (format_printf("%u", y));
+		}
 	}
 	return (NULL);
 }

--- a/options-table.c
+++ b/options-table.c
@@ -53,6 +53,9 @@ static const char *options_table_status_justify_list[] = {
 static const char *options_table_status_position_list[] = {
 	"top", "bottom", NULL
 };
+static const char *options_table_side_status_list[] = {
+	"off", "left", "right", NULL
+};
 static const char *options_table_bell_action_list[] = {
 	"none", "any", "current", "other", NULL
 };
@@ -235,6 +238,34 @@ static const char *options_table_status_format_default[] = {
 	OPTIONS_TABLE_STATUS_FORMAT1,
 	OPTIONS_TABLE_STATUS_FORMAT2,
 	OPTIONS_TABLE_STATUS_FORMAT3,
+	NULL
+};
+
+/* Default side status line format: one row for each window. */
+#define OPTIONS_TABLE_SIDE_STATUS_FORMAT1 \
+	"#[list=on]" \
+	"#[list=left-marker]^#[nl]" \
+	"#[list=right-marker]v#[nl]" \
+	"#{W:" \
+		"#[range=window|#{window_index} #{E:window-status-style}]" \
+		"#[push-default]" \
+		"#{T:window-status-format}" \
+		"#[pop-default]" \
+		"#[norange default]#[nl]" \
+	"," \
+		"#[range=window|#{window_index} list=focus " \
+			"#{?#{!=:#{E:window-status-current-style},default}," \
+				"#{E:window-status-current-style}," \
+				"#{E:window-status-style}" \
+			"}" \
+		"]" \
+		"#[push-default]" \
+		"#{T:window-status-current-format}" \
+		"#[pop-default]" \
+		"#[norange list=on default]#[nl]" \
+	"}"
+static const char *options_table_side_status_format_default[] = {
+	OPTIONS_TABLE_SIDE_STATUS_FORMAT1,
 	NULL
 };
 
@@ -979,6 +1010,35 @@ const struct options_table_entry options_table[] = {
 	  .scope = OPTIONS_TABLE_SESSION,
 	  .default_str = "#S:#I:#W - \"#T\" #{session_alerts}",
 	  .text = "Format of the terminal title to set."
+	},
+
+	{ .name = "side-status",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .choices = options_table_side_status_list,
+	  .default_num = 0,
+	  .text = "Whether to draw a vertical status line at the left or "
+		  "right of the terminal."
+	},
+
+	{ .name = "side-status-format",
+	  .type = OPTIONS_TABLE_STRING,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .flags = OPTIONS_TABLE_IS_ARRAY,
+	  .default_arr = options_table_side_status_format_default,
+	  .text = "Formats for the side status line. "
+		  "Each array member may produce multiple rows with the nl "
+		  "style; the rows for each member follow those of the "
+		  "previous member."
+	},
+
+	{ .name = "side-status-width",
+	  .type = OPTIONS_TABLE_NUMBER,
+	  .scope = OPTIONS_TABLE_SESSION,
+	  .minimum = 1,
+	  .maximum = SHRT_MAX,
+	  .default_num = 24,
+	  .text = "Width of the side status line."
 	},
 
 	{ .name = "silence-action",

--- a/options.c
+++ b/options.c
@@ -1411,6 +1411,8 @@ options_push_changes(const char *name)
 		status_timer_start_all();
 	if (strcmp(name, "status") == 0 ||
 	    strcmp(name, "status-position") == 0 ||
+	    strcmp(name, "side-status") == 0 ||
+	    strcmp(name, "side-status-width") == 0 ||
 	    strcmp(name, "pane-border-indicators") == 0 ||
 	    strcmp(name, "pane-border-lines") == 0 ||
 	    strcmp(name, "pane-border-status") == 0 ||

--- a/regress/side-status-results/side-left.result
+++ b/regress/side-status-results/side-left.result
@@ -1,0 +1,24 @@
+0:editor                SERVER
+1:server*
+2:logs-
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/regress/side-status-results/side-off.result
+++ b/regress/side-status-results/side-off.result
@@ -1,0 +1,24 @@
+SERVER
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+[test]0:editor  1:server* 2:logs-

--- a/regress/side-status-results/side-right-narrow.result
+++ b/regress/side-status-results/side-right-narrow.result
@@ -1,0 +1,24 @@
+SERVER                                                              0:editor
+                                                                    1:server*
+                                                                    2:logs-
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+[test]0:editor  1:server* 2:logs-

--- a/regress/side-status-results/side-right-status.result
+++ b/regress/side-status-results/side-right-status.result
@@ -1,0 +1,24 @@
+SERVER                                                  0:editor
+                                                        1:server*
+                                                        2:logs-
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+[test]0:editor  1:server* 2:logs-

--- a/regress/side-status-results/side-right.result
+++ b/regress/side-status-results/side-right.result
@@ -1,0 +1,24 @@
+SERVER                                                  0:editor
+                                                        1:server*
+                                                        2:logs-
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/regress/side-status.sh
+++ b/regress/side-status.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Side status line rendering: geometry on the left and right, coexistence
+# with the horizontal status line, width changes and turning it off. Scenes
+# are rendered in an inner tmux attached inside an outer tmux pane; the outer
+# pane is captured and compared with goldens in side-status-results/.
+#
+# Run with GENERATE=1 to (re)create the golden files.
+
+PATH=/bin:/usr/bin
+TERM=screen
+LC_ALL=C.UTF-8
+export TERM LC_ALL
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+TMUX2="$TEST_TMUX -LtestB$$ -f/dev/null"
+RESULTS=side-status-results
+
+TMP=$(mktemp)
+trap "rm -f $TMP; $TMUX kill-server 2>/dev/null; $TMUX2 kill-server 2>/dev/null" \
+	0 1 15
+
+fail() {
+	echo "$*" >&2
+	exit 1
+}
+
+compare() {
+	sleep 1
+	$TMUX capturep -p >$TMP || exit 1
+	if [ -n "$GENERATE" ]; then
+		cp $TMP "$RESULTS/$1.result" || exit 1
+	else
+		cmp -s $TMP "$RESULTS/$1.result" ||
+		    fail "scene $1 differs from $RESULTS/$1.result"
+	fi
+}
+
+mkdir -p "$RESULTS"
+
+$TMUX kill-server 2>/dev/null
+$TMUX2 kill-server 2>/dev/null
+$TMUX new-session -d -x 80 -y 24 || exit 1
+
+# Inner server with fixed pane content so captures are stable.
+$TMUX2 new-session -d -s work -n editor "sh -c 'printf EDITOR; exec sleep 100'"
+$TMUX2 new-window -n server "sh -c 'printf SERVER; exec sleep 100'"
+$TMUX2 new-window -n logs "sh -c 'printf LOGS; exec sleep 100'"
+$TMUX2 select-window -t:1
+$TMUX2 set -g status off
+$TMUX2 set -g status-left "[test]"
+$TMUX2 set -g status-right ""
+$TMUX2 set -g side-status left
+
+$TMUX send-keys "exec $TEST_TMUX -LtestB$$ -f/dev/null attach" Enter
+sleep 1
+compare side-left
+
+$TMUX2 set -g side-status right
+compare side-right
+
+$TMUX2 set -g status on
+compare side-right-status
+
+$TMUX2 set -g side-status-width 12
+compare side-right-narrow
+
+$TMUX2 set -g side-status off
+compare side-off
+
+exit 0

--- a/resize.c
+++ b/resize.c
@@ -190,7 +190,7 @@ clients_calculate_size(int type, int current, struct client *c,
 		if (w == NULL ||
 		    !control_get_window_size(loop, w->id, &cx, &cy) ||
 		    cx == 0 || cy == 0) {
-			cx = loop->tty.sx;
+			cx = loop->tty.sx - side_status_size(loop);
 			cy = loop->tty.sy - status_line_size(loop);
 		}
 
@@ -295,7 +295,7 @@ default_window_size(struct client *c, struct session *s, struct window *w,
 	 * client and no window, use the default size as for manual type.
 	 */
 	if (type == WINDOW_SIZE_LATEST && c != NULL && !ignore_client_size(c)) {
-		*sx = c->tty.sx;
+		*sx = c->tty.sx - side_status_size(c);
 		*sy = c->tty.sy - status_line_size(c);
 		*xpixel = c->tty.xpixel;
 		*ypixel = c->tty.ypixel;

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -94,6 +94,7 @@ enum redraw_span_type {
 #define REDRAW_STATUS 0x40
 #define REDRAW_MENU 0x80
 #define REDRAW_OVERLAY 0x100
+#define REDRAW_SIDE_STATUS 0x200
 
 /* Draw everything. */
 #define REDRAW_ALL 0x7fffffff
@@ -1694,7 +1695,8 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 	struct screen		*sl;
 	struct redraw_scene	*scene;
 	struct window_pane	*loop;
-	u_int			 width, i, y, lines, j;
+	u_int			 width, i, y, lines, j, side_cols;
+	int			 side_x;
 	struct redraw_span	*first;
 	struct visible_ranges	*r;
 	struct visible_range	*rr;
@@ -1715,6 +1717,15 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 			if (flags == 0)
 				return;
 		}
+	}
+
+	if (flags & REDRAW_SIDE_STATUS) {
+		if (side_status_size(c) == 0)
+			flags &= ~REDRAW_SIDE_STATUS;
+		else if (!side_status_redraw(c) && !REDRAW_IS_ALL(flags))
+			flags &= ~REDRAW_SIDE_STATUS;
+		if (flags == 0)
+			return;
 	}
 
 	if (log_get_level() != 0) {
@@ -1796,6 +1807,30 @@ redraw_draw(struct client *c, struct window_pane *wp, int flags)
 	}
 	if (w->menu != NULL && (flags & REDRAW_MENU))
 		redraw_draw_menu_lines(&dctx);
+
+	if (flags & REDRAW_SIDE_STATUS) {
+		side_cols = side_status_size(c);
+		side_x = side_status_at_column(c);
+		if (side_cols != 0 && side_x != -1) {
+			if (dctx.flags & REDRAW_STATUS_TOP)
+				y = dctx.status_lines;
+			else
+				y = 0;
+			for (i = 0; i < side_status_rows(c); i++) {
+				r = tty_check_overlay_range(tty, side_x, y + i,
+				    side_cols);
+				for (j = 0; j < r->used; j++) {
+					rr = &r->ranges[j];
+					if (rr->nx == 0)
+						continue;
+					tty_draw_line(tty,
+					    &c->side_status.screen,
+					    rr->px - side_x, i, rr->nx, rr->px,
+					    y + i, NULL);
+				}
+			}
+		}
+	}
 
 	if (flags & REDRAW_STATUS) {
 		lines = dctx.status_lines;
@@ -1884,7 +1919,8 @@ redraw_screen(struct client *c)
 		if (c->flags & CLIENT_REDRAWBORDERS)
 			flags |= (REDRAW_PANE_BORDER|REDRAW_PANE_STATUS);
 		if (c->flags & CLIENT_REDRAWSTATUS)
-			flags |= (REDRAW_STATUS|REDRAW_PANE_STATUS);
+			flags |= (REDRAW_STATUS|REDRAW_PANE_STATUS|
+			    REDRAW_SIDE_STATUS);
 		if (c->flags & CLIENT_REDRAWOVERLAY)
 			flags |= REDRAW_OVERLAY;
 		if (c->flags & CLIENT_REDRAWMENU)

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -236,6 +236,7 @@ struct redraw_draw_ctx {
 	struct window_pane	*marked;
 
 	u_int			 status_lines;
+	u_int			 side_left;
 	enum pane_lines		 pane_lines;
 	struct grid_cell	 default_gc;
 
@@ -282,7 +283,7 @@ redraw_get_window_offset(struct client *c, u_int *ox, u_int *oy, u_int *sx,
 
 	tty_window_offset(&c->tty, ox, oy, sx, sy);
 
-	tty_sx = c->tty.sx;
+	tty_sx = c->tty.sx - side_status_size(c);
 	tty_sy = c->tty.sy - status_line_size(c);
 	if (*sx < tty_sx)
 		*sx = tty_sx;
@@ -1122,7 +1123,7 @@ redraw_draw_pane_span(struct redraw_draw_ctx *dctx,
 	style_ctx.palette = &wp->palette;
 	style_ctx.hyperlinks = s->hyperlinks;
 
-	px = span->data.p.px + (x - span->x);
+	px = span->data.p.px + (x - dctx->side_left - span->x);
 	py = span->data.p.py;
 	tty_draw_line(tty, s, px, py, n, x, y, &style_ctx);
 }
@@ -1276,7 +1277,7 @@ redraw_draw_status_span(struct redraw_draw_ctx *dctx,
 	struct screen		*s = &wp->status_screen;
 	u_int			 px, sx = screen_size_x(s);
 
-	px = span->data.st.offset + (x - span->x);
+	px = span->data.st.offset + (x - dctx->side_left - span->x);
 	if (px < sx) {
 		if (n > sx - px)
 			n = sx - px;
@@ -1338,7 +1339,7 @@ redraw_draw_scrollbar_span(struct redraw_draw_ctx *dctx,
 
 	sb_w = sb_style->width;
 	sb_pad = sb_style->pad;
-	off = x - span->x;
+	off = x - dctx->side_left - span->x;
 
 	tty_cursor(tty, x, y);
 	for (i = 0; i < n; i++) {
@@ -1372,7 +1373,7 @@ redraw_draw_menu_span(struct redraw_draw_ctx *dctx,
 	struct screen		*s = menu_screen(span->data.m.md);
 	u_int			 px;
 
-	px = span->data.m.px + (x - span->x);
+	px = span->data.m.px + (x - dctx->side_left - span->x);
 	tty_draw_line(tty, s, px, span->data.m.py, n, x, y, NULL);
 }
 
@@ -1393,7 +1394,8 @@ redraw_draw_span(struct redraw_draw_ctx *dctx, struct redraw_span *span,
 	if (type == REDRAW_SPAN_STATUS && ~data->st.wp->flags & PANE_NEWSTATUS)
 		return;
 
-	r = tty_check_overlay_range(tty, span->x, y, span->width);
+	r = tty_check_overlay_range(tty, dctx->side_left + span->x, y,
+	    span->width);
 	for (i = 0; i < r->used; i++) {
 		rr = &r->ranges[i];
 		if (rr->nx == 0)
@@ -1617,6 +1619,9 @@ redraw_set_draw_context(struct redraw_draw_ctx *dctx,
 		dctx->flags |= REDRAW_STATUS_TOP;
 	dctx->status_lines = lines;
 
+	if (side_status_at_column(c) == 0)
+		dctx->side_left = side_status_size(c);
+
 	if ((c->flags & CLIENT_UTF8) && tty_term_has(tty->term, TTYC_BIDI))
 		dctx->flags |= REDRAW_ISOLATES;
 }
@@ -1673,7 +1678,8 @@ redraw_draw_pane_prompt(struct redraw_draw_ctx *dctx, struct window_pane *wp)
 	prompt_draw(wp->prompt, &pdd);
 	screen_write_stop(&ctx);
 
-	tty_draw_line(tty, &screen, 0, offset, width, px, cy, NULL);
+	tty_draw_line(tty, &screen, 0, offset, width, dctx->side_left + px, cy,
+	    NULL);
 	screen_free(&screen);
 }
 

--- a/screen-write.c
+++ b/screen-write.c
@@ -171,6 +171,8 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
+	if (side_status_at_column(c) == 0)
+		ttyctx->xoff += side_status_size(c);
 
 	return (1);
 }

--- a/server-client.c
+++ b/server-client.c
@@ -846,16 +846,77 @@ server_client_check_mouse_in_pane(struct window_pane *wp, int px, int py,
 	return (KEYC_MOUSE_LOCATION_NOWHERE);
 }
 
+/* Resolve a status line range under the mouse to a location and target. */
+static int
+server_client_range_location(struct session *s, struct style_range *sr,
+    struct mouse_event *m, enum key_code_mouse_location *loc)
+{
+	struct winlink		*fwl;
+	struct window_pane	*fwp;
+	struct session		*fs;
+	u_int			 n;
+
+	switch (sr->type) {
+	case STYLE_RANGE_NONE:
+		return (-1);
+	case STYLE_RANGE_LEFT:
+		log_debug("mouse range: left");
+		*loc = KEYC_MOUSE_LOCATION_STATUS_LEFT;
+		break;
+	case STYLE_RANGE_RIGHT:
+		log_debug("mouse range: right");
+		*loc = KEYC_MOUSE_LOCATION_STATUS_RIGHT;
+		break;
+	case STYLE_RANGE_PANE:
+		fwp = window_pane_find_by_id(sr->argument);
+		if (fwp == NULL)
+			return (-1);
+		m->wp = sr->argument;
+
+		log_debug("mouse range: pane %%%u", m->wp);
+		*loc = KEYC_MOUSE_LOCATION_STATUS;
+		break;
+	case STYLE_RANGE_WINDOW:
+		fwl = winlink_find_by_index(&s->windows, sr->argument);
+		if (fwl == NULL)
+			return (-1);
+		m->w = fwl->window->id;
+
+		log_debug("mouse range: window @%u", m->w);
+		*loc = KEYC_MOUSE_LOCATION_STATUS;
+		break;
+	case STYLE_RANGE_SESSION:
+		fs = session_find_by_id(sr->argument);
+		if (fs == NULL)
+			return (-1);
+		m->s = sr->argument;
+
+		log_debug("mouse range: session $%u", m->s);
+		*loc = KEYC_MOUSE_LOCATION_STATUS;
+		break;
+	case STYLE_RANGE_USER:
+		log_debug("mouse range: user");
+		*loc = KEYC_MOUSE_LOCATION_STATUS;
+		break;
+	case STYLE_RANGE_CONTROL:
+		n = sr->argument; /* parsing keeps this < 10 */
+		log_debug("mouse range: control %u", n);
+		*loc = KEYC_MOUSE_LOCATION_CONTROL0 + n;
+		break;
+	}
+	return (0);
+}
+
 /* Check for mouse keys. */
 static key_code
 server_client_check_mouse(struct client *c, struct key_event *event)
 {
 	struct mouse_event		*m = &event->m;
-	struct session			*s = c->session, *fs;
+	struct session			*s = c->session;
 	struct window			*w = s->curw->window;
-	struct winlink			*fwl;
-	struct window_pane		*wp, *fwp, *lwp = NULL;
+	struct window_pane		*wp, *lwp = NULL;
 	u_int				 x, y, sx, sy, px, py, n, sl_mpos = 0;
+	u_int				 sidey;
 	u_int				 b, bn;
 	int				 ignore = 0;
 	int				 modal_drag = 0;
@@ -954,62 +1015,35 @@ have_event:
 	/* Is this on the status line? */
 	m->statusat = status_at_line(c);
 	m->statuslines = status_line_size(c);
+	m->sideat = side_status_at_column(c);
+	m->sidecols = side_status_size(c);
 	if (m->statusat != -1 &&
 	    y >= (u_int)m->statusat &&
 	    y < m->statusat + m->statuslines) {
 		sr = status_get_range(c, x, y - m->statusat);
-		if (sr == NULL) {
+		if (sr == NULL)
 			loc = KEYC_MOUSE_LOCATION_STATUS_DEFAULT;
-		} else {
-			switch (sr->type) {
-			case STYLE_RANGE_NONE:
+		else if (server_client_range_location(s, sr, m, &loc) != 0)
+			return (KEYC_UNKNOWN);
+	}
+
+	/* Is this on the side status line? */
+	if (loc == KEYC_MOUSE_LOCATION_NOWHERE &&
+	    m->sideat != -1 &&
+	    x >= (u_int)m->sideat &&
+	    x < m->sideat + m->sidecols) {
+		if (m->statusat == 0)
+			sidey = m->statuslines;
+		else
+			sidey = 0;
+		if (y >= sidey && y - sidey < side_status_rows(c)) {
+			sr = side_status_get_range(c, x - m->sideat,
+			    y - sidey);
+			if (sr == NULL)
+				loc = KEYC_MOUSE_LOCATION_STATUS_DEFAULT;
+			else if (server_client_range_location(s, sr, m,
+			    &loc) != 0)
 				return (KEYC_UNKNOWN);
-			case STYLE_RANGE_LEFT:
-				log_debug("mouse range: left");
-				loc = KEYC_MOUSE_LOCATION_STATUS_LEFT;
-				break;
-			case STYLE_RANGE_RIGHT:
-				log_debug("mouse range: right");
-				loc = KEYC_MOUSE_LOCATION_STATUS_RIGHT;
-				break;
-			case STYLE_RANGE_PANE:
-				fwp = window_pane_find_by_id(sr->argument);
-				if (fwp == NULL)
-					return (KEYC_UNKNOWN);
-				m->wp = sr->argument;
-
-				log_debug("mouse range: pane %%%u", m->wp);
-				loc = KEYC_MOUSE_LOCATION_STATUS;
-				break;
-			case STYLE_RANGE_WINDOW:
-				fwl = winlink_find_by_index(&s->windows,
-				    sr->argument);
-				if (fwl == NULL)
-					return (KEYC_UNKNOWN);
-				m->w = fwl->window->id;
-
-				log_debug("mouse range: window @%u", m->w);
-				loc = KEYC_MOUSE_LOCATION_STATUS;
-				break;
-			case STYLE_RANGE_SESSION:
-				fs = session_find_by_id(sr->argument);
-				if (fs == NULL)
-					return (KEYC_UNKNOWN);
-				m->s = sr->argument;
-
-				log_debug("mouse range: session $%u", m->s);
-				loc = KEYC_MOUSE_LOCATION_STATUS;
-				break;
-			case STYLE_RANGE_USER:
-				log_debug("mouse range: user");
-				loc = KEYC_MOUSE_LOCATION_STATUS;
-				break;
-			case STYLE_RANGE_CONTROL:
-				n = sr->argument; /* parsing keeps this < 10 */
-				log_debug("mouse range: control %u", n);
-				loc = KEYC_MOUSE_LOCATION_CONTROL0 + n;
-				break;
-			}
 		}
 	}
 
@@ -1024,7 +1058,12 @@ have_event:
 			m->w = lwp->window->id;
 		}
 	} else if (loc == KEYC_MOUSE_LOCATION_NOWHERE) {
-		px = x;
+		if (m->sideat == 0 && x >= m->sidecols)
+			px = x - m->sidecols;
+		else if (m->sideat > 0 && x >= (u_int)m->sideat)
+			px = m->sideat - 1;
+		else
+			px = x;
 		if (m->statusat == 0 && y >= m->statuslines)
 			py = y - m->statuslines;
 		else if (m->statusat > 0 && y >= (u_int)m->statusat)
@@ -1688,16 +1727,25 @@ server_client_handle_menu_key(struct client *c, struct key_event *event)
 		m->statuslines = status_line_size(c);
 
 		tty_window_offset(&c->tty, &ox, &oy, &sx, &sy);
-		m->x += ox;
-		if (m->statusat == 0) {
-			if (m->y < m->statuslines)
+		if (m->sideat == 0 && m->x < m->sidecols)
+			m->x = m->y = UINT_MAX;
+		else if (m->sideat > 0 && m->x >= (u_int)m->sideat)
+			m->x = m->y = UINT_MAX;
+		else {
+			if (m->sideat == 0)
+				m->x -= m->sidecols;
+			m->x += ox;
+			if (m->statusat == 0) {
+				if (m->y < m->statuslines)
+					m->x = m->y = UINT_MAX;
+				else
+					m->y = m->y - m->statuslines + oy;
+			} else if (m->statusat > 0 &&
+			    m->y >= (u_int)m->statusat)
 				m->x = m->y = UINT_MAX;
 			else
-				m->y = m->y - m->statuslines + oy;
-		} else if (m->statusat > 0 && m->y >= (u_int)m->statusat)
-			m->x = m->y = UINT_MAX;
-		else
-			m->y += oy;
+				m->y += oy;
+		}
 	}
 
 	if (menu_key(c, w->menu, &new_event) == 1)

--- a/server-client.c
+++ b/server-client.c
@@ -302,6 +302,7 @@ server_client_create(int fd)
 	c->theme = THEME_UNKNOWN;
 
 	status_init(c);
+	side_status_init(c);
 	c->flags |= CLIENT_FOCUSED;
 
 	c->keytable = key_bindings_get_table("root", 1);
@@ -518,6 +519,7 @@ server_client_lost(struct client *c)
 	tty_term_free_list(c->term_caps, c->term_ncaps);
 
 	status_free(c);
+	side_status_free(c);
 	input_cancel_requests(c);
 
 	free(c->title);

--- a/server-client.c
+++ b/server-client.c
@@ -2091,6 +2091,8 @@ server_client_prompt_cursor(struct client *c, struct window_pane *wp, int *mode,
 	if (window_position_is_visible(r, *cx)) {
 		if (status_at_line(c) == 0)
 			*cy += status_line_size(c);
+		if (side_status_at_column(c) == 0)
+			*cx += side_status_size(c);
 		*mode |= MODE_CURSOR;
 	}
 	return (1);
@@ -2162,6 +2164,8 @@ server_client_reset_state(struct client *c)
 				cy -= oy;
 				if (status_at_line(c) == 0)
 					cy += status_line_size(c);
+				if (side_status_at_column(c) == 0)
+					cx += side_status_size(c);
 			}
 			prompt = 1;
 		} else {
@@ -2201,6 +2205,8 @@ server_client_reset_state(struct client *c)
 
 				if (status_at_line(c) == 0)
 					cy += status_line_size(c);
+				if (side_status_at_column(c) == 0)
+					cx += side_status_size(c);
 			}
 
 			if ((pane_mode & MODE_SYNC) || !cursor)

--- a/status.c
+++ b/status.c
@@ -388,6 +388,15 @@ side_status_free(struct client *c)
 	screen_free(&ss->screen);
 }
 
+/* Get side status range for position. */
+struct style_range *
+side_status_get_range(struct client *c, u_int x, u_int y)
+{
+	struct side_status_line	*ss = &c->side_status;
+
+	return (style_ranges_get_range_at(&ss->ranges, x, y));
+}
+
 /* Draw side status line for client. Returns 1 if changed. */
 int
 side_status_redraw(struct client *c)

--- a/status.c
+++ b/status.c
@@ -93,6 +93,20 @@ status_update_cache(struct session *s)
 		s->statusat = 0;
 	else
 		s->statusat = 1;
+
+	switch (options_get_number(s->options, "side-status")) {
+	case 1:
+		s->sidestatusat = 0;
+		break;
+	case 2:
+		s->sidestatusat = 1;
+		break;
+	default:
+		s->sidestatusat = -1;
+		break;
+	}
+	s->sidestatuswidth = options_get_number(s->options,
+	    "side-status-width");
 }
 
 /* Get screen line of status line. -1 means off. */
@@ -119,6 +133,46 @@ status_line_size(struct client *c)
 	if (s == NULL)
 		return (options_get_number(global_s_options, "status"));
 	return (s->statuslines);
+}
+
+/* Get width of side status line for client's session. 0 means off. */
+u_int
+side_status_size(struct client *c)
+{
+	struct session	*s = c->session;
+
+	if (c->flags & (CLIENT_SIDESTATUSOFF|CLIENT_CONTROL))
+		return (0);
+	if (s == NULL || s->sidestatusat == -1)
+		return (0);
+	if (c->tty.sx <= s->sidestatuswidth)
+		return (0);
+	return (s->sidestatuswidth);
+}
+
+/* Get starting column of side status line. -1 means off. */
+int
+side_status_at_column(struct client *c)
+{
+	struct session	*s = c->session;
+	u_int		 width = side_status_size(c);
+
+	if (width == 0)
+		return (-1);
+	if (s->sidestatusat == 0)
+		return (0);
+	return (c->tty.sx - width);
+}
+
+/* Get number of rows of side status line for client. */
+u_int
+side_status_rows(struct client *c)
+{
+	u_int	lines = status_line_size(c);
+
+	if (side_status_size(c) == 0 || c->tty.sy <= lines)
+		return (0);
+	return (c->tty.sy - lines);
 }
 
 /* Get the prompt line number for client's session. 1 means at the bottom. */

--- a/status.c
+++ b/status.c
@@ -367,6 +367,128 @@ status_redraw(struct client *c)
 	return (force || changed);
 }
 
+/* Prepare side status line. */
+void
+side_status_init(struct client *c)
+{
+	struct side_status_line	*ss = &c->side_status;
+
+	screen_init(&ss->screen, 1, 1, 0);
+	style_ranges_init(&ss->ranges);
+}
+
+/* Free side status line. */
+void
+side_status_free(struct client *c)
+{
+	struct side_status_line	*ss = &c->side_status;
+
+	style_ranges_free(&ss->ranges);
+	free(ss->expanded);
+	screen_free(&ss->screen);
+}
+
+/* Draw side status line for client. Returns 1 if changed. */
+int
+side_status_redraw(struct client *c)
+{
+	struct side_status_line		*ss = &c->side_status;
+	struct session			*s = c->session;
+	struct screen_write_ctx		 ctx;
+	struct grid_cell		 gc;
+	struct options_entry		*o;
+	struct options_array_item	*a;
+	union options_value		*ov;
+	struct format_tree		*ft;
+	char				*expanded, *joined, *tmp;
+	u_int				 width, rows, n;
+	int				 flags, force = 0, fg, bg;
+
+	log_debug("%s enter", __func__);
+
+	/* No side status line? */
+	width = side_status_size(c);
+	rows = side_status_rows(c);
+	if (width == 0 || rows == 0)
+		return (1);
+
+	/* Create format tree. */
+	flags = FORMAT_STATUS;
+	if (c->flags & CLIENT_STATUSFORCE)
+		flags |= FORMAT_FORCE;
+	ft = format_create(c, NULL, FORMAT_NONE, flags);
+	format_defaults(ft, c, NULL, NULL, NULL);
+
+	/* Set up default colour. */
+	style_apply(&gc, s->options, "status-style", ft);
+	fg = options_get_number(s->options, "status-fg");
+	if (!COLOUR_DEFAULT(fg))
+		gc.fg = fg;
+	bg = options_get_number(s->options, "status-bg");
+	if (!COLOUR_DEFAULT(bg))
+		gc.bg = bg;
+	if (!grid_cells_equal(&gc, &ss->style)) {
+		force = 1;
+		memcpy(&ss->style, &gc, sizeof ss->style);
+	}
+
+	/* Resize the target screen. */
+	if (screen_size_x(&ss->screen) != width ||
+	    screen_size_y(&ss->screen) != rows) {
+		screen_resize(&ss->screen, width, rows, 0);
+		force = 1;
+	}
+
+	/*
+	 * Expand and join the format array members with newlines: a newline
+	 * starts a new row, so each member's rows follow the previous
+	 * member's.
+	 */
+	joined = xstrdup("");
+	o = options_get(s->options, "side-status-format");
+	if (o != NULL) {
+		a = options_array_first(o);
+		while (a != NULL) {
+			ov = options_array_item_value(a);
+			expanded = format_expand_time(ft, ov->string);
+			if (*joined != '\0') {
+				xasprintf(&tmp, "%s\n%s", joined, expanded);
+				free(expanded);
+			} else
+				tmp = expanded;
+			free(joined);
+			joined = tmp;
+			a = options_array_next(a);
+		}
+	}
+	format_free(ft);
+
+	/* Skip the redraw if nothing has changed. */
+	if (!force &&
+	    ss->expanded != NULL &&
+	    strcmp(joined, ss->expanded) == 0) {
+		free(joined);
+		log_debug("%s exit: unchanged", __func__);
+		return (0);
+	}
+
+	/* Draw the rows over a blank background. */
+	screen_write_start(&ctx, &ss->screen);
+	screen_write_cursormove(&ctx, 0, 0, 0);
+	for (n = 0; n < width * rows; n++)
+		screen_write_putc(&ctx, &gc, ' ');
+	screen_write_cursormove(&ctx, 0, 0, 0);
+	style_ranges_free(&ss->ranges);
+	format_draw_lines(&ctx, &gc, width, rows, joined, &ss->ranges, 0);
+	screen_write_stop(&ctx);
+
+	free(ss->expanded);
+	ss->expanded = joined;
+
+	log_debug("%s exit: changed", __func__);
+	return (1);
+}
+
 /* Escape # characters in a string so format_draw treats them as literal. */
 static char *
 status_message_escape(const char *s)

--- a/style.c
+++ b/style.c
@@ -44,6 +44,8 @@ static struct style style_default = {
 
 	STYLE_DEFAULT_BASE,
 
+	0,
+
 	0
 };
 
@@ -110,6 +112,8 @@ style_parse(struct style *sy, const struct grid_cell *base, const char *in)
 			sy->default_type = STYLE_DEFAULT_POP;
 		else if (strcasecmp(tmp, "set-default") == 0)
 			sy->default_type = STYLE_DEFAULT_SET;
+		else if (strcasecmp(tmp, "nl") == 0)
+			sy->nl = 1;
 		else if (strcasecmp(tmp, "nolist") == 0)
 			sy->list = STYLE_LIST_OFF;
 		else if (strncasecmp(tmp, "list=", 5) == 0) {

--- a/style.c
+++ b/style.c
@@ -577,3 +577,18 @@ style_ranges_get_range(struct style_ranges *srs, u_int x)
 	}
 	return (NULL);
 }
+
+/* Get range for position and row from style ranges. */
+struct style_range *
+style_ranges_get_range_at(struct style_ranges *srs, u_int x, u_int y)
+{
+	struct style_range	*sr;
+
+	if (srs == NULL)
+		return (NULL);
+	TAILQ_FOREACH(sr, srs, entry) {
+		if (x >= sr->start && x < sr->end && y == sr->y)
+			return (sr);
+	}
+	return (NULL);
+}

--- a/tmux.1
+++ b/tmux.1
@@ -5465,6 +5465,34 @@ is on.
 Formats are expanded, see the
 .Sx FORMATS
 section.
+.It Xo Ic side\-status
+.Op Ic off | left | right
+.Xc
+Show a vertical status line at the left or right of the terminal.
+The side status line uses the
+.Ic status\-style
+colours and is updated every
+.Ic status\-interval
+seconds like the status line.
+.It Ic side\-status\-format[] Ar format
+Specify the formats used for the side status line.
+Each array member may produce multiple rows using the
+.Ic nl
+style or a newline character; the rows for each member follow those of the
+previous member.
+The default shows one row for each window.
+Rows drawn with
+.Ic list=on
+are trimmed to the available height and scrolled to keep the row drawn with
+.Ic list=focus
+visible; rows drawn with
+.Ic list=left\-marker
+and
+.Ic list=right\-marker
+replace the first and last visible list row when rows are hidden above or
+below.
+.It Ic side\-status\-width Ar width
+Set the width of the side status line.
 .It Xo Ic silence\-action
 .Op Ic any | none | current | other
 .Xc
@@ -7640,6 +7668,13 @@ and
 .Ic list=right\-marker
 mark the text to be used to mark that text has been trimmed from the left or
 right of the list if there is not enough space.
+.It Ic nl
+End the current row in areas drawn over multiple rows, such as the side
+status line (see the
+.Ic side\-status
+option).
+Colours, attributes and any open range continue on the next row.
+Ignored in areas of a single line.
 .It Ic noattr
 Do not copy attributes from the default style.
 .It Xo Ic push\-default ,

--- a/tmux.h
+++ b/tmux.h
@@ -2773,6 +2773,9 @@ void	 events_fire_winlink(const char *, struct winlink *);
 /* format-draw.c */
 void	 format_draw(struct screen_write_ctx *, const struct grid_cell *,
 	     u_int, const char *, struct style_ranges *, int);
+u_int	 format_draw_lines(struct screen_write_ctx *,
+	     const struct grid_cell *, u_int, u_int, const char *,
+	     struct style_ranges *, int);
 u_int	 format_width(const char *);
 char	*format_trim_left(const char *, u_int);
 char	*format_trim_right(const char *, u_int);

--- a/tmux.h
+++ b/tmux.h
@@ -1688,6 +1688,8 @@ struct mouse_event {
 
 	int		statusat;
 	u_int		statuslines;
+	int		sideat;
+	u_int		sidecols;
 
 	u_int		x;
 	u_int		y;
@@ -3389,6 +3391,7 @@ u_int	 side_status_rows(struct client *);
 void	 side_status_init(struct client *);
 void	 side_status_free(struct client *);
 int	 side_status_redraw(struct client *);
+struct style_range *side_status_get_range(struct client *, u_int, u_int);
 struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);

--- a/tmux.h
+++ b/tmux.h
@@ -1019,6 +1019,8 @@ struct style {
 
 	enum style_default_type	default_type;
 
+	int			nl;
+
 	u_int			link;
 };
 

--- a/tmux.h
+++ b/tmux.h
@@ -975,6 +975,7 @@ struct style_range {
 
 	u_int			 start;
 	u_int			 end; /* not included */
+	u_int			 y; /* row for multi-row areas */
 
 	TAILQ_ENTRY(style_range) entry;
 };
@@ -4197,6 +4198,8 @@ void		 style_set_scrollbar_style_from_option(struct style *,
 void		 style_ranges_init(struct style_ranges *);
 void		 style_ranges_free(struct style_ranges *);
 struct style_range *style_ranges_get_range(struct style_ranges *, u_int);
+struct style_range *style_ranges_get_range_at(struct style_ranges *, u_int,
+		     u_int);
 
 /* spawn.c */
 struct winlink	*spawn_window(struct spawn_context *, char **);

--- a/tmux.h
+++ b/tmux.h
@@ -1627,6 +1627,8 @@ struct session {
 
 	int		 statusat;
 	u_int		 statuslines;
+	int		 sidestatusat; /* -1 off, 0 left, 1 right */
+	u_int		 sidestatuswidth;
 
 	struct options	*options;
 
@@ -2286,7 +2288,7 @@ struct client {
 #define CLIENT_STARTSERVER 0x10000000
 #define CLIENT_REDRAWMENU 0x20000000
 #define CLIENT_NOFORK 0x40000000
-/* 0x80000000ULL unused */
+#define CLIENT_SIDESTATUSOFF 0x80000000ULL
 #define CLIENT_CONTROL_PAUSEAFTER 0x100000000ULL
 #define CLIENT_CONTROL_WAITEXIT 0x200000000ULL
 #define CLIENT_WINDOWSIZECHANGED 0x400000000ULL
@@ -3371,6 +3373,9 @@ void	 status_update_cache(struct session *);
 u_int	 status_prompt_line_at(struct client *);
 int	 status_at_line(struct client *);
 u_int	 status_line_size(struct client *);
+u_int	 side_status_size(struct client *);
+int	 side_status_at_column(struct client *);
+u_int	 side_status_rows(struct client *);
 struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);

--- a/tmux.h
+++ b/tmux.h
@@ -2079,6 +2079,15 @@ struct status_line {
 	struct style_line_entry entries[STATUS_LINES_LIMIT];
 };
 
+/* Side status line. */
+struct side_status_line {
+	struct screen		 screen;
+
+	struct grid_cell	 style;
+	char			*expanded;
+	struct style_ranges	 ranges;
+};
+
 /* File in client. */
 typedef void (*client_file_cb) (struct client *, const char *, int, int,
     struct evbuffer *, void *);
@@ -2252,6 +2261,7 @@ struct client {
 	struct mouse_event	 click_event;
 
 	struct status_line	 status;
+	struct side_status_line	 side_status;
 	struct event		 cycle_timer;
 	enum client_theme	 theme;
 
@@ -3376,6 +3386,9 @@ u_int	 status_line_size(struct client *);
 u_int	 side_status_size(struct client *);
 int	 side_status_at_column(struct client *);
 u_int	 side_status_rows(struct client *);
+void	 side_status_init(struct client *);
+void	 side_status_free(struct client *);
+int	 side_status_redraw(struct client *);
 struct style_range *status_get_range(struct client *, u_int, u_int);
 void	 status_init(struct client *);
 void	 status_free(struct client *);

--- a/tty.c
+++ b/tty.c
@@ -939,7 +939,8 @@ tty_window_bigger(struct tty *tty)
 	struct client	*c = tty->client;
 	struct window	*w = c->session->curw->window;
 
-	return (tty->sx < w->sx || tty->sy - status_line_size(c) < w->sy);
+	return (tty->sx - side_status_size(c) < w->sx ||
+	    tty->sy - status_line_size(c) < w->sy);
 }
 
 /* What offset should this window be drawn at? */
@@ -961,11 +962,12 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 	struct client		*c = tty->client;
 	struct window		*w = c->session->curw->window;
 	struct window_pane	*wp = w->active;
-	u_int			 cx, cy, lines;
+	u_int			 cx, cy, lines, side;
 
 	lines = status_line_size(c);
+	side = side_status_size(c);
 
-	if (tty->sx >= w->sx && tty->sy - lines >= w->sy) {
+	if (tty->sx - side >= w->sx && tty->sy - lines >= w->sy) {
 		*ox = 0;
 		*oy = 0;
 		*sx = w->sx;
@@ -975,7 +977,7 @@ tty_window_offset1(struct tty *tty, u_int *ox, u_int *oy, u_int *sx, u_int *sy)
 		return (0);
 	}
 
-	*sx = tty->sx;
+	*sx = tty->sx - side;
 	*sy = tty->sy - lines;
 
 	if (c->pan_window == w) {
@@ -1540,9 +1542,12 @@ tty_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	else
 		ttyctx->flags &= ~TTY_CTX_WINDOW_BIGGER;
 
+	ttyctx->xoff = ttyctx->rxoff = wp->xoff;
 	ttyctx->yoff = ttyctx->ryoff = wp->yoff;
 	if (status_at_line(c) == 0)
 		ttyctx->yoff += status_line_size(c);
+	if (side_status_at_column(c) == 0)
+		ttyctx->xoff += side_status_size(c);
 
 	return (1);
 }


### PR DESCRIPTION
Implements the vertical status line described by @nicm in #4910.

## What this does

A vertical status line ("side status line") at the left or right of the terminal, drawn from formats like the existing status line:

```
0:editor                $ ...window content...
1:server*
2:logs-
```

Three new session options:

- `side-status` (`off`/`left`/`right`, default `off`) — enable and position.
- `side-status-width` (default 24) — fixed width in columns.
- `side-status-format[]` — format array; each member may produce multiple rows. The default shows one row per window, using the existing `window-status-format`/`window-status-current-format`.

It reuses `status-style` and `status-interval` rather than adding parallel options, and works instead of or in addition to the horizontal status line (`status off` + `side-status left` gives vertical only).

## Against the requirements from #4910

- **"a way to express new line here"** — a new `nl` style (`#[nl]`), plus literal newlines in the expanded string. Because `#[...]` passes through format expansion untouched, `#[nl]` can be emitted conditionally inside `#{W:...}`/`#{P:...}` loops, so a loop produces one row per item. Colours, attributes and any open range carry over the break (an open range is closed at the end of the row and reopened on the next, giving one range per row).
- **"ranges would need a y position as well as an x range"** — `struct style_range` gains a `y` field, stamped with the row a range was drawn on. The side status keeps one flat y-aware range list; the horizontal status line's per-line lists are unchanged.
- **"trimming and keeping the current window visible"** — rows drawn under `list=on` form a vertical list section trimmed to the available height and scrolled to keep the `list=focus` row centred; rows drawn under `list=left-marker`/`list=right-marker` replace the first/last visible list row when rows are hidden above/below. Same syntax as the horizontal list, transposed.
- **Mouse** — clicks on the bar resolve ranges by column and row and fire the existing `MouseDown1Status`/`...StatusDefault`/etc. bindings (no new key names); `mouse_status_range`, `mouse_status_line`, `mouse_x`, `mouse_y` work with bar-relative positions. Window-area clicks subtract the bar's columns everywhere the status lines are already subtracted from rows.

## Commit structure

The first three commits are behaviour-preserving and independently useful (y on ranges, the `nl` keyword, `format_draw_lines`); one small fix (default-aligned lists were silently dropped by `format_draw`); then options, geometry, rendering, mouse, docs. Each commit builds cleanly.

## Known tradeoff

With any side bar no pane is ever full-width, so the linefeed/scroll fast paths fall back to region redraws on terminals **without** DECSLRM left/right margin support. Terminals with margins (xterm, iTerm2, wezterm, recent VTE) are unaffected. This is the same cost vertically-split panes already pay, but the bar imposes it on full-screen panes too.

Naming (`side-status-*` vs something else) and the default format are easy to change if you'd prefer different colours on this bikeshed.

## QA / testing

Regress: `regress/side-status.sh` (golden scenes for left/right/coexistence/width/off, regenerate with `GENERATE=1`). The full regress suite passes except `screen-redraw-menus.sh`, which fails identically on unpatched master on macOS.

Quick start:

```
./tmux -Ltest -f/dev/null new -A -s test
set -g side-status left            # bar appears, window shrinks
set -g side-status right           # moves to the right
set -g side-status-width 30        # resizes
set -g status off                  # vertical only
set -g mouse on                    # click a window row to select it
```

Worth exercising interactively:

- Create/kill/rename windows: the bar updates immediately; more windows than rows scrolls the list around the current window with `^`/`v` marker rows.
- Both status lines on (`status 2` + `side-status left`), messages and the command prompt (they overdraw the bar and restore on the next redraw), `display-popup` and menus over the bar.
- Mouse: click window rows (select), pane clicks/drags land on the right cells with a left bar, border drag-resize, `split-window`/`join-pane` mouse targets.
- Resize the terminal below `side-status-width` + 1: the bar disables itself; above: it returns.
- `window-size latest` with two clients of different widths attached to the same session; zoomed panes; a window bigger than the client (panning).
- Scroll a full-screen pane (e.g. `yes`) on a terminal without margin support to feel the redraw cost described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017EBimQYoNdaRG5SvwSSmPJ
