### PR TITLE
WIP: Select the buffer affected by set-clipboard/OSC 52

### DIFF
--- a/cmd-load-buffer.c
+++ b/cmd-load-buffer.c
@@ -61,6 +61,7 @@ cmd_load_buffer_done(__unused struct client *c, const char *path, int error,
 	size_t				 bsize = EVBUFFER_LENGTH(buffer);
 	void				*copy;
 	char				*cause;
+	const char			*clip;
 
 	if (!closed)
 		return;
@@ -76,8 +77,10 @@ cmd_load_buffer_done(__unused struct client *c, const char *path, int error,
 			free(copy);
 		} else if (tc != NULL &&
 		    tc->session != NULL &&
-		    (~tc->flags & CLIENT_DEAD))
-			tty_set_selection(&tc->tty, "", copy, bsize);
+		    (~tc->flags & CLIENT_DEAD)) {
+			clip = window_copy_clipboard_target();
+			tty_set_selection(&tc->tty, clip, copy, bsize);
+		}
 		if (tc != NULL)
 			server_client_unref(tc);
 	}

--- a/cmd-refresh-client.c
+++ b/cmd-refresh-client.c
@@ -182,6 +182,7 @@ cmd_refresh_client_exec(struct cmd *self, struct cmdq_item *item)
 	const char		*errstr;
 	u_int			 adjust;
 	struct args_value	*av;
+	const char			*clip;
 
 	if (args_has(args, 'c') ||
 	    args_has(args, 'L') ||
@@ -235,7 +236,8 @@ cmd_refresh_client_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	if (args_has(args, 'l')) {
-		tty_clipboard_query(&tc->tty);
+		clip = window_copy_clipboard_target();
+		tty_clipboard_query(&tc->tty, clip);
 		return (CMD_RETURN_NORMAL);
 	}
 

--- a/cmd-set-buffer.c
+++ b/cmd-set-buffer.c
@@ -61,6 +61,7 @@ cmd_set_buffer_exec(struct cmd *self, struct cmdq_item *item)
 	char			*bufname = NULL, *bufdata = NULL, *cause = NULL;
 	const char		*olddata;
 	size_t			 bufsize = 0, newsize;
+	const char		*clip;
 
 	if (args_get(args, 'b') != NULL) {
 		bufname = xstrdup(args_get(args, 'b'));
@@ -124,8 +125,10 @@ cmd_set_buffer_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "%s", cause);
 		goto fail;
 	}
-	if (args_has(args, 'w') && tc != NULL)
- 		tty_set_selection(&tc->tty, "", bufdata, bufsize);
+	if (args_has(args, 'w') && tc != NULL) {
+		clip = window_copy_clipboard_target();
+		tty_set_selection(&tc->tty, clip, bufdata, bufsize);
+	}
 
 	return (CMD_RETURN_NORMAL);
 

--- a/input.c
+++ b/input.c
@@ -3587,6 +3587,7 @@ input_add_request(struct input_ctx *ictx, enum input_request_type type, int idx)
 	struct client		*c = NULL, *loop;
 	struct input_request	*ir;
 	char			 s[64];
+	const char		*clip;
 
 	if (wp == NULL)
 		return (-1);
@@ -3619,7 +3620,8 @@ input_add_request(struct input_ctx *ictx, enum input_request_type type, int idx)
 		tty_puts(&c->tty, s);
 		break;
 	case INPUT_REQUEST_CLIPBOARD:
-		tty_putcode_ss(&c->tty, TTYC_MS, "", "?");
+		clip = window_copy_clipboard_target();
+		tty_putcode_ss(&c->tty, TTYC_MS, clip, "?");
 		break;
 	case INPUT_REQUEST_QUEUE:
 		break;

