### PR TITLE
Use correct X position when combining characters

### DIFF
--- a/regress/tty-draw-line.sh
+++ b/regress/tty-draw-line.sh
@@ -105,6 +105,21 @@ sleep 1
 CLIENT=$($TMUX2 list-clients -F '#{client_name}' | head -1)
 [ -n "$CLIENT" ] || fail "no inner client"
 
+# A variation selector which widens the previous character must use window
+# coordinates when checking visibility in a pane with a nonzero x offset.
+$TMUX2 set -s variation-selector-always-wide on || exit 1
+WINDOW=$($TMUX2 neww -dPF '#{window_id}' "exec sleep 100") || exit 1
+PANE=$($TMUX2 splitw -dhPF '#{pane_id}' -t "$WINDOW" \
+	"exec sleep 100") || exit 1
+$TMUX2 selectw -t "$WINDOW" || exit 1
+$TMUX2 respawnp -k -t "$PANE" \
+	"printf '\nA\342\234\217\357\270\217B'; exec sleep 100" || exit 1
+sleep 1
+$TMUX2 capturep -p -t "$PANE" >$TMP || exit 1
+EXPECTED=$(printf 'A\342\234\217\357\270\217B')
+check_line 2 "$EXPECTED"
+$TMUX2 killw -t "$WINDOW" || exit 1
+
 # Long line, then short line: default cells after cellsize must clear stale text.
 capture
 check_line 1 "abcdefghijklmnopqrst"

--- a/screen-write.c
+++ b/screen-write.c
@@ -2852,10 +2852,11 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	struct grid		*gd = s->grid;
 	const struct utf8_data	*ud = &gc->data;
 	struct options		*oo = global_options;
-	u_int			 i, n, cx = s->cx, cy = s->cy, vis, yoff = 0;
+	u_int			 i, n, cx = s->cx, cy = s->cy, vis;
 	struct grid_cell	 last;
 	struct tty_ctx		 ttyctx;
 	int			 force_wide = 0, zero_width = 0;
+	int			 xoff = 0, yoff = 0;
 	struct visible_ranges	*r;
 
 	/* Ignore U+3164 HANGUL_FILLER entirely. */
@@ -2949,9 +2950,11 @@ screen_write_combine(struct screen_write_ctx *ctx, const struct grid_cell *gc)
 	 * obscured in the middle, only on left or right, but there could be an
 	 * empty range in the visible ranges so we add them all up.
 	 */
-	if (wp != NULL)
+	if (wp != NULL) {
+		xoff = wp->xoff;
 		yoff = wp->yoff;
-	r = window_visible_ranges(wp, cx - n, cy + yoff, n, NULL);
+	}
+	r = window_visible_ranges(wp, xoff + cx - n, cy + yoff, n, NULL);
 	for (i = 0, vis = 0; i < r->used; i++)
 		vis += r->ranges[i].nx;
 	if (vis < n) {


### PR DESCRIPTION
## Context

With `variation-selector-always-wide` enabled, a variation-selector sequence written below the first row of a right-hand pane can be replaced by a space. For example, `A✏️B` becomes `A B`.

## Problem

`screen_write_combine()` passes a pane-local X position to `window_visible_ranges()`, which expects window coordinates. In a pane with a nonzero X offset, the visibility check can therefore inspect another pane and treat the combined character as obscured.

## Solution

Add the pane X offset when checking the combined character's visible range, matching the coordinate conversion already used by `screen_write_cell()`.

Add an attached-client regression test with a horizontally split window. The test fails on unmodified `master` with:

```
line 2: expected 'A✏️B', got 'A B'
```

## Testing

- The new regression passes with the fix.
- Focused checks preserve `ℹ️`, `⚠️`, and `✏️` in a right-hand pane.
- The full regression suite passes except `input-replies.sh` and `screen-redraw-menus.sh`; both failures reproduce on unmodified `master`.

## AI assistance

This issue was diagnosed and the patch was developed with OpenAI/OpenCode assistance. I reviewed the change and verified it locally.
