### PR TITLE
Detach clients when processing `destroy-unattached`

### DIFF
--- a/server-fn.c
+++ b/server-fn.c
@@ -551,6 +551,7 @@ server_check_unattached(void)
 				continue;
 			break;
 		}
+		server_destroy_session(s);
 		session_destroy(s, 1, __func__);
 	}
 }


### PR DESCRIPTION
There can be an exiting client that is not counted as attached but still has c->session set. `session_destroy` can leave that clients with a dangling reference.

Fix: call `server_destroy_session` to clear c->session of those clients.

---

# Longer description

tmux server can occasionally SIGSEGV in a following scenario:

1. Two clients attached to a separate session. client C1 attached to S1, C2
   attached to S2. Also, there are C2I, C2O piped to C2's stdio.
2. C2 set `destroy-unattached on`, which applied to S2.
3. Need to have following to happen simultaneously:
  - Another client C3 tries `tmux list-sessions`
  - kill -9 C2 C2I C2O (SIGTERM may work as well, but SIGKILL is easier)

There will be three events fired at arbitrary order, and this specific order can
trigger SEGFAULT:

- E0: C2I or C2O kill event -> server flag C2 as CLIENT_EXIT
- E1: C3 disconnects -> server_client_lost(C3):
  - recalculate_sizes() -> update S2->attached = 0 because C2->flags has
    CLIENT_EXIT bit
  - server_check_unattached() -> session_destroy(S2, ...). S2 is now destroyed.
- E2: C2 kill event -> server_client_lost(C2):
  - it tries to fire "client-detached" event, try to resolve destroyed S2,
    causing SIGSEGV

Fix: call `server_destroy_session` which set C2->session = NULL

## Reproduction script

Here is reproduction script (generated by LLM). The issue was reproducible at latest master.

