### PR TITLE
Hold client redraws until resized panes repaint

### DIFF
--- a/cmd-break-pane.c
+++ b/cmd-break-pane.c
@@ -99,6 +99,7 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct session		*dst_s = target->s;
 	struct window_pane	*wp = source->wp;
 	struct window		*w = wl->window, *old_w = w;
+	struct window_pane_resize_sync_token token = { 0 };
 	char			*cause, *cp;
 	int			 idx = target->idx, before, old_idx = wl->idx;
 	const char		*template, *name = args_get(args, 'n');
@@ -150,6 +151,7 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
+	window_pane_resize_sync_detach(w, wp, &token);
 	TAILQ_REMOVE(&w->panes, wp, entry);
 	TAILQ_REMOVE(&w->z_index, wp, zentry);
 	server_client_remove_pane(wp);
@@ -164,6 +166,7 @@ cmd_break_pane_exec(struct cmd *self, struct cmdq_item *item)
 	TAILQ_INSERT_HEAD(&w->z_index, wp, zentry);
 	w->active = wp;
 	w->latest = tc;
+	window_pane_resize_sync_attach(wp, &token);
 
 	free(w->name);
 	if (name == NULL)

--- a/cmd-join-pane.c
+++ b/cmd-join-pane.c
@@ -417,6 +417,7 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct winlink		*src_wl, *dst_wl;
 	struct window		*src_w, *dst_w;
 	struct window_pane	*src_wp, *dst_wp;
+	struct window_pane_resize_sync_token token = { 0 };
 	const char		*s;
 	char			*cause = NULL;
 	int			 flags = 0, dst_idx;
@@ -485,8 +486,9 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		return (CMD_RETURN_ERROR);
 	}
 
+	if (src_w != dst_w)
+		window_pane_resize_sync_detach(src_w, src_wp, &token);
 	layout_close_pane(src_wp);
-
 	server_client_remove_pane(src_wp);
 	window_lost_pane(src_w, src_wp);
 	TAILQ_REMOVE(&src_w->panes, src_wp, entry);
@@ -502,6 +504,8 @@ cmd_join_pane_exec(struct cmd *self, struct cmdq_item *item)
 		TAILQ_INSERT_AFTER(&dst_w->panes, dst_wp, src_wp, entry);
 		TAILQ_INSERT_AFTER(&dst_w->z_index, dst_wp, src_wp, zentry);
 	}
+	if (src_w != dst_w)
+		window_pane_resize_sync_attach(src_wp, &token);
 	layout_assign_pane(lc, src_wp, 0);
 	colour_palette_from_option(&src_wp->palette, src_wp->options);
 

--- a/cmd-swap-pane.c
+++ b/cmd-swap-pane.c
@@ -66,6 +66,8 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	struct cmd_find_state	*target = cmdq_get_target(item);
 	struct window		*src_w, *dst_w;
 	struct window_pane	*tmp_wp, *src_wp, *dst_wp;
+	struct window_pane_resize_sync_token src_token = { 0 };
+	struct window_pane_resize_sync_token dst_token = { 0 };
 	struct layout_cell	*src_lc, *dst_lc;
 	u_int			 sx, sy, xoff, yoff;
 	int			 src_idx, dst_idx;
@@ -117,6 +119,10 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	if (src_wp == dst_wp)
 		goto out;
 
+	if (src_w != dst_w) {
+		window_pane_resize_sync_detach(src_w, src_wp, &src_token);
+		window_pane_resize_sync_detach(dst_w, dst_wp, &dst_token);
+	}
 	server_client_remove_pane(src_wp);
 	server_client_remove_pane(dst_wp);
 
@@ -153,6 +159,10 @@ cmd_swap_pane_exec(struct cmd *self, struct cmdq_item *item)
 	dst_wp->window = src_w;
 	options_set_parent(dst_wp->options, src_w->options);
 	dst_wp->flags |= (PANE_STYLECHANGED|PANE_THEMECHANGED);
+	if (src_w != dst_w) {
+		window_pane_resize_sync_attach(src_wp, &src_token);
+		window_pane_resize_sync_attach(dst_wp, &dst_token);
+	}
 
 	sx = src_wp->sx; sy = src_wp->sy;
 	xoff = src_wp->xoff; yoff = src_wp->yoff;

