### PR TITLE
cmd-find: reject invalid relative target offsets

### DIFF
--- a/cmd-find.c
+++ b/cmd-find.c
@@ -388,9 +388,11 @@ cmd_find_get_window_with_session(struct cmd_find_state *fs, const char *window)
 
 	/* Try as an offset. */
 	if (!exact && (window[0] == '+' || window[0] == '-')) {
-		if (window[1] != '\0')
-			n = strtonum(window + 1, 1, INT_MAX, NULL);
-		else
+		if (window[1] != '\0') {
+			n = strtonum(window + 1, 1, INT_MAX, &errstr);
+			if (errstr != NULL)
+				return (-1);
+		} else
 			n = 1;
 		s = fs->s;
 		if (fs->flags & CMD_FIND_WINDOW_INDEX) {
@@ -626,9 +628,11 @@ cmd_find_get_pane_with_window(struct cmd_find_state *fs, const char *pane)
 
 	/* Try as an offset. */
 	if (pane[0] == '+' || pane[0] == '-') {
-		if (pane[1] != '\0')
-			n = strtonum(pane + 1, 1, INT_MAX, NULL);
-		else
+		if (pane[1] != '\0') {
+			n = strtonum(pane + 1, 1, INT_MAX, &errstr);
+			if (errstr != NULL)
+				return (-1);
+		} else
 			n = 1;
 		wp = fs->w->active;
 		if (pane[0] == '+')

--- a/regress/targets-panes.sh
+++ b/regress/targets-panes.sh
@@ -97,6 +97,10 @@ check "p:.{top-left}" "%0"
 check_ok select-pane -t p:0.%0
 check "p:0.+" "1" '#{pane_index}'	# next pane
 check "p:0.-" "3" '#{pane_index}'	# previous pane (wraps)
+check_fail "can't find pane: +0" "p:0.+0"
+check_fail "can't find pane: +foo" "p:0.+foo"
+check_fail "can't find pane: -0" "p:0.-0"
+check_fail "can't find pane: -foo" "p:0.-foo"
 
 # --- last pane (!) --------------------------------------------------------
 check_ok select-pane -t p:0.%2

--- a/regress/targets.sh
+++ b/regress/targets.sh
@@ -154,6 +154,13 @@ check "alpha:{previous}" "3"
 check "alpha:!" "2"		# last window
 check "alpha:{last}" "2"
 
+# Malformed relative offsets must fail rather than silently selecting the
+# current window.
+check_fail "can't find window: +0" "alpha:+0"
+check_fail "can't find window: +foo" "alpha:+foo"
+check_fail "can't find window: -0" "alpha:-0"
+check_fail "can't find window: -foo" "alpha:-foo"
+
 # --- combined and empty forms ---------------------------------------------
 #
 # Empty targets use the current pane from TMUX_PANE when there is no client.


### PR DESCRIPTION


Invalid relative target offsets such as `+0`, `-0`, `+foo`, and `-foo` are currently accepted by target resolution.

The relative window and pane target parsers call `strtonum()` without checking its error result. When parsing fails, the value returned by `strtonum()` is zero. Passing zero to the relative target helpers leaves the target unchanged, so the invalid target silently resolves to the current window or pane.



I check the `strtonum()` error result when parsing relative window and pane offsets. Return an unresolved-target error when the offset is invalid.



