### PR TITLE
Keep floating panes inside the window when it is resized

### DIFF
--- a/layout.c
+++ b/layout.c
@@ -789,6 +789,60 @@ layout_free(struct window *w, int only_nodes)
 	layout_free_cell(w->layout_root, only_nodes);
 }
 
+/*
+ * Move, and if necessary shrink, floating panes so they stay inside the
+ * window. layout_resize_adjust walks only tiled cells, so a floating cell
+ * keeps the geometry it was given when it was created: after the window
+ * shrinks it can be left partly or entirely outside, where it cannot be seen
+ * or reached.
+ *
+ * A floating cell is the inside of the pane, so the borders around it have to
+ * be counted here as they are when it is created (see
+ * layout_floating_args_parse).
+ */
+static void
+layout_clamp_floating_panes(struct window *w, u_int sx, u_int sy)
+{
+	struct window_pane	*wp;
+	struct layout_cell	*lc;
+	u_int			 pad, avail, csx, csy;
+
+	TAILQ_FOREACH(wp, &w->z_index, zentry) {
+		lc = wp->layout_cell;
+		if (lc == NULL || (~lc->flags & LAYOUT_CELL_FLOATING))
+			continue;
+		if (window_pane_get_pane_lines(wp) == PANE_LINES_NONE)
+			pad = 0;
+		else
+			pad = 1;
+
+		csx = lc->g.sx;
+		avail = (sx > 2 * pad) ? sx - 2 * pad : 0;
+		if (csx > avail)
+			csx = (avail > PANE_MINIMUM) ? avail : PANE_MINIMUM;
+		csy = lc->g.sy;
+		avail = (sy > 2 * pad) ? sy - 2 * pad : 0;
+		if (csy > avail)
+			csy = (avail > PANE_MINIMUM) ? avail : PANE_MINIMUM;
+		if (csx != lc->g.sx || csy != lc->g.sy)
+			layout_set_size(lc, csx, csy, lc->g.xoff,
+			    lc->g.yoff);
+
+		if (lc->g.xoff + lc->g.sx + pad > sx) {
+			if (lc->g.sx + 2 * pad >= sx)
+				lc->g.xoff = pad;
+			else
+				lc->g.xoff = sx - lc->g.sx - pad;
+		}
+		if (lc->g.yoff + lc->g.sy + pad > sy) {
+			if (lc->g.sy + 2 * pad >= sy)
+				lc->g.yoff = pad;
+			else
+				lc->g.yoff = sy - lc->g.sy - pad;
+		}
+	}
+}
+
 /* Resize the entire layout after window resize. */
 void
 layout_resize(struct window *w, u_int sx, u_int sy)
@@ -840,6 +894,7 @@ layout_resize(struct window *w, u_int sx, u_int sy)
 
 	/* Fix cell offsets. */
 	layout_fix_offsets(w);
+	layout_clamp_floating_panes(w, sx, sy);
 	layout_fix_panes(w, NULL);
 }
 


### PR DESCRIPTION
Fixes #5581.

`layout_resize_adjust` walks only tiled cells (`layout_resize_check` counts
`is_leaf && !is_floating`), and `layout_fix_panes` then copies each floating
cell through unchanged — so a floating pane keeps the geometry it was created
with, and shrinking the window can leave it partly or entirely outside, where
it cannot be seen or reached. Reachable by detaching and reattaching from a
smaller terminal, or moving a client between a monitor and a laptop screen.

This clamps floating cells at the end of `layout_resize`, per the discussion on
the issue — moving them back inside, and shrinking them only when they no
longer fit.

Two details that are not obvious:

- the size parameters are used rather than `w->sx`/`w->sy`: `resize.c` resizes
  the layout *before* the window ("Resize the layout first", `resize.c:63`), so
  `w->sx` is still the old size in here;
- a floating cell is the *inside* of the pane, so the border is counted the way
  `layout_floating_args_parse` counts it on creation (`-x` -> `sx -= 2`, `-X` ->
  `ox += 1` unless `pane-border-lines` is `none`), or a bordered float ends up
  one cell over the edge.

### Verification

Built from this branch on `master` (1b87cb75), against a build of the same tree
with the patch reverted as a control:

```
$ tmux -f/dev/null new-session -d -x 120 -y 40
$ tmux new-pane -x 30 -y 10 -X 85 -Y 25
$ tmux resize-window -x 60 -y 20
$ tmux list-panes -F "#{pane_width}x#{pane_height} at #{pane_left},#{pane_top}"

without the patch:   60x20 at 0,0   /   28x8 at 86,26    <- outside a 60x20 window
with the patch:      60x20 at 0,0   /   28x8 at 31,11    <- inside
```