--- a/regress/resize-sync-redraw.sh
+++ b/regress/resize-sync-redraw.sh
@@ -1,0 +1,1423 @@
+#!/bin/sh
+
+# A layout resize must notify synchronized applications before the pending
+# geometry redraw is presented. Their first post-resize frames are collected in
+# the backing screens and the client receives one final redraw, not a stale
+# geometry frame followed by one correction per pane.
+
+PATH=/bin:/usr/bin
+TERM=screen
+LC_ALL=C.UTF-8
+export PATH TERM LC_ALL
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+python3 - "$TEST_TMUX" <<'PY'
+import fcntl
+import os
+import re
+import select
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+
+
+tmux = sys.argv[1]
+label = "test-resize-sync-redraw-%d" % os.getpid()
+server = [tmux, "-L" + label, "-f/dev/null"]
+width = 100
+height = 30
+sync_start = b"\033[?2026h"
+sync_end = b"\033[?2026l"
+barrier_deadline = 0.15
+prompt_release_deadline = 0.13
+release_quiet = barrier_deadline + 0.15
+
+emitter_source = r'''
+import os
+import signal
+import sys
+import time
+
+
+name, update_mode, ready, arm, resized, winches, gate, painted, preopen, \
+    preopened, preclose, preclosed, partial, partial_started, \
+    partial_finish, skip, repeat, repeat_started, repeat_stop, exit_frame, \
+    exit_started, flood, flood_started, flood_stop, flood_done, same_batch, \
+    same_batch_written = sys.argv[1:]
+pending = False
+generation = 0
+resize_times = []
+
+
+def touch(path):
+    with open(path, "w", encoding="utf-8"):
+        pass
+
+
+def on_resize(_signum, _frame):
+    global pending
+    size = os.get_terminal_size(1)
+    resize_times.append((time.monotonic(), size.columns, size.lines))
+    if os.path.exists(arm):
+        pending = True
+
+
+def paint(phase):
+    size = os.get_terminal_size(1)
+    rows = []
+    for row in range(size.lines):
+        marker = "%s_%s_%02d_" % (name, phase, row)
+        fill = chr(ord("A") + (row * 7 + len(phase)) % 26)
+        rows.append((marker + fill * size.columns)[:size.columns])
+    start = "\033[?2026h" if update_mode != "plain" else ""
+    end = "\033[?2026l" if update_mode != "plain" else ""
+    payload = (start + "\033[H" + "\r\n".join(rows) + end).encode()
+    written = os.write(1, payload)
+    if written != len(payload):
+        raise RuntimeError("short frame write")
+
+
+def paint_partial(phase):
+    size = os.get_terminal_size(1)
+    split = max(1, size.lines // 2)
+    top = []
+    bottom = []
+    for row in range(size.lines):
+        half = "TOP" if row < split else "BOTTOM"
+        marker = "%s_%s_%s_%02d_" % (name, phase, half, row)
+        fill = chr(ord("A") + (row * 7 + len(phase)) % 26)
+        line = (marker + fill * size.columns)[:size.columns]
+        if row < split:
+            top.append(line)
+        else:
+            bottom.append(line)
+    first = ("\033[?2026h\033[H" + "\r\n".join(top)).encode()
+    written = os.write(1, first)
+    if written != len(first):
+        raise RuntimeError("short partial frame start write")
+    touch(partial_started)
+    while not os.path.exists(partial_finish):
+        time.sleep(0.001)
+    os.unlink(partial_finish)
+    second = ("\r\n" + "\r\n".join(bottom) + "\033[?2026l").encode()
+    written = os.write(1, second)
+    if written != len(second):
+        raise RuntimeError("short partial frame finish write")
+
+
+def paint_repeated(phase):
+    size = os.get_terminal_size(1)
+    marker = ("%s_%s_REPEAT_" % (name, phase)).ljust(size.columns, "R")
+    payload = ("\033[?2026h\033[H" + marker).encode()
+    written = os.write(1, payload)
+    if written != len(payload):
+        raise RuntimeError("short repeated frame start write")
+    touch(repeat_started)
+    next_repeat = time.monotonic() + 0.1
+    while not os.path.exists(repeat_stop):
+        if time.monotonic() >= next_repeat:
+            os.write(1, b"\033[?2026h")
+            next_repeat = time.monotonic() + 0.1
+        time.sleep(0.001)
+    os.write(1, b"\033[?2026l")
+
+
+def paint_and_exit(phase):
+    size = os.get_terminal_size(1)
+    marker = ("%s_%s_EXIT_" % (name, phase)).ljust(size.columns, "X")
+    payload = ("\033[?2026h\033[H" + marker).encode()
+    written = os.write(1, payload)
+    if written != len(payload):
+        raise RuntimeError("short exiting frame write")
+    touch(exit_started)
+    os._exit(0)
+
+
+def write_backpressure():
+    payload = ((name + "_BACKPRESSURE_\r\n") * 256).encode()[:4096]
+    touch(flood_started)
+    while not os.path.exists(flood_stop):
+        os.write(1, payload)
+    touch(flood_done)
+
+
+def write_same_batch():
+    # Must stay far below the smallest pty buffer: the server is stopped
+    # while this runs, so a write larger than the buffer blocks and the
+    # marker below is never written. macOS buffers much less than Linux.
+    payload = ("\033[2J\033[H" + name + "_SAME_BATCH_").encode()
+    written = os.write(1, payload)
+    if written != len(payload):
+        raise RuntimeError("short same-batch write")
+    touch(same_batch_written)
+
+
+def paint_open():
+    size = os.get_terminal_size(1)
+    marker = ("%s_OPEN_" % name).ljust(size.columns, "O")
+    payload = ("\033[?2026h\033[H" + marker).encode()
+    written = os.write(1, payload)
+    if written != len(payload):
+        raise RuntimeError("short open frame write")
+    touch(preopened)
+
+
+def close_preopen():
+    if not os.path.exists(preclose):
+        return
+    os.unlink(preclose)
+    written = os.write(1, b"\033[?2026l")
+    if written != len(b"\033[?2026l"):
+        raise RuntimeError("short pre-resize frame close write")
+    touch(preclosed)
+
+
+signal.signal(signal.SIGWINCH, on_resize)
+if update_mode != "sync-primary":
+    os.write(1, b"\033[?1049h")
+paint("BEFORE")
+touch(ready)
+
+while True:
+    if resize_times:
+        with open(winches, "a", encoding="utf-8") as handle:
+            for resize_time, columns, lines in resize_times:
+                handle.write("%.9f %d %d\n" %
+                    (resize_time, columns, lines))
+        resize_times.clear()
+    close_preopen()
+    if os.path.exists(same_batch):
+        os.unlink(same_batch)
+        write_same_batch()
+        continue
+    if os.path.exists(flood):
+        os.unlink(flood)
+        write_backpressure()
+        continue
+    if os.path.exists(preopen):
+        os.unlink(preopen)
+        paint_open()
+        continue
+    if not pending:
+        time.sleep(0.001)
+        continue
+    pending = False
+    generation += 1
+    touch(resized)
+    while not os.path.exists(gate):
+        close_preopen()
+        time.sleep(0.001)
+    if os.path.exists(skip):
+        pass
+    elif os.path.exists(repeat):
+        paint_repeated("AFTER%d" % generation)
+    elif os.path.exists(exit_frame):
+        paint_and_exit("AFTER%d" % generation)
+    elif os.path.exists(partial):
+        paint_partial("AFTER%d" % generation)
+    else:
+        paint("AFTER%d" % generation)
+    touch(painted)
+'''
+
+
+def run(*args, check=True):
+    return subprocess.run(
+        server + list(args),
+        check=check,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def wait_for(predicate, timeout, message):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    fail(message)
+
+
+def read_available(fd, duration):
+    output = bytearray()
+    deadline = time.monotonic() + duration
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.005)
+        if fd not in readable:
+            continue
+        try:
+            output.extend(os.read(fd, 1 << 20))
+        except (BlockingIOError, OSError):
+            break
+    return bytes(output)
+
+
+def read_before(fd, deadline, message):
+    while time.monotonic() < deadline:
+        timeout = min(0.005, deadline - time.monotonic())
+        readable, _, _ = select.select([fd], [], [], timeout)
+        if fd not in readable:
+            continue
+        try:
+            output = os.read(fd, 1 << 20)
+        except (BlockingIOError, OSError):
+            output = b""
+        if output:
+            return output
+    fail(message)
+
+
+def drain_until_quiet(fd, quiet, timeout):
+    output = bytearray()
+    deadline = time.monotonic() + timeout
+    quiet_deadline = time.monotonic() + quiet
+    while time.monotonic() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.005)
+        if fd in readable:
+            try:
+                chunk = os.read(fd, 1 << 20)
+            except (BlockingIOError, OSError):
+                chunk = b""
+            if chunk:
+                output.extend(chunk)
+                quiet_deadline = time.monotonic() + quiet
+                continue
+        if time.monotonic() >= quiet_deadline:
+            return bytes(output)
+    fail("client output did not become quiet")
+
+
+def attach(session="resize", columns=width, lines=height):
+    pid, fd = os.forkpty()
+    if pid == 0:
+        fcntl.ioctl(
+            1,
+            termios.TIOCSWINSZ,
+            struct.pack("HHHH", lines, columns, 0, 0),
+        )
+        os.environ["TERM"] = "xterm-256color"
+        os.execl(
+            tmux,
+            tmux,
+            "-L" + label,
+            "-f/dev/null",
+            "attach-session",
+            "-t",
+            session,
+        )
+    os.set_blocking(fd, False)
+    return pid, fd
+
+
+def complete_client_startup(fd, expected_clients=1):
+    query = b"\033[>q"
+    output = bytearray()
+    deadline = time.monotonic() + 5
+    while query not in output:
+        output.extend(read_before(
+            fd,
+            deadline,
+            "client did not request extended device attributes",
+        ))
+
+    terminal_type = b"XTerm(370)"
+    response = b"\033P>|" + terminal_type + b"\033\\"
+    if os.write(fd, response) != len(response):
+        fail("short extended device attributes response")
+    wait_for(
+        lambda: run(
+            "list-clients", "-F", "#{client_termtype}"
+        ).stdout.splitlines().count(terminal_type) >= expected_clients,
+        2,
+        "server did not process extended device attributes response",
+    )
+    drain_until_quiet(fd, 0.2, 5)
+
+
+def close_client(pid=None, fd=None):
+    if fd is not None:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    if pid is not None:
+        try:
+            os.kill(pid, signal.SIGHUP)
+        except ProcessLookupError:
+            pass
+
+
+def cleanup(pid=None, fd=None):
+    close_client(pid, fd)
+    run("kill-server", check=False)
+
+
+run("kill-server", check=False)
+with tempfile.TemporaryDirectory() as directory:
+    emitter = os.path.join(directory, "emitter.py")
+    with open(emitter, "w", encoding="utf-8") as handle:
+        handle.write(emitter_source)
+
+    paths = {}
+    for name in ("LEFT", "RIGHT"):
+        paths[name] = {
+            key: os.path.join(directory, "%s-%s" % (name.lower(), key))
+            for key in ("ready", "arm", "resized", "winches", "gate", "painted",
+                "preopen", "preopened", "preclose", "preclosed", "partial",
+                "partial_started", "partial_finish", "skip", "repeat",
+                "repeat_started", "repeat_stop", "exit_frame", "exit_started",
+                "flood", "flood_started", "flood_stop", "flood_done",
+                "same_batch", "same_batch_written")
+        }
+
+    def command(name, synchronized=True, alternate=True):
+        pane = paths[name]
+        values = [
+            name,
+            ("sync" if alternate else "sync-primary")
+                if synchronized else "plain",
+            pane["ready"],
+            pane["arm"],
+            pane["resized"],
+            pane["winches"],
+            pane["gate"],
+            pane["painted"],
+            pane["preopen"],
+            pane["preopened"],
+            pane["preclose"],
+            pane["preclosed"],
+            pane["partial"],
+            pane["partial_started"],
+            pane["partial_finish"],
+            pane["skip"],
+            pane["repeat"],
+            pane["repeat_started"],
+            pane["repeat_stop"],
+            pane["exit_frame"],
+            pane["exit_started"],
+            pane["flood"],
+            pane["flood_started"],
+            pane["flood_stop"],
+            pane["flood_done"],
+            pane["same_batch"],
+            pane["same_batch_written"],
+        ]
+        return "python3 -u %s %s" % (emitter, " ".join(values))
+
+    def clear_controls():
+        for pane in paths.values():
+            for path in pane.values():
+                if os.path.exists(path):
+                    os.unlink(path)
+
+    def respawn_emitters(right_synchronized=True, left_alternate=True):
+        clear_controls()
+        for pane_id in (left, right):
+            run("set-option", "-p", "-t", pane_id,
+                "remain-on-exit", "off")
+        run("respawn-pane", "-k", "-t", left,
+            command("LEFT", alternate=left_alternate))
+        run("respawn-pane", "-k", "-t", right,
+            command("RIGHT", right_synchronized))
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["ready"])
+                for name in paths),
+            5,
+            "respawned applications did not become ready",
+        )
+        wait_for(
+            lambda: b"LEFT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout and b"RIGHT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", right
+            ).stdout,
+            5,
+            "respawned initial frames did not reach both backing screens",
+        )
+        initial = bytearray()
+        initial_deadline = time.monotonic() + 5
+        while (b"LEFT_BEFORE_00_" not in initial or
+                b"RIGHT_BEFORE_00_" not in initial):
+            initial.extend(read_before(
+                fd,
+                initial_deadline,
+                "respawned initial frames did not reach the client",
+            ))
+        drain_until_quiet(fd, 0.2, 5)
+
+    pid = None
+    fd = None
+    watch_pid = None
+    watch_fd = None
+    try:
+        run(
+            "new-session",
+            "-d",
+            "-s",
+            "resize",
+            "-x",
+            str(width),
+            "-y",
+            str(height),
+            command("LEFT"),
+        )
+        left = run(
+            "display-message", "-p", "#{pane_id}"
+        ).stdout.decode().strip()
+        right = run(
+            "split-window",
+            "-d",
+            "-h",
+            "-t",
+            left,
+            "-PF",
+            "#{pane_id}",
+            command("RIGHT"),
+        ).stdout.decode().strip()
+        run("set-option", "-g", "status", "off")
+        run("set-option", "-g", "set-titles", "off")
+        run("set-option", "-g", "window-size", "manual")
+        run("set-option", "-g", "automatic-rename", "off")
+        run("set-option", "-as", "terminal-features", "*:sync")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["ready"])
+                for name in paths),
+            5,
+            "synchronized applications did not become ready",
+        )
+        wait_for(
+            lambda: b"LEFT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout and b"RIGHT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", right
+            ).stdout,
+            5,
+            "initial synchronized frames did not reach both backing screens",
+        )
+
+        pid, fd = attach()
+        complete_client_startup(fd)
+        wait_for(
+            lambda: b"sync" in run(
+                "list-clients", "-F", "#{client_termfeatures}"
+            ).stdout,
+            5,
+            "sync-capable client did not attach",
+        )
+        client_size = run(
+            "list-clients", "-F", "#{client_width}x#{client_height}"
+        ).stdout.decode().strip()
+        if client_size != "%dx%d" % (width, height):
+            fail("client attached at %s instead of %dx%d" %
+                (client_size, width, height))
+
+        for pane in paths.values():
+            open(pane["preopen"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["preopened"])
+                for name in paths),
+            2,
+            "applications did not open synchronized pre-resize frames",
+        )
+        wait_for(
+            lambda: b"LEFT_OPEN_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout and b"RIGHT_OPEN_" in run(
+                "capture-pane", "-p", "-t", right
+            ).stdout,
+            2,
+            "open synchronized frames did not reach the backing screens",
+        )
+        drain_until_quiet(fd, 0.05, 1)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+
+        before_widths = (
+            int(run("display-message", "-p", "-t", left,
+                "#{pane_width}").stdout),
+            int(run("display-message", "-p", "-t", right,
+                "#{pane_width}").stdout),
+        )
+        resize_started = time.monotonic()
+        run("resize-pane", "-t", left, "-R", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            2,
+            "both applications did not receive SIGWINCH",
+        )
+
+        for pane in paths.values():
+            open(pane["preclose"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["preclosed"])
+                for name in paths),
+            0.05,
+            "applications did not close their pre-resize synchronized frames",
+        )
+
+        before_release = read_available(fd, 0.03)
+        if before_release:
+            fail("client received %d bytes before applications repainted" %
+                len(before_release))
+
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "left application did not finish its synchronized repaint",
+        )
+        after_one = read_available(fd, 0.02)
+        if b"LEFT_AFTER1_00_" in after_one:
+            fail("left post-resize frame reached the client before every "
+                "application repainted")
+        if b"RIGHT_AFTER1_00_" in after_one:
+            fail("right post-resize frame reached the client before it "
+                "repainted")
+        if after_one:
+            fail("client emitted %d bytes before every application repainted: "
+                "%s" % (len(after_one), after_one.hex()))
+
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "right application did not finish its synchronized repaint",
+        )
+        first = read_before(
+            fd,
+            resize_started + prompt_release_deadline,
+            "completed synchronized repaint was not released before %.0fms" %
+                (prompt_release_deadline * 1000),
+        )
+        release_elapsed = time.monotonic() - resize_started
+        final = first + drain_until_quiet(fd, release_quiet, 2)
+
+        if b"LEFT_AFTER1_00_" not in final:
+            client_size = run(
+                "list-clients", "-F", "#{client_width}x#{client_height}"
+            ).stdout.decode().strip()
+            fail("final redraw does not contain the left post-resize frame "
+                "(before=%d, after-one=%d, final=%d, left-before=%s, "
+                "right-before=%s, right-after=%s, sync=%d/%d, client=%s)" %
+                (len(before_release), len(after_one), len(final),
+                b"LEFT_BEFORE_00_" in final,
+                b"RIGHT_BEFORE_00_" in final,
+                b"RIGHT_AFTER1_00_" in final,
+                final.count(sync_start), final.count(sync_end), client_size))
+        if b"RIGHT_AFTER1_00_" not in final:
+            fail("final redraw does not contain the right post-resize frame")
+        if final.count(sync_start) != 1 or final.count(sync_end) != 1:
+            fail("final redraw was not one synchronized client transaction: "
+                "%d starts, %d ends" %
+                (final.count(sync_start), final.count(sync_end)))
+        if release_elapsed >= prompt_release_deadline:
+            fail("completed synchronized repaint released too late at %.3fs" %
+                release_elapsed)
+
+        later = read_available(fd, 0.2)
+        if later:
+            fail("client received a late corrective redraw of %d bytes" %
+                len(later))
+
+        after_widths = (
+            int(run("display-message", "-p", "-t", left,
+                "#{pane_width}").stdout),
+            int(run("display-message", "-p", "-t", right,
+                "#{pane_width}").stdout),
+        )
+        if after_widths != (before_widths[0] + 10, before_widths[1] - 10):
+            fail("unexpected final widths: %r -> %r" %
+                (before_widths, after_widths))
+
+        for pane in paths.values():
+            for key in ("resized", "gate", "painted"):
+                os.unlink(pane[key])
+            for key in ("preopened", "preclosed"):
+                if os.path.exists(pane[key]):
+                    os.unlink(pane[key])
+            open(pane["preopen"], "w", encoding="utf-8").close()
+
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["preopened"])
+                for name in paths),
+            0.05,
+            "applications did not reopen synchronized pre-resize frames",
+        )
+        drain_until_quiet(fd, 0.05, 1)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+            open(pane["gate"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["partial"], "w", encoding="utf-8").close()
+
+        run("resize-pane", "-t", left, "-L", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            2,
+            "both applications did not receive the spanning-frame SIGWINCH",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.05,
+            "left application did not start its spanning synchronized frame",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "right application did not finish its spanning-frame repaint",
+        )
+
+        spanning_early = read_available(fd, barrier_deadline + 0.07)
+        if spanning_early:
+            fail("client received %d bytes while a post-resize synchronized "
+                "frame spanned the 150ms soft deadline" %
+                len(spanning_early))
+
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "left application did not finish its spanning synchronized frame",
+        )
+        spanning_final = drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER2_TOP_00_" not in spanning_final:
+            fail("spanning redraw lost the top half of the synchronized frame")
+        if b"LEFT_AFTER2_BOTTOM_" not in spanning_final:
+            fail("spanning redraw lost the bottom half of the "
+                "synchronized frame")
+        if b"RIGHT_AFTER2_00_" not in spanning_final:
+            fail("spanning redraw lost the completed right frame")
+        if (spanning_final.count(sync_start) != 1 or
+                spanning_final.count(sync_end) != 1):
+            fail("spanning redraw was not one synchronized client transaction: "
+                "%d starts, %d ends" %
+                (spanning_final.count(sync_start),
+                spanning_final.count(sync_end)))
+        spanning_late = read_available(fd, 0.2)
+        if spanning_late:
+            fail("spanning redraw produced a late correction of %d bytes" %
+                len(spanning_late))
+
+        spanning_widths = (
+            int(run("display-message", "-p", "-t", left,
+                "#{pane_width}").stdout),
+            int(run("display-message", "-p", "-t", right,
+                "#{pane_width}").stdout),
+        )
+        if spanning_widths != before_widths:
+            fail("unexpected spanning-frame widths: %r -> %r" %
+                (after_widths, spanning_widths))
+
+        respawn_emitters()
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+            open(pane["gate"], "w", encoding="utf-8").close()
+            open(pane["skip"], "w", encoding="utf-8").close()
+
+        no_start_at = time.monotonic()
+        run("resize-pane", "-t", left, "-R", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["painted"])
+                for name in paths),
+            0.05,
+            "no-start applications did not acknowledge SIGWINCH",
+        )
+        no_start_early = read_available(
+            fd, max(0, no_start_at + 0.12 - time.monotonic()))
+        if no_start_early:
+            fail("capable panes that never started released before the "
+                "150ms soft deadline")
+        no_start_first = read_before(
+            fd,
+            no_start_at + 0.5,
+            "capable panes that never started waited for the hard deadline",
+        )
+        no_start_elapsed = time.monotonic() - no_start_at
+        no_start_final = no_start_first + drain_until_quiet(fd, 0.2, 2)
+        if no_start_elapsed < 0.12 or no_start_elapsed >= 0.5:
+            fail("no-start soft release occurred at %.3fs" % no_start_elapsed)
+        if (no_start_final.count(sync_start) != 1 or
+                no_start_final.count(sync_end) != 1):
+            fail("no-start release was not one synchronized transaction")
+
+        respawn_emitters()
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+            open(pane["gate"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["repeat"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["skip"], "w", encoding="utf-8").close()
+
+        hard_at = time.monotonic()
+        run("resize-pane", "-t", left, "-L", "10")
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["repeat_started"]),
+            0.05,
+            "repeated synchronized frame did not start",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "hard-fallback companion pane did not acknowledge SIGWINCH",
+        )
+        hard_early = read_available(
+            fd, max(0, hard_at + 0.22 - time.monotonic()))
+        if hard_early:
+            fail("repeated DECSET exposed a frame at the soft deadline")
+        hard_first = read_before(
+            fd,
+            hard_at + 1.6,
+            "repeated DECSET postponed the fixed hard fallback",
+        )
+        hard_elapsed = time.monotonic() - hard_at
+        open(paths["LEFT"]["repeat_stop"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.5,
+            "repeated synchronized frame did not stop",
+        )
+        hard_final = hard_first + drain_until_quiet(fd, 0.2, 2)
+        if hard_elapsed < 1.0 or hard_elapsed >= 1.6:
+            fail("hard fallback occurred at %.3fs" % hard_elapsed)
+        if b"LEFT_AFTER1_REPEAT_" not in hard_final:
+            fail("hard fallback redraw lost the open synchronized frame")
+        if (hard_final.count(sync_start) != 1 or
+                hard_final.count(sync_end) != 1):
+            fail("hard fallback was not one synchronized transaction")
+        if read_available(fd, 0.2):
+            fail("hard fallback produced a correction after the later DECRST")
+
+        respawn_emitters()
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+            open(pane["gate"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["partial"], "w", encoding="utf-8").close()
+
+        run("resize-pane", "-t", left, "-R", "10")
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.05,
+            "resize A synchronized frame did not start",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "resize A peer frame did not finish",
+        )
+        resize_a_early = read_available(fd, 0.03)
+        if resize_a_early:
+            fail("resize A emitted %d bytes before resize B: %s" %
+                (len(resize_a_early), resize_a_early.hex()))
+
+        for pane in paths.values():
+            for key in ("gate", "resized", "painted"):
+                if os.path.exists(pane[key]):
+                    os.unlink(pane[key])
+        os.unlink(paths["LEFT"]["partial_started"])
+
+        run("resize-pane", "-t", left, "-L", "5")
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "resize A delayed DECRST was not emitted",
+        )
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            0.05,
+            "resize B notification did not supersede resize A",
+        )
+        if read_available(fd, 0.03):
+            fail("resize A delayed DECRST released resize B")
+
+        os.unlink(paths["LEFT"]["painted"])
+        for pane in paths.values():
+            open(pane["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.05,
+            "resize B synchronized frame did not start",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "resize B peer frame did not finish",
+        )
+        repeated_early = read_available(fd, barrier_deadline + 0.07)
+        if repeated_early:
+            fail("resize A state or timer released open resize B frame")
+
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "resize B synchronized frame did not finish",
+        )
+        repeated_final = drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER2_TOP_00_" not in repeated_final:
+            fail("repeated-resize redraw lost resize B top rows")
+        if b"LEFT_AFTER2_BOTTOM_" not in repeated_final:
+            fail("repeated-resize redraw lost resize B bottom rows")
+        if b"RIGHT_AFTER2_00_" not in repeated_final:
+            fail("repeated-resize redraw lost resize B peer rows")
+        if (repeated_final.count(sync_start) != 1 or
+                repeated_final.count(sync_end) != 1):
+            fail("repeated resize was not one synchronized transaction")
+
+        respawn_emitters()
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+            open(pane["gate"], "w", encoding="utf-8").close()
+            open(pane["skip"], "w", encoding="utf-8").close()
+        original_width = int(run(
+            "display-message", "-p", "-t", left, "#{pane_width}"
+        ).stdout)
+        run(
+            "resize-pane", "-t", left, "-x", str(original_width + 5),
+            ";",
+            "resize-pane", "-t", left, "-x", str(original_width),
+        )
+
+        def left_winch_events():
+            if not os.path.exists(paths["LEFT"]["winches"]):
+                return []
+            with open(paths["LEFT"]["winches"], encoding="utf-8") as handle:
+                return [
+                    (float(timestamp), int(columns), int(lines))
+                    for timestamp, columns, lines in
+                    (value.split() for value in handle if value.strip())
+                ]
+
+        wait_for(
+            lambda: len(left_winch_events()) >= 2,
+            0.5,
+            "A-B-A resize did not deliver two distinct SIGWINCH callbacks",
+        )
+        winch_events = left_winch_events()
+        winch_gap = winch_events[1][0] - winch_events[0][0]
+        if winch_gap < 0.005:
+            fail("A-B-A resize callbacks were only %.3fms apart" %
+                (winch_gap * 1000))
+        if winch_events[0][1:] == winch_events[1][1:]:
+            fail("A-B-A resize callbacks observed the same geometry %dx%d" %
+                winch_events[0][1:])
+        if winch_events[1][1] != original_width:
+            fail("A-B-A resize ended at width %d instead of %d" %
+                (winch_events[1][1], original_width))
+        drain_until_quiet(fd, 0.2, 2)
+
+        respawn_emitters()
+        run("set-option", "-p", "-t", left, "remain-on-exit", "on")
+        run("set-option", "-p", "-t", left, "remain-on-exit-format", "")
+        drain_until_quiet(fd, 0.2, 5)
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["exit_frame"], "w", encoding="utf-8").close()
+
+        run("resize-pane", "-t", left, "-R", "10")
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["exit_started"]),
+            0.05,
+            "exiting synchronized frame did not start",
+        )
+        wait_for(
+            lambda: run(
+                "display-message", "-p", "-t", left, "#{pane_dead}"
+            ).stdout.strip() == b"1",
+            0.05,
+            "remain-on-exit pane did not become dead",
+        )
+        exit_early = read_available(fd, 0.03)
+        if exit_early:
+            fail("client output escaped before the pane-exit companion "
+                "completed")
+
+        exit_at = time.monotonic()
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "pane-exit companion frame did not finish",
+        )
+        exit_first = read_before(
+            fd,
+            exit_at + prompt_release_deadline,
+            "dead synchronized pane held the barrier to the soft deadline",
+        )
+        exit_elapsed = time.monotonic() - exit_at
+        exit_final = exit_first + drain_until_quiet(fd, release_quiet, 2)
+        if exit_elapsed >= prompt_release_deadline:
+            fail("pane-exit barrier released too late at %.3fs" % exit_elapsed)
+        if b"LEFT_AFTER1_EXIT_" not in exit_final:
+            fail("pane-exit redraw lost the dead producer's final state")
+        if b"RIGHT_AFTER1_00_" not in exit_final:
+            fail("pane-exit redraw lost the surviving participant's frame")
+        exit_starts = exit_final.count(sync_start)
+        exit_ends = exit_final.count(sync_end)
+        if exit_starts != 1 or exit_ends != 1:
+            fail("pane-exit redraw was not one synchronized transaction")
+
+        respawn_emitters(False, False)
+        open(paths["LEFT"]["preopen"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["preopened"]),
+            0.05,
+            "primary-screen application did not open its pre-resize frame",
+        )
+        wait_for(
+            lambda: b"LEFT_OPEN_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout,
+            0.05,
+            "primary-screen pre-resize frame did not reach the backing screen",
+        )
+        drain_until_quiet(fd, 0.05, 1)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        run("resize-pane", "-t", left, "-L", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            0.05,
+            "primary-screen applications did not receive SIGWINCH",
+        )
+
+        open(paths["LEFT"]["preclose"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["preclosed"]),
+            0.05,
+            "primary-screen application did not close its old frame",
+        )
+        primary_old = read_available(fd, 0.03)
+        if primary_old:
+            fail("primary-screen old DECRST released %d bytes" %
+                len(primary_old))
+
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "primary-screen plain peer did not repaint",
+        )
+        primary_peer = read_available(fd, 0.03)
+        if primary_peer:
+            fail("primary-screen plain peer escaped the barrier")
+
+        primary_release_at = time.monotonic()
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "primary-screen application did not finish its fresh frame",
+        )
+        primary_first = read_before(
+            fd,
+            primary_release_at + prompt_release_deadline,
+            "primary-screen fresh frame did not release promptly",
+        )
+        primary_final = primary_first + drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER1_00_" not in primary_final:
+            fail("primary-screen redraw lost the fresh synchronized frame")
+        if b"RIGHT_AFTER1_00_" not in primary_final:
+            fail("primary-screen redraw lost the plain peer frame")
+        if (primary_final.count(sync_start) != 1 or
+                primary_final.count(sync_end) != 1):
+            fail("primary-screen redraw was not one synchronized transaction")
+        if read_available(fd, 0.2):
+            fail("primary-screen redraw produced a late correction")
+
+        respawn_emitters(False)
+        run("bind-key", "-n", "C-]", "resize-pane", "-t", left, "-R", "10")
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["partial"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["skip"], "w", encoding="utf-8").close()
+
+        server_pid = int(run(
+            "display-message", "-p", "#{pid}"
+        ).stdout.decode())
+        drain_until_quiet(fd, 0.05, 1)
+        os.kill(server_pid, signal.SIGSTOP)
+        try:
+            open(paths["LEFT"]["same_batch"], "w", encoding="utf-8").close()
+            wait_for(
+                lambda: os.path.exists(paths["LEFT"]["same_batch_written"]),
+                0.5,
+                "same-batch pane output was not queued while server stopped",
+            )
+            os.write(fd, b"\035")
+            time.sleep(0.02)
+        finally:
+            os.kill(server_pid, signal.SIGCONT)
+
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            0.5,
+            "same-batch resize did not reach both panes",
+        )
+        race_output = bytearray()
+        race_deadline = time.monotonic() + 0.5
+        while sync_start not in race_output:
+            if time.monotonic() >= race_deadline:
+                fail("same-batch pane output did not reach the client")
+            race_output.extend(read_available(fd, 0.002))
+        balance_deadline = time.monotonic() + 0.05
+        while (race_output.count(sync_start) -
+                race_output.count(sync_end)) != 0:
+            if time.monotonic() >= balance_deadline:
+                fail("resize barrier left a pre-resize synchronized update "
+                    "open: %d starts, %d ends" %
+                    (race_output.count(sync_start),
+                        race_output.count(sync_end)))
+            race_output.extend(read_available(fd, 0.002))
+        if os.path.exists(paths["LEFT"]["painted"]):
+            fail("same-batch resize frame finished before the barrier was "
+                "observed")
+
+        for pane in paths.values():
+            open(pane["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.5,
+            "same-batch resize frame did not start",
+        )
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["painted"])
+                for name in paths),
+            0.5,
+            "same-batch resize frames did not finish",
+        )
+        race_final = race_output + drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER1_BOTTOM_" not in race_final:
+            fail("same-batch resize lost the completed frame")
+        if race_final.count(sync_start) != race_final.count(sync_end):
+            fail("same-batch resize left a client transaction open")
+        run("unbind-key", "-n", "C-]")
+        run("resize-pane", "-t", left, "-L", "10")
+        drain_until_quiet(fd, release_quiet, 3)
+
+        respawn_emitters(False)
+        open(paths["RIGHT"]["flood"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["flood_started"]),
+            0.5,
+            "plain peer did not begin the backpressure stream",
+        )
+        time.sleep(0.05)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["partial"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["skip"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+
+        soft_race_at = time.monotonic()
+        run("resize-pane", "-t", left, "-R", "10")
+        time.sleep(max(0, soft_race_at + barrier_deadline + 0.05 -
+            time.monotonic()))
+
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.5,
+            "late synchronized frame did not start under backpressure",
+        )
+        wait_for(
+            lambda: b"LEFT_AFTER1_TOP_00_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout,
+            0.5,
+            "late synchronized frame did not reach the backing screen",
+        )
+
+        open(paths["RIGHT"]["flood_stop"], "w", encoding="utf-8").close()
+        backlog = bytearray()
+        backlog_deadline = time.monotonic() + 5
+        while not os.path.exists(paths["RIGHT"]["flood_done"]):
+            if time.monotonic() >= backlog_deadline:
+                fail("backpressure stream did not stop while draining")
+            readable, _, _ = select.select([fd], [], [], 0.005)
+            if fd not in readable:
+                continue
+            try:
+                backlog.extend(os.read(fd, 1 << 20))
+            except (BlockingIOError, OSError):
+                pass
+        backlog.extend(drain_until_quiet(fd, 0.05, 2))
+        if b"LEFT_AFTER1_TOP_00_" in backlog:
+            fail("soft-expired WAIT_START committed after a late DECSET")
+        if read_available(fd, 0.05):
+            fail("late synchronized frame did not re-block redraw")
+
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.5,
+            "late synchronized frame did not finish after backpressure",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.5,
+            "backpressure peer did not acknowledge its resize",
+        )
+        soft_race_finish = time.monotonic()
+        soft_race_first = read_before(
+            fd,
+            soft_race_finish + prompt_release_deadline,
+            "late synchronized frame did not release after DECRST",
+        )
+        soft_race_final = soft_race_first + drain_until_quiet(
+            fd, release_quiet, 2)
+        if b"LEFT_AFTER1_TOP_00_" not in soft_race_final:
+            fail("soft-to-redraw race lost the top half of the frame")
+        if b"LEFT_AFTER1_BOTTOM_" not in soft_race_final:
+            fail("soft-to-redraw race lost the bottom half of the frame")
+        if (soft_race_final.count(sync_start) != 1 or
+                soft_race_final.count(sync_end) != 1):
+            fail("soft-to-redraw race was not one synchronized transaction")
+        if read_available(fd, 0.2):
+            fail("soft-to-redraw race produced a late correction")
+
+        for pane in paths.values():
+            for path in pane.values():
+                if os.path.exists(path):
+                    os.unlink(path)
+        run("respawn-pane", "-k", "-t", left, command("LEFT"))
+        run("respawn-pane", "-k", "-t", right, command("RIGHT", False))
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["ready"])
+                for name in paths),
+            5,
+            "mixed-mode applications did not become ready",
+        )
+        wait_for(
+            lambda: b"LEFT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", left
+            ).stdout and b"RIGHT_BEFORE_00_" in run(
+                "capture-pane", "-p", "-t", right
+            ).stdout,
+            5,
+            "mixed-mode initial frames did not reach both backing screens",
+        )
+        drain_until_quiet(fd, 0.2, 5)
+        time.sleep(0.3)
+        drain_until_quiet(fd, 0.05, 1)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        run("resize-pane", "-t", left, "-R", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            2,
+            "mixed-mode applications did not receive SIGWINCH",
+        )
+
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "plain application did not finish its repaint",
+        )
+        mixed_early = read_available(fd, 0.03)
+        if b"RIGHT_AFTER1_00_" in mixed_early:
+            fail("plain application frame escaped the active resize barrier")
+        if mixed_early:
+            fail("client emitted %d bytes before the synchronized repaint: %s" %
+                (len(mixed_early), mixed_early.hex()))
+
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "synchronized application did not finish its mixed-mode repaint",
+        )
+        mixed_final = drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER1_00_" not in mixed_final:
+            fail("mixed-mode redraw lost the synchronized application frame")
+        if b"RIGHT_AFTER1_00_" not in mixed_final:
+            fail("mixed-mode redraw lost the plain application frame")
+        if (mixed_final.count(sync_start) != 1 or
+                mixed_final.count(sync_end) != 1):
+            fail("mixed-mode redraw was not one synchronized transaction: "
+                "%d starts, %d ends" %
+                (mixed_final.count(sync_start), mixed_final.count(sync_end)))
+
+        respawn_emitters(False)
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["skip"], "w", encoding="utf-8").close()
+
+        run("resize-pane", "-t", left, "-L", "10")
+        wait_for(
+            lambda: all(os.path.exists(paths[name]["resized"])
+                for name in paths),
+            0.05,
+            "WAIT_START transfer applications did not receive SIGWINCH",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "WAIT_START transfer peer did not acknowledge its resize",
+        )
+
+        transfer_at = time.monotonic()
+        moved = run(
+            "break-pane", "-d", "-P", "-F", "#{pane_id}",
+            "-n", "transfer-wait", "-s", left,
+        ).stdout.decode().strip()
+        if moved != left:
+            fail("break-pane changed the transferred pane id")
+        transfer_first = read_before(
+            fd,
+            transfer_at + prompt_release_deadline,
+            "WAIT_START pane transfer did not release the source promptly",
+        )
+        transfer_source = transfer_first + drain_until_quiet(fd, 0.01, 0.03)
+        if b"LEFT_AFTER1_" in transfer_source:
+            fail("WAIT_START pane transfer exposed the moved pane's old epoch")
+
+        run("select-window", "-t", "resize:transfer-wait")
+        drain_until_quiet(fd, 0.2, 2)
+        run(
+            "resize-window", "-t", "resize:transfer-wait",
+            "-x", "110", "-y", str(height),
+        )
+        if read_available(fd, 0.03):
+            fail("transferred pane did not establish a fresh destination epoch")
+        destination_release_at = time.monotonic()
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "transferred pane did not paint its fresh destination frame",
+        )
+        destination_first = read_before(
+            fd,
+            destination_release_at + prompt_release_deadline,
+            "fresh destination frame did not release promptly",
+        )
+        destination_final = destination_first + drain_until_quiet(
+            fd, release_quiet, 2)
+        destination_frames = set(re.findall(
+            rb"LEFT_AFTER[0-9]+_00_", destination_final))
+        backing_frames = set(re.findall(
+            rb"LEFT_AFTER[0-9]+_00_",
+            run("capture-pane", "-p", "-t", left).stdout,
+        ))
+        if not destination_frames:
+            fail("fresh destination epoch lost the transferred pane frame")
+        if destination_frames.isdisjoint(backing_frames):
+            fail("fresh destination client frame did not match the backing "
+                "screen: client=%r backing=%r" %
+                (sorted(destination_frames), sorted(backing_frames)))
+
+        run("join-pane", "-d", "-h", "-s", left, "-t", right)
+        drain_until_quiet(fd, 0.2, 5)
+        respawn_emitters(False)
+
+        swap_target = run(
+            "new-window", "-d", "-t", "resize:", "-n", "transfer-swap",
+            "-P", "-F", "#{pane_id}", "sleep 1000",
+        ).stdout.decode().strip()
+        run(
+            "split-window", "-d", "-h", "-t", swap_target,
+            "sleep 1000",
+        )
+        swap_width = 10 + int(run(
+            "display-message", "-p", "-t", left, "#{pane_width}"
+        ).stdout)
+        run("resize-pane", "-t", swap_target, "-x", str(swap_width))
+        run("new-session", "-d", "-t", "resize", "-s", "swap-watch")
+        run("select-window", "-t", "swap-watch:transfer-swap")
+        watch_pid, watch_fd = attach("swap-watch")
+        complete_client_startup(watch_fd, 2)
+        drain_until_quiet(watch_fd, 0.2, 2)
+
+        for pane in paths.values():
+            open(pane["arm"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["partial"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["skip"], "w", encoding="utf-8").close()
+        open(paths["LEFT"]["gate"], "w", encoding="utf-8").close()
+        open(paths["RIGHT"]["gate"], "w", encoding="utf-8").close()
+
+        run("resize-pane", "-t", left, "-x", str(swap_width))
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["partial_started"]),
+            0.05,
+            "cross-window swap frame did not enter IN_FRAME",
+        )
+        wait_for(
+            lambda: os.path.exists(paths["RIGHT"]["painted"]),
+            0.05,
+            "cross-window swap peer did not acknowledge its resize",
+        )
+        left_width = run(
+            "display-message", "-p", "-t", left, "#{pane_width}"
+        ).stdout
+        target_width = run(
+            "display-message", "-p", "-t", swap_target, "#{pane_width}"
+        ).stdout
+        if left_width != target_width:
+            fail("cross-window swap widths differ: left=%r target=%r" %
+                (left_width, target_width))
+
+        swap_at = time.monotonic()
+        run("swap-pane", "-d", "-s", left, "-t", swap_target)
+        swap_early = read_available(watch_fd, 0.1)
+        if swap_early:
+            fail("cross-window swap exposed %d destination bytes before the "
+                "moved synchronized frame finished: %s" %
+                (len(swap_early), swap_early[:80].hex()))
+        swap_first = read_before(
+            fd,
+            swap_at + prompt_release_deadline,
+            "IN_FRAME cross-window swap did not release the source promptly",
+        )
+        swap_source = swap_first + drain_until_quiet(fd, release_quiet, 2)
+        if b"LEFT_AFTER1_TOP_00_" in swap_source:
+            fail("cross-window swap exposed the moved pane's partial frame")
+
+        open(paths["LEFT"]["partial_finish"], "w", encoding="utf-8").close()
+        wait_for(
+            lambda: os.path.exists(paths["LEFT"]["painted"]),
+            0.05,
+            "cross-window swapped frame did not finish after detach",
+        )
+        swap_destination_first = read_before(
+            watch_fd,
+            time.monotonic() + prompt_release_deadline,
+            "cross-window swapped frame did not release to the destination",
+        )
+        swap_destination = swap_destination_first + drain_until_quiet(
+            watch_fd, release_quiet, 2)
+        if b"LEFT_AFTER1_TOP_" not in swap_destination:
+            fail("cross-window swap lost the moved pane's top frame half")
+        if b"LEFT_AFTER1_BOTTOM_" not in swap_destination:
+            fail("cross-window swap lost the moved pane's completed frame")
+        if (swap_destination.count(sync_start) != 1 or
+                swap_destination.count(sync_end) != 1):
+            fail("cross-window swap destination was not one synchronized "
+                "transaction")
+    finally:
+        close_client(watch_pid, watch_fd)
+        cleanup(pid, fd)
+PY

