### PR TITLE
Keep ESU collection inside synchronized output

### DIFF
--- a/input.c
+++ b/input.c
@@ -1978,7 +1978,7 @@ input_csi_dispatch_rm_private(struct input_ctx *ictx)
 			screen_write_mode_clear(sctx, MODE_BRACKETPASTE);
 			break;
 		case 2026:
-			screen_write_stop_sync(ictx->wp);
+			screen_write_end_sync(sctx);
 			break;
 		case 2031:
 			screen_write_mode_clear(sctx, MODE_THEME_UPDATES);

--- a/screen-write.c
+++ b/screen-write.c
@@ -1059,6 +1059,19 @@ screen_write_stop_sync(struct window_pane *wp)
 	log_debug("%s: %%%u stopped sync mode", __func__, wp->id);
 }
 
+/* Flush pending output before ESU clears sync mode. */
+void
+screen_write_end_sync(struct screen_write_ctx *ctx)
+{
+	struct window_pane	*wp = ctx->wp;
+
+	if (wp == NULL)
+		return;
+	if (wp->base.mode & MODE_SYNC)
+		screen_write_collect_flush(ctx, 0, __func__);
+	screen_write_stop_sync(wp);
+}
+
 /* Cursor up by ny. */
 void
 screen_write_cursorup(struct screen_write_ctx *ctx, u_int ny)

--- a/tmux.h
+++ b/tmux.h
@@ -3597,6 +3597,7 @@ void	 screen_write_mode_set(struct screen_write_ctx *, int);
 void	 screen_write_mode_clear(struct screen_write_ctx *, int);
 void	 screen_write_start_sync(struct window_pane *);
 void	 screen_write_stop_sync(struct window_pane *);
+void	 screen_write_end_sync(struct screen_write_ctx *);
 void	 screen_write_clear_dirty(struct window_pane *);
 void	 screen_write_cursorup(struct screen_write_ctx *, u_int);
 void	 screen_write_cursordown(struct screen_write_ctx *, u_int);


### PR DESCRIPTION
## Problem

When an application sends BSU, printable cells and ESU in one pane input batch, the printable cells may still be pending in the active `screen_write_ctx` collection when ESU is handled.

`screen_write_stop_sync()` clears `MODE_SYNC` and redraws lines already recorded in `sync_dirty`. The still-pending collection is only flushed later by `screen_write_stop()`, after synchronized mode has ended, so those cells can be written to the physical client outside the outgoing `CSI ?2026h` / `CSI ?2026l` transaction. The final pane grid is correct, but a capable terminal may display the frame progressively instead of atomically.

This is distinct from #4983, which covered structural TTY writes while BSU and ESU span multiple pane reads, and from #5419/#5420, which concerned cursor visibility during client redraw.

## Fix

Handle application ESU with a `screen_write_ctx`-aware helper:

1. While `MODE_SYNC` is still set, flush the active collection. In synchronized mode this records the affected lines in `sync_dirty` instead of writing them to the client.
2. Then call the existing `screen_write_stop_sync()` to clear the mode and redraw the complete dirty set inside physical synchronized output.

The existing pane-only stop helper remains unchanged for resize, teardown and redraw callers that do not have an active parser collection.

## Test evidence

The regression script is intentionally provided as a PR attachment rather than committed:

- [sync-output-atomic.sh](https://github.com/xz-dev/tmux/releases/download/synchronized-esu-collection-evidence/sync-output-atomic.sh)
- SHA-256: `53adcc9f8024bfde719724557242d2ebda7109d91d28e4fac15af12c33316da9`

It starts an attached sync-capable nested tmux client, sends two complete 80x24 application synchronized-output frames, captures the physical client byte stream, and requires every frame-row marker to occur inside balanced outgoing DEC 2026 transactions.

Results against the same workload:

- `master` (`851c5a933d4838c32ad06c248b2ba975d106149c`): fails with `marker 000000:00 outside synchronized output`.
- This branch: passes repeatedly (5/5).

Additional validation:

- clean `./configure --enable-utf8proc --enable-asan` and build
- `decrqm-sync.sh`
- `input-requests.sh`
- `screen-redraw-cache.sh`
- `screen-redraw-outside.sh`
- `tty-draw-line.sh`
