### PR TITLE
Fix memory leak when destroying pane

### DIFF
--- a/window.c
+++ b/window.c
@@ -1555,6 +1555,7 @@ window_pane_free(struct window_pane *wp)
 	cmd_free_argv(wp->argc, wp->argv);
 	colour_palette_free(&wp->palette);
 	style_ranges_free(&wp->border_status_line.ranges);
+	free(wp->border_status_line.expanded);
 	free(wp);
 }
 


### PR DESCRIPTION
expanded field should be freed when destroying pane.

---

Originally found by LeakSanitizer.

## Reproduction script LLM generated

```
#!/usr/bin/env bash
#
# Shows the pane border status string leak: a pane's
# border_status_line.expanded holds the last expansion of
# pane-border-format, and the pane is freed without it.
#
# tmux has never freed it -- 3.7b frees the ranges beside it in
# window_pane_destroy and stops there, and master (c1f947a3) still stops
# there in window_pane_free, having moved the drawing to window-border.c
# in between. The client's own five copies of the same struct are freed,
# in status.c; only the pane's is missed.
#
# One string leaks per destroyed pane, and pane-border-format is the
# user's to set, so the size of each is the user's too. That is what
# makes it measurable: the run below destroys the same number of panes
# twice, once with a one-character format and once with a large one, and
# charges the difference in the server's resident size to the leak.
# Everything else a pane costs is the same in both halves and cancels.
#
# Measured at PANES=30 FILL=100000, against a 2929 kB prediction:
#
#   tmux 3.7b                 4228 kB   leaking
#   this crate                 300 kB   clean
#   this crate, free removed  3160 kB   leaking
#
# The last of those is the check that the script answers to this defect
# and not to something else a pane happens to cost.
#
# Usage: ./demo-expanded-mem.sh [server-binary]     (default: $BIN, else tmux)
#        PANES=200 FILL=100000 ./demo-expanded-mem.sh ./target/debug/tmux

set -u

BIN=${1:-${BIN:-tmux}}
PANES=${PANES:-150}
FILL=${FILL:-100000}

command -v "$BIN" >/dev/null 2>&1 || [ -x "$BIN" ] || {
	echo "no such server binary: $BIN" >&2
	exit 1
}

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dxm.XXXXXX") || exit 1
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 1
fi

CLIENT_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# A command line carrying the whole format is refused ("command too
# long") well before the sizes this needs, so the long one arrives in a
# file instead.
set_format() {
	{
		printf 'set-option -g pane-border-format "'
		printf 'x%.0s' $(seq "$1")
		printf '"\n'
	} >"$DIR/fmt.conf"
	tm source-file "$DIR/fmt.conf" >/dev/null 2>&1
}

tm new-session -d -x 80 -y 24 2>/dev/null || {
	echo "could not start a server with $BIN" >&2
	exit 1
}
tm set-option -g status off
tm set-option -g pane-border-status top

# A pane's border status is only expanded while somebody is looking at
# it, so the server needs a client on a terminal. script(1) supplies one.
script -qfc "$BIN -S $SOCK attach" /dev/null >/dev/null 2>&1 &
CLIENT_PID=$!
sleep 1

SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 1; }

rss() { ps -o rss= -p "$SERVER_PID" 2>/dev/null | tr -d ' '; }

# Builds and destroys $PANES panes, each of which draws its border status
# at least once, so each carries a live expanded string to its grave.
churn() {
	local i pane
	for i in $(seq "$PANES"); do
		pane=$(tm split-window -d -P -F '#{pane_id}' 'sleep 600' 2>/dev/null)
		[ -n "$pane" ] || return 1
		tm refresh-client >/dev/null 2>&1
		tm kill-pane -t "$pane" >/dev/null 2>&1 || return 1
	done
	tm refresh-client >/dev/null 2>&1
	sleep 0.5
}

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'panes    %s destroyed per round\n\n' "$PANES"

set_format 1
churn || { echo "warm-up failed" >&2; exit 1; }   # let the allocator settle

before_short=$(rss)
churn
after_short=$(rss)
grew_short=$((after_short - before_short))
printf 'round 1  pane-border-format is 1 byte\n'
printf '         RSS %s -> %s kB  (+%s kB)\n\n' "$before_short" "$after_short" "$grew_short"

set_format "$FILL"
before_long=$(rss)
churn
after_long=$(rss)
grew_long=$((after_long - before_long))
printf 'round 2  pane-border-format is %s bytes\n' "$FILL"
printf '         RSS %s -> %s kB  (+%s kB)\n\n' "$before_long" "$after_long" "$grew_long"

charged=$((grew_long - grew_short))
predicted=$((PANES * FILL / 1024))
printf 'charged to the format string: %s kB\n' "$charged"
printf 'one leak per pane would be:   %s kB\n\n' "$predicted"

# Half the predicted figure is a wide margin -- the point is to tell a
# leak that scales with the format from the noise of everything else a
# pane costs, which round 1 already paid for.
if [ "$charged" -ge $((predicted / 2)) ]; then
	printf 'LEAKING: the format string is kept once per destroyed pane.\n'
	exit 1
fi
printf 'clean: destroying a pane lets go of its expanded format.\n'
exit 0
```