### PR TITLE
Do not wait forever for a message the client does not understand

### DIFF
--- a/client.c
+++ b/client.c
@@ -664,6 +664,7 @@ client_dispatch_wait(struct imsg *imsg)
 		    "(client %d, server %u)\n", PROTOCOL_VERSION,
 		    imsg->hdr.peerid & 0xff);
 		client_exitval = 1;
+		client_exitflag = 1;
 		proc_exit(client_proc);
 		break;
 	case MSG_FLAGS:
@@ -720,6 +721,7 @@ client_dispatch_wait(struct imsg *imsg)
 		fprintf(stderr, "unknown message type %u from server\n",
 		    imsg->hdr.type);
 		client_exitval = 1;
+		client_exitflag = 1;
 		proc_exit(client_proc);
 		break;
 	}

--- a/client.c
+++ b/client.c
@@ -712,6 +712,16 @@ client_dispatch_wait(struct imsg *imsg)
 		fprintf(stderr, "server version is too old for client\n");
 		proc_exit(client_proc);
 		break;
+	default:
+		/*
+		 * There is nothing to wait for anymore, so do not just ignore
+		 * the message and hang forever.
+		 */
+		fprintf(stderr, "unknown message type %u from server\n",
+		    imsg->hdr.type);
+		client_exitval = 1;
+		proc_exit(client_proc);
+		break;
 	}
 }
 


### PR DESCRIPTION
Fixes #5453.

### Problem

`client_dispatch_wait` has no `default:` label, so an imsg whose type the client does not recognise is silently discarded and the client stays in the same untimed wait: nothing on stdout or stderr, no exit status, forever. This is the residual case of #2189 / #2659 - the version mismatch hang is fixed, but a message with a matching version and an unhandled type still falls off the end of the switch.

```
$ python3 fake.py /tmp/sock unknown-type &
$ tmux -S /tmp/sock kill-server        # still running after 60s, no output
```

### Fix

Add a `default:` that says what happened and exits 1.

The second commit fixes something that showed up while testing it. A client that gives up on a message prints why and exits, but the end of the connection was then read as the server having gone away, so a second and wrong line was printed after the first:

```
protocol version mismatch (client 9, server 8)
server exited unexpectedly                      <- the client hung up, not the server
```

Setting `client_exitflag` marks the exit as deliberate, which is what `client_dispatch` already checks before blaming the server. That covers the version mismatch case as well as the new one.

### Testing

Against the fake server from the issue:

```
before: still running after 60s, no output, no status
after:  unknown message type 999 from server
        exit: 1
```

Version mismatch, tested against a 3.7-era build, now prints one line rather than two.

Full suite: 125/128 pass. The three that do not (`control-client-exit-stalled`, `pane-ops`, `screen-redraw-menus`) fail the same way on an unmodified build on this machine and pass when run individually.
