### PR TITLE
layout-custom: bound layout_construct's recursion depth

### DIFF
--- a/layout-custom.c
+++ b/layout-custom.c
@@ -28,7 +28,17 @@ static u_short			 layout_checksum(const char *);
 static int			 layout_append(struct layout_cell *, char *,
 				     size_t);
 static int			 layout_construct(struct layout_cell *,
-				     const char **, struct layout_cell **);
+				     const char **, struct layout_cell **,
+				     u_int);
+
+/*
+ * Maximum nesting depth for a layout string. This exists purely to bound
+ * layout_construct's recursion: without it, a layout string with enough
+ * nested { or [ groups drives unbounded recursion and exhausts the stack
+ * long before any other limit in the parser kicks in. No real layout tmux
+ * itself ever produces comes remotely close to this.
+ */
+#define LAYOUT_MAX_DEPTH 1000
 static void			 layout_assign(struct window_pane **,
 				     struct layout_cell *, int);
 
@@ -191,7 +201,7 @@ layout_parse(struct window *w, const char *layout, char **cause)
 	}
 
 	/* Build the layout. */
-	if (layout_construct(NULL, &layout, &tiled_lc) != 0) {
+	if (layout_construct(NULL, &layout, &tiled_lc, 0) != 0) {
 		*cause = xstrdup("invalid layout");
 		return (-1);
 	}
@@ -374,9 +384,12 @@ layout_construct_cell(struct layout_cell *lcparent, const char **layout)
  */
 static int
 layout_construct(struct layout_cell *lcparent, const char **layout,
-    struct layout_cell **lc)
+    struct layout_cell **lc, u_int depth)
 {
 	struct layout_cell	*lcchild;
+
+	if (depth > LAYOUT_MAX_DEPTH)
+		return (-1);
 
 	*lc = layout_construct_cell(lcparent, layout);
 	if (*lc == NULL)
@@ -401,7 +414,7 @@ layout_construct(struct layout_cell *lcparent, const char **layout,
 
 	do {
 		(*layout)++;
-		if (layout_construct(*lc, layout, &lcchild) != 0)
+		if (layout_construct(*lc, layout, &lcchild, depth + 1) != 0)
 			goto fail;
 		TAILQ_INSERT_TAIL(&(*lc)->cells, lcchild, entry);
 	} while (**layout == ',');

--- a/regress/layout-nesting-limit.sh
+++ b/regress/layout-nesting-limit.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# A layout string with enough nested { or [ groups used to drive unbounded
+# recursion in layout_construct and exhaust the stack, crashing the server.
+# Check that a deeply nested layout is now rejected cleanly instead, and
+# that the server and an existing session survive the attempt.
+
+PATH=/bin:/usr/bin
+TERM=screen
+export PATH TERM
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+DIR=$(mktemp -d) || exit 1
+TMUX_TMPDIR=$DIR
+export TMUX_TMPDIR
+TMUX="$TEST_TMUX -Ltest$$ -f/dev/null"
+
+fail()
+{
+	echo "$*" >&2
+	exit 1
+}
+
+cleanup()
+{
+	$TMUX kill-server 2>/dev/null
+	rm -rf "$DIR"
+}
+trap cleanup 0 1 15
+
+$TMUX new-session -d -s deep -x80 -y24 'exec sleep 100' || exit 1
+
+# Build a layout string nested one thousand levels deep, with the checksum
+# tmux's own format expects, so this fails on depth rather than on the
+# checksum check. The body only ever uses digits and { } , x, so the
+# checksum can be computed from a small fixed character map instead of a
+# full byte table.
+layout=$(awk -v depth=1500 'BEGIN {
+	body = ""
+	for (i = 0; i < depth; i++)
+		body = body "1x1,0,0{"
+	body = body "1x1,0,0"
+	for (i = 0; i < depth; i++)
+		body = body "}"
+
+	csum = 0
+	n = length(body)
+	for (i = 1; i <= n; i++) {
+		c = substr(body, i, 1)
+		if (c == "{")
+			ord = 123
+		else if (c == "}")
+			ord = 125
+		else if (c == ",")
+			ord = 44
+		else if (c == "x")
+			ord = 120
+		else if (c == "0")
+			ord = 48
+		else if (c == "1")
+			ord = 49
+		bit = csum % 2
+		csum = int(csum / 2) + bit * 32768
+		csum = (csum + ord) % 65536
+	}
+	printf "%04x,%s", csum, body
+}')
+
+$TMUX select-layout -t deep "$layout" >/dev/null 2>&1 &&
+	fail "an excessively nested layout string was accepted"
+
+$TMUX has-session -t deep || fail "server died on a deeply nested layout string"
+[ "$($TMUX list-panes -t deep | wc -l)" -eq 1 ] ||
+	fail "the original pane did not survive the rejected layout"
+
+exit 0


### PR DESCRIPTION
Follows up on #5543 with a fix.

layout_construct recurses once for every nested `{` (LEFTRIGHT) or `[` (TOPBOTTOM) group in a layout string, and nothing caps how deep that goes. A layout string with enough nested groups drives unbounded C recursion until the stack is exhausted and the server crashes. This is reachable from `select-layout`, from a config file that sets a layout, and from a restored or saved session, so anything able to get tmux to parse a layout string it doesn't fully control (a crafted config, a malicious or corrupted saved session) can trigger it.

I built tmux with ASan/UBSan and confirmed this directly: a layout string nested 100000 levels deep crashes with "Thread stack size exceeded due to excessive recursion" in `layout_construct` at layout-custom.c:404, matching the reachability described in #5543. With the fix in place the same input is rejected as an invalid layout instead, and the server keeps running.

The fix adds a `LAYOUT_MAX_DEPTH` constant (1000, well past anything a real layout would ever need) and threads a depth counter through `layout_construct`'s recursive calls, returning an error once it's exceeded rather than recursing further.

Added `regress/layout-nesting-limit.sh`, checking that a layout nested past the limit is rejected and that the server and an existing session survive the attempt. Ran the full regress suite locally alongside it, no other failures.