### PR TITLE
Set exit status on server socket failure

### DIFF
--- a/regress/server-socket-error.sh
+++ b/regress/server-socket-error.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Server socket creation failures must produce a nonzero client exit status.
+
+PATH=/bin:/usr/bin
+TERM=screen
+export TERM
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+# Root bypasses directory mode bits, so it cannot trigger this failure.
+[ "$(id -u)" -eq 0 ] && exit 0
+
+TMP=$(mktemp -d) || exit 1
+SOCKET="$TMP/ro/socket"
+
+cleanup()
+{
+	chmod 700 "$TMP/ro" 2>/dev/null
+	rm -rf "$TMP"
+}
+
+fail()
+{
+	echo "$1" >&2
+	cleanup
+	exit 1
+}
+
+mkdir "$TMP/ro" || exit 1
+chmod 500 "$TMP/ro" || exit 1
+trap cleanup 0 1 15
+
+check_failure()
+{
+	output=$($TEST_TMUX -S "$SOCKET" -f/dev/null "$@" 2>&1)
+	retval=$?
+
+	[ "$retval" -ne 0 ] || fail "tmux $* exited zero: $output"
+	case "$output" in
+	"error creating $SOCKET ("*) ;;
+	*) fail "tmux $* produced unexpected error: $output" ;;
+	esac
+}
+
+check_failure start-server
+check_failure new-session -d
+
+exit 0

--- a/server.c
+++ b/server.c
@@ -240,6 +240,7 @@ server_start(struct tmuxproc *client, uint64_t flags, struct event_base *base,
 	if (cause != NULL) {
 		if (c != NULL) {
 			c->exit_message = cause;
+			c->retval = 1;
 			c->flags |= CLIENT_EXIT;
 		} else {
 			fprintf(stderr, "%s\n", cause);


### PR DESCRIPTION
## Summary

When the server could not create its listening socket, it sent the error message to the client with the default zero return value. Set the client return value to 1 before exiting and add regression coverage for both `start-server` and detached `new-session`.

## Testing

- `make clean && make -j$(nproc)`
- `regress/server-socket-error.sh` as an unprivileged user
- `regress/control-client-exit.sh`
- `regress/control-client-wait-exit.sh`
- `regress/new-session-no-client.sh`
- `sh -n regress/server-socket-error.sh`
- `git diff HEAD^ HEAD --check`

Fixes #5452
