### PR TITLE
Wait to hear how a file write went before reporting success

### DIFF
--- a/file.c
+++ b/file.c
@@ -563,9 +563,11 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
 {
 	struct client_file	*cf = arg;
 
-	log_debug("write error file %d", cf->stream);
-
-	cf->error = EIO;
+	/* errno is still from the write that failed, so it is worth keeping. */
+	cf->error = errno;
+	if (cf->error == 0)
+		cf->error = EIO;
+	log_debug("write error file %d: %s", cf->stream, strerror(cf->error));
 
 	bufferevent_free(cf->event);
 	cf->event = NULL;

--- a/file.c
+++ b/file.c
@@ -552,7 +552,6 @@ file_write_finish(struct client_file *cf)
 	msg.error = cf->error;
 	proc_send(cf->peer, MSG_WRITE_DONE, -1, &msg, sizeof msg);
 
-	RB_REMOVE(client_files, cf->tree, cf);
 	file_free(cf);
 }
 
@@ -721,7 +720,6 @@ file_read_error_callback(__unused struct bufferevent *bev, short what,
 
 	bufferevent_free(cf->event);
 	close(cf->fd);
-	RB_REMOVE(client_files, cf->tree, cf);
 	file_free(cf);
 }
 

--- a/file.c
+++ b/file.c
@@ -333,7 +333,8 @@ file_write(struct client *c, const char *path, int flags, const void *bdata,
 			cf->error = EIO;
 			goto done;
 		}
-		fclose(f);
+		if (fclose(f) != 0)
+			cf->error = errno;
 		goto done;
 	}
 
@@ -500,9 +501,13 @@ file_push(struct client_file *cf)
 		cf->references++;
 		event_once(-1, EV_TIMEOUT, file_push_cb, cf, NULL);
 	} else if (cf->stream > 2) {
+		/*
+		 * The client has all of the data but has not necessarily
+		 * written it yet, so wait for it to say how it went rather
+		 * than reporting success now.
+		 */
 		close.stream = cf->stream;
 		proc_send(cf->peer, MSG_WRITE_CLOSE, -1, &close, sizeof close);
-		file_fire_done(cf);
 	}
 	free(msg);
 }
@@ -527,6 +532,30 @@ file_write_left(struct client_files *files)
 	return (waiting != 0);
 }
 
+/* Finish with a file and tell the server how the write went (client). */
+static void
+file_write_finish(struct client_file *cf)
+{
+	struct msg_write_done	 msg;
+
+	if (cf->event != NULL) {
+		bufferevent_free(cf->event);
+		cf->event = NULL;
+	}
+	if (cf->fd != -1) {
+		if (close(cf->fd) != 0 && cf->error == 0)
+			cf->error = errno;
+		cf->fd = -1;
+	}
+
+	msg.stream = cf->stream;
+	msg.error = cf->error;
+	proc_send(cf->peer, MSG_WRITE_DONE, -1, &msg, sizeof msg);
+
+	RB_REMOVE(client_files, cf->tree, cf);
+	file_free(cf);
+}
+
 /* Client file write error callback. */
 static void
 file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
@@ -536,6 +565,8 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
 
 	log_debug("write error file %d", cf->stream);
 
+	cf->error = EIO;
+
 	bufferevent_free(cf->event);
 	cf->event = NULL;
 
@@ -544,6 +575,13 @@ file_write_error_callback(__unused struct bufferevent *bev, __unused short what,
 
 	if (cf->cb != NULL)
 		cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
+
+	/*
+	 * The rest of the data cannot be written. If the server has not closed
+	 * the file yet, it is told about the error when it does.
+	 */
+	if (cf->closed)
+		file_write_finish(cf);
 }
 
 /* Client file write callback. */
@@ -557,12 +595,8 @@ file_write_callback(__unused struct bufferevent *bev, void *arg)
 	if (cf->cb != NULL)
 		cf->cb(NULL, NULL, 0, -1, NULL, cf->data);
 
-	if (cf->closed && EVBUFFER_LENGTH(cf->event->output) == 0) {
-		bufferevent_free(cf->event);
-		close(cf->fd);
-		RB_REMOVE(client_files, cf->tree, cf);
-		file_free(cf);
-	}
+	if (cf->closed && EVBUFFER_LENGTH(cf->event->output) == 0)
+		file_write_finish(cf);
 }
 
 /* Handle a file write open message (client). */
@@ -664,14 +698,9 @@ file_write_close(struct client_files *files, struct imsg *imsg)
 		fatalx("unknown stream number");
 	log_debug("close file %d", cf->stream);
 
