### PR TITLE
Let next-word-end with vi keys move on to the next line

### DIFF
--- a/regress/copy-mode-vi-word-end.sh
+++ b/regress/copy-mode-vi-word-end.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# next-word-end and next-space-end with vi keys have to cross the end of a
+# line the way vi does. The character under the cursor was stepped over
+# without wrapping, so at the last word of a line the same word end was found
+# again and the cursor never moved.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -Ltest -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp -d) || exit 1
+trap "$TMUX kill-server 2>/dev/null; rm -rf $TMP" 0 1 15
+
+$TMUX new-session -d -x40 -y10 cat || exit 1
+$TMUX set -g mode-keys vi || exit 1
+$TMUX send-keys 'hello world' Enter 'foo bar baz' Enter || exit 1
+sleep 1
+
+# Returns the cursor position in copy mode as "y,x".
+pos() {
+	$TMUX display-message -p '#{copy_cursor_y},#{copy_cursor_x}'
+}
+
+check() {
+	[ "$(pos)" = "$1" ] || {
+		echo "expected $1, got $(pos)" >&2
+		exit 1
+	}
+}
+
+$TMUX copy-mode || exit 1
+$TMUX send-keys -X history-top || exit 1
+$TMUX send-keys -X start-of-line || exit 1
+
+$TMUX send-keys -X next-word || exit 1
+check '0,6'
+$TMUX send-keys -X next-word-end || exit 1
+check '0,10'
+# The end of the last word on the line: this has to move on to the next line.
+$TMUX send-keys -X next-word-end || exit 1
+check '1,2'
+$TMUX send-keys -X next-word-end || exit 1
+check '1,6'
+
+# The same for next-space-end.
+$TMUX send-keys -X history-top || exit 1
+$TMUX send-keys -X start-of-line || exit 1
+$TMUX send-keys -X next-space-end || exit 1
+check '0,4'
+$TMUX send-keys -X next-space-end || exit 1
+check '0,10'
+$TMUX send-keys -X next-space-end || exit 1
+check '1,2'
+
+exit 0

--- a/window-copy.c
+++ b/window-copy.c
@@ -6668,8 +6668,13 @@ window_copy_cursor_next_word_end_pos(struct window_mode_entry *wme,
 
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
+		/*
+		 * Step over the character under the cursor, wrapping if it is
+		 * the last one on the line - otherwise the end of the last
+		 * word on a line is found again and the cursor never moves.
+		 */
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0, 0);
+			grid_reader_cursor_right(&gr, 1, 0, 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else
@@ -6698,8 +6703,13 @@ window_copy_cursor_next_word_end(struct window_mode_entry *wme,
 
 	grid_reader_start(&gr, back_s->grid, px, py);
 	if (options_get_number(oo, "mode-keys") == MODEKEY_VI) {
+		/*
+		 * Step over the character under the cursor, wrapping if it is
+		 * the last one on the line - otherwise the end of the last
+		 * word on a line is found again and the cursor never moves.
+		 */
 		if (!grid_reader_in_set(&gr, WHITESPACE))
-			grid_reader_cursor_right(&gr, 0, 0, 0);
+			grid_reader_cursor_right(&gr, 1, 0, 0);
 		grid_reader_cursor_next_word_end(&gr, separators);
 		grid_reader_cursor_left(&gr, 1);
 	} else


### PR DESCRIPTION
Fixes #5491.

### Problem

With `mode-keys vi`, `e` at the last word of a line does not move. In vi it advances to the end of the first word on the next line. `w`/`W` and `b`/`B` already cross lines, only `e`/`E` are stuck.

With "hello world" on one line and "foo bar baz" on the next, positions as `y,x`:

```
next-word      : 0,6
next-word-end  : 0,10
next-word-end  : 0,10     <- should be 1,2, the end of "foo"
next-word-end  : 0,10
```

### Cause

The vi branch of `window_copy_cursor_next_word_end` steps over the character under the cursor before searching:

```c
		if (!grid_reader_in_set(&gr, WHITESPACE))
			grid_reader_cursor_right(&gr, 0, 0, 0);
```

With `wrap` zero, `grid_reader_cursor_right` will not move past `grid_line_limit`, which is the last character of the line. So at the end of "world" the cursor does not advance, `grid_reader_cursor_next_word_end` finds the end of the same word again, and the following `grid_reader_cursor_left` puts it back where it started.

`grid_reader_cursor_next_word_end` itself crosses lines correctly - the emacs path, which calls it without the step-over, is not affected.

### Fix

Wrap when stepping over that character. Applied to both `window_copy_cursor_next_word_end` and `window_copy_cursor_next_word_end_pos` so the movement and the position reported for highlighting stay in agreement.

After:

```
next-word-end  : 0,10
next-word-end  : 1,2
next-word-end  : 1,6
```

### Testing

New `regress/copy-mode-vi-word-end.sh` walks `next-word-end` and `next-space-end` across a line boundary and checks `copy_cursor_x`/`copy_cursor_y` at each step. It fails before the change (`expected 1,2, got 0,10`) and passes after.
