### PR TITLE
Add pane-border-collapse to draw a pane over a tiled separator

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -55,6 +55,8 @@ static int	layout_set_size_check(struct window *, struct layout_cell *,
 		    enum layout_type, int);
 static void	layout_resize_child_cells(struct window *,
 		    struct layout_cell *);
+static int	layout_pane_grows_over_separator(struct window_pane *,
+		    enum layout_type, int);
 
 /* Initializes cell geometry to sentinel values. */
 static void
@@ -471,6 +473,25 @@ layout_fix_panes(struct window *w, struct window_pane *skip)
 				sy--;
 		}
 
+		/*
+		 * Grow over each separator this pane has collapsed. The cell
+		 * keeps its size and only the pane inside it is made larger,
+		 * so the rest of the layout - and the layout string - are the
+		 * same as they would be without the option.
+		 */
+		if (layout_pane_grows_over_separator(wp, LAYOUT_TOPBOTTOM, 1)) {
+			wp->yoff--;
+			sy++;
+		}
+		if (layout_pane_grows_over_separator(wp, LAYOUT_TOPBOTTOM, 0))
+			sy++;
+		if (layout_pane_grows_over_separator(wp, LAYOUT_LEFTRIGHT, 1)) {
+			wp->xoff--;
+			sx++;
+		}
+		if (layout_pane_grows_over_separator(wp, LAYOUT_LEFTRIGHT, 0))
+			sx++;
+
 		if (window_pane_scrollbar_reserve(wp)) {
 			sb_w = wp->scrollbar_style.width;
 			sb_pad = wp->scrollbar_style.pad;
@@ -702,6 +723,173 @@ layout_cell_get_neighbour(struct layout_cell *lc)
 	return (lcother);
 }
 
