### PR TITLE
Fix memory leak when losing client

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -524,6 +524,7 @@ server_client_lost(struct client *c)
 	input_cancel_requests(c);
 
 	free(c->title);
+	free(c->path);
 	free((void *)c->cwd);
 
 	evtimer_del(&c->repeat_timer);


### PR DESCRIPTION
there's no reason to keep `path` not to be freed while we free title, cwd.

---

## Again, LLM generated reproduction script

```
#!/usr/bin/env bash
#
# Shows the leak of a lost client's path, fixed on branch
# fix-path-leak: whatever runs in a pane may report its directory with
# OSC 7, the active pane's path is copied into each client by
# server_client_set_path() when set-titles is on, and
# server_client_lost() freed every other string the client owns --
# title, set right beside path, included -- but not path, so the last
# one a client held went with it. One string leaks per lost client, and
# input-buffer-size lets the pane make it a megabyte.
#
# The repro: a pane announces a path with OSC 7, then N (default 10)
# clients in turn attach -- picking the path up on their first redraw --
# and detach. Under AddressSanitizer the exit report of an unfixed
# server holds
#
#     Direct leak of 400 byte(s) in 10 object(s) allocated from:
#         #1 xstrdup xmalloc.c:91
#         #2 server_client_set_path server-client.c:2607
#         #3 server_client_check_redraw server-client.c:2547
#
# and the script's verdict is exactly that: a Direct leak block whose
# stack passes through server_client_set_path. Other leaks the server
# may have are ignored, so the answer is to this defect and not to
# whatever else the exit report happens to hold.
#
# Measured at N=10:
#
#   c1f947a3 (origin/master)            10 objects   LEAKING
#   + this fix                           0 objects   clean
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-path-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=30 ./demo-path-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-10}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dcp.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

CLIENT_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

# The pane announces its path with OSC 7 and stays; every client that
# attaches later finds it on the active pane and copies it.
tm -f /dev/null new-session -d -x 80 -y 24 \
    "printf '\\033]7;file://host/leaked/by/every/lost/client\\033\\\\'; sleep 600" \
    2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

# server_client_set_path only runs when titles are being set.
tm set-option -g set-titles on
tm set-option -g status off

# Wait for OSC 7 to have been parsed into the pane.
for i in $(seq 50); do
	[ -n "$(tm display-message -p '#{pane_path}' 2>/dev/null)" ] && break
	sleep 0.1
done
[ -n "$(tm display-message -p '#{pane_path}')" ] || {
	echo "pane path was not set" >&2
	exit 2
}

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'clients  %s attached and lost, each holding "%s"\n\n' "$N" \
    "$(tm display-message -p '#{pane_path}')"

# Each round attaches a client on a terminal from script(1), lets it
# draw once so server_client_set_path runs for it, and detaches it, so
# server_client_lost sees a client whose path is set.
for i in $(seq "$N"); do
	script -qfc "$BIN -S $SOCK attach" /dev/null >/dev/null 2>&1 &
	CLIENT_PID=$!
	for j in $(seq 50); do
		[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] && break
		sleep 0.1
	done
	tm refresh-client 2>/dev/null
	sleep 0.2
	tm detach-client -a 2>/dev/null
	for j in $(seq 50); do
		kill -0 "$CLIENT_PID" 2>/dev/null || break
		sleep 0.1
	done
	CLIENT_PID=
done

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks whose allocation stack goes
# through server_client_set_path -- the copy this defect never freed.
awk -v RS= -v ORS='\n\n' '/Direct leak/ && /server_client_set_path/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s lost client(s) took their path string with them.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: losing a client frees its path.\n'
exit 0
```