### PR TITLE
file: report the real error from a failed async file write

### DIFF
--- a/file.c
+++ b/file.c
@@ -533,6 +533,7 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
     void *arg)
 {
 	struct client_file	*cf = arg;
+	int			 error = errno;
 
 	log_debug("write error file %d", cf->stream);
 
@@ -542,8 +543,10 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
 	close(cf->fd);
 	cf->fd = -1;
 
+	if (error == 0)
+		error = EIO;
 	if (cf->cb != NULL)
-		cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
+		cf->cb(NULL, NULL, error, -1, NULL, cf->data);
 }
 
 /* Client file write callback. */


### PR DESCRIPTION
Fixes #5451.

### Root cause

`file_write_error_callback()` is the bufferevent error callback invoked when a file write fails partway through (`ENOSPC`, `EDQUOT`, `EIO`, `EFBIG`, `EPIPE`, ...). It unconditionally called the completion callback with `error=0`:

```c
if (cf->cb != NULL)
    cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
```

`cmd_save_buffer_done()` only reports an error when `error != 0`, so it silently reported success even though the destination had already been truncated (`O_TRUNC`) and only partially written — data lost in both directions with no indication anything went wrong, as described in #5451.

### Fix

Capture `errno` at the point the write failed (the callback runs synchronously off the failing write, so `errno` is still valid) and pass it through instead of a hardcoded 0, falling back to `EIO` if it's somehow unset.

### Verification

I confirmed the bug by code inspection — this is the only caller of the completion callback on the error path, and it's the only one that hardcodes 0. I was not able to reproduce the exact repro from #5451 locally: it uses `ulimit -f` to force a write failure, but on macOS this delivers `SIGXFSZ` and kills the writing process outright rather than returning `EFBIG` from `write()`, so it doesn't exercise this exact code path the same way it does on Linux (where the issue was filed). The fix itself is a straightforward propagation of an already-available `errno` value at the one place it was being dropped.