### PR TITLE
Add default terminal features for Rio

### DIFF
--- a/tty-features.c
+++ b/tty-features.c
@@ -596,6 +596,18 @@ tty_default_features(int *feat, const char *name, u_int version)
 			      "usstyle,"
 			      "progressbar"
 		},
+		{ .name = "Rio",
+		  .features = TTY_FEATURES_BASE_MODERN_XTERM ","
+			      "ccolour,"
+			      "cstyle,"
+			      "focus,"
+			      "overline,"
+			      "hyperlinks,"
+			      "osc7,"
+			      "sync,"
+			      "usstyle,"
+			      "progressbar"
+		},
 		{ .name = "XTerm",
 		  /*
 		   * xterm also supports DECSLRM and DECFRA, but they can be

--- a/tty-keys.c
+++ b/tty-keys.c
@@ -1667,6 +1667,8 @@ tty_keys_extended_device_attributes(struct tty *tty, const char *buf,
 		tty_default_features(features, "WezTerm", 0);
 	else if (strncmp(tmp, "ghostty ", 8) == 0)
 		tty_default_features(features, "ghostty", 0);
+	else if (strncmp(tmp, "Rio ", 4) == 0)
+		tty_default_features(features, "Rio", 0);
 	log_debug("%s: received extended DA %.*s", c->name, (int)*size, buf);
 
 	free(c->term_type);


### PR DESCRIPTION
Rio replies to XTVERSION with `Rio x.y.z`. This adds it to the detected terminals with the features it implements, the same set as ghostty minus extkeys and margins.