### PR TITLE
window-copy: skip zero-length cells when building search string

### DIFF
--- a/window-copy.c
+++ b/window-copy.c
@@ -4301,7 +4301,7 @@ window_copy_stringify(struct grid *gd, u_int py, u_int first, u_int last,
 		}
 		if (dlen == 1)
 			buf[bx++] = *d;
-		else {
+		else if (dlen != 0) {
 			memcpy(buf + bx, d, dlen);
 			bx += dlen;
 		}


### PR DESCRIPTION
window_copy_stringify appends each cell's text to a buffer with memcpy(buf + bx, d, dlen). window_copy_cellstring returns a NULL pointer with dlen 0 for padding cells (the trailing half of a wide character) and for zero-size extended cells, so this becomes memcpy(dst, NULL, 0) -- undefined behaviour, as the source is declared nonnull -- and aborts under UBSan. It is reached from copy-mode search over lines that contain wide characters.

Skip cells with a zero length. Found with UBSan, driven by Bombadil.