### PR TITLE
security(workflows): set persist-credentials: false on regress.yml's checkout

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- `actions/checkout` persists the job's `GITHUB_TOKEN` in `.git/config` by default for the rest of the job.
- `regress.yml`'s token is `contents: read` only, and none of the build/test steps (`autogen.sh`, `configure`, `make`, the regress suite) run any git commands after checkout — I checked the whole file for `git fetch`/`pull`/`push` and found none. So there's no write capability to lose, and no later step depends on the persisted credential.
- Turning it off shrinks what a compromised build dependency or test step could do with a credential it has no reason to touch, for free.

## Test plan
- [x] File parses as valid YAML after the change.
- [x] Confirmed no step after checkout runs a `git` command that would need the persisted credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)