### PR TITLE
Fix memory leak when drawing tree mode preview

### DIFF
--- a/window-tree.c
+++ b/window-tree.c
@@ -642,6 +642,7 @@ window_tree_draw_session(struct window_tree_modedata *data, struct session *s,
 			}
 			free(label);
 		}
+		format_free(ft);
 
 		if (loop != end - 1) {
 			screen_write_cursormove(ctx, cx + offset + width, cy,
@@ -790,6 +791,7 @@ window_tree_draw_window(struct window_tree_modedata *data, struct session *s,
 			}
 			free(label);
 		}
+		format_free(ft);
 
 		if (loop != end - 1) {
 			screen_write_cursormove(ctx, cx + offset + width, cy,


### PR DESCRIPTION
`ft` is local variable and never be freed during the loops. it should be freed per each loop iteration in both functions.

---

## LLM generated repro script

```
#!/usr/bin/env bash
#
# Shows the leak of tree mode's preview format trees, fixed on branch
# fix-tree-preview-leak: window_tree_draw_session() and
# window_tree_draw_window() create a format tree for each window or pane
# they put in the preview and never free it. Every other format tree in
# the file is freed -- window_tree_draw_info() frees the one it expands
# its lines with, and so do the three build functions -- so only the two
# preview loops were missed.
#
# The preview is drawn on every key that moves the selection, so this
# grows for as long as tree mode is on screen, at one tree per previewed
# window or pane per draw.
#
# The repro: a client attaches, opens tree mode with choose-tree -w, and
# is sent N (default 40) Down keys. Under AddressSanitizer the exit
# report of an unfixed server holds
#
#     Direct leak of 5376 byte(s) in 32 object(s) allocated from:
#         #2 format_create format.c:4211
#         #3 window_tree_draw_window window-tree.c:764
#         #4 window_tree_draw window-tree.c:906
#         #5 mode_tree_draw mode-tree.c:1026
#
# and the same out of window_tree_draw_session for the sessions the
# selection passes over. The script's verdict is exactly that: a Direct
# leak block whose stack passes through both format_create and
# window_tree_draw. Other leaks the server may have are ignored, so the
# answer is to this defect and not to whatever else the exit report
# happens to hold.
#
# The count is not N: a draw makes one tree per previewed window or
# pane, and how many that is depends on where the selection has got to.
#
# Measured at N=40 over a session of four windows:
#
#   c1f947a3 (origin/master)            59 objects   LEAKING
#   + this fix                           0 objects   clean
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-tree-preview-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=100 ./demo-tree-preview-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-40}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dtp.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

CLIENT_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d -x 80 -y 24 'sleep 600' 2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

tm set-option -g status off

# More than one window, so the selection has somewhere to move and the
# preview has something to make a tree for.
for i in 1 2 3; do
	tm new-window -d 'sleep 600' >/dev/null 2>&1
done

# The preview is drawn for a client, so there has to be one.
script -qfc "$BIN -S $SOCK attach" /dev/null >/dev/null 2>&1 &
CLIENT_PID=$!
for i in $(seq 50); do
	[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] && break
	sleep 0.1
done
[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] || {
	echo "no client attached" >&2
	exit 2
}
sleep 0.3

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'keys     %s Down in tree mode over %s windows\n\n' "$N" \
    "$(tm list-windows | wc -l)"

tm choose-tree -w -t 0 2>"$DIR/mode.err" || {
	echo "could not open tree mode" >&2
	cat "$DIR/mode.err" >&2
	exit 2
}
sleep 0.3

# Each key moves the selection, and each move draws the preview again.
for i in $(seq "$N"); do
	tm send-keys -t 0 Down 2>/dev/null
done
sleep 0.5
tm send-keys -t 0 q 2>/dev/null
sleep 0.3

tm detach-client -a 2>/dev/null
for i in $(seq 50); do
	kill -0 "$CLIENT_PID" 2>/dev/null || break
	sleep 0.1
done
kill "$CLIENT_PID" 2>/dev/null
CLIENT_PID=

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks whose allocation stack goes
# through window_tree_draw -- the preview trees of this defect -- and not
# the format trees the rest of tree mode makes.
awk -v RS= -v ORS='\n\n' \
    '/Direct leak/ && /format_create/ && /window_tree_draw/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s format tree(s) made for the preview were never freed.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: the preview frees the format trees it makes.\n'
exit 0
```