--- a/screen-write.c
+++ b/screen-write.c
@@ -1030,10 +1030,8 @@ screen_write_sync_callback(__unused int fd, __unused short events, void *arg)
 	log_debug("%s: %%%u sync timer expired", __func__, wp->id);
 	evtimer_del(&wp->sync_timer);
 
-	if (wp->base.mode & MODE_SYNC) {
-		wp->base.mode &= ~MODE_SYNC;
-		screen_write_flush_dirty(wp);
-	}
+	if (wp->base.mode & MODE_SYNC)
+		screen_write_stop_sync(wp);
 }
 
 /* Start sync mode. */
@@ -1046,6 +1044,7 @@ screen_write_start_sync(struct window_pane *wp)
 		return;
 
 	wp->base.mode |= MODE_SYNC;
+	window_pane_resize_sync_capture(wp);
 	if (!event_initialized(&wp->sync_timer))
 		evtimer_set(&wp->sync_timer, screen_write_sync_callback, wp);
 	evtimer_add(&wp->sync_timer, &tv);
@@ -1065,6 +1064,7 @@ screen_write_stop_sync(struct window_pane *wp)
 	wp->base.mode &= ~MODE_SYNC;
 
 	screen_write_flush_dirty(wp);
+	window_pane_resize_sync_stop(wp);
 
 	log_debug("%s: %%%u stopped sync mode", __func__, wp->id);
 }

