### PR TITLE
Do not unzoom in window_destroy, it destroys the window twice

### DIFF
--- a/regress/kill-session-zoomed.sh
+++ b/regress/kill-session-zoomed.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Killing a session whose window is zoomed must not crash the server:
+# window_destroy used to unzoom the window, which resized the panes and
+# fired pane-resized with the window in the payload, and releasing that
+# reference destroyed the window a second time.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+$TMUX -f/dev/null new -d -sfoo || exit 1
+$TMUX split-window -d -h -tfoo:0 || exit 1
+$TMUX resize-pane -Z -tfoo:0 || exit 1
+$TMUX new -d -sbar || exit 1
+$TMUX kill-session -tfoo || exit 1
+$TMUX has-session -tbar || exit 1
+
+# The same with the zoomed window in a session killed by kill-server.
+$TMUX new -d -sbaz || exit 1
+$TMUX split-window -d -v -tbaz:0 || exit 1
+$TMUX resize-pane -Z -tbaz:0 || exit 1
+$TMUX kill-server || exit 1
+
+exit 0

--- a/window.c
+++ b/window.c
@@ -449,9 +449,25 @@ window_create(u_int sx, u_int sy, u_int xpixel, u_int ypixel)
 static void
 window_destroy(struct window *w)
 {
+	struct window_pane	*wp;
+
 	log_debug("window @%u destroyed (%d references)", w->id, w->references);
 
-	window_unzoom(w, 0);
+	/*
+	 * Clear any zoom rather than calling window_unzoom(): that resizes
+	 * the panes and fires pane-resized, whose payload takes a reference
+	 * on the window, and releasing it with the count already at zero
+	 * destroys the window a second time. Both layouts are freed below,
+	 * but the flags must go so nothing tries to unzoom while the panes
+	 * are destroyed (GitHub issue 3717).
+	 */
+	if (w->flags & WINDOW_ZOOMED) {
+		w->flags &= ~WINDOW_ZOOMED;
+		TAILQ_FOREACH(wp, &w->panes, entry) {
+			wp->flags &= ~PANE_ZOOMED;
+			wp->saved_layout_cell = NULL;
+		}
+	}
 	RB_REMOVE(windows, &windows, w);
 
 	layout_free_cell(w->layout_root, 0);


### PR DESCRIPTION
window_destroy() calls window_unzoom() so that the zoomed layout is put back before the panes are destroyed (GitHub issue 3717). Since events replaced notifications, window_unzoom() also resizes the panes through layout_fix_panes() and window_pane_resize() fires pane-resized with the window in the payload. The payload takes a reference on a window whose count is already zero; releasing it fires window-closed a second time and calls window_destroy() again from inside the first call, which frees the panes that the outer layout_fix_panes() is still walking.

Reproducer (server exits unexpectedly on the last command):

    tmux -f /dev/null new -d -s m
    tmux split-window -d -h -t m:0
    tmux resize-pane -Z -t m:0
    tmux new -d -s d
    tmux kill-session -t m

ASan: heap-use-after-free in layout_fix_panes (layout.c:477), from window_unzoom <- window_destroy <- winlink_remove <- session_destroy; freed by window_pane_free <- window_destroy_panes <- window_destroy <- window_remove_ref <- event_payload_free_value.

Both layouts are freed by window_destroy() anyway, so just clear the zoom flags on the window and its panes instead of calling window_unzoom(): nothing gets resized and no event fires, and a later unzoom while the panes are destroyed is still prevented. This is the same problem bad8d0fd20 fixed in 2013 before the call came back with 36e1ac6556.

Add a regress test for kill-session and kill-server with a zoomed window.