### PR TITLE
Keep floating panes inside the window when it shrinks

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -789,6 +789,60 @@ layout_free(struct window *w, int only_nodes)
 	layout_free_cell(w->layout_root, only_nodes);
 }
 
+/*
+ * Move, and if necessary shrink, floating panes so they stay inside the
+ * window. layout_resize_adjust walks only tiled cells, so a floating cell
+ * keeps the geometry it was given when it was created: after the window
+ * shrinks it can be left partly or entirely outside, where it cannot be seen
+ * or reached.
+ *
+ * A floating cell is the inside of the pane, so the borders around it have to
+ * be counted here as they are when it is created (see
+ * layout_floating_args_parse).
+ */
+static void
+layout_clamp_floating_panes(struct window *w, u_int sx, u_int sy)
+{
+	struct window_pane	*wp;
+	struct layout_cell	*lc;
+	u_int			 pad, avail, csx, csy;
+
+	TAILQ_FOREACH(wp, &w->z_index, zentry) {
+		lc = wp->layout_cell;
+		if (lc == NULL || (~lc->flags & LAYOUT_CELL_FLOATING))
+			continue;
+		if (window_pane_get_pane_lines(wp) == PANE_LINES_NONE)
+			pad = 0;
+		else
+			pad = 1;
+
+		csx = lc->g.sx;
+		avail = (sx > 2 * pad) ? sx - 2 * pad : 0;
+		if (csx > avail)
+			csx = (avail > PANE_MINIMUM) ? avail : PANE_MINIMUM;
+		csy = lc->g.sy;
+		avail = (sy > 2 * pad) ? sy - 2 * pad : 0;
+		if (csy > avail)
+			csy = (avail > PANE_MINIMUM) ? avail : PANE_MINIMUM;
+		if (csx != lc->g.sx || csy != lc->g.sy)
+			layout_set_size(lc, csx, csy, lc->g.xoff,
+			    lc->g.yoff);
+
+		if (lc->g.xoff + lc->g.sx + pad > sx) {
+			if (lc->g.sx + 2 * pad >= sx)
+				lc->g.xoff = pad;
+			else
+				lc->g.xoff = sx - lc->g.sx - pad;
+		}
+		if (lc->g.yoff + lc->g.sy + pad > sy) {
+			if (lc->g.sy + 2 * pad >= sy)
+				lc->g.yoff = pad;
+			else
+				lc->g.yoff = sy - lc->g.sy - pad;
+		}
+	}
+}
+
 /* Resize the entire layout after window resize. */
 void
 layout_resize(struct window *w, u_int sx, u_int sy)
@@ -809,8 +863,11 @@ layout_resize(struct window *w, u_int sx, u_int sy)
 	 * out proportionately - this should leave the layout fitting the new
 	 * window size.
 	 */
-	if (lc->type == LAYOUT_WINDOWPANE && (lc->flags & LAYOUT_CELL_FLOATING))
+	if (lc->type == LAYOUT_WINDOWPANE && (lc->flags & LAYOUT_CELL_FLOATING)) {
+		layout_clamp_floating_panes(w, sx, sy);
+		layout_fix_panes(w, NULL);
 		return;
+	}
 	xchange = sx - lc->g.sx;
 	xlimit = layout_resize_check(w, lc, LAYOUT_LEFTRIGHT);
 	if (xchange < 0 && xchange < -xlimit)
@@ -840,6 +897,7 @@ layout_resize(struct window *w, u_int sx, u_int sy)
 
 	/* Fix cell offsets. */
 	layout_fix_offsets(w);
+	layout_clamp_floating_panes(w, sx, sy);
 	layout_fix_panes(w, NULL);
 }
 

--- a/regress/floating-pane-geometry.sh
+++ b/regress/floating-pane-geometry.sh
@@ -268,5 +268,149 @@ $TMUX kill-pane -t "$floating" || exit 1
 $TMUX kill-pane -t "$right" || exit 1
 $TMUX kill-pane -t "$lower" || exit 1
 