-	if (cf->event == NULL || EVBUFFER_LENGTH(cf->event->output) == 0) {
-		if (cf->event != NULL)
-			bufferevent_free(cf->event);
-		if (cf->fd != -1)
-			close(cf->fd);
-		RB_REMOVE(client_files, files, cf);
-		file_free(cf);
-	}
+	cf->closed = 1;
+	if (cf->event == NULL || EVBUFFER_LENGTH(cf->event->output) == 0)
+		file_write_finish(cf);
 }
 
 /* Client file read error callback. */
@@ -826,6 +855,26 @@ file_write_ready(struct client_files *files, struct imsg *imsg)
 		file_fire_done(cf);
 	} else
 		file_push(cf);
+	return (0);
+}
+
+/* Handle a write done message (server). */
+int
+file_write_done(struct client_files *files, struct imsg *imsg)
+{
+	struct msg_write_done	*msg = imsg->data;
+	size_t			 msglen = imsg->hdr.len - IMSG_HEADER_SIZE;
+	struct client_file	 find, *cf;
+
+	if (msglen != sizeof *msg)
+		return (-1);
+	find.stream = msg->stream;
+	if ((cf = RB_FIND(client_files, files, &find)) == NULL)
+		return (0);
+
+	log_debug("file %d write done", cf->stream);
+	cf->error = msg->error;
+	file_fire_done(cf);
 	return (0);
 }
 

--- a/regress/save-buffer-write-error.sh
+++ b/regress/save-buffer-write-error.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# save-buffer has to report a failed write. The data is handed to the client to
+# write and the server used to report success as soon as it had sent all of it
+# rather than waiting to hear how the write went, so a failure was silent - and
+# with O_TRUNC the previous contents of the destination were already gone.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp -d) || exit 1
+PIPE="$TMP/pipe"
+DATA="$TMP/data"
+OUT="$TMP/out"
+mkfifo "$PIPE" || exit 1
+trap "$TMUX kill-server 2>/dev/null; rm -rf $TMP" 0 1 15
+
+# The buffer needs to be bigger than the pipe so that the write is still going
+# when the reader disappears.
+i=0
+while [ $i -lt 2000 ]; do
+	echo '0123456789012345678901234567890123456789012345678901234567890123'
+	i=$((i + 1))
+done >"$DATA"
+
+$TMUX new-session -d 'sleep 1000' || exit 1
+$TMUX load-buffer -b big "$DATA" || exit 1
+
+# Take a few bytes and go away, leaving save-buffer with a broken pipe.
+(head -c 8 <"$PIPE" >/dev/null) &
+sleep 1
+$TMUX save-buffer -b big "$PIPE" 2>"$OUT" && exit 1
+[ -s "$OUT" ] || exit 1
+wait
+
+# A write that works must still be reported as working.
+$TMUX save-buffer -b big "$TMP/copy" || exit 1
+cmp -s "$DATA" "$TMP/copy" || exit 1
+
+exit 0

--- a/regress/save-buffer-write-error.sh
+++ b/regress/save-buffer-write-error.sh
@@ -35,10 +35,30 @@ $TMUX load-buffer -b big "$DATA" || exit 1
 sleep 1
 $TMUX save-buffer -b big "$PIPE" 2>"$OUT" && exit 1
 [ -s "$OUT" ] || exit 1
+# The message has to say what actually went wrong, not just that something did.
+grep -q 'Broken pipe' "$OUT" || exit 1
 wait
 
-# A write that works must still be reported as working.
-$TMUX save-buffer -b big "$TMP/copy" || exit 1
+# Appending has the same problem and must report it the same way.
+(head -c 8 <"$PIPE" >/dev/null) &
+sleep 1
+$TMUX save-buffer -a -b big "$PIPE" 2>"$OUT" && exit 1
+[ -s "$OUT" ] || exit 1
+wait
+
+# A write to somewhere that cannot be opened at all was always reported and
+# still has to be.
+$TMUX save-buffer -b big "$TMP/nosuchdir/out" 2>"$OUT" && exit 1
+[ -s "$OUT" ] || exit 1
+
+# A write that works must still be reported as working, and say nothing.
+$TMUX save-buffer -b big "$TMP/copy" 2>"$OUT" || exit 1
+[ -s "$OUT" ] && exit 1
 cmp -s "$DATA" "$TMP/copy" || exit 1
+
+# So must appending to it.
+$TMUX save-buffer -a -b big "$TMP/copy" 2>"$OUT" || exit 1
+[ -s "$OUT" ] && exit 1
+[ "$(wc -c <"$TMP/copy")" -eq "$(($(wc -c <"$DATA") * 2))" ] || exit 1
 
 exit 0

