### PR TITLE
Restore umask if bind fails when creating the server socket

### DIFF
--- a/server.c
+++ b/server.c
@@ -129,6 +129,7 @@ server_create_socket(uint64_t flags, char **cause)
 		mask = umask(S_IXUSR|S_IRWXG|S_IRWXO);
 	if (bind(fd, (struct sockaddr *)&sa, sizeof sa) == -1) {
 		saved_errno = errno;
+		umask(mask);
 		close(fd);
 		errno = saved_errno;
 		goto fail;


### PR DESCRIPTION
`server_create_socket()` saves the umask, sets a restrictive one to create
the socket, and restores it only on the success path. If `bind()` fails it
jumps to `fail:` with the umask still changed.

That's harmless from `server_start()`, which gives up anyway. But the
`SIGUSR1` handler calls it on a running server and ignores a -1 return, so
one failed SIGUSR1 leaves the server at the temporary umask permanently, and
every pane forked from it gets that too.

For the default socket it's `S_IXUSR|S_IXGRP|S_IRWXO` (0117), which clears
the execute bit. Files are fine, directories aren't: `mkdir(0700)` gives
`0600`, so you can't enter a directory you just made. `mkdtemp(3)` callers
get EACCES inside a directory they created successfully, which took me a
while to track down.

### Reproducing (3.7c)

```sh
D=$(mktemp -d); export TMUX_TMPDIR=$D
tmux new-session -d -s repro 'sleep 300'
SRV=$(tmux display-message -p '#{pid}')
awk '/^Umask:/{print $2}' /proc/$SRV/status     # 0002

chmod 500 "$D/tmux-$(id -u)"                    # make bind() fail
kill -USR1 $SRV; sleep 1
awk '/^Umask:/{print $2}' /proc/$SRV/status     # 0117
chmod 700 "$D/tmux-$(id -u)"

tmux new-window -t repro -d 'sh -c "sleep 60"'  # this pane runs at 0117
tmux kill-server
```

Before: `0002 -> 0117`, and the new pane runs at `0117`. After:
`0002 -> 0002`, pane `0002`. Socket mode is still 660 and sessions work the
same.

`uname -sp` Linux x86_64 (Ubuntu 24.04), `tmux -V` 3.7c, `TERM`
xterm-256color. master has the same code.

I hit this on a server that had been up two weeks at umask 0117 while its
first pane was still 0002, so it changed while running. I couldn't catch the
original `bind()` failure though, so I don't know what sent SIGUSR1 or why
bind failed there; the repro above forces it.
