### PR TITLE
Add a pane output generation format

### DIFF
--- a/format.c
+++ b/format.c
@@ -2276,6 +2276,17 @@ format_cb_pane_last_output_time(struct format_tree *ft)
 	return (NULL);
 }
 
+/* Callback for pane_output_generation. */
+static void *
+format_cb_pane_output_generation(struct format_tree *ft)
+{
+	struct window_pane	*wp = ft->wp;
+
+	if (wp != NULL)
+		return (format_printf("%llu", (unsigned long long)wp->output_generation));
+	return (NULL);
+}
+
 /* Callback for pane_last_prompt_time. */
 static void *
 format_cb_pane_last_prompt_time(struct format_tree *ft)
@@ -3848,6 +3859,9 @@ static const struct format_table_entry format_table[] = {
 	},
 	{ "pane_mode", FORMAT_TABLE_STRING,
 	  format_cb_pane_mode
+	},
+	{ "pane_output_generation", FORMAT_TABLE_STRING,
+	  format_cb_pane_output_generation
 	},
 	{ "pane_path", FORMAT_TABLE_STRING,
 	  format_cb_pane_path

--- a/input.c
+++ b/input.c
@@ -1049,6 +1049,7 @@ input_parse_buffer(struct window_pane *wp, const u_char *buf, size_t len)
 	if (len == 0)
 		return;
 
+	wp->output_generation++;
 	window_update_activity(wp->window);
 	if (~wp->flags & PANE_ACTIVITY) {
 		wp->flags |= PANE_ACTIVITY;

--- a/regress/format-variables.sh
+++ b/regress/format-variables.sh
@@ -124,6 +124,7 @@ pane_left
 pane_marked
 pane_marked_set
 pane_mode
+pane_output_generation
 pane_path
 pane_pb_progress
 pane_pb_state

--- a/regress/pane-output-generation.sh
+++ b/regress/pane-output-generation.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+export TERM
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/tmux-output-generation.XXXXXXXXXX") ||
+	exit 1
+test_socket="$test_dir/tmux.sock"
+test_name="output-generation-$$"
+test_session=""
+
+fail()
+{
+	echo "$*" >&2
+	exit 1
+}
+
+test_tmux()
+{
+	"$TEST_TMUX" -S "$test_socket" "$@"
+}
+
+cleanup()
+{
+	status=$?
+	trap - 0 1 2 15
+
+	sessions=$(test_tmux list-sessions -F '#{session_id}|#{session_name}' \
+	    2>/dev/null) || sessions=""
+	if [ -n "$sessions" ]; then
+		if [ -z "$test_session" ] || \
+		    [ "$sessions" != "$test_session|$test_name" ]; then
+			echo "unexpected sessions on test socket $test_socket; refusing cleanup" >&2
+			echo "$sessions" >&2
+			exit 1
+		fi
+		test_tmux kill-session -t "$test_session" >/dev/null 2>&1 ||
+			exit 1
+	fi
+
+	if test_tmux list-sessions >/dev/null 2>&1; then
+		echo "test server still running on $test_socket; refusing cleanup" >&2
+		exit 1
+	fi
+	[ ! -e "$test_socket" ] || rm -f "$test_socket"
+	rmdir "$test_dir" || exit 1
+	exit "$status"
+}
+
+generation()
+{
+	test_tmux display-message -p -t "$1" '#{pane_output_generation}'
+}
+
+wait_for_new_generation()
+{
+	pane=$1
+	before=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		after=$(generation "$pane") || exit 1
+		[ "$after" != "$before" ] && {
+			echo "$after"
+			return 0
+		}
+		sleep 0.01
+		i=$((i + 1))
+	done
+	echo "pane $pane generation remained $before" >&2
+	return 1
+}
+
+trap cleanup 0 1 2 15
+
+test_session=$(test_tmux -f /dev/null new-session -d -P \
+	-F '#{session_id}' -s "$test_name" 'exec sleep 1000') ||
+	exit 1
+pane0=$(test_tmux display-message -p -t "$test_session":0.0 '#{pane_id}') ||
+	exit 1
+pane1=$(test_tmux split-window -d -P -F '#{pane_id}' \
+	-t "$test_session":0 'exec sleep 1000') || exit 1
+
+generation0=$(generation "$pane0") || exit 1
+generation1=$(generation "$pane1") || exit 1
+[ -n "$generation0" ] || fail "initial generation for $pane0 is empty"
+[ -n "$generation1" ] || fail "initial generation for $pane1 is empty"
+
+test_tmux capture-pane -p -t "$pane0" >/dev/null || exit 1
+[ "$(generation "$pane0")" = "$generation0" ] ||
+	fail "capture-pane changed generation for $pane0"
+
+pane0_tty=$(test_tmux display-message -p -t "$pane0" '#{pane_tty}') ||
+	exit 1
+printf 'visible output' >"$pane0_tty" || exit 1
+generation0=$(wait_for_new_generation "$pane0" "$generation0") || exit 1
+[ "$(generation "$pane1")" = "$generation1" ] ||
+	fail "output in $pane0 changed generation for $pane1"
+
+printf '\033]2;control-only output\007' >"$pane0_tty" || exit 1
+wait_for_new_generation "$pane0" "$generation0" >/dev/null || exit 1
+
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -7415,6 +7415,7 @@ The following variables are available, where appropriate:
 .It Li "pane_marked_set" Ta "" Ta "1 if a marked pane is set"
 .It Li "pane_modal_flag" Ta "" Ta "1 if pane is modal"
 .It Li "pane_mode" Ta "" Ta "Name of pane mode, if any"
+.It Li "pane_output_generation" Ta "" Ta "Generation incremented when pane output is processed"
 .It Li "pane_path" Ta "" Ta "Path of pane (can be set by application)"
 .It Li "pane_pid" Ta "" Ta "PID of first process in pane"
 .It Li "pane_pipe" Ta "" Ta "1 if pane is being piped"

--- a/tmux.h
+++ b/tmux.h
@@ -1360,6 +1360,7 @@ struct window_pane {
 	struct cmdq_item *wait_item;	/* new-pane -W: waiting for pane exit */
 	struct spawn_editor_state *editor;
 
+	uint64_t	 output_generation;
 	time_t		 last_output_time;
 	time_t		 last_prompt_time;
 	time_t		 cmd_start_time;


### PR DESCRIPTION
`pane_last_output_time` has one-second resolution, so an external poller cannot always tell whether output arrived since its previous check. Waiting a second between polls does not avoid this: later output in the same wall-clock second as the previously recorded output leaves the value unchanged.

This adds `pane_output_generation`, a per-pane 64-bit value that changes whenever tmux processes a nonempty pane-output buffer. A periodic pane-content saver can remember this value and, after also checking pane identity and geometry, avoid capturing panes that received no output. This enables a more efficient external design than repeatedly capturing every pane, as snapshot-based tools such as tmux-resurrect with tmux-continuum do.

The value is an opaque change token. tmux processes output in batches, so the numerical difference is not a count of bytes, characters, writes, lines or screen changes. Control-only output changes it, while `capture-pane` does not. Resizes, respawns and other changes unrelated to pane output must be tracked separately.

The implementation adds one 64-bit value per pane and one increment per nonempty buffer, with no per-character work. Saving policy and storage remain external to tmux.

The regression checks independent panes, non-mutating capture, visible output and control-only output.