+# --- Floating panes clamped when the window shrinks (issue #5581, PR #5582) ---
+#
+# layout_resize clamps floating panes back inside the window when it shrinks:
+# move them and, only if they cannot fit, shrink them (never below
+# PANE_MINIMUM). A floating cell is the pane's content, so with the default
+# single-line border the clamp counts 1 cell of border per side, exactly as
+# layout_floating_args_parse does on creation; with no border it counts 0.
+# Each case below gets its own window, since resize-window fixes a window at
+# a manual size for the rest of its life.
+
+# Case 1: a lone floating pane -- break-pane -W on a window's only pane --
+# takes the early-return path in layout_resize, added during PR #5582's
+# review round, since there is no tiled tree to walk.
+win=$($TMUX new-window -dPF '#{window_id}') ||
+	fail "new-window for lone float failed"
+
+# -x 20 -y 6 -> pane 18x4; -X 60 -Y 18 -> pane_left 61, pane_top 19: with the
+# border, the footprint is columns 60-79, rows 18-23, flush with the 80x24
+# window's right and bottom edges, so the float fits before it is shrunk.
+$TMUX break-pane -W -s "$win" -x 20 -y 6 -X 60 -Y 18 ||
+	fail "break-pane -W for lone float failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   61
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    19
+
+# Shrink to 40x16. The float still fits at its own size (18 <= 40-2, 4 <=
+# 16-2) so only its position moves, flush to the new right/bottom edges:
+# xoff = 40 - 18 - 1 = 21; yoff = 16 - 4 - 1 = 11.
+$TMUX resize-window -t "$win" -x 40 -y 16 ||
+	fail "resize-window (lone float) failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   21
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    11
+
+# Case 5: grow the window back. The clamp must not chase the window back
+# outward -- it only ever pulls a float in, never restores where it was.
+$TMUX resize-window -t "$win" -x 80 -y 24 ||
+	fail "resize-window grow (lone float) failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   21
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    11
+$TMUX kill-window -t "$win" || exit 1
+
+# Case 2: the same float, but with a tiled sibling surviving alongside it, so
+# the window's root cell stays tiled and layout_resize takes the normal path
+# (the clamp call after layout_fix_offsets) instead of the early return
+# above. Same geometry as case 1, so the same numbers should come out.
+win=$($TMUX new-window -dPF '#{window_id}') ||
+	fail "new-window for tiled sibling failed"
+$TMUX split-window -t "$win" 'sleep 100' ||
+	fail "split-window for tiled sibling failed"
+$TMUX break-pane -W -s "$win" -x 20 -y 6 -X 60 -Y 18 ||
+	fail "break-pane -W for tiled sibling failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   61
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    19
+
+$TMUX resize-window -t "$win" -x 40 -y 16 ||
+	fail "resize-window (tiled sibling) failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   21
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    11
+$TMUX kill-window -t "$win" || exit 1
+
+# Case 3: new-pane float, the original repro from issue #5581 and the PR
+# body -- also the normal path, via the tiled base pane new-window creates.
+win=$($TMUX new-window -dPF '#{window_id}') ||
+	fail "new-window for new-pane repro failed"
+$TMUX resize-window -t "$win" -x 120 -y 40 ||
+	fail "resize-window to 120x40 failed"
+
+# -x 30 -y 10 -> pane 28x8; -X 85 -Y 25 -> pane_left 86, pane_top 26.
+floating=$($TMUX new-pane -t "$win" -dPF '#{pane_id}' \
+	-x 30 -y 10 -X 85 -Y 25 'sleep 100') ||
+	fail "new-pane for new-pane repro failed"
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_width}')"  28
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_height}')" 8
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_left}')"   86
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_top}')"    26
+
+# Shrink to 60x20: xoff = 60 - 28 - 1 = 31; yoff = 20 - 8 - 1 = 11.
+$TMUX resize-window -t "$win" -x 60 -y 20 ||
+	fail "resize-window (new-pane repro) failed"
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_width}')"  28
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_height}')" 8
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_left}')"   31
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_top}')"    11
+$TMUX kill-window -t "$win" || exit 1
+
+# Case 4: a float that already fits inside the shrunk window is left alone --
+# assert position and size are both unchanged, not just one of them.
+win=$($TMUX new-window -dPF '#{window_id}') ||
+	fail "new-window for untouched float failed"
+
+# -x 20 -y 6 -> pane 18x4; -X 8 -Y 3 -> pane_left 9, pane_top 4 (as at the top
+# of this file). Footprint columns 8-27, rows 3-8: well inside 60x20 too.
+floating=$($TMUX new-pane -t "$win" -dPF '#{pane_id}' \
+	-x 20 -y 6 -X 8 -Y 3 'sleep 100') ||
+	fail "new-pane for untouched float failed"
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_left}')"   9
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_top}')"    4
+
+$TMUX resize-window -t "$win" -x 60 -y 20 ||
+	fail "resize-window (untouched float) failed"
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_width}')"  18
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_height}')" 4
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_left}')"   9
+must_equal "$($TMUX display-message -p -t "$floating" '#{pane_top}')"    4
+$TMUX kill-window -t "$win" || exit 1
+
+# Case 6: pad = 0, via the pane-border-lines window option set to none. The
+# border arithmetic differs here (no -2/+1 adjustment either on creation or
+# in the clamp).
+win=$($TMUX new-window -dPF '#{window_id}') ||
+	fail "new-window for pad=0 float failed"
+$TMUX set-option -w -t "$win" pane-border-lines none ||
+	fail "set pane-border-lines none failed"
+
+# No border: -x 20 -y 6 -> pane 20x6 directly; -X 60 -Y 18 -> pane_left 60,
+# pane_top 18 directly. Footprint (== content, no border) is columns 60-79,
+# rows 18-23: flush right/bottom of the 80x24 window, same as case 1.
+$TMUX break-pane -W -s "$win" -x 20 -y 6 -X 60 -Y 18 ||
+	fail "break-pane -W for pad=0 float failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  20
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 6
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   60
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    18
+
+# Shrink to 40x16 with pad=0: xoff = 40 - 20 - 0 = 20; yoff = 16 - 6 - 0 = 10.
+$TMUX resize-window -t "$win" -x 40 -y 16 ||
+	fail "resize-window (pad=0 float) failed"
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_width}')"  20
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_height}')" 6
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_left}')"   20
+must_equal "$($TMUX display-message -p -t "$win" '#{pane_top}')"    10
+$TMUX kill-window -t "$win" || exit 1
+
 $TMUX kill-server 2>/dev/null
 exit 0