--- a/options-table.c
+++ b/options-table.c
@@ -114,6 +114,9 @@ static const char *options_table_theme_list[] = {
 static const char *options_table_copy_mode_line_numbers_list[] = {
 	"off", "default", "absolute", "relative", "hybrid", NULL
 };
+static const char *options_table_clipboard_target_list[] = {
+	"default", "clipboard", "primary", "selection", NULL,
+};
 
 /* Status line format. */
 #define OPTIONS_TABLE_STATUS_FORMAT1 \
@@ -303,6 +306,16 @@ const struct options_table_entry options_table[] = {
 	  .default_num = 50,
 	  .text = "The maximum number of automatic buffers. "
 		  "When this is reached, the oldest buffer is deleted."
+	},
+
+	{ .name = "clipboard-target",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_SERVER,
+	  .choices = options_table_clipboard_target_list,
+	  .default_num = 0,
+	  .text = "Choose which buffer to read selection from/write "
+	          "selection to. default delegates the decision to the "
+	          "terminal."
 	},
 
 	{ .name = "command-alias",

--- a/tmux.h
+++ b/tmux.h
@@ -2926,7 +2926,7 @@ void	tty_margin_off(struct tty *);
 void	tty_cursor(struct tty *, u_int, u_int);
 int	tty_fake_bce(const struct tty *, const struct grid_cell *, u_int);
 void	tty_repeat_space(struct tty *, u_int);
-void	tty_clipboard_query(struct tty *);
+void	tty_clipboard_query(struct tty *, const char*);
 void	tty_putcode(struct tty *, enum tty_code_code);
 void	tty_putcode_i(struct tty *, enum tty_code_code, int);
 void	tty_putcode_ii(struct tty *, enum tty_code_code, int, int);
@@ -4000,6 +4000,7 @@ int		 window_copy_get_current_offset(struct window_pane *, u_int *,
 		     u_int *);
 char		*window_copy_get_hyperlink(struct window_pane *, u_int, u_int);
 void		 window_copy_set_line_numbers(struct window_pane *, int);
+const char	*window_copy_clipboard_target(void);
 
 /* window-customize.c */
 extern const struct window_mode window_customize_mode;

--- a/tty.c
+++ b/tty.c
@@ -3184,12 +3184,12 @@ tty_clipboard_query_callback(__unused int fd, __unused short events, void *data)
 }
 
 void
-tty_clipboard_query(struct tty *tty)
+tty_clipboard_query(struct tty *tty, const char* clip)
 {
 	struct timeval	 tv = { .tv_sec = TTY_QUERY_TIMEOUT };
 
 	if ((tty->flags & TTY_STARTED) && (~tty->flags & TTY_OSC52QUERY)) {
-		tty_putcode_ss(tty, TTYC_MS, "", "?");
+		tty_putcode_ss(tty, TTYC_MS, clip, "?");
 		tty->flags |= TTY_OSC52QUERY;
 		evtimer_add(&tty->clipboard_timer, &tv);
 	}

--- a/window-copy.c
+++ b/window-copy.c
@@ -6035,6 +6035,7 @@ window_copy_copy_buffer(struct window_mode_entry *wme, const char *prefix,
 	struct window_pane	*wp = wme->wp;
 	struct screen_write_ctx	 ctx;
 	int			 redraw = 0;
+	const char *clip;
 
 	if (set_clip &&
 	    options_get_number(global_options, "set-clipboard") != 0) {
@@ -6045,7 +6046,8 @@ window_copy_copy_buffer(struct window_mode_entry *wme, const char *prefix,
 			wp->flags &= ~PANE_REDRAW;
 		}
 		screen_write_start_pane(&ctx, wp, NULL);
-		screen_write_setselection(&ctx, "", buf, len);
+		clip = window_copy_clipboard_target();
+		screen_write_setselection(&ctx, clip, buf, len);
 		screen_write_stop(&ctx);
 		wp->flags |= redraw;
 		events_fire_pane("pane-set-clipboard", wp);
@@ -6124,6 +6126,7 @@ window_copy_append_selection(struct window_mode_entry *wme)
 	const char			*bufdata;
 	size_t				 len, bufsize;
 	struct screen_write_ctx		 ctx;
+	const char			*clip;
 
 	buf = window_copy_get_selection(wme, &len);
 	if (buf == NULL)
@@ -6131,7 +6134,8 @@ window_copy_append_selection(struct window_mode_entry *wme)
 
 	if (options_get_number(global_options, "set-clipboard") != 0) {
 		screen_write_start_pane(&ctx, wp, NULL);
-		screen_write_setselection(&ctx, "", buf, len);
+		clip = window_copy_clipboard_target();
+		screen_write_setselection(&ctx, clip, buf, len);
 		screen_write_stop(&ctx);
 		events_fire_pane("pane-set-clipboard", wp);
 	}
@@ -7233,4 +7237,17 @@ window_copy_acquire_cursor_down(struct window_mode_entry *wme, u_int hsize,
 		window_copy_update_cursor(wme, px, cy);
 	if (window_copy_update_selection(wme, 1, no_reset))
 		window_copy_redraw_lines(wme, oldy, nd);
+}
+
+const char *
+window_copy_clipboard_target(void)
+{
+	int target = options_get_number(global_options, "clipboard-target");
+	switch (target) {
+		case 0: return "";   /* let the terminal choose */
+		case 1: return "c";  /* clipboard */
+		case 2: return "p";  /* primary */
+		case 3: return "s";  /* selection */
+		default: return "";
+	}
 }


### PR DESCRIPTION
Hello,

I would like tmux to use the primary selection instead of the clipboard because it matches the behavior of other software on linux: select with a mouse drag, paste with middle-click.

To make this possible in a compatible manner, I propose to introduce a new global option `clipboard-target` that could have the values `"clipboard", "primary", "selection"`. This maps easily to how OSC 52 works. Since the functions leading to the OSC 52 escape sequence already took a clip parameter, it was straightforward to make this option work.
This has been successfully tested in the foot terminal.

No AI code btw.

Now, this PR is a working proof of concept of what I am trying to achieve when it comes to tmux->primary (set-clipboard), unfortunately I am still figuring how the primary->tmux direction (get-clipboard).

Feedback welcome! (also if anything in here is wrong for the project please tell me, I am happy to rework).