### PR TITLE
ci: only run `lock` and `regress` workflows on the main repo

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   action:
     runs-on: ubuntu-latest
+    if: github.repository == 'tmux/tmux'
     steps:
       - uses: dessant/lock-threads@v6
         with:

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -16,6 +16,7 @@ jobs:
   regress:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    if: github.repository == 'tmux/tmux'
     timeout-minutes: 45
 
     strategy:


### PR DESCRIPTION
Forks are just wasting CI cycles spinning actions which are probably not looked at. Also avoid locking issues and PRs on any forks with upstream's policies.