### PR TITLE
window-copy: clear stale marks when a search regex fails to compile

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -4851,6 +4851,8 @@ window_copy_search_marks(struct window_mode_entry *wme, struct screen *ssp,
 			cflags |= REG_ICASE;
 		if (regcomp(&reg, sbuf, cflags) != 0) {
 			free(sbuf);
+			free(data->searchmark);
+			data->searchmark = NULL;
 			return (0);
 		}
 		free(sbuf);


### PR DESCRIPTION
When window_copy_search_marks rebuilds the marks (for example after a resize, via window_copy_scroll_up) it recompiles the search pattern first. If regcomp fails it returned without touching data->searchmark, leaving the previous mark array in place -- but that array was allocated with xcalloc for the old grid size, while the drawing code (window_copy_update_style) indexes it with the current geometry. On a grown grid this reads past the end of the array (a heap overflow).

Free and NULL the mark array on the regcomp failure path so the drawing code skips it. Found with AddressSanitizer, driven by Bombadil (an invalid search regex followed by a resize and scroll).