### PR TITLE
compat: use socklen_t for getsockopt length

### DIFF
--- a/compat/getpeereid.c
+++ b/compat/getpeereid.c
@@ -31,7 +31,7 @@ getpeereid(int s, uid_t *uid, gid_t *gid)
 {
 #ifdef HAVE_SO_PEERCRED
 	struct ucred	uc;
-	int		len = sizeof uc;
+	socklen_t	len = sizeof uc;
 
 	if (getsockopt(s, SOL_SOCKET, SO_PEERCRED, &uc, &len) == -1)
 		return (-1);


### PR DESCRIPTION
 Use `socklen_t` for the `getsockopt()` length argument in `getpeereid()`.                                                                                          
                                                                                                                                                                        
 This fixes an incompatible pointer type warning when compiling with Clang.        