### PR TITLE
Do not skip the chdir when there is nowhere to come back to

### DIFF
--- a/regress/spawn-cwd-removed.sh
+++ b/regress/spawn-cwd-removed.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# A new pane has to start in the directory it was given even if the server's
+# own working directory has been removed. The chdir was guarded by getcwd,
+# which fails once there is nothing to come back to, so -c was ignored and the
+# child inherited the removed directory instead.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp -d) || exit 1
+DOOMED="$TMP/doomed"
+TARGET="$TMP/target"
+OUT="$TMP/out"
+mkdir "$DOOMED" "$TARGET" || exit 1
+trap "$TMUX kill-server 2>/dev/null; rm -rf $TMP" 0 1 15
+
+WANT=$(cd "$TARGET" && pwd -P) || exit 1
+
+# Start the server from a directory that is then taken away.
+cd "$DOOMED" || exit 1
+$TMUX new-session -d 'sleep 1000' || exit 1
+cd "$TMP" || exit 1
+rmdir "$DOOMED" || exit 1
+
+$TMUX split-window -d -c "$TARGET" "pwd -P >$OUT; sleep 1000" || exit 1
+
+i=0
+while [ ! -s "$OUT" ] && [ $i -lt 50 ]; do
+	sleep 0.1
+	i=$((i + 1))
+done
+
+[ "$(cat "$OUT")" = "$WANT" ] || exit 1
+
+exit 0

--- a/spawn.c
+++ b/spawn.c
@@ -448,15 +448,24 @@ spawn_pane(struct spawn_context *sc, char **cause)
 	}
 	new_wp->flags &= ~PANE_EMPTY;
 
-	/* Store current working directory and change to new one. */
-	if (getcwd(path, sizeof path) != NULL) {
-		if (chdir(new_wp->cwd) == 0)
-			actual_cwd = new_wp->cwd;
-		else if (home != NULL && chdir(home) == 0)
-			actual_cwd = home;
-		else if (chdir("/") == 0)
-			actual_cwd = "/";
+	/*
+	 * Store current working directory and change to new one. The current
+	 * directory may have been removed, in which case there is nothing to
+	 * come back to, but the child still needs to be given the right one so
+	 * go somewhere that exists instead.
+	 */
+	if (getcwd(path, sizeof path) == NULL) {
+		if (home != NULL)
+			strlcpy(path, home, sizeof path);
+		else
+			strlcpy(path, "/", sizeof path);
 	}
+	if (chdir(new_wp->cwd) == 0)
+		actual_cwd = new_wp->cwd;
+	else if (home != NULL && chdir(home) == 0)
+		actual_cwd = home;
+	else if (chdir("/") == 0)
+		actual_cwd = "/";
 
 	/* Fork the new process. */
 	new_wp->pid = fdforkpty(ptm_fd, &new_wp->fd, new_wp->tty, NULL, &ws);


### PR DESCRIPTION
Fixes #5473.

### Problem

Once the server's own working directory has been removed, new panes ignore `-c` and start in the removed directory instead:

```sh
mkdir /tmp/doomed && cd /tmp/doomed
tmux -Ltest -f/dev/null new-session -d -s repro
rm -rf /tmp/doomed
tmux -Ltest split-window -t repro -c /tmp
lsof -a -p "$(tmux -Ltest display-message -t repro.1 -p '#{pane_pid}')" -d cwd
```

```
start_path: /tmp
zsh  55817  cwd  DIR  /private/tmp/doomed        <- removed directory, not /tmp
```

`spawn_pane` guards the chdir with `getcwd`:

```c
	if (getcwd(path, sizeof path) != NULL) {
		if (chdir(new_wp->cwd) == 0)
			...
	}
```

`getcwd` fails with ENOENT once the directory is gone, so the chdir is skipped along with setting `PWD` in the child's environment, and the child inherits the removed directory. Every spawn is affected until the server is restarted.

This came in with the move of the chdir before the fork (the fix for #4719); the old child-side code had no guard, so an absolute `-c` always worked.

### Fix

Only the *return* path needs a valid old directory. When `getcwd` fails, use the home directory (or `/`) as the place to come back to and carry on with the chdir as normal.

After:

```
start_path: /tmp
zsh  55980  cwd  DIR  /private/tmp
```

### Testing

New `regress/spawn-cwd-removed.sh` starts a server in a directory, removes it, then splits with `-c` into a directory that exists and checks the child's actual working directory rather than just `pane_start_path`. It fails before the change and passes after.
