### PR TITLE
Fix memory leak when losing detached client

### DIFF
--- a/server-client.c
+++ b/server-client.c
@@ -526,6 +526,8 @@ server_client_lost(struct client *c)
 	free(c->title);
 	free(c->path);
 	free((void *)c->cwd);
+	free(c->exit_session);
+	free(c->exit_message);
 
 	evtimer_del(&c->repeat_timer);
 	evtimer_del(&c->click_timer);
@@ -2407,8 +2409,6 @@ server_client_check_exit(struct client *c, int force)
 		proc_send(c->peer, c->exit_msgtype, -1, name, strlen(name) + 1);
 		break;
 	}
-	free(c->exit_session);
-	free(c->exit_message);
 }
 
 /* Redraw timer callback. */


### PR DESCRIPTION
exit_session and exit_message can leak when lost client first before processing server_client_check_exit. One possible scenario it can happen:

1. control client attaches
2. make a case control client does not read what server sent
3. server now have a pending writes
4. control client detaches - set exit_session
5. server_client_check_exit checks `control_all_done` but fail, it set timer but early return
6. `kill -9` control client
7. server_client_lost called - client cleanup except exit_session and exit_message.

Fix: cleanup exit_session and exit_message at _lost function. Plus set NULL at _check_exit so that _lost won't double free.

---

## LLM generated repro script

```
#!/usr/bin/env bash
#
# Shows the leak of a detached client's exit strings, fixed on branch
# fix-exit-message-leak: exit_session and exit_message are freed in
# server_client_check_exit(), which returns at once if CLIENT_DEAD is
# set, and server_client_lost() sets CLIENT_DEAD as its first statement.
# A client that goes away between being detached and the next pass
# through check_exit therefore takes both strings with it, and nothing
# can reach them afterwards. exit_session is the name of the session
# being left, which the user chooses the length of.
#
# check_exit did not clear the pointers after freeing them either, so
# freeing them in server_client_lost() alone would be a double free on
# the ordinary path; the fix clears them there as well.
#
# The repro has to keep check_exit from reaching the free, which it does
# with a control client whose output the reader never takes: the pipe
# fills, the server's write buffer for that client stops draining, and
# check_exit returns early on control_all_done(). Each of N (default 5)
# rounds attaches such a client to a session whose pane is writing
# steadily, detaches it -- which is what sets exit_session -- and kills
# it before the exit timer can run. Under AddressSanitizer the exit
# report of an unfixed server holds
#
#     Direct leak of 10 byte(s) in 5 object(s) allocated from:
#         #1 xstrdup xmalloc.c:91
#         #2 server_client_detach server-client.c:619
#
# and the script's verdict is exactly that: a Direct leak block whose
# stack passes through server_client_detach. Other leaks the server may
# have are ignored, so the answer is to this defect and not to whatever
# else the exit report happens to hold.
#
# Measured at N=5:
#
#   c1f947a3 (origin/master)             5 objects   LEAKING
#   + this fix                           0 objects   clean
#
# Needs a tmux built with AddressSanitizer:
#
#     ./configure CFLAGS="-O1 -g -fsanitize=address" \
#                 LDFLAGS="-fsanitize=address" && make
#
# Usage: ./demo-exit-message-leak.sh [asan-tmux-binary]  (default: $BIN, else ./tmux)
#        N=20 ./demo-exit-message-leak.sh ./tmux

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-5}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
	echo "no such server binary: $BIN" >&2
	exit 2
}

# Without instrumentation there is no exit report and silence would read
# as clean, so refuse a binary that does not carry ASan.
if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
	echo "$BIN is not built with AddressSanitizer" >&2
	echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
	exit 2
fi

# sun_path is 108 bytes including the NUL, and an agent's scratch
# directory alone can spend that, so keep the whole path short.
DIR=$(mktemp -d "${TMPDIR:-/tmp}/dem.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
	echo "socket path too long: $SOCK" >&2
	exit 2
fi

CLIENT_PID=
WRITER_PID=
READER_PID=
cleanup() {
	[ -n "$CLIENT_PID" ] && kill -9 "$CLIENT_PID" 2>/dev/null
	[ -n "$WRITER_PID" ] && kill "$WRITER_PID" 2>/dev/null
	[ -n "$READER_PID" ] && kill "$READER_PID" 2>/dev/null
	"$BIN" -S "$SOCK" kill-server 2>/dev/null
	rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

# LeakSanitizer reports when the process exits, so the report belongs to
# the server, written to its own log_path.<pid> file. exitcode=0 keeps
# the clients' own exit reports from failing the commands below.
export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

# The pane writes steadily so the control client always has output owed
# to it, which is what keeps check_exit from finishing.
tm -f /dev/null new-session -d -x 80 -y 24 \
    'while :; do dd if=/dev/urandom bs=1024 count=16 2>/dev/null | od -c; done' \
    2>"$DIR/start.err" || {
	echo "could not start a server with $BIN" >&2
	cat "$DIR/start.err" >&2
	exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

tm set-option -g status off

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'clients  %s control clients detached from "%s" and killed\n\n' "$N" \
    "$(tm display-message -p '#{session_name}')"

# A control client needs its standard input to stay open or it exits at
# once, and its output has to go somewhere with a reader that never
# reads, so the pipe fills and the server's buffer for it stops
# draining.
mkfifo "$DIR/in" "$DIR/out" || exit 2
sleep 600 >"$DIR/in" &
WRITER_PID=$!
sleep 600 <"$DIR/out" &
READER_PID=$!

for i in $(seq "$N"); do
	"$BIN" -S "$SOCK" -C attach <"$DIR/in" >"$DIR/out" 2>/dev/null &
	CLIENT_PID=$!
	NAME=
	for j in $(seq 50); do
		NAME=$(tm list-clients -F '#{client_name}' 2>/dev/null | head -1)
		[ -n "$NAME" ] && break
		sleep 0.1
	done
	[ -n "$NAME" ] || {
		echo "no control client attached" >&2
		exit 2
	}

	# Let the pipe fill, so check_exit has something to wait for.
	sleep 1

	tm detach-client -t "$NAME" 2>>"$DIR/detach.err"
	kill -9 "$CLIENT_PID" 2>/dev/null
	wait "$CLIENT_PID" 2>/dev/null
	CLIENT_PID=
	sleep 0.3
done

kill "$WRITER_PID" 2>/dev/null; WRITER_PID=
kill "$READER_PID" 2>/dev/null; READER_PID=

tm kill-server 2>/dev/null
for i in $(seq 100); do
	kill -0 "$SERVER_PID" 2>/dev/null || break
	sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
	echo "server did not exit" >&2
	exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"   # a clean server writes no log at all

# The verdict is only the Direct leak blocks whose allocation stack goes
# through server_client_detach -- the session name this defect never
# freed.
awk -v RS= -v ORS='\n\n' '/Direct leak/ && /server_client_detach/' \
    "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
	objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
	    awk '{ n += $2 } END { print n + 0 }')
	cat "$DIR/hit"
	printf 'LEAKING: %s lost client(s) took their exit strings with them.\n' \
	    "$objects"
	exit 1
fi
printf 'clean: losing a detached client frees its exit strings.\n'
exit 0
```