### PR DESCRIPTION
Fixes #5581.

`layout_resize_adjust` walks only tiled cells — `layout_resize_check` counts
`is_leaf && !is_floating` — and `layout_fix_panes` then copies each floating
cell through to its pane unchanged. So a floating pane keeps the geometry it
was created with, and shrinking the window can leave it partly or entirely
outside, where it cannot be seen or reached. Detaching and reattaching from a
smaller terminal is enough to hit it.

This clamps floating cells at the end of `layout_resize`, per the discussion on
the issue: force them visible for now, ahead of any layout-hints work.

Two things that are not obvious from the surrounding code, and are why the
patch looks the way it does:

- the `sx`/`sy` parameters are used rather than `w->sx`/`w->sy`, because
  `resize.c` resizes the layout *before* the window ("Resize the layout
  first", `resize.c:63`), so `w->sx` is still the old size in here;

- a floating cell is the *inside* of the pane, so the border has to be counted
  the way `layout_floating_args_parse` counts it on creation (`-x` → `sx -= 2`,
  `-X` → `ox += 1` unless `pane-border-lines` is `none`), or a bordered float
  ends up one cell over the edge.

A pane is shrunk only when it cannot fit at its current size, and never below
`PANE_MINIMUM`; otherwise it is only moved.

### Test

Built on `master` at 1b87cb75 with no new warnings. The repro from the issue,
against the same build with and without the patch:

```
$ tmux -f/dev/null new-session -d -x 120 -y 40
$ tmux new-pane -x 30 -y 10 -X 85 -Y 25
$ tmux resize-window -x 60 -y 20
$ tmux list-panes -F '#{pane_width}x#{pane_height} at #{pane_left},#{pane_top}'
```

before — the float is wholly outside the 60x20 window:

```
62x20 at 0,0
30x10 at 85,25
```

after — moved and shrunk to fit, with the border accounted for
(31+28 = 59 <= 60, 11+8 = 19 <= 20):

```
60x20 at 0,0
28x8 at 31,11
```
