### PR TITLE
Explicitly zero linedata after calloc in grid_create

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -382,8 +382,10 @@ grid_create(u_int sx, u_int sy, u_int hlimit)
 		gd->flags = GRID_HISTORY;
 	gd->hlimit = hlimit;
 
-	if (gd->sy != 0)
+	if (gd->sy != 0) {
 		gd->linedata = xcalloc(gd->sy, sizeof *gd->linedata);
+		memset(gd->linedata, 0, gd->sy * sizeof *gd->linedata);
+	}
 
 #ifdef __APPLE__
 	assert(gd->hsize == 0);


### PR DESCRIPTION
## Problem

tmux crashes with `SIGABRT` when entering copy-mode on macOS Tahoe (26.x), particularly after the server has been running for several hours with large scrollback history:

```
BUG IN CLIENT OF LIBMALLOC: pointer being freed was not allocated
grid_free_line
grid_clear_lines
screen_reinit
window_copy_clone_screen
window_copy_init
window_pane_set_mode
cmd_copy_mode_exec
```

## Root Cause

macOS Tahoe has a kernel bug where `calloc` can return non-zeroed memory for large allocations that go through `mmap`. This is the same class of bug reported by Firefox (Mozilla bug 2015359), where pages reused via `MADV_FREE_REUSABLE` and `MADV_FREE_REUSE` are not properly zeroed.

In `grid_create`, `linedata` is allocated with `xcalloc(gd->sy, sizeof *gd->linedata)`. For a pane with large scrollback (e.g. `sy=9566`, `sizeof(grid_line)=40`), this is ~382 KB, which exceeds macOS mmap threshold (~32 KB).

When `calloc` returns dirty memory, the `grid_line` fields `celldata` and `extddata` contain arbitrary values (in the captured case, environment variable string addresses such as `TERM_PROGRAM=tmux`, `GHOSTTY_RESOURCES_DIR`, etc.). When `screen_reinit` subsequently calls `grid_clear_lines` -> `grid_free_line`, it attempts to `free()` these invalid pointers, triggering the abort.

## Evidence

Instrumented `grid_check_is_clear` to dump the dirty memory before aborting. The captured log shows:

- `linedata` address `0x7f2f00000` -- mmap region (1 MB aligned)
- `linedata` contents are environment variable strings (`GREP_COLOR=37;45`, `MANPATH=...`, `STARSHIP_SHELL=zsh`, `TERM_PROGRAM=tmux`, `GHOSTTY_RESOURCES_DIR=...`)
- 1230 of 9566 `grid_line` entries are non-zero (48 KB dirty, 333 KB zero)
- macOS version: 26.6.1 (25G76)

The crash path is:

```
grid_create
  -> xcalloc(sy, sizeof(grid_line))     // calloc returns dirty mmap memory
  -> grid_check_is_clear                // assertion fires (debug build)
                                         // (release build continues...)
screen_reinit
  -> grid_clear_lines
    -> grid_free_line                   // free() on invalid pointers -> abort
```

## Fix

Add an explicit `memset` after `xcalloc` to guarantee zeroed memory regardless of allocator behaviour:

```c
if (gd->sy != 0) {
    gd->linedata = xcalloc(gd->sy, sizeof *gd->linedata);
    memset(gd->linedata, 0, gd->sy * sizeof *gd->linedata);
}
```

This mirrors the existing pattern in `grid_free_line`, which already does `memset(gl, 0, sizeof *gl)` rather than relying on the allocator.

## References

- Mozilla bug 2015359: macOS Tahoe `MADV_FREE_REUSABLE`/`MADV_FREE_REUSE` kernel bug
  https://github.com/mozilla-firefox/firefox/commit/4b8faa68bcc3bfe2d3103f2adc0f0c9500947bfb

#### Test plan

- [x] Compiles cleanly with no warnings
- [ ] Long-running server with large scrollback + repeated copy-mode entry no longer crashes
- [ ] `grid_check_is_clear` assertions no longer fire
