### PR TITLE
vi: skip trailing whitespace after e/E word-end motion

### DIFF
--- a/grid-reader.c
+++ b/grid-reader.c
@@ -234,7 +234,7 @@ grid_reader_cursor_next_word(struct grid_reader *gr, const char *separators)
 void
 grid_reader_cursor_next_word_end(struct grid_reader *gr, const char *separators)
 {
-	u_int	xx, yy;
+	u_int	xx, yy, width;
 
 	/* Do not break up wrapped words. */
 	if (grid_get_line(gr->gd, gr->cy)->flags & GRID_LINE_WRAPPED)
@@ -263,16 +263,19 @@ grid_reader_cursor_next_word_end(struct grid_reader *gr, const char *separators)
 			while (grid_reader_handle_wrap(gr, &xx, &yy) &&
 			    grid_reader_in_set(gr, separators) &&
 			    !grid_reader_in_set(gr, WHITESPACE));
-			return;
+			break;
 		} else {
 			do
 				gr->cx++;
 			while (grid_reader_handle_wrap(gr, &xx, &yy) &&
 			    !(grid_reader_in_set(gr, WHITESPACE) ||
 			    grid_reader_in_set(gr, separators)));
-			return;
+			break;
 		}
 	}
+	while (grid_reader_handle_wrap(gr, &xx, &yy) &&
+	    (width = grid_reader_in_set(gr, WHITESPACE)))
+		gr->cx += width;
 }
 
 /* Move to the previous place where a word begins. */


### PR DESCRIPTION
Fixes #5491.

grid_reader_cursor_next_word_end 'return's from the inner
do/while loops without continuing the outer wrap loop. Its sibling
grid_reader_cursor_next_word breaks out of the inner loops and then
runs a trailing WHITESPACE-skip loop; this function should match that
pattern. Without the trailing skip, e/E in vi copy-mode land on the
first character of the next word rather than on the last character of
the current one whenever the next word is on a fresh, wrapping line.

Fall through from the inner branches with 'break' instead of 'return',
preserve the outer wrap guard, and add the trailing WHITESPACE-skip
loop. Declare 'width' locally for the skip loop.

AI-assisted: implementation, commit message, and PR text prepared with AI assistance.