--- a/server-client.c
+++ b/server-client.c
@@ -30,7 +30,9 @@
 #include "tmux.h"
 
 static void	server_client_free(int, short, void *);
-static void	server_client_check_pane_resize(struct window_pane *);
+static int	server_client_pane_resize_ready(struct window_pane *);
+static void	server_client_check_pane_resize(struct window_pane *, int);
+static void	server_client_check_window_pane_resize(struct window *);
 static void	server_client_check_pane_buffer(struct window_pane *);
 static void	server_client_check_window_resize(struct window *);
 static key_code	server_client_check_mouse(struct client *, struct key_event *);
@@ -1888,6 +1890,10 @@ server_client_loop(void)
 		}
 	}
 
+	/* Notify resized panes before redrawing their new geometry. */
+	RB_FOREACH(w, windows, &windows)
+		server_client_check_window_pane_resize(w);
+
 	/* Check clients. */
 	TAILQ_FOREACH(c, &clients, entry) {
 		server_client_check_exit(c, 0);
@@ -1904,10 +1910,8 @@ server_client_loop(void)
 	 */
 	RB_FOREACH(w, windows, &windows) {
 		TAILQ_FOREACH(wp, &w->panes, entry) {
-			if (wp->fd != -1) {
-				server_client_check_pane_resize(wp);
+			if (wp->fd != -1)
 				server_client_check_pane_buffer(wp);
-			}
 			wp->flags &= ~(PANE_REDRAW|PANE_REDRAWSCROLLBAR|
 			    PANE_ACTIVITY);
 		}
@@ -1919,6 +1923,49 @@ server_client_loop(void)
 		TAILQ_FOREACH(wp, &w->panes, entry)
 			window_pane_send_theme_update(wp);
 	}
+}
+
+static int
+server_client_pane_resize_ready(struct window_pane *wp)
+{
+	if (TAILQ_EMPTY(&wp->resize_queue))
+		return (0);
+	if (event_initialized(&wp->resize_timer) &&
+	    evtimer_pending(&wp->resize_timer, NULL))
+		return (0);
+	return (1);
+}
+
+/*
+ * Tell panes about their new size. While the barrier is dirty every queued
+ * resize is drained at once, including from panes still inside their debounce,
+ * so that the deadline started afterwards covers every pane in the window
+ * rather than only the ones that happened to be ready.
+ */
+static void
+server_client_check_window_pane_resize(struct window *w)
+{
+	struct window_pane	*wp;
+	int			 drain, queued = 0;
+
+	drain = window_resize_sync_dirty(w);
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->fd == -1)
+			continue;
+		if (!drain) {
+			if (server_client_pane_resize_ready(wp))
+				server_client_check_pane_resize(wp, 0);
+			continue;
+		}
+		if (!TAILQ_EMPTY(&wp->resize_queue))
+			server_client_check_pane_resize(wp, 1);
+		if (!TAILQ_EMPTY(&wp->resize_queue))
+			queued = 1;
+	}
+	if (!drain)
+		return;
+	if (!queued)
+		window_resize_sync_arm(w);
 }
 
 /* Check if window needs to be resized. */
