### PR TITLE
Add scroll-passthrough, so every scrolled line reaches the client

### DIFF
--- a/options-table.c
+++ b/options-table.c
@@ -1731,6 +1731,24 @@ const struct options_table_entry options_table[] = {
 	  .text = "Style of matched characters in switch mode."
 	},
 
+	{ .name = "scroll-passthrough",
+	  .type = OPTIONS_TABLE_FLAG,
+	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,
+	  .default_num = 0,
+	  .text = "Whether to paint pending output to the client before each "
+		  "line scrolls off the top. tmux normally batches writes and "
+		  "emits the scroll before painting them, discarding the "
+		  "pending write for the outgoing line and clamping a batch of "
+		  "scrolls to the height of the scroll region. Neither is "
+		  "visible in the pane, but a client whose terminal keeps its "
+		  "own scrollback (smcup and rmcup removed with "
+		  "terminal-overrides) only keeps what tmux sends, so those "
+		  "lines never reach its history. With this set the outgoing "
+		  "row is replayed and its scroll emitted one at a time, which "
+		  "costs extra output. No effect in copy mode or inside a "
+		  "synchronized update."
+	},
+
 	{ .name = "synchronize-panes",
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_WINDOW|OPTIONS_TABLE_PANE,

--- a/screen-write.c
+++ b/screen-write.c
@@ -34,6 +34,8 @@ static void	screen_write_collect_clear(struct screen_write_ctx *, u_int,
 static void	screen_write_collect_scroll(struct screen_write_ctx *, u_int);
 static void	screen_write_collect_flush(struct screen_write_ctx *, int,
 		    const char *);
+static u_int	screen_write_collect_flush_line(struct screen_write_ctx *,
+		    u_int);
 static int	screen_write_overwrite(struct screen_write_ctx *,
 		    struct grid_cell *, u_int);
 static int	screen_write_combine(struct screen_write_ctx *,
@@ -1812,6 +1814,8 @@ screen_write_linefeed(struct screen_write_ctx *ctx, int wrapped, u_int bg)
 	int			 redraw = 0;
 #endif
 	u_int			 rupper = s->rupper, rlower = s->rlower;
+	u_int			 cx, cy;
+	int			 passthrough;
 
 	gl = grid_get_line(gd, gd->hsize + s->cy);
 	if (wrapped)
@@ -1840,9 +1844,36 @@ screen_write_linefeed(struct screen_write_ctx *ctx, int wrapped, u_int bg)
 		ctx->wp->flags |= PANE_REDRAW;
 #endif
 
+	/*
+	 * A client whose terminal keeps its own scrollback - smcup and rmcup
+	 * removed with terminal-overrides, so tmux stays on the primary screen
+	 * - only ever keeps what tmux actually sends it, so the row leaving the
+	 * top of the region has to be on the client before it goes. The
+	 * collector normally emits the scroll first and paints afterwards, and
+	 * screen_write_collect_scroll() below drops the pending write for that
+	 * row, so on such a client the row is never sent and the terminal files
+	 * away whatever stale content it still had instead.
+	 *
+	 * Replay just the outgoing row and emit its scroll, rather than
+	 * flushing the whole screen: the visible rows are painted by the
+	 * ordinary flush at the end of the batch.
+	 */
+	passthrough = (ctx->wp != NULL &&
+	    options_get_number(ctx->wp->options, "scroll-passthrough"));
+	if (passthrough) {
+		cx = s->cx;
+		cy = s->cy;
+		screen_write_collect_flush_line(ctx, s->rupper);
+		s->cx = cx;
+		s->cy = cy;
+	}
+
 	grid_view_scroll_region_up(gd, s->rupper, s->rlower, bg);
 	screen_write_collect_scroll(ctx, bg);
 	ctx->scrolled++;
+
+	if (passthrough)
+		screen_write_collect_flush(ctx, 1, __func__);
 }
 
 /* Scroll up. */
@@ -1857,6 +1888,11 @@ screen_write_scrollup(struct screen_write_ctx *ctx, u_int lines, u_int bg)
 		lines = 1;
 	else if (lines > s->rlower - s->rupper + 1)
 		lines = s->rlower - s->rupper + 1;
+
+	/* See the comment in screen_write_linefeed(). */
+	if (ctx->wp != NULL &&
+	    options_get_number(ctx->wp->options, "scroll-passthrough"))
+		screen_write_collect_flush(ctx, 0, __func__);
 
 	if (bg != ctx->bg) {
 		screen_write_collect_flush(ctx, 1, __func__);


### PR DESCRIPTION
### The problem

With `smcup`/`rmcup` removed via `terminal-overrides`, tmux stays on the outer
terminal's primary screen and lines scrolling off a full-window pane land in that
terminal's own scrollback. This is a long-standing way to get native scrollback
(swipe/wheel on a phone, for instance) instead of copy-mode.

It doesn't work reliably: scroll back and a large fraction of the output simply
isn't there, and in its place you find rows of whatever the application had
pinned at the bottom of the screen.

This is **not** the `TTY_BLOCK` backoff from #1019 — `client_discarded` is 0 throughout.

### Cause

Two things in the write collector, both correct for a pane and both lossy for a
client whose terminal keeps its own scrollback:

1. `screen_write_collect_scroll()` discards the pending write for the row being
   scrolled out, and `screen_write_collect_flush()` emits the scroll *before*
   painting the collected writes — so the row the terminal files away is stale.

2. `screen_write_collect_flush_scrolled()` clamps a batch of pending scrolls to
   the height of the scroll region and drops the excess:

   ```c
   if (ctx->scrolled > s->rlower - s->rupper + 1)
           ctx->scrolled = s->rlower - s->rupper + 1;
   ```

The pane is unaffected either way — the grid history has the lines and copy-mode
shows them. But a terminal keeping its own scrollback only ever keeps what tmux
actually sends it.

### The change

A window/pane flag `scroll-passthrough`, **off by default**.

When set, `screen_write_linefeed()` replays the outgoing row with
`screen_write_collect_flush_line()` and emits that one scroll, instead of
flushing the whole screen — the visible rows are still painted by the ordinary
flush at the end of the batch. `screen_write_scrollup()`, a much rarer path,
takes a full flush before the scroll instead.

Both run before the background is latched: a full flush resets `ctx->bg` to 8, and
the scroll would otherwise go out with the default background rather than `bg`.

### Measurements

51x29 window, an application redrawing the way a full-screen TUI does (rewind
with `CSI nA`, rewrite in place, keep a footer pinned at the bottom), writing
~4000 lines in bursts:

| `scroll-passthrough` | content lines never sent | footer rows wrongly pushed into scrollback |
|---|---|---|
| `off` (current behaviour) | 2067 | 55 |
| `on` | **0** | **0** |

Eight consecutive runs with the option on were clean; one earlier run left 3
footer rows, which I have not isolated.

A plain `cat` of a 3000-line file, same window: 283–1359 lines lost with the
option off (varies by run), 0 with it on.

Replaying just the outgoing row rather than flushing the whole screen costs about
9% fewer bytes on that test — 80kB against 88kB across three runs — and leaves
background handling identical to the option being off (97 of 98 scrolls carrying
the active background in both cases).

With the option off, behaviour is unchanged from stock, verified by running the
same harness against an unpatched build of the same tree.

### Cost and limitations

- Extra output per scrolled line, hence off by default.
- No effect while a pane is in copy mode — `input.c` deliberately uses a
  pane-less write context there, so the guard is false.
- No effect for output inside a synchronized update: `screen_write_collect_flush()`
  discards queued items under `MODE_SYNC` and `CSI ?2026l` schedules a full
  redraw. Preserving those would need outgoing rows retained and replayed across
  the update.
- A tall SIXEL image still scrolls in `screen_write_sixelimage()` without
  consulting the option.