+/* Find the first or last child of a cell that is tiled or contains a tile. */
+static struct layout_cell *
+layout_cell_get_end_tiled(struct layout_cell *lc, int last)
+{
+	struct layout_cell	*lcchild;
+
+	if (last) {
+		TAILQ_FOREACH_REVERSE(lcchild, &lc->cells, layout_cells,
+		    entry) {
+			if (layout_cell_is_tiled(lcchild) ||
+			    layout_cell_has_tiled_child(lcchild))
+				return (lcchild);
+		}
+		return (NULL);
+	}
+	TAILQ_FOREACH(lcchild, &lc->cells, entry) {
+		if (layout_cell_is_tiled(lcchild) ||
+		    layout_cell_has_tiled_child(lcchild))
+			return (lcchild);
+	}
+	return (NULL);
+}
+
+/*
+ * Check every pane along one edge of a cell has asked to be drawn over the
+ * separator on that edge. type is the axis the separator lies across and last
+ * is whether this is the bottom or right edge of the cell rather than the top
+ * or left. A pane with a status line never claims a separator because the
+ * status line is drawn in it.
+ */
+static int
+layout_cell_claims_separator(struct layout_cell *lc, enum layout_type type,
+    int last)
+{
+	struct layout_cell	*lcchild;
+	int			 collapse, want;
+
+	if (lc->type == LAYOUT_WINDOWPANE) {
+		if (lc->wp == NULL)
+			return (0);
+		if (window_pane_get_pane_status(lc->wp) != PANE_STATUS_OFF)
+			return (0);
+		collapse = options_get_number(lc->wp->options,
+		    "pane-border-collapse");
+		if (collapse == PANE_COLLAPSE_ALL)
+			return (1);
+		if (type == LAYOUT_TOPBOTTOM)
+			want = last ? PANE_COLLAPSE_BOTTOM : PANE_COLLAPSE_TOP;
+		else
+			want = last ? PANE_COLLAPSE_RIGHT : PANE_COLLAPSE_LEFT;
+		return (collapse == want);
+	}
+
+	/*
+	 * Cells stacked along the axis of the separator reach the edge only
+	 * with the one at the end, cells running across it all reach it.
+	 */
+	if (lc->type == type) {
+		lcchild = layout_cell_get_end_tiled(lc, last);
+		if (lcchild == NULL)
+			return (0);
+		return (layout_cell_claims_separator(lcchild, type, last));
+	}
+	TAILQ_FOREACH(lcchild, &lc->cells, entry) {
+		if (!layout_cell_is_tiled(lcchild) &&
+		    !layout_cell_has_tiled_child(lcchild))
+			continue;
+		if (!layout_cell_claims_separator(lcchild, type, last))
+			return (0);
+	}
+	return (1);
+}
+
+/*
+ * Return the cell drawn over the separator after a cell, or NULL if it is
+ * drawn as a border. When the cells on both sides claim it the one before it
+ * wins, so setting the option for a whole window removes every separator
+ * rather than none of them.
+ */
+static struct layout_cell *
+layout_cell_separator_owner(struct layout_cell *lc)
+{
+	struct layout_cell	*lcnext;
+	enum layout_type	 type;
+
+	if (lc->parent == NULL)
+		return (NULL);
+	type = lc->parent->type;
+	if (type != LAYOUT_LEFTRIGHT && type != LAYOUT_TOPBOTTOM)
+		return (NULL);
+
+	lcnext = layout_cell_get_neighbour_direction(lc, 1);
+	if (lcnext == NULL)
+		return (NULL);
+
+	if (layout_cell_claims_separator(lc, type, 1))
+		return (lc);
+	if (layout_cell_claims_separator(lcnext, type, 0))
+		return (lcnext);
+	return (NULL);
+}
+
+/*
+ * Find the cell immediately before the separator on one side of a cell, or
+ * NULL if that side is the edge of the window. before is whether to look at
+ * the top or left side rather than the bottom or right.
+ */
+static struct layout_cell *
+layout_cell_find_separator(struct layout_cell *lc, enum layout_type type,
+    int before)
+{
+	struct layout_cell	*lcother;
+
+	while (lc->parent != NULL) {
+		if (lc->parent->type == type) {
+			lcother = layout_cell_get_neighbour_direction(lc,
+			    !before);
+			if (lcother != NULL)
+				return (before ? lcother : lc);
+		}
+		lc = lc->parent;
+	}
+	return (NULL);
+}
+
+/* Is the separator on one side of a pane collapsed? */
+int
+layout_pane_separator_collapsed(struct window_pane *wp, enum layout_type type,
+    int before)
+{
+	struct layout_cell	*lc = wp->layout_cell;
+
+	if (lc == NULL || (lc->flags & LAYOUT_CELL_FLOATING))
+		return (0);
+	lc = layout_cell_find_separator(lc, type, before);
+	if (lc == NULL)
+		return (0);
+	return (layout_cell_separator_owner(lc) != NULL);
+}
+
+/*
+ * Is this the pane that grows over the separator on one side of it? Walking up
+ * from a pane reaches the cell that owns the separator only when the pane is
+ * on the edge of that cell facing it, so the panes further inside are left
+ * alone.
+ */
+static int
+layout_pane_grows_over_separator(struct window_pane *wp, enum layout_type type,
+    int before)
+{
+	struct layout_cell	*lc = wp->layout_cell, *lcsep, *lcowner;
+
+	if (lc == NULL || (lc->flags & LAYOUT_CELL_FLOATING))
+		return (0);
+	lcsep = layout_cell_find_separator(lc, type, before);
+	if (lcsep == NULL)
+		return (0);
+	lcowner = layout_cell_separator_owner(lcsep);
+	if (lcowner == NULL)
+		return (0);
+
+	for (; lc != NULL; lc = lc->parent) {
+		if (lc == lcowner)
+			return (1);
+	}
+	return (0);
+}
 
 /* Destroy a cell and redistribute the space. */
 void

