### PR TITLE
Give the source-file nesting depth back to the client it was taken from

### DIFF
--- a/cmd-source-file.c
+++ b/cmd-source-file.c
@@ -50,6 +50,7 @@ const struct cmd_entry cmd_source_file_entry = {
 
 struct cmd_source_file_data {
 	struct cmdq_item	 *item;
+	struct client		 *client;
 	int			  flags;
 
 	struct cmdq_item	 *after;
@@ -61,9 +62,9 @@ struct cmd_source_file_data {
 };
 
 static enum cmd_retval
-cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
+cmd_source_file_complete_cb(struct cmdq_item *item, void *data)
 {
-	struct client	*c = cmdq_get_client(item);
+	struct client	*c = data;
 
 	if (c == NULL) {
 		cmd_source_file_depth--;
@@ -71,6 +72,7 @@ cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
 	} else {
 		c->source_file_depth--;
 		log_debug("%s: depth now %u", __func__, c->source_file_depth);
+		server_client_unref(c);
 	}
 
 	cfg_print_causes(item);
@@ -78,8 +80,9 @@ cmd_source_file_complete_cb(struct cmdq_item *item, __unused void *data)
 }
 
 static void
-cmd_source_file_complete(struct client *c, struct cmd_source_file_data *cdata)
+cmd_source_file_complete(struct cmd_source_file_data *cdata)
 {
+	struct client		*c = cdata->client;
 	struct cmdq_item	*new_item;
 	u_int			 i;
 
@@ -88,9 +91,10 @@ cmd_source_file_complete(struct client *c, struct cmd_source_file_data *cdata)
 		    c != NULL &&
 		    c->session == NULL)
 			c->retval = 1;
-		new_item = cmdq_get_callback(cmd_source_file_complete_cb, NULL);
+		new_item = cmdq_get_callback(cmd_source_file_complete_cb, c);
 		cmdq_insert_after(cdata->after, new_item);
-	}
+	} else if (c != NULL)
+		server_client_unref(c);
 
 	for (i = 0; i < cdata->nfiles; i++)
 		free(cdata->files[i]);
@@ -127,7 +131,7 @@ cmd_source_file_done(struct client *c, const char *path, int error,
 	if (n < cdata->nfiles)
 		file_read(c, cdata->files[n], cmd_source_file_done, cdata);
 	else {
-		cmd_source_file_complete(c, cdata);
+		cmd_source_file_complete(cdata);
 		cmdq_continue(item);
 	}
 }
@@ -185,8 +189,16 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 		log_debug("%s: depth now %u", __func__, c->source_file_depth);
 	}
 
+	/*
+	 * The depth must be given back to the same client it was taken from:
+	 * the item may be given a temporary client while the command runs, so
+	 * it cannot be looked up again later.
+	 */
 	cdata = xcalloc(1, sizeof *cdata);
 	cdata->item = item;
+	cdata->client = c;
+	if (c != NULL)
+		c->references++;
 
 	if (args_has(args, 'q'))
 		cdata->flags |= CMD_PARSE_QUIET;
@@ -249,7 +261,7 @@ cmd_source_file_exec(struct cmd *self, struct cmdq_item *item)
 		file_read(c, cdata->files[0], cmd_source_file_done, cdata);
 		retval = CMD_RETURN_WAIT;
 	} else
-		cmd_source_file_complete(c, cdata);
+		cmd_source_file_complete(cdata);
 
 	free(cwd);
 	return (retval);

--- a/regress/source-file-hook-depth.sh
+++ b/regress/source-file-hook-depth.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# source-file must give its nesting depth back to whatever it took it from.
+# A command item with no client of its own is lent one while it runs, so the
+# depth was taken from that client but given back to the global counter by the
+# completion callback, which runs afterwards. Every source-file from a hook
+# therefore left the client one deeper than it found it and after 50 of them
+# the client could not source anything at all.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp -d) || exit 1
+CONF="$TMP/tmux.conf"
+LEAF="$TMP/leaf.conf"
+FIFO="$TMP/fifo"
+OUT="$TMP/out"
+COUNT="$TMP/count"
+mkfifo "$FIFO" || exit 1
+: >"$COUNT"
+trap "$TMUX kill-server 2>/dev/null; rm -rf $TMP" 0 1 15
+
+echo "run-shell -b 'printf . >>$COUNT'" >"$LEAF"
+echo "set-hook -g session-window-changed 'source-file $LEAF'" >"$CONF"
+
+$TMUX -f"$CONF" new-session -d -x80 -y24 'sleep 1000' || exit 1
+$TMUX new-window -d 'sleep 1000' || exit 1
+
+# The depth is lost on the client the hook borrows, so one client has to fire
+# the hook more times than the nesting limit for it to run out.
+exec 3<>"$FIFO"
+$TMUX -C attach <&3 >"$OUT" 2>&1 &
+CLIENT=$!
+sleep 1
+
+i=0
+while [ $i -lt 60 ]; do
+	printf 'next-window\n' >&3
+	sleep 0.05
+	i=$((i + 1))
+done
+sleep 1
+
+kill $CLIENT 2>/dev/null
+wait $CLIENT 2>/dev/null
+exec 3>&-
+
+grep -q 'too many nested files' "$OUT" && exit 1
+[ "$(($(wc -c <"$COUNT")))" -eq 60 ] || exit 1
+
+exit 0


### PR DESCRIPTION
Fixes #5437.

### Problem

`cmd_source_file_exec` takes the nesting depth from `cmdq_get_client(item)`, but a command item with no client of its own is lent one for the duration of the command: `cmdq_fire_command` does

```c
	if (item->client == NULL)
		item->client = cmd_find_client(item, NULL, 1);
```

and restores `item->client = saved` at `out:`. The completion callback runs later, as a separate queue item, so it looks the client up again, finds none, and gives the depth back to the file-static counter instead.

Every `source-file` from a hook therefore leaves the borrowed client one level deeper than it found it while the global counter underflows. After 50 of them that client cannot source anything at all, including from ordinary key bindings that never nested anything:

```
cmd_source_file_exec: CLIENT depth now 1 c 0x9e1464000
cmd_source_file_complete_cb: STATIC depth now 4294967295 item 0x9e04d3d00
cmd_source_file_exec: CLIENT depth now 2 c 0x9e1464000
cmd_source_file_complete_cb: STATIC depth now 4294967294 item 0x9e04d3b00
```

(instrumented build, hook running `source-file` on `session-window-changed`)

### Fix

Remember the client the depth was taken from in `cmd_source_file_data`, with a reference so it cannot go away first, and hand it to the completion callback rather than looking it up again. The reference is dropped in the callback, or straight away when the callback is not queued because the configuration is still loading.

### Testing

New `regress/source-file-hook-depth.sh` drives 60 hook-fired `source-file` invocations through one long-lived client. It fails before the change and passes after:

```
before: 1
after:  0
```

Full suite: 125/128 pass. The three that do not (`control-client-exit-stalled`, `pane-ops`, `screen-redraw-menus`) fail the same way on an unmodified build on this machine and pass when run individually.
