### PR TITLE
Treat space as Unicode whitespace in word handling

### DIFF
--- a/grid.c
+++ b/grid.c
@@ -1711,21 +1711,28 @@ grid_in_set(struct grid *gd, u_int px, u_int py, const char *set)
 {
 	struct grid_cell	gc, tmp_gc;
 	u_int			pxx;
+	int			has_tab, has_space;
 
 	grid_get_cell(gd, px, py, &gc);
-	if (strchr(set, '\t')) {
-		if (gc.flags & GRID_FLAG_PADDING) {
-			pxx = px;
-			do
-				grid_get_cell(gd, --pxx, py, &tmp_gc);
-			while (pxx > 0 && tmp_gc.flags & GRID_FLAG_PADDING);
-			if (tmp_gc.flags & GRID_FLAG_TAB)
-				return (tmp_gc.data.width - (px - pxx));
-		} else if (gc.flags & GRID_FLAG_TAB)
-			return (gc.data.width);
-	}
-	if (gc.flags & GRID_FLAG_PADDING)
+	has_tab = (strchr(set, '\t') != NULL);
+	has_space = (strchr(set, ' ') != NULL);
+	if (gc.flags & GRID_FLAG_PADDING) {
+		if (!has_tab && !has_space)
+			return (0);
+		pxx = px;
+		do
+			grid_get_cell(gd, --pxx, py, &tmp_gc);
+		while (pxx > 0 && tmp_gc.flags & GRID_FLAG_PADDING);
+		if (((has_tab || has_space) &&
+		    (tmp_gc.flags & GRID_FLAG_TAB)) ||
+		    (has_space && utf8_has_whitespace(&tmp_gc.data)))
+			return (tmp_gc.data.width - (px - pxx));
 		return (0);
+	}
+	if ((has_tab || has_space) && (gc.flags & GRID_FLAG_TAB))
+		return (gc.data.width);
+	if (has_space && utf8_has_whitespace(&gc.data))
+		return (gc.data.width == 0 ? 1 : gc.data.width);
 	return (utf8_cstrhas(set, &gc.data));
 }
 

--- a/options-table.c
+++ b/options-table.c
@@ -1250,7 +1250,8 @@ const struct options_table_entry options_table[] = {
 	   * underscore.
 	   */
 	  .default_str = "!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~",
-	  .text = "Characters considered to separate words."
+	  .text = "Characters considered to separate words; a space matches "
+		  "any character with the Unicode White_Space property."
 	},
 
 	/* Window options. */

