### PR TITLE
security(workflows): pin third-party Actions to a commit SHA

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'tmux/tmux'
     steps:
-      - uses: dessant/lock-threads@v6
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'

--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: dependencies
         if: runner.os == 'Linux'
@@ -81,7 +81,7 @@ jobs:
 
       - name: logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: regress-logs-${{ matrix.name }}
           path: regress/logs/*.log


### PR DESCRIPTION
## Summary
- Pin `dessant/lock-threads@v6`, `actions/checkout@v4`, and `actions/upload-artifact@v4` in `.github/workflows/{lock,regress}.yml` to their current tag's full commit SHA, keeping the tag as a trailing comment.
- Tags are mutable — a compromised maintainer account (or a supply-chain attack on the action's own repo, as happened to `tj-actions/changed-files` in 2025) can retarget a tag your workflow already trusts, silently changing what code runs with that job's token.
- `lock.yml` runs weekly with an `issues: write`, `pull-requests: write`, `discussions: write` token, so a hijacked `lock-threads` tag would have real reach even though the workflow never runs on untrusted PR code.

## Test plan
- [x] Both modified files parse as valid YAML.
- [x] Diffed to confirm only the three `uses:` lines changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)