--- a/options-table.c
+++ b/options-table.c
@@ -78,6 +78,9 @@ static const char *options_table_pane_border_indicators_list[] = {
 static const char *options_table_pane_border_lines_list[] = {
 	"single", "double", "heavy", "simple", "number", "spaces", "none", NULL
 };
+static const char *options_table_pane_border_collapse_list[] = {
+	"off", "top", "bottom", "left", "right", "all", NULL
+};
 static const char *options_table_popup_border_lines_list[] = {
 	"single", "double", "heavy", "simple", "rounded", "padded", "none", NULL
 };
@@ -1556,6 +1559,16 @@ const struct options_table_entry options_table[] = {
 	  .maximum = USHRT_MAX,
 	  .default_num = 0,
 	  .text = "Index of the first pane in each window."
+	},
+
+	{ .name = "pane-border-collapse",
+	  .type = OPTIONS_TABLE_CHOICE,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .choices = options_table_pane_border_collapse_list,
+	  .default_num = PANE_COLLAPSE_OFF,
+	  .text = "Which side of the pane is drawn over the separator "
+		  "between it and the next pane instead of leaving room for "
+		  "a border."
 	},
 
 	{ .name = "pane-border-format",

--- a/options.c
+++ b/options.c
@@ -1412,6 +1412,7 @@ options_push_changes(const char *name)
 	if (strcmp(name, "status") == 0 ||
 	    strcmp(name, "status-position") == 0 ||
 	    strcmp(name, "pane-border-indicators") == 0 ||
+	    strcmp(name, "pane-border-collapse") == 0 ||
 	    strcmp(name, "pane-border-lines") == 0 ||
 	    strcmp(name, "pane-border-status") == 0 ||
 	    strcmp(name, "pane-scrollbars") == 0 ||
@@ -1444,6 +1445,10 @@ options_push_changes(const char *name)
 			    "pane-scrollbars-position");
 			layout_fix_panes(w, NULL);
 		}
+	}
+	if (strcmp(name, "pane-border-collapse") == 0) {
+		RB_FOREACH(w, windows, &windows)
+			layout_fix_panes(w, NULL);
 	}
 	if (strcmp(name, "pane-scrollbars") == 0) {
 		RB_FOREACH(wp, window_pane_tree, &all_window_panes)

--- a/regress/pane-border-collapse.sh
+++ b/regress/pane-border-collapse.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+
+# pane-border-collapse: a pane is drawn over the separator between it and the
+# next pane instead of leaving room for a border, so that a one row pane can
+# sit directly on top of another with nothing in between.
+#
+# Only the pane that claims the separator changes size, by one cell, and only
+# when every pane along its edge claims it. The layout cells are not touched,
+# so #{window_layout} is the same with the option set and unset. If the panes
+# on both sides claim the separator the one before it wins.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+fail()
+{
+	echo "$*" >&2
+	$TMUX kill-server 2>/dev/null
+	exit 1
+}
+
+must_equal()
+{
+	got=$1
+	want=$2
+	[ "$got" = "$want" ] || fail "got '$got', expected '$want'"
+}
+
+geometry()
+{
+	$TMUX display-message -p -t "$1" \
+	    '#{pane_top} #{pane_height} #{pane_left} #{pane_width}'
+}
+
+collapse()
+{
+	$TMUX set-option -p -t "$1" pane-border-collapse "$2" ||
+	    fail "set pane-border-collapse $2 failed"
+}
+
+uncollapse()
+{
+	$TMUX set-option -p -t "$1" -u pane-border-collapse ||
+	    fail "unset pane-border-collapse failed"
+}
+
+$TMUX new-session -d -x 80 -y 24 || exit 1
+upper=$($TMUX display-message -p '#{pane_id}') || exit 1
+lower=$($TMUX split-window -v -l 22 -P -F '#{pane_id}') || exit 1
+
+# A one row pane above a 22 row pane: the separator is row 1, so the lower
+# pane starts at row 2.
+must_equal "$(geometry "$upper")" "0 1 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+layout=$($TMUX display-message -p '#{window_layout}')
+
+# --- The pane after the separator claims it ---
+
+# The lower pane grows up over row 1 and the upper pane is left alone, so one
+# row of real pane content sits directly on top of the other.
+collapse "$lower" top
+must_equal "$(geometry "$upper")" "0 1 0 80"
+must_equal "$(geometry "$lower")" "1 23 0 80"
+
+# The layout cells are unchanged, so the layout string still describes the
+# same tiling and can be parsed by a tmux without this option.
+must_equal "$($TMUX display-message -p '#{window_layout}')" "$layout"
+
+uncollapse "$lower"
+must_equal "$(geometry "$upper")" "0 1 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+
+# --- The pane before the separator claims it ---
+
+# The same option on the other side grows the upper pane down instead, which
+# is what a status bar below the content needs.
+collapse "$upper" bottom
+must_equal "$(geometry "$upper")" "0 2 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+uncollapse "$upper"
+
+# --- The side facing away from a separator is ignored ---
+
+# The lower pane has no separator below it, so claiming that side does
+# nothing.
+collapse "$lower" bottom
+must_equal "$(geometry "$upper")" "0 1 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+uncollapse "$lower"
+
+# --- Both sides claiming the separator ---
+
+# The pane before it wins, so the separator is only ever covered once.
+collapse "$upper" bottom
+collapse "$lower" top
+must_equal "$(geometry "$upper")" "0 2 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+uncollapse "$upper"
+uncollapse "$lower"
+
+# --- all ---
+
+# Set for the whole window every separator is claimed by the pane before it.
+$TMUX set-option -w pane-border-collapse all || exit 1
+must_equal "$(geometry "$upper")" "0 2 0 80"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+$TMUX set-option -w -u pane-border-collapse || exit 1
+
+# --- A pane status line keeps its separator ---
+
+# The status line is drawn in the separator, so a pane with one cannot claim
+# it and neither can the pane on the other side of it.
+$TMUX set-option -w pane-border-status top || exit 1
+collapse "$lower" top
+must_equal "$(geometry "$lower")" "2 22 0 80"
+$TMUX set-option -w -u pane-border-status || exit 1
+uncollapse "$lower"
+
+# --- Every pane along the edge must claim the separator ---
+
+# Split the top pane so the separator below it is shared by two panes. With
+# only one of them claiming it the separator stays.
+right=$($TMUX split-window -h -t "$upper" -P -F '#{pane_id}') || exit 1
+must_equal "$(geometry "$upper")" "0 1 0 40"
+must_equal "$(geometry "$right")" "0 1 41 39"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+
+collapse "$upper" bottom
+must_equal "$(geometry "$upper")" "0 1 0 40"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+
+# With both of them claiming it they both grow over it.
+collapse "$right" bottom
+must_equal "$(geometry "$upper")" "0 2 0 40"
+must_equal "$(geometry "$right")" "0 2 41 39"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+
+# A single pane on the other side of a shared separator is enough on its own.
+uncollapse "$upper"
+uncollapse "$right"
+collapse "$lower" top
+must_equal "$(geometry "$upper")" "0 1 0 40"
+must_equal "$(geometry "$right")" "0 1 41 39"
+must_equal "$(geometry "$lower")" "1 23 0 80"
+uncollapse "$lower"
+
+# --- Left and right ---
+
+# The same applies across a left to right split.
+collapse "$right" left
+must_equal "$(geometry "$upper")" "0 1 0 40"
+must_equal "$(geometry "$right")" "0 1 40 40"
+uncollapse "$right"
+
+collapse "$upper" right
+must_equal "$(geometry "$upper")" "0 1 0 41"
+must_equal "$(geometry "$right")" "0 1 41 39"
+uncollapse "$upper"
+
+must_equal "$(geometry "$upper")" "0 1 0 40"
+must_equal "$(geometry "$right")" "0 1 41 39"
+must_equal "$(geometry "$lower")" "2 22 0 80"
+
+$TMUX kill-server 2>/dev/null
+exit 0

--- a/screen-redraw.c
+++ b/screen-redraw.c
@@ -717,6 +717,22 @@ redraw_mark_pane_borders(struct redraw_build_ctx *bctx, struct window_pane *wp,
 			mark_bottom = 0;
 		else if (pane_status == PANE_STATUS_BOTTOM)
 			mark_top = 0;
+
+		/*
+		 * A collapsed separator is covered by pane content, so no
+		 * border is drawn along that side. The cells at either end of
+		 * it belong to other panes and must not be given a line
+		 * pointing this way, or they are drawn as a T instead of a
+		 * straight line.
+		 */
+		if (layout_pane_separator_collapsed(wp, LAYOUT_TOPBOTTOM, 1))
+			mark_top = 0;
+		if (layout_pane_separator_collapsed(wp, LAYOUT_TOPBOTTOM, 0))
+			mark_bottom = 0;
+		if (layout_pane_separator_collapsed(wp, LAYOUT_LEFTRIGHT, 1))
+			mark_left = 0;
+		if (layout_pane_separator_collapsed(wp, LAYOUT_LEFTRIGHT, 0))
+			mark_right = 0;
 	}
 
 	if (mark_top) {

--- a/tmux.1
+++ b/tmux.1
@@ -5926,6 +5926,32 @@ Like
 .Ic base\-index ,
 but set the starting index for pane numbers.
 .Pp
+.It Xo Ic pane\-border\-collapse
+.Op Ic off | top | bottom | left | right | all
+.Xc
+Draw the pane over the separator between it and the next pane on the given
+side instead of leaving a cell for a border.
+The pane grows by one cell and the pane on the other side of the separator is
+not moved or resized, so a one row pane may sit directly on top of another
+with nothing in between.
+.Pp
+A separator is only covered if every pane along that side of it asks for it,
+so a pane which shares a separator with a neighbour that does not ask is left
+alone.
+If the panes on both sides ask for it, the pane before it wins, so
+.Ic all
+removes every separator in a window rather than none of them.
+A pane with a pane border status line never covers a separator because the
+status line is drawn in it.
+.Pp
+Only the size of the pane is changed and not the layout, so the layout
+described by
+.Ic list\-windows
+is the same whether or not this option is set.
+A covered separator cannot be dragged with the mouse, but the panes either
+side of it may still be resized with
+.Ic resize\-pane .
+.Pp
 .It Ic pane\-border\-format Ar format
 Set the text shown in pane border status lines.
 .Pp

--- a/tmux.h
+++ b/tmux.h
@@ -1533,6 +1533,14 @@ TAILQ_HEAD(winlink_stack, winlink);
 #define PANE_STATUS_TOP_FLOATING 3
 #define PANE_STATUS_BOTTOM_FLOATING 4
 
+/* Pane border collapse option. */
+#define PANE_COLLAPSE_OFF 0
+#define PANE_COLLAPSE_TOP 1
+#define PANE_COLLAPSE_BOTTOM 2
+#define PANE_COLLAPSE_LEFT 3
+#define PANE_COLLAPSE_RIGHT 4
+#define PANE_COLLAPSE_ALL 5
+
 /* Pane scrollbars option. */
 #define PANE_SCROLLBARS_OFF 0
 #define PANE_SCROLLBARS_MODAL 1
@@ -3860,6 +3868,8 @@ void		 layout_make_leaf(struct layout_cell *, struct window_pane *);
 void		 layout_make_node(struct layout_cell *, enum layout_type);
 void		 layout_fix_zindexes(struct window *, struct layout_cell *);
 int		 layout_cell_is_tiled(struct layout_cell *);
+int		 layout_pane_separator_collapsed(struct window_pane *,
+		     enum layout_type, int);
 int		 layout_add_horizontal_border(struct layout_cell *,
 		     struct layout_cell *, int);
 void		 layout_fix_offsets(struct window *);


### PR DESCRIPTION
Hello - this is a draft for discussion rather than a finished proposal; please
say if the approach is wrong and I will change it or drop it.

### Problem

A tiled pane always has a cell reserved for the separator between it and its
neighbour, so a one row pane used as a bar above or below another pane costs
two rows rather than one.

There is currently no way to get that cell back:

- `pane-border-lines spaces` and `pane-border-format` change what is drawn in
  the separator, not that it is there.
- `pane-border-status` adds a line rather than removing one.
- The border geometry is fixed in the layout.

Drawing the bar with a status format instead of a real pane is not always an
option, because a real pane keeps copy mode, mouse selection and drag to copy.

### What this adds

`pane-border-collapse`, a choice option (`off` | `top` | `bottom` | `left` |
`right` | `all`) with window and pane scope, default `off`, so nothing changes
unless it is set.

It names the side of a pane that should be drawn over the separator on it
instead of leaving room for a border. That pane grows by one cell and the pane
on the other side is neither moved nor resized.

- A separator is only covered when every pane along that side of it asks, so a
  pane sharing a separator with a neighbour that does not ask is left alone and
  mixed layouts keep the current behaviour.
- When the panes on both sides ask, the one before it wins, so `all` removes
  every separator in a window rather than none of them.
- A pane with a `pane-border-status` line never claims a separator, because the
  status line is drawn in it.

### Approach

The layout cells are deliberately left alone and only the pane inside a cell is
made larger, in the same place `layout_fix_panes()` already shrinks a pane to
make room for a pane border status line.

This keeps the change small, but more importantly it keeps `#{window_layout}`
identical whether or not the option is set, so layouts stay portable between
builds with and without it in both directions. Changing the cell sizes would
not, since `layout_check()` assumes one cell per boundary.

Panes drawn over a separator also stop marking a border along that side,
otherwise the cells at each end of it are given a line pointing at a separator
that is no longer drawn and appear as a T.

### Trade-offs

- A covered separator cannot be dragged with the mouse, because pane content
  now covers it. The panes either side can still be resized with `resize-pane`,
  as the separator still exists in the layout.
- `pane-border-status` and this option do not combine on the same separator, by
  design.

### Tests

`regress/pane-border-collapse.sh` covers geometry on both sides of a
separator, all four directions, the side facing away from a separator being
ignored, both sides claiming, `all`, `pane-border-status` blocking a claim, and
a separator shared by two panes where only one of them claims it. It also
asserts `#{window_layout}` is unchanged.

Also checked by hand: rendering with `pane-border-lines simple` (no stray T
where a collapsed separator crosses a vertical one), `resize-pane` across a
collapsed separator, window resize and a shrink to 20x5, layout dump and
re-apply, zoom and unzoom, and floating panes, which never claim a separator.

The rest of `regress` passes apart from `input-keys.sh` and
`screen-redraw-menus.sh`, which behave the same way on master here.

### Related

#5433 is related but solves a different problem in the opposite direction:
`pane-border-type separate` draws a full border around each pane and
`separate-active` keeps a blank gutter, so both use more cells between
neighbours rather than fewer. #4236 and #2720 asked for borders to be removed
and were closed. I could not find existing work that reclaims tiled border
geometry, but I may have missed it.