--- a/server-client.c
+++ b/server-client.c
@@ -2694,6 +2694,10 @@ server_client_dispatch(struct imsg *imsg, void *arg)
 		if (file_write_ready(&c->files, imsg) != 0)
 			goto bad;
 		break;
+	case MSG_WRITE_DONE:
+		if (file_write_done(&c->files, imsg) != 0)
+			goto bad;
+		break;
 	case MSG_READ:
 		if (file_read_data(&c->files, imsg) != 0)
 			goto bad;

--- a/tmux-protocol.h
+++ b/tmux-protocol.h
@@ -20,7 +20,7 @@
 #define TMUX_PROTOCOL_H
 
 /* Protocol version. */
-#define PROTOCOL_VERSION 8
+#define PROTOCOL_VERSION 9
 
 /* Message types. */
 enum msgtype {
@@ -67,6 +67,7 @@ enum msgtype {
 	MSG_WRITE,
 	MSG_WRITE_READY,
 	MSG_WRITE_CLOSE,
+	MSG_WRITE_DONE,
 	MSG_READ_CANCEL
 };
 
@@ -114,6 +115,11 @@ struct msg_write_ready {
 
 struct msg_write_close {
 	int	stream;
+};
+
+struct msg_write_done {
+	int	stream;
+	int	error;
 };
 
 #endif /* TMUX_PROTOCOL_H */

--- a/tmux.h
+++ b/tmux.h
@@ -3279,6 +3279,7 @@ void	 file_write_close(struct client_files *, struct imsg *);
 void	 file_read_open(struct client_files *, struct tmuxpeer *, struct imsg *,
 	     int, int, client_file_cb, void *);
 int	 file_write_ready(struct client_files *, struct imsg *);
+int	 file_write_done(struct client_files *, struct imsg *);
 int	 file_read_data(struct client_files *, struct imsg *);
 int	 file_read_done(struct client_files *, struct imsg *);
 void	 file_read_cancel(struct client_files *, struct imsg *);


### PR DESCRIPTION
Fixes #5451.

### Problem

`save-buffer` exits 0 and prints nothing when the write fails. The destination has already been truncated by `open(O_TRUNC)` at that point, so the previous contents are gone and the buffer is not written either.

The server hands the data to the client to write, and `file_push` reported the write as done as soon as it had sent all of it:

```c
	} else if (cf->stream > 2) {
		close.stream = cf->stream;
		proc_send(cf->peer, MSG_WRITE_CLOSE, -1, &close, sizeof close);
		file_fire_done(cf);	/* before the client has written anything */
	}
```

The client noticed the error in `file_write_error_callback` but had no way to tell the server about it.

### Fix

Add `MSG_WRITE_DONE` for the client to report the result, and make the server wait for it rather than assuming success. `PROTOCOL_VERSION` goes to 9.

Three smaller things found while in there, in separate commits:

* The client turned every write error into `EIO`, so a full disk and a broken pipe both came out as "Input/output error". `errno` is still set from the failed write when the bufferevent error callback runs, so it is kept now.
* `file_write_close` never set `cf->closed`, so a file still draining when the server closed it was never finished or its fd closed.
* `fclose(3)` was unchecked on the writes the server does itself, where a buffered write can fail at close.
* Callers removed the file from the tree and then called `file_free`, which removes it again once the last reference goes - a second `RB_REMOVE` of a node no longer in the tree.

### Before / after

```
$ tmux save-buffer -b big pipe-with-no-reader; echo $?
0                                    <- silent, buffer lost

$ tmux save-buffer -b big pipe-with-no-reader; echo $?
Broken pipe: /tmp/.../pipe
1
```

### Testing

New `regress/save-buffer-write-error.sh` covers a broken pipe, the same for `-a`, an unopenable destination, and that a successful write still exits 0 silently and round-trips. It fails before the change and passes after.

Full suite: 125/128 pass. The three that do not (`control-client-exit-stalled`, `pane-ops`, `screen-redraw-menus`) fail the same way on an unmodified build on this machine and pass when run individually.

### Note

Bumping `PROTOCOL_VERSION` means a running server will not talk to a new client until it is restarted. Version mismatch is refused cleanly in both directions, tested against a 3.7-era build.

One behaviour change worth flagging: `save-buffer` to a pipe whose reader has stalled now waits for the write instead of returning a false success. That matches `cat > pipe`, and a lost client is still cleaned up by the existing `server_client_lost` path.
