### PR TITLE
Fix memory leak of a command list parsed from a string

### DIFF
--- a/arguments.c
+++ b/arguments.c
@@ -762,8 +762,6 @@ args_make_commands_now(struct cmd *self, struct cmdq_item *item, u_int idx,
 		cmdq_error(item, "%s", error);
 		free(error);
 	}
-	else
-		cmdlist->references++;
 	args_make_commands_free(state);
 	return (cmdlist);
 }
@@ -827,8 +825,10 @@ args_make_commands(struct args_command_state *state, int argc, char **argv,
 	int			 i;
 
 	if (state->cmdlist != NULL) {
-		if (argc == 0)
+		if (argc == 0) {
+			state->cmdlist->references++;
 			return (state->cmdlist);
+		}
 		return (cmd_list_copy(state->cmdlist, argc, argv));
 	}
 

--- a/cmd-command-prompt.c
+++ b/cmd-command-prompt.c
@@ -242,9 +242,11 @@ cmd_command_prompt_callback(struct client *c, void *data, const char *s,
 	} else if (item == NULL) {
 		new_item = cmdq_get_command(cmdlist, NULL);
 		cmdq_append(c, new_item);
+		cmd_list_free(cmdlist);
 	} else {
 		new_item = cmdq_get_command(cmdlist, cmdq_get_state(item));
 		cmdq_insert_after(item, new_item);
+		cmd_list_free(cmdlist);
 	}
 	cmd_free_argv(argc, argv);
 

--- a/cmd-if-shell.c
+++ b/cmd-if-shell.c
@@ -98,6 +98,7 @@ cmd_if_shell_exec(struct cmd *self, struct cmdq_item *item)
 			return (CMD_RETURN_ERROR);
 		new_item = cmdq_get_command(cmdlist, cmdq_get_state(item));
 		cmdq_insert_after(item, new_item);
+		cmd_list_free(cmdlist);
 		return (CMD_RETURN_NORMAL);
 	}
 
@@ -164,9 +165,11 @@ cmd_if_shell_callback(struct job *job)
 	} else if (item == NULL) {
 		new_item = cmdq_get_command(cmdlist, NULL);
 		cmdq_append(c, new_item);
+		cmd_list_free(cmdlist);
 	} else {
 		new_item = cmdq_get_command(cmdlist, cmdq_get_state(item));
 		cmdq_insert_after(item, new_item);
+		cmd_list_free(cmdlist);
 	}
 
 out:

--- a/cmd-run-shell.c
+++ b/cmd-run-shell.c
@@ -233,9 +233,11 @@ cmd_run_shell_timer(__unused int fd, __unused short events, void* arg)
 	} else if (item == NULL) {
 		new_item = cmdq_get_command(cmdlist, NULL);
 		cmdq_append(c, new_item);
+		cmd_list_free(cmdlist);
 	} else {
 		new_item = cmdq_get_command(cmdlist, cmdq_get_state(item));
 		cmdq_insert_after(item, new_item);
+		cmd_list_free(cmdlist);
 	}
 
 	if (cdata->item != NULL)

--- a/window-panes.c
+++ b/window-panes.c
@@ -1009,6 +1009,7 @@ window_panes_run_command(struct window_panes_modedata *data, struct client *c,
 	} else {
 		new_item = cmdq_get_command(cmdlist, NULL);
 		cmdq_append(c, new_item);
+		cmd_list_free(cmdlist);
 	}
 	free(expanded);
 }


### PR DESCRIPTION
There are two cases which need to parse command arguments:

1. `if-shell -F 1 { set -g @x 1 }`
2. `if-shell -F 1 'set -g @x 1`

For case 2, `cmd_parse_from_string()` is called and returns `pr->cmdlist`. But it already have `references = 1` set by `cmd_list_new()`.

As a result, case 2 got `references` being 2 at creation, and won't get freed. LEAK