--- a/regress/copy-mode-unicode-whitespace.sh
+++ b/regress/copy-mode-unicode-whitespace.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+
+fail()
+{
+	echo "$1"
+	[ -z "$TMUX" ] || $TMUX kill-server 2>/dev/null
+	exit 1
+}
+
+goto_cell()
+{
+	row=$1
+	column=$2
+
+	$TMUX send-keys -X history-top || fail "$mode: history-top failed"
+	$TMUX send-keys -X start-of-line || fail "$mode: start-of-line failed"
+	[ "$row" -eq 0 ] ||
+	    $TMUX send-keys -X -N "$row" cursor-down ||
+	    fail "$mode: cursor-down failed"
+	[ "$column" -eq 0 ] ||
+	    $TMUX send-keys -X -N "$column" cursor-right ||
+	    fail "$mode: cursor-right failed"
+}
+
+check_cursor()
+{
+	expected=$1
+	actual=$($TMUX display-message -p '#{copy_cursor_x},#{copy_cursor_y}')
+	[ "$actual" = "$expected" ] ||
+	    fail "$mode: expected cursor $expected, got $actual"
+}
+
+check_word()
+{
+	row=$1
+	column=$2
+	expected=$3
+
+	goto_cell "$row" "$column"
+	$TMUX set-buffer sentinel || fail "$mode: set-buffer failed"
+	$TMUX send-keys -X select-word || fail "$mode: select-word failed"
+	$TMUX send-keys -X copy-selection || fail "$mode: copy-selection failed"
+	actual=$($TMUX show-buffer 2>/dev/null)
+	[ "$actual" = "$expected" ] ||
+	    fail "$mode: expected word '$expected', got '$actual'"
+}
+
+check_next_word()
+{
+	row=$1
+	expected=$2
+
+	goto_cell "$row" 0
+	$TMUX send-keys -X next-word || fail "$mode: next-word failed"
+	$TMUX set-buffer sentinel || fail "$mode: set-buffer failed"
+	$TMUX send-keys -X select-word || fail "$mode: select-word failed"
+	$TMUX send-keys -X copy-selection || fail "$mode: copy-selection failed"
+	actual=$($TMUX show-buffer 2>/dev/null)
+	[ "$actual" = "$expected" ] ||
+	    fail "$mode: expected next word '$expected', got '$actual'"
+}
+
+for mode in emacs vi; do
+	TMUX="$TEST_TMUX -Lunicode-whitespace-$mode-$$ -f/dev/null"
+	$TMUX kill-server 2>/dev/null
+	$TMUX new-session -d -x16 -y20 \
+	    "printf 'aa bb\naa\tbb\naa\302\240bb\naa\343\200\200bb\naa:bb\naaaaaaaaaaaaaaa\302\240b\nabcdefghijklmnopq\nhardone\nhardtwo\naa\341\232\200bb\naa\342\200\200bb\naa\342\200\250bb\naa\342\200\251bb\naa\342\200\257bb\naa\342\201\237bb\nxa\302\205b c\n'; exec cat" ||
+	    fail "$mode: new-session failed"
+	$TMUX set-option -g window-size manual || fail "$mode: set size failed"
+	$TMUX set-window-option -g mode-keys "$mode" ||
+	    fail "$mode: set mode-keys failed"
+	$TMUX set-window-option -g word-separators "" ||
+	    fail "$mode: clear word-separators failed"
+	$TMUX copy-mode || fail "$mode: copy-mode failed"
+
+	# ASCII space and TAB retain their existing behaviour.
+	goto_cell 0 0
+	$TMUX send-keys -X next-space || fail "$mode: ASCII next-space failed"
+	check_cursor 3,0
+	goto_cell 1 0
+	$TMUX send-keys -X next-space || fail "$mode: TAB next-space failed"
+	check_cursor 8,1
+	$TMUX send-keys -X previous-space ||
+	    fail "$mode: TAB previous-space failed"
+	check_cursor 0,1
+
+	# NBSP is whitespace for selection and word movement.
+	goto_cell 2 0
+	$TMUX send-keys -X next-word || fail "$mode: NBSP next-word failed"
+	check_cursor 3,2
+	$TMUX send-keys -X previous-word ||
+	    fail "$mode: NBSP previous-word failed"
+	check_cursor 0,2
+	check_word 2 0 aa
+	goto_cell 2 0
+	$TMUX send-keys -X next-word-end ||
+	    fail "$mode: NBSP next-word-end failed"
+	if [ "$mode" = emacs ]; then
+		check_cursor 2,2
+	else
+		check_cursor 1,2
+	fi
+
+	# U+3000 is two columns wide; both its leading and padding cells must be
+	# skipped as one whitespace character in either direction.
+	goto_cell 3 0
+	$TMUX send-keys -X next-word || fail "$mode: U+3000 next-word failed"
+	check_cursor 4,3
+	$TMUX send-keys -X previous-word ||
+	    fail "$mode: U+3000 previous-word failed"
+	check_cursor 0,3
+	goto_cell 3 0
+	$TMUX send-keys -X next-space-end ||
+	    fail "$mode: U+3000 next-space-end failed"
+	if [ "$mode" = emacs ]; then
+		check_cursor 2,3
+	else
+		check_cursor 1,3
+	fi
+
+	# Other characters in word-separators remain literal when space enables
+	# Unicode whitespace matching.
+	$TMUX set-window-option -g word-separators ': ' ||
+	    fail "$mode: set custom word-separators failed"
+	goto_cell 4 0
+	$TMUX send-keys -X next-word || fail "$mode: literal next-word failed"
+	check_cursor 2,4
+	$TMUX set-window-option -g word-separators "" ||
+	    fail "$mode: restore word-separators failed"
+
+	# Whitespace in the last column remains a boundary across a soft wrap.
+	goto_cell 5 0
+	$TMUX send-keys -X next-space ||
+	    fail "$mode: wrapped NBSP next-space failed"
+	check_cursor 0,6
+
+	# A word split only by a soft wrap remains one word, while a hard line
+	# boundary still terminates selection.
+	check_word 7 0 abcdefghijklmnopq
+	check_word 9 0 hardone
+
+	# Check the remaining representative White_Space ranges and U+0085
+	# combined into a cell with another character.
+	check_next_word 11 bb
+	check_next_word 12 bb
+	check_next_word 13 bb
+	check_next_word 14 bb
+	check_next_word 15 bb
+	check_next_word 16 bb
+	goto_cell 17 0
+	$TMUX send-keys -X next-word ||
+	    fail "$mode: combined U+0085 next-word failed"
+	check_cursor 2,17
+
+	$TMUX kill-server 2>/dev/null
+done
+
+exit 0

