### PR TITLE
cmd-resize-pane: fix use-after-free when resizing a zoomed pane

### DIFF
--- a/cmd-resize-pane.c
+++ b/cmd-resize-pane.c
@@ -93,6 +93,12 @@ cmd_resize_pane_exec(struct cmd *self, struct cmdq_item *item)
 	}
 	server_unzoom_window(w);
 
+	/*
+	 * Unzooming frees and rebuilds the layout, so the cell captured above
+	 * may have been freed; re-read it from the pane.
+	 */
+	lc = wp->layout_cell;
+
 	if (args_has(args, 'x')) {
 		x = args_percentage(args, 'x', 0, PANE_MAXIMUM, w->sx, &cause);
 		if (cause != NULL) {


### PR DESCRIPTION
cmd_resize_pane_exec reads the target pane's layout cell into a local variable at the top of the function, then calls server_unzoom_window. For a zoomed window that frees the entire zoomed layout tree — including that cell — and restores the saved layout. The stale cell is then dereferenced again near the end of the function when fixing up offsets, a use-after-free.

Re-read the layout cell from the pane after unzooming. Reproduce by splitting a window, zooming it (resize-pane -Z), then resize-pane -x. Found with AddressSanitizer, driven by Bombadil.