For case 1, we can justify increasing `references` as the cmdlist is being shared.

---

## Reproduction script written by LLM

```
#!/usr/bin/env bash
#
# Shows the leak of a command list parsed from a string, fixed on branch
# fix-cmdlist-leak: args_make_commands_now() takes a reference on the
# list it answers, which is right for a command given in braces --
# args_make_commands_prepare() takes one for the state and
# args_make_commands_free() gives it back again, so without the extra
# one the caller would hold none. A command given as a string is parsed
# by args_make_commands(), and a parse result already carries the
# caller's reference. Taking another leaves the list one reference above
# zero for ever.
#
# The repro uses confirm-before, not if-shell -F: both take their list
# from args_make_commands_now(), but if-shell also fails to give back the
# reference it holds -- a separate defect, fixed on branch
# fix-if-shell-leak -- so a string given to if-shell leaks whichever of
# the two fixes is applied alone. confirm-before frees its reference in
# cmd_confirm_before_free(), so it is clean the moment the extra one is
# no longer taken, and this fix can be seen on its own.
#
# A client attaches and is given N (default 20) commands of
#
#     confirm-before -b -p q 'set -g @x 1'
#
# and the prompts are then thrown away with the client. Under
# AddressSanitizer the exit report of an unfixed server holds
#
#     Direct leak of 304 byte(s) in 19 object(s) allocated from:
#         #2 cmd_list_new cmd.c:600
#         #3 cmd_parse_build_commands cmd-parse.y:901
#         #4 cmd_parse_from_buffer cmd-parse.y:1057
#         #5 cmd_parse_from_string cmd-parse.y:980
#         #6 args_make_commands arguments.c:846
#         #7 args_make_commands_now arguments.c:760
#
# and the script's verdict is exactly that: a Direct leak block whose
# stack passes through args_make_commands, the string parse of this
# defect. Other leaks the server may have are ignored, so the answer is
# to this defect and not to whatever else the exit report happens to
# hold.
#
# The count is N-1: the prompt the client is still showing when it goes
# holds the last list, which is freed with it.
#
# Measured at N=20:
#
#   c1f947a3 (origin/master)                    19 objects   LEAKING
#   + the sibling if-shell fix, alone           19 objects   LEAKING
#   + this fix                                   0 objects   clean
#
# The middle row is the check that this is the string-parse leak and not
# the sibling one: if-shell giving back its own reference does nothing
# for a list confirm-before holds.
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-cmdlist-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=100 ./demo-cmdlist-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-20}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dcl.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

CLIENT_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d -x 80 -y 24 'sleep 600' 2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

tm set-option -g status off

# confirm-before puts its prompt on a client, so there has to be one.
script -qfc "$BIN -S $SOCK attach" /dev/null >/dev/null 2>&1 &
CLIENT_PID=$!
for i in $(seq 50); do
	[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] && break
	sleep 0.1
done
[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] || {
	echo "no client attached" >&2
	exit 2
}

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'commands %s of "confirm-before -b -p q %s"\n\n' "$N" "'set -g @x 1'"

# -b so the command does not wait for the answer: each new prompt
# replaces the one before it, which frees the reference confirm-before
# holds and leaves only the extra one.
for i in $(seq "$N"); do
	tm confirm-before -b -p "q$i" 'set -g @x 1' 2>>"$DIR/cb.err"
done
sleep 0.5

tm detach-client -a 2>/dev/null
for i in $(seq 50); do
	kill -0 "$CLIENT_PID" 2>/dev/null || break
	sleep 0.1
done
kill "$CLIENT_PID" 2>/dev/null
CLIENT_PID=

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks whose allocation stack goes
# through args_make_commands -- the string parse of this defect.
awk -v RS= -v ORS='\n\n' '/Direct leak/ && /args_make_commands/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s command list(s) parsed from a string were never freed.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: no command list parsed from a string was leaked.\n'
exit 0

```