### PR TITLE
permit selecting by target window in new-window

### DIFF
--- a/cmd-new-window.c
+++ b/cmd-new-window.c
@@ -74,8 +74,10 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 	}
 
 	/*
-	 * If -S and -n are given and -t is not and a single window with this
-	 * name already exists, select it.
+	 * If -S is given, select an existing window instead of creating a
+	 * new one: preferring -t if it already points at a window, or
+	 * otherwise -n if one exists with that name. If neither matches,
+	 * fall through and create a window as normal.
 	 */
 	name = args_get(args, 'n');
 	if (name != NULL) {
@@ -88,32 +90,38 @@ cmd_new_window_exec(struct cmd *self, struct cmdq_item *item)
 		wname = clean_name(expanded, 0);
 		free(expanded);
 	}
-	if (args_has(args, 'S') && wname != NULL && target->idx == -1) {
-		expanded = format_single(item, wname, c, s, NULL, NULL);
-		RB_FOREACH(wl, winlinks, &s->windows) {
-			if (strcmp(wl->window->name, expanded) != 0)
-				continue;
-			if (new_wl == NULL) {
-				new_wl = wl;
-				continue;
+	if (args_has(args, 'S')) {
+		if (target->idx != -1) {
+			new_wl = winlink_find_by_index(&s->windows, target->idx);
+		} else if (wname != NULL) {
+			expanded = format_single(item, wname, c, s, NULL, NULL);
+			RB_FOREACH(wl, winlinks, &s->windows) {
+				if (strcmp(wl->window->name, expanded) != 0)
+					continue;
+				if (new_wl == NULL) {
+					new_wl = wl;
+					continue;
+				}
+				cmdq_error(item, "multiple windows named %s", wname);
+				free(wname);
+				free(expanded);
+				return (CMD_RETURN_ERROR);
 			}
-			cmdq_error(item, "multiple windows named %s", wname);
-			free(wname);
 			free(expanded);
-			return (CMD_RETURN_ERROR);
 		}
-		free(expanded);
-		if (new_wl != NULL) {
-			free(wname);
-			if (args_has(args, 'd'))
-				return (CMD_RETURN_NORMAL);
-			if (session_set_current(s, new_wl) == 0)
-				server_redraw_session(s);
-			if (c != NULL && c->session != NULL)
-				s->curw->window->latest = c;
-			recalculate_sizes();
+	}
+
+	/* Found an existing window to select instead of creating a new one. */
+	if (new_wl != NULL) {
+		free(wname);
+		if (args_has(args, 'd'))
 			return (CMD_RETURN_NORMAL);
-		}
+		if (session_set_current(s, new_wl) == 0)
+			server_redraw_session(s);
+		if (c != NULL && c->session != NULL)
+			s->curw->window->latest = c;
+		recalculate_sizes();
+		return (CMD_RETURN_NORMAL);
 	}
 
 	before = args_has(args, 'b');

--- a/regress/window-ops.sh
+++ b/regress/window-ops.sh
@@ -8,7 +8,7 @@
 # This exercises:
 # - new-window placement: next free index, explicit index, index in use with
 #   and without -k, -a (after) and -b (before) insertion with shuffling, and
-#   -S selecting an existing window by name instead of creating;
+#   -S selecting an existing window by name or target instead of creating;
 # - move-window to a free index, to an occupied index with and without -k,
 #   -a insertion and -r renumbering (including base-index);
 # - renumber-windows closing gaps;
@@ -139,6 +139,36 @@ check_ok select-window -t W:0
 check_ok new-window -S -t W: -n w3
 check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 9:w9k'
 check_fmt 'W:' '#{window_index}:#{window_name}' '5:w3'
+
+# -S with a target-window that already exists selects it directly, ignoring
+# -n (with -d it does not switch).
+check_ok select-window -t W:0
+check_ok new-window -S -t W:9 -n ignored
+check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 9:w9k'
+check_fmt 'W:' '#{window_index}:#{window_name}' '9:w9k'
+check_ok select-window -t W:0
+check_ok new-window -S -d -t W:9 -n ignored
+check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 9:w9k'
+check_fmt 'W:' '#{window_index}:#{window_name}' '0:wB'
+
+# -S with a target-window that does not yet exist still creates it normally.
+check_ok new-window -S -t W:20 -n w20
+check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 9:w9k 20:w20'
+check_fmt 'W:' '#{window_index}:#{window_name}' '20:w20'
+check_ok kill-window -t W:20
+
+# -S also works with a relative target-window (+N): selects the window at
+# that offset if it exists, or creates it there if not.
+check_ok select-window -t W:0
+check_ok new-window -S -t W:+1
+check_fmt 'W:' '#{window_index}:#{window_name}' '1:w0'
+check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 9:w9k'
+
+check_ok select-window -t W:0
+check_ok new-window -S -t W:+6 -n rel6
+check_fmt 'W:' '#{window_index}:#{window_name}' '6:rel6'
+check_windows W '0:wB 1:w0 2:w1 3:wA 4:w2 5:w3 6:rel6 9:w9k'
+check_ok kill-window -t W:6
 
 # Clean up to a known arrangement.
 check_ok kill-window -t W:wB

--- a/tmux.1
+++ b/tmux.1
@@ -3595,11 +3595,15 @@ is the name given to the new window, if any.
 .Pp
 If
 .Fl S
-is given and a window named
-.Ar window\-name
-already exists, it is selected (unless
+is given, an existing window is selected instead of creating a new one
+(unless
 .Fl d
-is also given in which case the command does nothing).
+is also given in which case the command does nothing):
+.Ar target\-window
+is preferred if it already identifies an existing window; otherwise a
+window named
+.Ar window\-name
+is selected if one exists.
 .Pp
 .Ar shell\-command
 is the command to execute.

--- a/tmux.1
+++ b/tmux.1
@@ -3590,6 +3590,9 @@ represents the window to be created; if the target already exists an error is
 shown, unless the
 .Fl k
 flag is used, in which case it is destroyed.
+.Ar window\-name
+is the name given to the new window, if any.
+.Pp
 If
 .Fl S
 is given and a window named


### PR DESCRIPTION
As discussed in #5563, this adds support for `-S -t` in `new-window`.

- implemented the feature
- added regression tests for the feature
- explicitly document what `-n` does on `new-window`
- compiled and passed regression tests

It feels a bit weird that `-S` without either `-n` or `-t` is allowed (since the flag becomes a no-op), but I haven't touched that behaviour as to not introduce any regressions.

Closes: https://github.com/tmux/tmux/issues/5563