@@ -1948,12 +1995,13 @@ server_client_resize_timer(__unused int fd, __unused short events, void *data)
 	struct window_pane	*wp = data;
 
 	log_debug("%s: %%%u resize timer expired", __func__, wp->id);
+	wp->resize_timer_second = 0;
 	evtimer_del(&wp->resize_timer);
 }
 
 /* Check if pane should be resized. */
 static void
-server_client_check_pane_resize(struct window_pane *wp)
+server_client_check_pane_resize(struct window_pane *wp, int force)
 {
 	struct window_pane_resize	*r, *first, *last;
 	struct timeval			 tv = { .tv_usec = 250000 };
@@ -1963,8 +2011,12 @@ server_client_check_pane_resize(struct window_pane *wp)
 
 	if (!event_initialized(&wp->resize_timer))
 		evtimer_set(&wp->resize_timer, server_client_resize_timer, wp);
-	if (evtimer_pending(&wp->resize_timer, NULL))
-		return;
+	if (evtimer_pending(&wp->resize_timer, NULL)) {
+		if (!force || wp->resize_timer_second)
+			return;
+		evtimer_del(&wp->resize_timer);
+	}
+	wp->resize_timer_second = 0;
 
 	log_debug("%s: %%%u needs to be resized", __func__, wp->id);
 	TAILQ_FOREACH(r, &wp->resize_queue, entry) {
@@ -2008,6 +2060,7 @@ server_client_check_pane_resize(struct window_pane *wp)
 		window_pane_send_resize(wp, r->sx, r->sy);
 		window_pane_clear_resizes(wp, last);
 		tv.tv_usec = 10000;
+		wp->resize_timer_second = 1;
 	}
 	evtimer_add(&wp->resize_timer, &tv);
 }
