### PR TITLE
Prevent crashing when splitting a zoomed-in floating pane

### DIFF
--- a/cmd-split-window.c
+++ b/cmd-split-window.c
@@ -96,6 +96,8 @@ cmd_split_window_exec(struct cmd *self, struct cmdq_item *item)
 	enum pane_lines		 lines;
 	u_int			 count = args_count(args);
 
+	window_unzoom(w, 1);
+
 	if (cmd_get_entry(self) == &cmd_new_pane_entry)
 		is_floating = !args_has(args, 'L');
 	else {


### PR DESCRIPTION
Currently, trying to `splitw` from a zoomed floating window causes tmux to crash.

Reproduction:

```tmux
newp -O
resizep -Z
splitw
```

Here I propose to save its layout cell `saved_lc` and ensure both `SPAWN_FLOATING` and `SPAWN_SPLIT` are used, so that we get the same split as we would otherwise, had the floating pane not be zoomed in.