--- a/tmux.1
+++ b/tmux.1
@@ -2208,14 +2208,14 @@ Move to the end of the next word.
 .Xc
 Same as
 .Ic next\-word
-but use a space alone as the word separator.
+but treat all non-whitespace characters as a word.
 .It Xo
 .Ic next\-space\-end
 (vi: E)
 .Xc
 Same as
 .Ic next\-word\-end
-but use a space alone as the word separator.
+but treat all non-whitespace characters as a word.
 .It Xo
 .Ic other\-end
 (vi: o)
@@ -2289,7 +2289,7 @@ Move to the previous word.
 .Xc
 Same as
 .Ic previous\-word
-but use a space alone as the word separator.
+but treat all non-whitespace characters as a word.
 .It Xo
 .Ic rectangle\-on
 .Xc
@@ -2574,8 +2574,8 @@ Word separators can be customized with the
 session option.
 Next word moves to the start of the next word, next word end to the end of the
 next word and previous word to the start of the previous word.
-The three next and previous space keys work similarly but use a space alone as
-the word separator.
+The three next and previous space keys work similarly but treat all
+non-whitespace characters as a word.
 Setting
 .Em word\-separators
 to the empty string makes next/previous word equivalent to next/previous space.
@@ -5647,6 +5647,11 @@ If set to both, a bell and a message are produced.
 Sets the session's conception of what characters are considered word
 separators, for the purposes of the next and previous word commands in
 copy mode.
+A space in
+.Ar string
+matches any character with the Unicode
+.Em White_Space
+property.
 .El
 .Pp
 Available window options are:

--- a/tmux.h
+++ b/tmux.h
@@ -4106,6 +4106,7 @@ void		 session_update_history(struct session *);
 /* utf8.c */
 enum utf8_state	 utf8_towc (const struct utf8_data *, wchar_t *);
 enum utf8_state	 utf8_fromwc(wchar_t wc, struct utf8_data *);
+int		 utf8_has_whitespace(const struct utf8_data *);
 void		 utf8_update_width_cache(void);
 utf8_char	 utf8_build_one(u_char);
 enum utf8_state	 utf8_from_data(const struct utf8_data *, utf8_char *);

--- a/utf8.c
+++ b/utf8.c
@@ -603,6 +603,69 @@ utf8_towc(const struct utf8_data *ud, wchar_t *wc)
 	return (UTF8_DONE);
 }
 
+/* Unicode White_Space property, from Unicode 17.0.0 PropList.txt. */
+static const struct {
+	u_int	first;
+	u_int	last;
+} utf8_whitespace[] = {
+	{ 0x0009, 0x000d },
+	{ 0x0020, 0x0020 },
+	{ 0x0085, 0x0085 },
+	{ 0x00a0, 0x00a0 },
+	{ 0x1680, 0x1680 },
+	{ 0x2000, 0x200a },
+	{ 0x2028, 0x2028 },
+	{ 0x2029, 0x2029 },
+	{ 0x202f, 0x202f },
+	{ 0x205f, 0x205f },
+	{ 0x3000, 0x3000 }
+};
+
+/* Check whether a grid cell contains a Unicode whitespace character. */
+int
+utf8_has_whitespace(const struct utf8_data *ud)
+{
+	struct utf8_data	 tmp;
+	wchar_t		 wc;
+	size_t		 offset = 0, size;
+	u_int		 i, cp;
+	u_char		 ch;
+
+	while (offset < ud->size) {
+		ch = ud->data[offset];
+		if (ch < 0x80) {
+			wc = ch;
+			size = 1;
+		} else {
+			if (ch >= 0xc2 && ch <= 0xdf)
+				size = 2;
+			else if (ch >= 0xe0 && ch <= 0xef)
+				size = 3;
+			else if (ch >= 0xf0 && ch <= 0xf4)
+				size = 4;
+			else
+				return (0);
+			if (size > ud->size - offset)
+				return (0);
+
+			memset(&tmp, 0, sizeof tmp);
+			memcpy(tmp.data, ud->data + offset, size);
+			tmp.size = tmp.have = size;
+			if (utf8_towc(&tmp, &wc) != UTF8_DONE)
+				return (0);
+		}
+		offset += size;
+
+		cp = wc;
+		for (i = 0; i < nitems(utf8_whitespace); i++) {
+			if (cp >= utf8_whitespace[i].first &&
+			    cp <= utf8_whitespace[i].last)
+				return (1);
+		}
+	}
+	return (0);
+}
+
 /* Convert wide character to UTF-8 character. */
 enum utf8_state
 utf8_fromwc(wchar_t wc, struct utf8_data *ud)

