### PR TITLE
Reject an invalid monitor subscription target instead of silently making it a session monitor

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -614,8 +614,10 @@ monitor_parse(const char *value, char **name, enum monitor_type *type, int *id,
 		*type = MONITOR_ALL_WINDOWS;
 	else if (sscanf(what, "@%d", id) == 1 && *id >= 0)
 		*type = MONITOR_WINDOW;
-	else
+	else if (*what == '\0')
 		*type = MONITOR_SESSION;
+	else
+		goto fail;
 	*name = xstrdup(copy);
 	*format = xstrdup(split);
 


### PR DESCRIPTION
monitor_parse() matches the four documented target forms and lets
everything else fall through to `MONITOR_SESSION`, so a mistyped target is
accepted and quietly changes the scope of the monitor:

```
$ tmux set-hook -B "@a:%0:#{pane_current_command}"    # per pane
$ tmux set-hook -B "@a:pane:#{pane_current_command}"  # accepted, per session
$ tmux set-hook -B "@a:zzzz:#{pane_current_command}"  # accepted, per session
$ tmux set-hook -B "@a:%-1:#{pane_current_command}"   # accepted, per session
$ tmux show-hooks -B
@a::#{pane_current_command}
```

The scope silently becomes the session, and the only hint is that
`show-hooks -B` echoes an empty target — after the fact, and only if you
look. `%O` (letter O for zero) behaves the same way, which is the shape
this is most likely to take in practice.

An empty target still selects the session, as documented. Anything that is
not one of the documented forms now fails, which both callers
(`cmd-set-option.c`, `cmd-refresh-client.c`) already check for and report.

Tested on next-3.8 with `set-hook -B`: `%0`, `%*`, `@0`, `@*` and the empty
target are still accepted and round-trip through `show-hooks -B` unchanged;
`pane`, `zzzz`, `%-1` and `%O` now report `invalid subscription: ...`.
`refresh-client -B` shares the same parser.