### PR TITLE
Fix memory leak when destroying pane

### DIFF
--- a/window.c
+++ b/window.c
@@ -1549,6 +1549,8 @@ window_pane_free(struct window_pane *wp)
 	screen_free(&wp->status_screen);
 	screen_free(&wp->base);
 
+	free(wp->r.ranges);
+
 	options_free(wp->options);
 	free((void *)wp->cwd);
 	free(wp->shell);


### PR DESCRIPTION
Found this field was not freed. should be cleaned up during pane destroy.

---

## LLM generated reproduction script

```
#!/usr/bin/env bash
#
# Shows the leak of a pane's visible ranges, fixed on branch
# fix-pane-ranges-leak: a pane that writes output makes the server work
# out which of its columns are not obscured, and window_visible_ranges()
# grows the pane's own struct visible_ranges r through
# server_client_ensure_ranges(). The other two owners of one give the
# array back -- tty_free() frees tty->r.ranges and popup_free_cb() frees
# pd->r.ranges -- but window_pane_free() never freed the pane's, so
# every pane the server destroys loses one allocation.
#
# The repro is the one in the commit message: N (default 20) panes are
# split off, each printing a line so it has ranges worked out for it,
# and killed. Under AddressSanitizer the exit report of an unfixed
# server holds
#
#     Direct leak of 160 byte(s) in 20 object(s) allocated from:
#         #1 xrecallocarray xmalloc.c:80
#         #2 server_client_ensure_ranges server-client.c:160
#         #3 window_visible_ranges window-visible.c:91
#         #4 screen_write_collect_flush_line screen-write.c:2344
#         #7 screen_write_stop screen-write.c:414
#         #8 input_parse_pane input.c:1038
#         #9 window_pane_read_callback window.c:1585
#
# and the script's verdict is exactly that: a Direct leak block whose
# stack passes through both server_client_ensure_ranges and
# window_pane_read_callback. The second frame is what makes the block
# the pane's own array rather than one worked out for a client, so the
# answer is to this defect and not to whatever else the exit report
# happens to hold.
#
# Measured at N=20:
#
#   c1f947a3 (origin/master)            20 objects   LEAKING
#   + this fix                           0 objects   clean
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-pane-ranges-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=50 ./demo-pane-ranges-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-20}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dpr.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

cleanup() {
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d -x 80 -y 24 'sleep 600' 2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

tm set-option -g status off

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'panes    %s split and killed, each printing a line\n\n' "$N"

# Each round makes a pane that writes once -- the write is what has the
# server work out the pane's visible ranges -- and kills it.
for i in $(seq "$N"); do
	tm split-window -d -t '{top}' "echo pane $i; sleep 600" >/dev/null 2>&1 || {
		echo "could not split a pane" >&2
		exit 2
	}
	tm kill-pane -t '{bottom}' 2>/dev/null
done

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks worked out for a pane's own
# array -- through server_client_ensure_ranges, below a pane read -- and
# not the ones a client keeps in its tty.
awk -v RS= -v ORS='\n\n' \
    '/Direct leak/ && /server_client_ensure_ranges/ && /window_pane_read_callback/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s destroyed pane(s) took their visible ranges with them.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: destroying a pane frees its visible ranges.\n'
exit 0
```