@@ -2161,6 +2214,20 @@ server_client_reset_state(struct client *c)
 
 	if (c->flags & (CLIENT_CONTROL|CLIENT_SUSPENDED))
 		return;
+	/*
+	 * Do not apply state for the new geometry before its redraw. A
+	 * synchronized update opened before the barrier engaged must still be
+	 * ended here: it is this function that closes the ones begun by pane
+	 * output, the terminal presents nothing until it arrives, and tmux
+	 * itself gives an unfinished update only a second.
+	 */
+	if (window_resize_sync_active(w)) {
+		flags = (tty->flags & TTY_BLOCK);
+		tty->flags &= ~TTY_BLOCK;
+		tty_sync_end(tty);
+		tty->flags |= flags;
+		return;
+	}
 
 	/* Disable the block flag. */
 	flags = (tty->flags & TTY_BLOCK);
@@ -2496,6 +2563,10 @@ server_client_check_redraw(struct client *c)
 		c->flags &= ~CLIENT_STATUSFORCE;
 		return;
 	}
+	if (!window_resize_sync_redraw_ready(w)) {
+		log_debug("%s: redraw deferred for resize sync", c->name);
+		return;
+	}
 
 	/*
 	 * If there is outstanding data, defer the redraw until it has been
@@ -2522,6 +2593,10 @@ server_client_check_redraw(struct client *c)
 			if (wp->flags & PANE_REDRAWSCROLLBAR)
 				c->flags |= CLIENT_REDRAWSCROLLBARS;
 		}
+		return;
+	}
+	if (!window_resize_sync_commit(w)) {
+		log_debug("%s: commit deferred for resize sync", c->name);
 		return;
 	}
 

--- a/server-fn.c
+++ b/server-fn.c
@@ -372,6 +372,7 @@ server_destroy_pane(struct window_pane *wp, int notify)
 		close(wp->fd);
 		wp->fd = -1;
 	}
+	window_pane_resize_sync_forget(wp);
 	if (wp->pipe_fd != -1) {
 		bufferevent_free(wp->pipe_event);
 		wp->pipe_event = NULL;

--- a/tmux.h
+++ b/tmux.h
@@ -1274,6 +1274,27 @@ struct window_pane_resize {
 };
 TAILQ_HEAD(window_pane_resizes, window_pane_resize);
 
+enum window_resize_sync_state {
+	WINDOW_RESIZE_SYNC_IDLE,
+	WINDOW_RESIZE_SYNC_DIRTY,
+	WINDOW_RESIZE_SYNC_WAIT_SOFT,
+	WINDOW_RESIZE_SYNC_WAIT_HARD
+};
+
+enum window_pane_resize_sync_phase {
+	WINDOW_PANE_RESIZE_SYNC_NONE,
+	WINDOW_PANE_RESIZE_SYNC_WAIT_START,
+	WINDOW_PANE_RESIZE_SYNC_IN_FRAME
+};
+
+struct window_pane_resize_sync_token {
+	enum window_pane_resize_sync_phase	 phase;
+	int					 expected;
+};
+
+#define WINDOW_RESIZE_SYNC_SOFT_TIMEOUT 150000
+#define WINDOW_RESIZE_SYNC_HARD_TIMEOUT 1000000
+
 /*
  * Client theme, this is worked out from the background colour if not reported
  * by terminal.
@@ -1338,9 +1359,13 @@ struct window_pane {
 #define PANE_CLOSEONCLICK 0x80000
 #define PANE_CAPTUREALLKEYS 0x100000
 #define PANE_FLOATOVERZOOM 0x200000
+#define PANE_RESIZE_SYNC_CAPABLE 0x400000
 
 	bitstr_t	*sync_dirty;
 	u_int		 sync_dirty_size;
+	pid_t		 resize_sync_pgrp;
+	enum window_pane_resize_sync_phase resize_sync_phase;
+	int		 resize_sync_expected;
 
 	u_int		 sb_slider_y;
 	u_int		 sb_slider_h;
@@ -1374,6 +1399,7 @@ struct window_pane {
 
 	struct window_pane_resizes resize_queue;
 	struct event	 resize_timer;
+	int		 resize_timer_second;
 	struct event	 sync_timer;
 
 	struct input_ctx *ictx;
@@ -1467,6 +1493,8 @@ struct window {
 	u_int			 new_ypixel;
 
 	uint64_t		 redraw_scene_generation;
+	enum window_resize_sync_state resize_sync_state;
+	struct event		 resize_sync_timer;
 
 	struct menu_data	*menu;
 	u_int			 menu_last_px;
@@ -3733,6 +3761,19 @@ struct window_pane *window_add_pane(struct window *, struct window_pane *,
 		     u_int, int);
 void		 window_resize(struct window *, u_int, u_int, int, int);
 void		 window_pane_send_resize(struct window_pane *, u_int, u_int);
+void		 window_resize_sync_arm(struct window *);
+int		 window_resize_sync_active(struct window *);
+int		 window_resize_sync_dirty(struct window *);
+int		 window_resize_sync_redraw_ready(struct window *);
+int		 window_resize_sync_commit(struct window *);
+void		 window_pane_resize_sync_capture(struct window_pane *);
+void		 window_pane_resize_sync_stop(struct window_pane *);
+void		 window_pane_resize_sync_detach(struct window *,
+		     struct window_pane *,
+		     struct window_pane_resize_sync_token *);
+void		 window_pane_resize_sync_attach(struct window_pane *,
+		     const struct window_pane_resize_sync_token *);
+void		 window_pane_resize_sync_forget(struct window_pane *);
 int		 window_zoom(struct window_pane *);
 int		 window_unzoom(struct window *, int);
 int		 window_active_pane_is_over_zoom(struct window *);

--- a/window.c
+++ b/window.c
@@ -75,6 +75,11 @@ static void	window_pane_free(struct window_pane *);
 static void	window_pane_scrollbar_timer(int, short, void *);
 static void	window_pane_full_size_offset(struct window_pane *, int *, int *,
 		    u_int *, u_int *);
+static void	window_resize_sync_callback(int, short, void *);
+static void	window_resize_sync_cancel(struct window *);
+static void	window_resize_sync_prepare(struct window *);
+static void	window_resize_sync_release(struct window *, const char *);
+static int	window_pane_resize_sync_capable(struct window_pane *);
 
 RB_GENERATE(windows, window, entry, window_cmp);
 RB_GENERATE(winlinks, winlink, entry, winlink_cmp);
@@ -458,6 +463,7 @@ window_destroy(struct window *w)
 	layout_free_cell(w->saved_layout_root, 0);
 	free(w->old_layout);
 
+	window_resize_sync_cancel(w);
 	menu_destroy(w);
 	window_destroy_panes(w);
 
@@ -582,11 +588,20 @@ window_pane_send_resize(struct window_pane *wp, u_int sx, u_int sy)
 {
 	struct window	*w = wp->window;
 	struct winsize	 ws;
+	int		 expected = 0;
 
-	if (wp->fd == -1)
+	if (wp->fd == -1) {
+		window_pane_resize_sync_forget(wp);
 		return;
+	}
 
 	log_debug("%s: %%%u resize to %u,%u", __func__, wp->id, sx, sy);
+	if (window_resize_sync_dirty(w)) {
+		expected = wp->resize_sync_expected ||
+		    wp->resize_sync_phase != WINDOW_PANE_RESIZE_SYNC_NONE ||
+		    window_pane_resize_sync_capable(wp);
+		screen_write_stop_sync(wp);
+	}
 
 	memset(&ws, 0, sizeof ws);
 	ws.ws_col = sx;
@@ -604,6 +619,308 @@ window_pane_send_resize(struct window_pane *wp, u_int sx, u_int sy)
 		if (errno != EINVAL && errno != ENXIO)
 #endif
 		fatal("ioctl failed");
+
+	if (window_resize_sync_dirty(w)) {
+		wp->resize_sync_expected = expected;
+		if (expected) {
+			wp->resize_sync_phase =
+			    WINDOW_PANE_RESIZE_SYNC_WAIT_START;
+		} else
+			wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+	}
+}
+
+static void
+window_resize_sync_release(struct window *w, const char *from)
+{
+	struct window_pane	*wp;
+
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_IDLE)
+		return;
+
+	log_debug("%s: @%u resize sync released (%s)", __func__, w->id, from);
+
+	if (event_initialized(&w->resize_sync_timer))
+		evtimer_del(&w->resize_sync_timer);
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+		wp->resize_sync_expected = 0;
+	}
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_IDLE;
+	server_redraw_window(w);
+}
+
+static void
+window_resize_sync_cancel(struct window *w)
+{
+	struct window_pane	*wp;
+
+	if (event_initialized(&w->resize_sync_timer))
+		evtimer_del(&w->resize_sync_timer);
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_IDLE;
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+		wp->resize_sync_expected = 0;
+	}
+}
+
+static int
+window_resize_sync_has_phase(struct window *w,
+    enum window_pane_resize_sync_phase phase)
+{
+	struct window_pane	*wp;
+
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->resize_sync_phase == phase)
+			return (1);
+	}
+	return (0);
+}
+
+static int
+window_resize_sync_has_pending(struct window *w)
+{
+	struct window_pane	*wp;
+
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->resize_sync_phase != WINDOW_PANE_RESIZE_SYNC_NONE)
+			return (1);
+	}
+	return (0);
+}
+
+static void
+window_resize_sync_callback(__unused int fd, __unused short events, void *data)
+{
+	struct window		*w = data;
+	struct window_pane	*wp, **open = NULL;
+	struct timeval		 tv;
+	u_int			 i, nopen = 0;
+
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_WAIT_SOFT) {
+		w->resize_sync_state = WINDOW_RESIZE_SYNC_WAIT_HARD;
+		tv.tv_sec = WINDOW_RESIZE_SYNC_HARD_TIMEOUT / 1000000;
+		tv.tv_usec = WINDOW_RESIZE_SYNC_HARD_TIMEOUT % 1000000;
+		evtimer_add(&w->resize_sync_timer, &tv);
+		log_debug("%s: @%u resize sync soft timeout", __func__, w->id);
+		server_redraw_window(w);
+		return;
+	}
+	if (w->resize_sync_state != WINDOW_RESIZE_SYNC_WAIT_HARD)
+		return;
+
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->resize_sync_phase == WINDOW_PANE_RESIZE_SYNC_IN_FRAME)
+			nopen++;
+	}
+	if (nopen != 0)
+		open = xcalloc(nopen, sizeof *open);
+	i = 0;
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->resize_sync_phase == WINDOW_PANE_RESIZE_SYNC_IN_FRAME)
+			open[i++] = wp;
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+		wp->resize_sync_expected = 0;
+	}
+	for (i = 0; i < nopen; i++)
+		screen_write_stop_sync(open[i]);
+	free(open);
+
+	log_debug("%s: @%u resize sync hard timeout", __func__, w->id);
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_IDLE;
+	server_redraw_window(w);
+}
+
+/*
+ * Hold client output from the moment geometry changes. The redraw marked here
+ * is what stops a pane writing lines straight to the terminal, so this must
+ * run before anything flushes a frame drawn at the old size.
+ */
+static void
+window_resize_sync_prepare(struct window *w)
+{
+	if (w->resize_sync_state != WINDOW_RESIZE_SYNC_DIRTY)
+		log_debug("%s: @%u resize sync dirty", __func__, w->id);
+	if (event_initialized(&w->resize_sync_timer))
+		evtimer_del(&w->resize_sync_timer);
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_DIRTY;
+	server_redraw_window(w);
+}
+
+void
+window_resize_sync_arm(struct window *w)
+{
+	struct window_pane	*wp;
+	struct timeval		 tv = {
+		.tv_usec = WINDOW_RESIZE_SYNC_SOFT_TIMEOUT
+	};
+
+	if (w->resize_sync_state != WINDOW_RESIZE_SYNC_DIRTY)
+		return;
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		if (wp->fd == -1) {
+			wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+			wp->resize_sync_expected = 0;
+		}
+	}
+	if (!window_resize_sync_has_pending(w)) {
+		window_resize_sync_release(w, "no participants");
+		return;
+	}
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_WAIT_SOFT;
+
+	if (!event_initialized(&w->resize_sync_timer)) {
+		evtimer_set(&w->resize_sync_timer, window_resize_sync_callback,
+		    w);
+	}
+	evtimer_add(&w->resize_sync_timer, &tv);
+	log_debug("%s: @%u resize sync armed", __func__, w->id);
+}
+
+int
+window_resize_sync_active(struct window *w)
+{
+	return (w->resize_sync_state != WINDOW_RESIZE_SYNC_IDLE);
+}
+
+int
+window_resize_sync_dirty(struct window *w)
+{
+	return (w->resize_sync_state == WINDOW_RESIZE_SYNC_DIRTY);
+}
+
+int
+window_resize_sync_redraw_ready(struct window *w)
+{
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_IDLE)
+		return (1);
+	if (w->resize_sync_state != WINDOW_RESIZE_SYNC_WAIT_HARD)
+		return (0);
+	return (!window_resize_sync_has_phase(w,
+	    WINDOW_PANE_RESIZE_SYNC_IN_FRAME));
+}
+
+int
+window_resize_sync_commit(struct window *w)
+{
+	struct window_pane	*wp;
+
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_IDLE)
+		return (1);
+	if (!window_resize_sync_redraw_ready(w))
+		return (0);
+
+	if (event_initialized(&w->resize_sync_timer))
+		evtimer_del(&w->resize_sync_timer);
+	TAILQ_FOREACH(wp, &w->panes, entry) {
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+		wp->resize_sync_expected = 0;
+	}
+	w->resize_sync_state = WINDOW_RESIZE_SYNC_IDLE;
+	log_debug("%s: @%u resize sync committed", __func__, w->id);
+	return (1);
+}
+
+/*
+ * A pane is worth holding the barrier for while it is inside a synchronized
+ * frame, or while both the alternate screen and the foreground process group
+ * it last used one in are still current. Without that lease the shell left
+ * behind by an exited full screen application would delay every later resize.
+ */
+static int
+window_pane_resize_sync_capable(struct window_pane *wp)
+{
+	if (wp->fd == -1)
+		return (0);
+	if (wp->base.mode & MODE_SYNC)
+		return (1);
+	if (~wp->flags & PANE_RESIZE_SYNC_CAPABLE)
+		return (0);
+	if (!SCREEN_IS_ALTERNATE(&wp->base))
+		return (0);
+	if (wp->resize_sync_pgrp == -1)
+		return (0);
+	return (tcgetpgrp(wp->fd) == wp->resize_sync_pgrp);
+}
+
+void
+window_pane_resize_sync_capture(struct window_pane *wp)
+{
+	if (wp->fd == -1)
+		return;
+	if (SCREEN_IS_ALTERNATE(&wp->base)) {
+		wp->flags |= PANE_RESIZE_SYNC_CAPABLE;
+		wp->resize_sync_pgrp = tcgetpgrp(wp->fd);
+	}
+	if (window_resize_sync_dirty(wp->window))
+		wp->resize_sync_expected = 1;
+	if (window_resize_sync_active(wp->window) &&
+	    wp->resize_sync_phase == WINDOW_PANE_RESIZE_SYNC_WAIT_START) {
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_IN_FRAME;
+	}
+}
+
+void
+window_pane_resize_sync_stop(struct window_pane *wp)
+{
+	struct window	*w = wp->window;
+
+	if (wp->resize_sync_phase != WINDOW_PANE_RESIZE_SYNC_IN_FRAME)
+		return;
+	wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_WAIT_SOFT &&
+	    !window_resize_sync_has_pending(w))
+		window_resize_sync_release(w, "frames complete");
+	else if (w->resize_sync_state == WINDOW_RESIZE_SYNC_WAIT_HARD)
+		server_redraw_window(w);
+}
+
+void
+window_pane_resize_sync_detach(struct window *w, struct window_pane *wp,
+    struct window_pane_resize_sync_token *token)
+{
+	int		 participated;
+
+	participated = wp->resize_sync_phase != WINDOW_PANE_RESIZE_SYNC_NONE;
+	if (token != NULL) {
+		token->phase = wp->resize_sync_phase;
+		token->expected = wp->resize_sync_expected;
+	}
+	wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+	wp->resize_sync_expected = 0;
+
+	if (!participated)
+		return;
+	if (w->resize_sync_state == WINDOW_RESIZE_SYNC_WAIT_SOFT &&
+	    !window_resize_sync_has_pending(w))
+		window_resize_sync_release(w, "pane removed");
+	else if (w->resize_sync_state == WINDOW_RESIZE_SYNC_WAIT_HARD)
+		server_redraw_window(w);
+}
+
+void
+window_pane_resize_sync_attach(struct window_pane *wp,
+    const struct window_pane_resize_sync_token *token)
+{
+	wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_NONE;
+	wp->resize_sync_expected = token->expected;
+	if (token->phase == WINDOW_PANE_RESIZE_SYNC_NONE && !token->expected)
+		return;
+
+	window_resize_sync_prepare(wp->window);
+	if (token->phase == WINDOW_PANE_RESIZE_SYNC_IN_FRAME)
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_IN_FRAME;
+	else
+		wp->resize_sync_phase = WINDOW_PANE_RESIZE_SYNC_WAIT_START;
+}
+
+void
+window_pane_resize_sync_forget(struct window_pane *wp)
+{
+	window_pane_resize_sync_detach(wp->window, wp, NULL);
+	wp->flags &= ~PANE_RESIZE_SYNC_CAPABLE;
+	wp->resize_sync_pgrp = -1;
 }
 
 int
