### PR TITLE
Fix memory leak during command parse

### DIFF
--- a/cmd-parse.y
+++ b/cmd-parse.y
@@ -802,6 +802,7 @@ cmd_parse_expand_alias(struct cmd_parse_command *cmd,
 	if (last == NULL) {
 		pr->status = CMD_PARSE_SUCCESS;
 		pr->cmdlist = cmd_list_new();
+		cmd_parse_free_commands(cmds);
 		return (1);
 	}
 
@@ -814,6 +815,7 @@ cmd_parse_expand_alias(struct cmd_parse_command *cmd,
 	pi->flags |= CMD_PARSE_NOALIAS;
 	cmd_parse_build_commands(cmds, pi, pr);
 	pi->flags &= ~CMD_PARSE_NOALIAS;
+	cmd_parse_free_commands(cmds);
 	return (1);
 }
 


### PR DESCRIPTION
`cmds` is local variable and should be freed before return.

---

## LLM generated repro script

```
#!/usr/bin/env bash

set -u

BIN=${1:-${BIN:-./tmux}}
N=${N:-20}

[ -x "$BIN" ] || command -v "$BIN" >/dev/null 2>&1 || {
        echo "no such server binary: $BIN" >&2
        exit 2
}

if ! { nm "$BIN" 2>/dev/null; ldd "$BIN" 2>/dev/null; } | grep -q asan; then
        echo "$BIN is not built with AddressSanitizer" >&2
        echo 'build with CFLAGS="-O1 -g -fsanitize=address" LDFLAGS="-fsanitize=address"' >&2
        exit 2
fi

DIR=$(mktemp -d "${TMPDIR:-/tmp}/dapl.XXXXXX") || exit 2
SOCK=$DIR/s
if [ "$(printf %s "$SOCK" | wc -c)" -ge 100 ]; then
        echo "socket path too long: $SOCK" >&2
        exit 2
fi

cleanup() {
        "$BIN" -S "$SOCK" kill-server 2>/dev/null
        rm -rf "$DIR"
}
trap cleanup EXIT

tm() { "$BIN" -S "$SOCK" "$@"; }

export ASAN_OPTIONS="detect_leaks=1:exitcode=0:log_path=$DIR/asan"

tm -f /dev/null new-session -d -s alias-leak 'sleep 300' 2>"$DIR/start.err" || {
        echo "could not start a server with $BIN" >&2
        cat "$DIR/start.err" >&2
        exit 2
}
SERVER_PID=$(tm display-message -p '#{pid}' 2>/dev/null)
[ -n "$SERVER_PID" ] || { echo "no server pid" >&2; exit 2; }

tm set-option -s 'command-alias[100]' 'leak=display-message -p ALIAS' || {
        echo "could not install command alias" >&2
        exit 2
}
for i in $(seq "$N"); do
        tm leak >/dev/null || {
                echo "alias invocation failed at iteration $i" >&2
                exit 2
        }
done

printf 'server   %s (pid %s)\n' "$("$BIN" -V)" "$SERVER_PID"
printf 'commands %s of command-alias expansion\n\n' "$N"

tm kill-server 2>/dev/null
for i in $(seq 100); do
        kill -0 "$SERVER_PID" 2>/dev/null || break
        sleep 0.1
done
if kill -0 "$SERVER_PID" 2>/dev/null; then
        echo "server did not exit" >&2
        exit 2
fi

LOG=$DIR/asan.$SERVER_PID
[ -s "$LOG" ] || : >"$LOG"
awk -v RS= -v ORS='\n\n' \
        '/(Direct|Indirect) leak/ && /cmd_parse_expand_alias/' \
        "$LOG" >"$DIR/hit"

if [ -s "$DIR/hit" ]; then
        objects=$(grep -o 'in [0-9]* object' "$DIR/hit" |
                awk '{ n += $2 } END { print n + 0 }')
        cat "$DIR/hit"
        printf 'LEAKING: %s allocation(s) came from command-alias expansion.\n' \
                "$objects"
        exit 1
fi
printf 'clean: no command-alias expansion leak was reported.\n'
exit 0
```