### PR TITLE
Add pane_private_modes format listing enabled DECSET private modes

### DIFF
--- a/format.c
+++ b/format.c
@@ -2101,6 +2101,60 @@ format_cb_synchronized_output_flag(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for pane_private_modes. */
+static void *
+format_cb_pane_private_modes(struct format_tree *ft)
+{
+	static const struct {
+		int	mode;
+		int	number;
+	} table[] = {
+		{ MODE_KCURSOR,		1 },	/* DECCKM */
+		{ MODE_ORIGIN,		6 },	/* DECOM */
+		{ MODE_WRAP,		7 },	/* DECAWM */
+		{ MODE_CURSOR_BLINKING,	12 },	/* cursor blinking */
+		{ MODE_CURSOR,		25 },	/* DECTCEM */
+		{ MODE_MOUSE_STANDARD,	1000 },	/* mouse: normal tracking */
+		{ MODE_MOUSE_BUTTON,	1002 },	/* mouse: button-event tracking */
+		{ MODE_MOUSE_ALL,	1003 },	/* mouse: any-event tracking */
+		{ MODE_FOCUSON,		1004 },	/* focus reporting */
+		{ MODE_MOUSE_UTF8,	1005 },	/* mouse: UTF-8 */
+		{ MODE_MOUSE_SGR,	1006 },	/* mouse: SGR */
+		{ MODE_BRACKETPASTE,	2004 },	/* bracketed paste */
+		{ MODE_SYNC,		2026 },	/* synchronized output */
+		{ MODE_THEME_UPDATES,	2031 },	/* theme update notifications */
+	};
+	int	 mode;
+	char	*value = NULL, *tmp;
+	u_int	 i;
+
+	if (ft->wp == NULL)
+		return (NULL);
+	mode = ft->wp->base.mode;
+
+	for (i = 0; i < nitems(table); i++) {
+		if (~mode & table[i].mode)
+			continue;
+		/*
+		 * Only report cursor blinking when set by the application, not
+		 * when it comes from the cursor-style option.
+		 */
+		if (table[i].mode == MODE_CURSOR_BLINKING &&
+		    (~mode & MODE_CURSOR_BLINKING_SET))
+			continue;
+		if (value == NULL)
+			xasprintf(&value, "%d", table[i].number);
+		else {
+			xasprintf(&tmp, "%s %d", value, table[i].number);
+			free(value);
+			value = tmp;
+		}
+	}
+	if (value == NULL)
+		return (xstrdup(""));
+	return (value);
+}
+
 /* Callback for pane_active. */
 static void *
 format_cb_pane_active(struct format_tree *ft)
@@ -3812,6 +3866,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_pipe_pid", FORMAT_TABLE_STRING,
 	  format_cb_pane_pipe_pid
+	},
+	{ "pane_private_modes", FORMAT_TABLE_STRING,
+	  format_cb_pane_private_modes
 	},
 	{ "pane_right", FORMAT_TABLE_STRING,
 	  format_cb_pane_right

--- a/tmux.1
+++ b/tmux.1
@@ -7397,6 +7397,7 @@ The following variables are available, where appropriate:
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"
 .It Li "pane_pipe" Ta "" Ta "1 if pane is being piped"
 .It Li "pane_pipe_pid" Ta "" Ta "PID of pipe process, if any"
+.It Li "pane_private_modes" Ta "" Ta "Space-separated list of enabled DECSET private mode numbers"
 .It Li "pane_pb_state" Ta "" Ta "Pane progress bar state, one of hidden, normal, error, indeterminate, paused (can be set by application)"
 .It Li "pane_pb_progress" Ta "" Ta "Pane progress bar progress percentage (can be set by application)"
 .It Li "pane_right" Ta "" Ta "Right of pane"


### PR DESCRIPTION
Report the DECSET private mode numbers currently enabled for a pane as a space-separated list (for example "7 25 1004 2004 1006"), so a control mode client attaching to an existing session can initialize its terminal state to match the pane's current state. Live changes already pass through in %output, but a newly attached client never sees the modes set before it connected; MODE_FOCUSON (1004) in particular had no format variable at all.

Alternately, we could add a new format for focus reporting, but this nicely futureproofs us against any future DECSETs.