@@ -1173,6 +1490,7 @@ window_lost_pane(struct window *w, struct window_pane *wp)
 void
 window_remove_pane(struct window *w, struct window_pane *wp)
 {
+	window_pane_resize_sync_forget(wp);
 	window_lost_pane(w, wp);
 	TAILQ_REMOVE(&w->panes, wp, entry);
 	TAILQ_REMOVE(&w->z_index, wp, zentry);
@@ -1604,6 +1922,8 @@ window_pane_error_callback(__unused struct bufferevent *bufev,
 void
 window_pane_set_event(struct window_pane *wp)
 {
+	window_pane_resize_sync_forget(wp);
+
 	setblocking(wp->fd, 0);
 
 	wp->event = bufferevent_new(wp->fd, window_pane_read_callback,
@@ -1621,6 +1941,8 @@ window_pane_clear_resizes(struct window_pane *wp,
 {
 	struct window_pane_resize	*r, *r1;
 
+	if (except == NULL)
+		wp->resize_timer_second = 0;
 	TAILQ_FOREACH_SAFE(r, &wp->resize_queue, entry, r1) {
 		if (r == except)
 			continue;
@@ -1636,9 +1958,17 @@ window_pane_resize(struct window_pane *wp, u_int sx, u_int sy)
 	struct window_pane_resize	*r;
 	struct event_payload		*ep;
 	struct cmd_find_state		 fs;
+	int				 capable;
 
 	if (sx == wp->sx && sy == wp->sy)
 		return;
+
+	capable = window_pane_resize_sync_capable(wp);
+	if (window_resize_sync_active(wp->window) || capable) {
+		window_resize_sync_prepare(wp->window);
+		if (capable)
+			wp->resize_sync_expected = 1;
+	}
 
 	screen_write_stop_sync(wp);
 


### PR DESCRIPTION
## Problem

Resizing a pane could make the whole viewport repaint line by line for 15 to
60 seconds, with the terminal effectively unusable until it finished. It was
reproducible in Terminal.app on macOS against a tmux server on another
machine, and this change removes that stall there.

The server applies new pane geometry immediately, but the application inside
each pane learns its new size only when `TIOCSWINSZ` delivers `SIGWINCH`.
Drawing between those two events sends the new layout filled with the old
pane contents, followed by one correction per pane as each application
catches up. Scrolling within a pane stayed fast throughout; only changing
geometry produced the burst.

The same workflow still has an unresolved slow path in iTerm2, so this PR
does not claim to fix iTerm2. That residue was observed on a tree that
already contains `e06207c9` ("Cache scrollbar options in window to avoid a
slow lookup..."), the fix for #5298, so it is something else again. I have
not root-caused it and it is not addressed here.

## Reproduction

Two full-screen applications using synchronized updates (DEC mode 2026), side
by side, with a client whose output drains more slowly than the server
generates redraws - in practice a Mac terminal attached over ssh. Resizing the
split repeatedly produces the stall; scrolling inside either pane does not.

`regress/resize-sync-redraw.sh` is that reproduction made deterministic. It
drives real applications through an attached PTY client and measures the bytes
the client receives:

- unpatched: 4259 bytes reach the client before either application has
  repainted, and the test fails at its first assertion;
- patched: zero bytes until both applications complete, then one synchronized
  transaction carrying both frames.

I do not have a video, and the applications above are synthetic emitters
rather than a real program. The byte counts are what the regression asserts,
so they can be reproduced by running it against either binary.

## Change

A window-scoped resize redraw barrier:

- mark the window dirty before a pre-resize synchronized frame can flush;
- establish each pane's resize epoch only after a successful `TIOCSWINSZ`;
- release immediately when post-resize frames complete;
- after 150 ms, stop waiting for capable panes that never started a frame,
  while preserving any frame already in progress;
- force a bounded release after one additional second;
- recheck the barrier after tty backpressure and immediately before redraw;
- carry a pane's participation to its destination when it moves between
  windows, without discarding the application's synchronized-update
  capability lease.

## This is a bounded exception to "redraw always wins"

On #4744 you wrote that an application should not be able to prevent tmux
redrawing a pane, and that redraw should cancel the sync flag rather than the
other way round. This patch is an exception to that, and I would rather name
it than let it be found.

The exception is narrow in three ways:

- **It applies only to a resize tmux itself performed**, from the geometry
  change until every pane in that window has been told its new size. Nothing
  else defers a redraw, and an application cannot enter the state on its own.
- **It is bounded by tmux, not by the application**: 150 ms, then a further
  1 s, both fixed. A pane that never answers costs the soft timeout once and
  is then dropped from the epoch.
- **`screen-redraw.c` is untouched.** `screen_redraw_draw_pane()` still stops
  sync and clears the dirty flag before drawing, so once the barrier commits,
  a redraw cancels an application's frame exactly as it does today.

What is deferred is not the application's frame but tmux's own: after tmux
changes geometry, it declines to draw the frame it knows to be wrong - new
layout, old contents - which it created itself and which nothing else will
correct.

If that trade is unacceptable I would rather know now than argue it; the
alternative I considered was drawing the stale frame immediately and
suppressing the corrections, which loses more.

## Interaction with the resize debounce (issue 2677)

`server_client_check_pane_resize()` has a branch for several resizes ending at
the same size, which deliberately sends one resize, leaves one queued, and
re-arms at 10 ms so the application is forced to redraw. Draining the queue at
barrier time would have deleted that timer and collapsed the two resizes into
one, which is exactly the case cb2943fa / 84e22168 / cf6034da fixed.

`resize_timer_second` marks that deliberate 10 ms timer so a forced drain
leaves it alone; ordinary 250 ms debounce timers are still drainable. The
regression asserts two `SIGWINCH` callbacks at least 5 ms apart with the
expected widths in order.

## Ending a synchronized update the barrier interrupted

`server_client_reset_state()` returns early while the barrier is active, so
that cursor placement and mode updates are not applied at the new geometry
before the client has seen the new frame. That return still calls
`tty_sync_end()` first, which is load-bearing rather than tidy.

`tty_sync_start()` is reached from `tty_cmd_syncstart()` on the ordinary pane
write path, and `server_client_reset_state()` is the only place that closes
what that opens. A synchronized update can be opened by pane output and the
barrier engage later in the same libevent batch - I measured 1.1 ms between
the two - and leaving it open would stop the terminal presenting anything
until the barrier released. tmux's own `screen_write_start_sync()` gives an
unfinished update just one second, which is shorter than the barrier's 1.15 s
worst case, so the terminal would time out mid-transaction.

## Regression coverage

`regress/resize-sync-redraw.sh` covers frames open before a resize, prompt
completion, frames spanning the soft timeout, no-start soft release, repeated
DECSET at the hard fallback, repeated resize supersession, pane exit,
primary-screen updates, a late DECSET parsed after soft expiry while client
output is backpressured, cross-window pane transfer during both `WAIT_START`
and `IN_FRAME` including an equal-sized swap, and a synchronized update opened
in the same event-loop batch as the resize that engages the barrier. The PTY
answers terminal feature discovery before any timing assertion begins, so
tmux's five-second startup fallback cannot be mistaken for a barrier redraw.

**It is timing-sensitive and I would rather you did not take it as it
stands.** It asserts that genuine completion releases well before the 150 ms
soft timeout - a real property of the change, but a 20 ms margin under ASan on
a shared runner, and you have already had one synchronized-output regression
from me fail in CI. Widening the deadline would stop it proving prompt
release, so there is no version of it that is both meaningful and generous.
Say the word and I will drop the second commit and keep the script somewhere
you can run it by hand.

## AI authorship

This patch was written with AI assistance, so to address the copyright point
you raised on #4744. The work used OpenAI and Anthropic models, and both
vendors assign ownership of model output to the user:

- OpenAI, Terms of Use, "Ownership of content"
  (https://openai.com/policies/terms-of-use/): "you ... own the Output. We
  hereby assign to you all our right, title, and interest, if any, in and to
  Output."
- Anthropic, Consumer Terms of Service, section 4
  (https://www.anthropic.com/legal/consumer-terms): "Subject to your
  compliance with our Terms, we assign to you all of our right, title, and
  interest-if any-in Outputs."

I own this code and license it under the ISC licence tmux uses.
