### PR TITLE
Fix memory leak of collected items left on a screen

### DIFF
--- a/screen-write.c
+++ b/screen-write.c
@@ -338,10 +338,18 @@ screen_write_make_list(struct screen *s)
 void
 screen_write_free_list(struct screen *s)
 {
-	u_int	y;
+	struct screen_write_cline	*cl;
+	struct screen_write_citem	*ci, *ci1;
+	u_int				 y;
 
-	for (y = 0; y < screen_size_y(s); y++)
-		free(s->write_list[y].data);
+	for (y = 0; y < screen_size_y(s); y++) {
+		cl = &s->write_list[y];
+		TAILQ_FOREACH_SAFE(ci, &cl->items, entry, ci1) {
+			TAILQ_REMOVE(&cl->items, ci, entry);
+			screen_write_free_citem(ci);
+		}
+		free(cl->data);
+	}
 	free(s->write_list);
 }
 


### PR DESCRIPTION
Simply speaking, it's not guaranteed that `screen_write_citem` does not remain in screen->write_list[]->items. Currently they are simply forgotten, resulting memory leak.

This can happen only when `screen_write_collect_flush_line` fail to flush, which can happen when screen width is zero (and few more cases).

This commit fix by iterate remaining items, which is safe no-op when items is empty.

---

## LLM generated reproduction script

```
#!/usr/bin/env bash
#
# Shows the leak of collected items left on a screen, fixed on branch
# fix-screen-items-leak: screen_write_collect_flush_line() writes out
# the part of each collected item that is visible and leaves the rest
# collected, so a line can still hold items when the screen is freed --
# there is nothing in front of the flush that promises it emptied the
# list. screen_write_free_list() freed the lines' text and the array and
# dropped whatever was still on them.
#
# A zero-width screen is the easy way to see it: format_draw() sizes its
# eight screens by the length of the string, so drawing an empty format
# gives each one the clear item screen_write_clearendofline() collected
# and no column to write it in.
#
# The repro: a client attaches with status-format[0] set to the empty
# string and the status is redrawn N (default 10) times. Under
# AddressSanitizer the exit report of an unfixed server holds
#
#     Direct leak of 384 byte(s) in 4 object(s) allocated from:
#         #2 screen_write_get_citem screen-write.c:73
#         #3 screen_write_init screen-write.c:358
#         #4 screen_write_start screen-write.c:401
#         #5 format_draw format-draw.c:748
#
# and the script's verdict is exactly that: a Direct leak block whose
# stack passes through both screen_write_get_citem and format_draw.
# Other leaks the server may have are ignored, so the answer is to this
# defect and not to whatever else the exit report happens to hold.
#
# The count is not N: the free list is reused between draws, so what is
# lost is the items left on the screens, not one set per redraw.
#
# Measured at N=10:
#
#   c1f947a3 (origin/master)                     7 objects   LEAKING
#   + the sibling unterminated-style fix, alone  7 objects   LEAKING
#   + this fix                                   0 objects   clean
#
# The middle row is the check that this is the leak of items left on a
# screen and not the sibling leak of an unterminated style: there is no
# unterminated style here, format_draw() runs to its ordinary end, and
# the items are still lost when the screens are freed.
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-screen-items-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=30 ./demo-screen-items-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-10}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dsl.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

CLIENT_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill "$CLIENT_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d -x 80 -y 24 'sleep 600' 2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

# The whole line has to be empty, not just status-left: format_draw()
# sizes its screens by the string it is given, and only an empty string
# leaves them no column to flush an item into.
tm set-option -g status on
tm set-option -g 'status-format[0]' ''

script -qfc "$BIN -S $SOCK attach" /dev/null >/dev/null 2>&1 &
CLIENT_PID=$!
for i in $(seq 50); do
	[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] && break
	sleep 0.1
done
[ "$(tm list-clients 2>/dev/null | wc -l)" -ge 1 ] || {
	echo "no client attached" >&2
	exit 2
}

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'status   an empty format redrawn %s times\n\n' "$N"

for i in $(seq "$N"); do
	tm refresh-client -S 2>/dev/null
	sleep 0.15
done

tm detach-client -a 2>/dev/null
for i in $(seq 50); do
	kill -0 "$CLIENT_PID" 2>/dev/null || break
	sleep 0.1
done
kill "$CLIENT_PID" 2>/dev/null
CLIENT_PID=

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks of collected items taken
# under format_draw -- the ones this defect dropped with the screen.
awk -v RS= -v ORS='\n\n' \
    '/Direct leak/ && /screen_write_get_citem/ && /format_draw/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s collected item(s) were dropped with the screen.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: freeing a screen hands its collected items back.\n'
exit 0
```