--- a/utf8.c
+++ b/utf8.c
@@ -603,32 +603,13 @@ utf8_towc(const struct utf8_data *ud, wchar_t *wc)
 	return (UTF8_DONE);
 }
 
-/* Unicode White_Space property, from Unicode 17.0.0 PropList.txt. */
-static const struct {
-	u_int	first;
-	u_int	last;
-} utf8_whitespace[] = {
-	{ 0x0009, 0x000d },
-	{ 0x0020, 0x0020 },
-	{ 0x0085, 0x0085 },
-	{ 0x00a0, 0x00a0 },
-	{ 0x1680, 0x1680 },
-	{ 0x2000, 0x200a },
-	{ 0x2028, 0x2028 },
-	{ 0x2029, 0x2029 },
-	{ 0x202f, 0x202f },
-	{ 0x205f, 0x205f },
-	{ 0x3000, 0x3000 }
-};
-
-/* Check whether a grid cell contains a Unicode whitespace character. */
+/* Check for a Unicode 17.0.0 White_Space character in a grid cell. */
 int
 utf8_has_whitespace(const struct utf8_data *ud)
 {
 	struct utf8_data	 tmp;
 	wchar_t		 wc;
 	size_t		 offset = 0, size;
-	u_int		 i, cp;
 	u_char		 ch;
 
 	while (offset < ud->size) {
@@ -656,11 +637,33 @@ utf8_has_whitespace(const struct utf8_data *ud)
 		}
 		offset += size;
 
-		cp = wc;
-		for (i = 0; i < nitems(utf8_whitespace); i++) {
-			if (cp >= utf8_whitespace[i].first &&
-			    cp <= utf8_whitespace[i].last)
-				return (1);
+		switch (wc) {
+		case 0x0009:
+		case 0x000A:
+		case 0x000B:
+		case 0x000C:
+		case 0x000D:
+		case 0x0020:
+		case 0x0085:
+		case 0x00A0:
+		case 0x1680:
+		case 0x2000:
+		case 0x2001:
+		case 0x2002:
+		case 0x2003:
+		case 0x2004:
+		case 0x2005:
+		case 0x2006:
+		case 0x2007:
+		case 0x2008:
+		case 0x2009:
+		case 0x200A:
+		case 0x2028:
+		case 0x2029:
+		case 0x202F:
+		case 0x205F:
+		case 0x3000:
+			return (1);
 		}
 	}
 	return (0);


### PR DESCRIPTION
## Summary

- treat an ASCII space in a grid membership set as any character with the Unicode `White_Space` property, using an in-tree switch for the 25 Unicode 17.0 code points
- inspect every code point stored in a cell, while preserving TAB and wide-cell padding widths
- update the copy-mode word/space documentation and add regressions for both emacs and vi mode keys

This keeps the implementation independent of utf8proc. The default `word-separators` value has no space, so its punctuation behavior is unchanged; a space in a custom value now means any Unicode whitespace.

## Testing

Passed with both `./configure --disable-utf8proc` and `./configure --enable-utf8proc`:

- `make -j4`
- `regress/copy-mode-unicode-whitespace.sh`
- `regress/copy-mode-test-emacs.sh`
- `regress/copy-mode-test-vi.sh`
- `regress/utf8-test.sh`

The new regression covers ASCII space and TAB, all 11 `White_Space` ranges (including NBSP and U+2029), U+3000 leading and padding cells, a mixed cell containing zero-width U+0085, custom literal separators, and soft/hard wrap behavior.

Also passed `git diff --check`, `sh -n`, and ShellCheck.

Addresses the whitespace portion of #5558.
