### PR TITLE
Add a key binding to change the pane title

### DIFF
--- a/key-bindings.c
+++ b/key-bindings.c
@@ -421,6 +421,7 @@ key_bindings_init(void)
 		"bind -N 'Spread panes out evenly' E { select-layout -E }",
 		"bind -N 'Switch to the last client' L { switch-client -l }",
 		"bind -N 'Clear the marked pane' M { select-pane -M }",
+		"bind -N 'Change the current pane title' T { command-prompt -I'#T' { select-pane -T '%%' } }",
 		"bind -N 'Enter copy mode' [ { copy-mode }",
 		"bind -N 'Paste the most recent paste buffer' ] { paste-buffer -p }",
 		"bind -N 'Create a new window' c { new-window }",

--- a/tmux.1
+++ b/tmux.1
@@ -356,6 +356,8 @@ Force redraw of the attached client.
 Select a new session for the attached client interactively.
 .It t
 Show the time.
+.It T
+Change the current pane title.
 .It w
 Choose the current window interactively.
 .It x


### PR DESCRIPTION
`select-pane -T` can already set a pane's title, but unlike sessions and windows there is no default key binding for it, so it is only reachable by typing the command out at the command prompt.

This adds `C-b T`, giving panes the key binding sessions and windows already have:

|         | key |
| ------- | --- |
| session | `$` |
| window  | `,` |
| pane    | `T` |

The prompt is pre-filled with the current title via `#T`, the same way `$` uses `#S` and `,` uses `#W`. `T` was previously unbound in the prefix table.

There is no new command and no new concept here — this only makes the existing `select-pane -T` reachable by a key, which is what the requests in #618, #807, #1227 and #3693 were each reaching for.

### What it looks like

`C-b T`, with the prompt pre-filled from the current title:

```
──0 "build"────────────────────────────────────────────────────[f][z][x]

──1 "logs"─────────────────────────────────────────────────────[f][z][x]

(select-pane) build
```

### Testing

Built with `--enable-utf8proc` on macOS; no new compiler warnings, and `mandoc -Tlint tmux.1` is clean.

Checked end to end by driving a real attached client from an outer server, the same way `regress/menu-mouse.sh` does:

- `C-b T` changes the pane title
- the prompt is pre-filled, so pressing Enter straight away leaves the title unchanged
- Escape cancels without changing the title
- with a split, only the active pane is affected
- clearing the prompt and accepting it clears the title

The `regress` suite shows no change: four tests fail here, and all four fail identically on unmodified master on this platform (`check-names`, `screen-redraw-fill-character`, `screen-redraw-menus` consistently; `prompt-mechanics` and `tty-draw-line` are timing-flaky on both).

### Changes since first version

- dropped the pane menu item, per review
- the binding note and man page entry now say "change the current pane title" rather than "rename", since panes have titles and not names

### One note

The prompt reads `(select-pane)`, since `command-prompt` falls back to the command name — the same mechanism that makes `,` read `(rename-window)`. It is consistent, but less self-explanatory. Happy to add an explicit `-p` if you would prefer something clearer.

I left `CHANGES` alone, assuming you would rather fold this in at release time.