```
#!/usr/bin/env bash
# Demo: a tmux 3.7b server crash. `destroy-unattached` frees a session that a
# departing client is still registered on, and the server dereferences it.
#
# tmux re-evaluates `destroy-unattached` on *every* client loss, one-shot
# command clients included (server-client.c: `server_client_lost` ->
# `server_check_unattached`). A client on its way out stops counting towards its
# session's attached count before the server has finished losing it, so a sweep
# that some *other* client's disconnect triggers inside that gap destroys the
# session the departing client is still registered on. `session_destroy` leaves
# `s->curw` NULL, and finishing that client's teardown walks straight into it:
#
#   #0  server_client_get_pane      <- s->curw is NULL
#   #1  cmd_find_from_client
#   #2  notify_client               <- "client-detached"
#   #3  server_client_lost
#
# The server dies with SIGSEGV; every client on it reports "server exited
# unexpectedly", including the session that was never eligible for the sweep.
#
# The two clients here are control-mode clients because they need no pty, but
# nothing about the crash is control-specific --- a session losing an attached
# client while another client disconnects is the whole recipe.
#
# hmux is unaffected: it sweeps the same sessions and stays up. See the
# "Known differences from tmux 3.7b" section of README.md.
#
# So: two attached sessions, the policy turned on while both still are, one
# client dropped, and `tmux list-sessions` running throughout to supply the
# disconnect that lands in the gap. A handful of trials in a run of 40 take the
# server down here, but the rate swings widely with the host --- raise the trial
# count if a run comes back clean. Exits 0 if any trial crashed the server.
#
#   ./demo-segfault.sh                     run 40 trials, report the crash rate
#   ./demo-segfault.sh 200                 run 200 trials
#   LOAD=0 PARALLEL=1 ./demo-segfault.sh   one trial at a time, no spinners
#   TMUX_SERVER=./tmux ./demo-segfault.sh  run one build's server against the
#                                          clients of whatever is on $PATH
#   TMUX_CLIENT=./tmux ./demo-segfault.sh  the reverse: stock server, this
#                                          build's clients
set -eu

SELF="$(readlink -f "$0")"
TRIALS="${1:-40}"
PARALLEL="${PARALLEL:-8}"
LOAD="${LOAD:-$(nproc 2> /dev/null || echo 8)}"

# The binary that starts the server and the one that runs the clients are
# chosen separately, so a build can be tested on one side of the wire at a
# time; pointing both at the same path (the default) is the ordinary case. Only
# `start-server` uses $TMUX_SERVER --- the server process is a fork of whichever
# binary started it, and every later command is just a client talking to it.
# The two must still agree on the tmux protocol version or nothing connects.
TMUX_SERVER="${TMUX_SERVER:-tmux}"
TMUX_CLIENT="${TMUX_CLIENT:-tmux}"
# Resolve now so the banner is unambiguous and every trial agrees on a path.
server_path="$(command -v "$TMUX_SERVER" || true)"
client_path="$(command -v "$TMUX_CLIENT" || true)"
[ -n "$server_path" ] || { echo "TMUX_SERVER: $TMUX_SERVER not found" >&2; exit 1; }
[ -n "$client_path" ] || { echo "TMUX_CLIENT: $TMUX_CLIENT not found" >&2; exit 1; }
TMUX_SERVER=$server_path
TMUX_CLIENT=$client_path
export TMUX_SERVER TMUX_CLIENT

SERVER_VERSION="$("$TMUX_SERVER" -V)"
CLIENT_VERSION="$("$TMUX_CLIENT" -V)"
if [ "$TMUX_SERVER" = "$TMUX_CLIENT" ]; then
    VERSION="$SERVER_VERSION"
else
    VERSION="server $SERVER_VERSION ($TMUX_SERVER), client $CLIENT_VERSION ($TMUX_CLIENT)"
fi

# Unix socket paths are capped at 107 bytes, and a long $TMPDIR eats that on its
# own; a server that cannot bind would look like the crash this is measuring.
BASE="${TRIAL_BASE:-$(mktemp -d "${TMPDIR:-/tmp}/tsegXXXXXX")}"
export TRIAL_BASE="$BASE"
if [ "$(printf %s "$BASE/000/s" | wc -c)" -gt 107 ]; then
    echo "socket path under $BASE is too long; set a shorter TMPDIR" >&2
    exit 1
fi

# One trial: two attached sessions, the policy turned on while both are still
# attached, then one client killed while command clients come and go. Prints
# "crashed" or "survived".
trial() {
    local dir=$1
    local sock=$dir/s
    local anchor victim writer reader hammer i pids verdict
    mkdir -p "$dir"
    mkfifo "$dir/ia" "$dir/iv" "$dir/oa" "$dir/ov"

    "$TMUX_SERVER" -f /dev/null -S "$sock" start-server \; set-option -g exit-empty off
    "$TMUX_CLIENT" -S "$sock" new-session -d -s anchor
    "$TMUX_CLIENT" -S "$sock" new-session -d -s victim

    # Control mode exits on end of input, so a writer has to hold each client's
    # stdin open for it to stay attached. Their output goes to a pipe rather
    # than /dev/null, which is not pollable on Linux (`epoll_ctl` gives EPERM)
    # and would leave the server on a different path than a real client's.
    sleep 60 > "$dir/ia" & pids="$!"
    cat "$dir/oa" > /dev/null & pids="$pids $!"
    sleep 60 > "$dir/iv" & writer=$!
    cat "$dir/ov" > /dev/null & reader=$!
    "$TMUX_CLIENT" -S "$sock" -C attach-session -t anchor < "$dir/ia" > "$dir/oa" 2>&1 &
    anchor=$!
    "$TMUX_CLIENT" -S "$sock" -C attach-session -t victim < "$dir/iv" > "$dir/ov" 2>&1 &
    victim=$!
    for _ in $(seq 200); do
        [ "$("$TMUX_CLIENT" -S "$sock" list-clients -F x 2>/dev/null | grep -c .)" = 2 ] && break
        sleep 0.025
    done

    # Both sessions are attached, so nothing is eligible yet: losing a client is
    # what runs the sweep.
    "$TMUX_CLIENT" -S "$sock" set-option -g destroy-unattached on

    # Command clients arriving and leaving around the departure below. Each one
    # that disconnects runs another sweep, and one of them lands inside the
    # victim client's teardown.
    touch "$dir/go"
    for i in 1 2 3; do
        while [ -e "$dir/go" ]; do
            "$TMUX_CLIENT" -S "$sock" list-sessions > /dev/null 2>&1 || true
        done &
        hammer="${hammer-} $!"
    done
    sleep 0.05

    # Everything on the victim's end of the wire goes at once, the way a real
    # client's process taking its pipes with it does. The end of its input is
    # what the server notices first --- control mode reads commands from there,
    # so EOF means this client is going --- and from that moment the session
    # counts as unattached even though the client is still registered on it and
    # its socket close has not been processed. That gap is the crash window.
    kill -9 "$victim" "$writer" "$reader" 2>/dev/null || true
    sleep 0.3
    rm -f "$dir/go"
    # shellcheck disable=SC2086 # word splitting is how the pid list is passed
    wait $hammer 2>/dev/null || true

    if "$TMUX_CLIENT" -S "$sock" display-message -p '' > /dev/null 2>&1; then
        verdict=survived
        "$TMUX_CLIENT" -S "$sock" kill-server 2>/dev/null || true
    else
        verdict=crashed
    fi
    # shellcheck disable=SC2086 # word splitting is how the pid list is passed
    kill -9 "$anchor" "$writer" "$reader" $pids 2>/dev/null || true
    wait 2>/dev/null || true
    printf %s "$verdict"
}

if [ "${TRIAL_DIR-}" != "" ]; then
    trial "$TRIAL_DIR" > "$TRIAL_DIR.verdict"
    exit 0
fi

echo "$VERSION, $TRIALS trials, $PARALLEL at a time under $LOAD spinners"
echo "(characterized on tmux 3.7b)"

# The gap the crash needs is a couple of milliseconds wide, so the server has to
# be descheduled at the wrong moment to fall into it. A quiet host manages that
# occasionally; spinners and concurrent trials make it common. That is also why
# this reaches the conformance suite as a flaky test rather than a failing one.
SPINNERS=""
spun=0
while [ "$spun" -lt "$LOAD" ]; do
    while :; do :; done &
    SPINNERS="$SPINNERS $!"
    spun=$((spun + 1))
done
# shellcheck disable=SC2064 # $BASE and $SPINNERS are meant to expand now
trap "kill $SPINNERS 2> /dev/null || true; rm -rf '$BASE'" EXIT INT TERM

seq "$TRIALS" |
    xargs -P "$PARALLEL" -I{} env TRIAL_DIR="$BASE/{}" "$SELF" > /dev/null 2>&1

crashed=0
for n in $(seq "$TRIALS"); do
    if [ "$(cat "$BASE/$n.verdict" 2> /dev/null)" = crashed ]; then
        crashed=$((crashed + 1))
        printf X
    else
        printf .
    fi
done
echo
echo "$crashed of $TRIALS trials lost the server"
[ "$crashed" -gt 0 ] || echo "(no crash this run; the window is narrow, try more trials)"

if [ "$crashed" -gt 0 ] && command -v coredumpctl > /dev/null; then
    echo
    echo "most recent tmux core:"
    coredumpctl info --no-pager 2>/dev/null |
        grep -E 'Signal:|^ +#[0-9]' | head -6 || true
fi

[ "$crashed" -gt 0 ]

```