### PR TITLE
security(workflows): add timeout-minutes to lock.yml's job

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -17,6 +17,7 @@ jobs:
   action:
     runs-on: ubuntu-latest
     if: github.repository == 'tmux/tmux'
+    timeout-minutes: 10
     steps:
       - uses: dessant/lock-threads@v6
         with:


### PR DESCRIPTION
## Summary
- `lock.yml`'s job had no `timeout-minutes`, so it defaults to GitHub's 360-minute maximum for a job that only calls the lock-threads action against the issue/PR/discussion API — that should normally finish in well under a minute.
- A hung run would otherwise hold the job's `issues`/`pull-requests`/`discussions` write token for up to 6 hours instead of failing fast. Set a 10-minute cap for comfortable headroom.

## Test plan
- [x] File parses as valid YAML after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)