### PR TITLE
Fix memory leak in set-buffer

### DIFF
--- a/cmd-set-buffer.c
+++ b/cmd-set-buffer.c
@@ -100,6 +100,7 @@ cmd_set_buffer_exec(struct cmd *self, struct cmdq_item *item)
 			cmdq_error(item, "%s", cause);
 			goto fail;
 		}
+		free(bufname);
 		return (CMD_RETURN_NORMAL);
 	}
 
@@ -107,8 +108,10 @@ cmd_set_buffer_exec(struct cmd *self, struct cmdq_item *item)
 		cmdq_error(item, "no data specified");
 		goto fail;
 	}
-	if ((newsize = strlen(args_string(args, 0))) == 0)
+	if ((newsize = strlen(args_string(args, 0))) == 0) {
+		free(bufname);
 		return (CMD_RETURN_NORMAL);
+	}
 
 	if (args_has(args, 'a') && pb != NULL) {
 		olddata = paste_buffer_data(pb, &bufsize);
@@ -127,6 +130,7 @@ cmd_set_buffer_exec(struct cmd *self, struct cmdq_item *item)
 	if (args_has(args, 'w') && tc != NULL)
  		tty_set_selection(&tc->tty, "", bufdata, bufsize);
 
+	free(bufname);
 	return (CMD_RETURN_NORMAL);
 
 fail:


### PR DESCRIPTION
`bufname` is allocated at L66, and it ends up in following:

- L83: freed before return, good.
- L103: returned without freed, note that paste_rename does not take ownership.
- L111: returned without freed
- L130: returned without freed
- L136: freed before return, good.

Sidenote: `bufdata` is allocated at L119, but paste_set will consume its ownership on success path. no need to explicit cleanup at L130

---

a few more remaining...

## LLM generated repro script

```
#!/usr/bin/env bash
#
# Shows the leak of set-buffer's buffer name, fixed on branch
# fix-set-buffer-leak: cmd_set_buffer_exec() copies the -b name, or
# takes the copy paste_get_top() makes when there is none, and freed it
# only on the delete-buffer and the error paths. paste_set() and
# paste_rename() take the name as a const char * and make their own copy
# of it, so the command's copy is the command's to free, and set-buffer,
# set-buffer -n and the empty-data case all returned without doing so.
#
# The repro is the one in the commit message: a server given N (default
# 10) set-buffer and N set-buffer -n commands. Under AddressSanitizer
# the exit report of an unfixed server holds
#
#     Direct leak of 80 byte(s) in 10 object(s) allocated from:
#         #1 xstrdup xmalloc.c:91
#         #2 paste_get_top paste.c:129
#         #3 cmd_set_buffer_exec cmd-set-buffer.c:93
#
# and the same out of the xstrdup of a -b name. The script's verdict is
# exactly that: a Direct leak block whose stack passes through
# cmd_set_buffer_exec. Other leaks the server may have are ignored, so
# the answer is to this defect and not to whatever else the exit report
# happens to hold.
#
# Measured at N=10:
#
#   c1f947a3 (origin/master)            10 objects   LEAKING
#   + this fix                           0 objects   clean
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-set-buffer-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=50 ./demo-set-buffer-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-10}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dsb.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

cleanup() {
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the client's own exit report from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d 2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'commands %s set-buffer and %s set-buffer -n\n\n' "$N" "$N"

# set-buffer takes the top buffer's name from paste_get_top(), which is
# a copy; set-buffer -n renames with a copy of its own.
for i in $(seq "$N"); do
	tm set-buffer "data $i"
	tm set-buffer -n "renamed $i" "data $i"
done

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks whose allocation stack goes
# through cmd_set_buffer_exec -- the name copy this defect never freed.
awk -v RS= -v ORS='\n\n' '/Direct leak/ && /cmd_set_buffer_exec/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s buffer name(s) set-buffer copied were never freed.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: set-buffer frees the buffer name it copied.\n'
exit 0
```