### PR TITLE
harden: variable 'line' was freed twice in cmd-capture-pane.c...

### DIFF
--- a/cmd-capture-pane.c
+++ b/cmd-capture-pane.c
@@ -166,6 +166,7 @@ cmd_capture_pane_grid(struct window_pane *wp, size_t *len)
 		}
 		buf = cmd_capture_pane_append(buf, len, line, strlen(line));
 		free(line);
+		line = NULL;
 
 		for (xx = 0; xx < gd->sx; xx++) {
 			line = cmd_capture_pane_cell(s, xx, yy);


### PR DESCRIPTION
## Summary
Harden input handling in `cmd-capture-pane.c` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | c.lang.security.double-free.double-free |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `c.lang.security.double-free.double-free` |
| **File** | `cmd-capture-pane.c:168` |
| **Assessment** | Defensive hardening |

**Description**: Variable 'line' was freed twice. This can lead to undefined behavior.

## Changes
- `cmd-capture-pane.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
