### PR TITLE
Fix source-file nesting depth leak when sourcing from a hook

### DIFF
--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -50,6 +50,7 @@ const struct cmd_entry cmd_source_file_entry = {
 
 struct cmd_source_file_data {
 	struct cmdq_item	 *item;
+	struct client		 *c;
 	int			  flags;
 
 	struct cmdq_item	 *after;
@@ -61,9 +62,9 @@ struct cmd_source_file_data {
 };
 
 static enum cmd_retval
-cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
+cmd_source_file_complete_cb(struct cmdq_item *item, void *data)
 {
-	struct client	*c = cmdq_get_client(item);
+	struct client	*c = data;
 
 	if (c == NULL) {
 		cmd_source_file_depth--;
@@ -71,6 +72,7 @@ cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
 	} else {
 		c->source_file_depth--;
 		log_debug("%s: depth now %u", __func__, c->source_file_depth);
+		server_client_unref(c);
 	}
 
 	cfg_print_causes(item);
@@ -78,8 +80,9 @@ cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
 }
 
 static void
-cmd_source_file_complete(struct client *c, struct cmd_source_file_data *cdata)
+cmd_source_file_complete(struct cmd_source_file_data *cdata)
 {
+	struct client		*c = cdata->c;
 	struct cmdq_item	*new_item;
 	u_int			 i;
 
@@ -88,7 +91,9 @@ cmd_source_file_complete(struct client *c, struct cmd_source_file_data *cdata)
 		    c != NULL &&
 		    c->session == NULL)
 			c->retval = 1;
-		new_item = cmdq_get_callback(cmd_source_file_complete_cb, NULL);
+		if (c != NULL)
+			c->references++;
+		new_item = cmdq_get_callback(cmd_source_file_complete_cb, c);
 		cmdq_insert_after(cdata->after, new_item);
 	}
 
@@ -127,7 +132,7 @@ cmd_source_file_done(struct client *c, const char *path, int error,
 	if (n < cdata->nfiles)
 		file_read(c, cdata->files[n], cmd_source_file_done, cdata);
 	else {
-		cmd_source_file_complete(c, cdata);
+		cmd_source_file_complete(cdata);
 		cmdq_continue(item);
 	}
 }
@@ -187,6 +192,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 
 	cdata = xcalloc(1, sizeof *cdata);
 	cdata->item = item;
+	cdata->c = c;
 
 	if (args_has(args, 'q'))
 		cdata->flags |= CMD_PARSE_QUIET;
@@ -249,7 +255,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 		file_read(c, cdata->files[0], cmd_source_file_done, cdata);
 		retval = CMD_RETURN_WAIT;
 	} else
-		cmd_source_file_complete(c, cdata);
+		cmd_source_file_complete(cdata);
 
 	free(cwd);
 	return (retval);


### PR DESCRIPTION
Fixes #5437.

`cmd_source_file_exec()` increments either the file-static `cmd_source_file_depth` (when there is no client) or `c->source_file_depth`. The completion callback re-derived its client from `cmdq_get_client()` on a *different* queue item — the callback item created by `cmdq_get_callback()` and inserted after the last item produced while loading the file — so it could decrement the other counter.

The mismatch is easy to hit in practice: `file_create_with_client()` clears the client when it is attached, so the client threaded through `file_read()` -> `cmd_source_file_done()` -> `cmd_source_file_complete()` is NULL for an attached client, while `cmd_source_file_exec()` saw the real client. For a hook-driven `source-file` the increment therefore lands on `c->source_file_depth` and the decrement on the static counter.

Consequences, per the issue report:

* `c->source_file_depth` grows by one per hook-driven `source-file` and never comes back down. Once it reaches 50, *every* `source-file` from that client fails with "too many nested files" — including ones from plain key bindings that never leaked anything, which then silently stop working.
* the file-static counter is decremented below zero and, being `u_int`, wraps to `UINT_MAX`.

The fix stores the client in `struct cmd_source_file_data` at exec time and passes it to the callback through the `cmdq_get_callback()` data argument, so the decrement always targets the counter that was incremented. A reference is taken on the client for the lifetime of the callback item.

## Verification

Built on macOS with the reproducer from #5437 (driven through a pty so the client is long-lived), 60 window switches with `set-hook -g session-window-changed "source-file leaf.conf"`:

Before:

```
increments : 50
decrements : 50
  cmd_source_file_exec: depth now 1
  cmd_source_file_complete_cb: depth now 4294967295
  cmd_source_file_exec: depth now 2
  cmd_source_file_complete_cb: depth now 4294967294
  cmd_source_file_exec: depth now 3
  cmd_source_file_complete_cb: depth now 4294967293
errors     : 10
```

After:

```
increments : 60
decrements : 60
  cmd_source_file_exec: depth now 1
  cmd_source_file_complete_cb: depth now 0
  cmd_source_file_exec: depth now 1
  cmd_source_file_complete_cb: depth now 0
  cmd_source_file_exec: depth now 1
  cmd_source_file_complete_cb: depth now 0
errors     : 0
```

Also checked that the unaffected paths still behave: sourcing from the startup config, nested `source-file` from a config file, repeated `tmux source-file` from the command line, and the error message for a missing file.