### PR TITLE
Add window-size manual-or-smallest

### DIFF
--- a/format.c
+++ b/format.c
@@ -3215,7 +3215,8 @@ format_cb_window_manual_height(struct format_tree *ft)
 
 	if (w == NULL)
 		return (NULL);
-	if (options_get_number(w->options, "window-size") != WINDOW_SIZE_MANUAL)
+	if (!WINDOW_SIZE_USES_MANUAL(options_get_number(w->options,
+	    "window-size")))
 		return (xstrdup(""));
 	return (format_printf("%u", w->manual_sy));
 }
@@ -3417,7 +3418,8 @@ format_cb_window_manual_width(struct format_tree *ft)
 
 	if (w == NULL)
 		return (NULL);
-	if (options_get_number(w->options, "window-size") != WINDOW_SIZE_MANUAL)
+	if (!WINDOW_SIZE_USES_MANUAL(options_get_number(w->options,
+	    "window-size")))
 		return (xstrdup(""));
 	return (format_printf("%u", w->manual_sx));
 }

--- a/options-table.c
+++ b/options-table.c
@@ -89,7 +89,7 @@ static const char *options_table_get_clipboard_list[] = {
 	"off", "buffer", "request", "both", NULL
 };
 static const char *options_table_window_size_list[] = {
-	"largest", "smallest", "manual", "latest", NULL
+	"largest", "smallest", "manual", "latest", "manual-or-smallest", NULL
 };
 static const char *options_table_remain_on_exit_list[] = {
 	"off", "on", "failed", "key", "failed-key", NULL
@@ -1260,10 +1260,10 @@ const struct options_table_entry options_table[] = {
 	  .type = OPTIONS_TABLE_FLAG,
 	  .scope = OPTIONS_TABLE_WINDOW,
 	  .default_num = 0,
-	  .text = "When 'window-size' is 'smallest', whether the maximum size "
-		  "of a window is the smallest attached session where it is "
-		  "the current window ('on') or the smallest session it is "
-		  "linked to ('off')."
+	  .text = "When 'window-size' is 'smallest' or 'manual-or-smallest', "
+		  "whether the maximum size of a window is the smallest "
+		  "attached session where it is the current window ('on') or "
+		  "the smallest session it is linked to ('off')."
 	},
 
 	{ .name = "allow-passthrough",
@@ -1823,8 +1823,9 @@ const struct options_table_entry options_table[] = {
 	  .text = "How window size is calculated. "
 		  "'latest' uses the size of the most recently used client, "
 		  "'largest' the largest client, 'smallest' the smallest "
-		  "client and 'manual' a size set by the 'resize-window' "
-		  "command."
+		  "client, 'manual' a size set by the 'resize-window' "
+		  "command and 'manual-or-smallest' the manual size unless a "
+		  "smaller client exists."
 	},
 
 	{ .name = "window-style",

--- a/regress/options-values.sh
+++ b/regress/options-values.sh
@@ -91,6 +91,14 @@ check_ok set -gw pane-border-lines rounded
 check_value "-gwv pane-border-lines" "rounded"
 check_ok set -gw pane-border-lines single
 
+# window-size accepts the manual-or-smallest choice and rejects unknown names.
+check_ok set -gw window-size manual-or-smallest
+check_value "-gwv window-size" "manual-or-smallest"
+check_fail "unknown value: manual-or-largest" set -gw window-size \
+    manual-or-largest
+check_value "-gwv window-size" "manual-or-smallest"
+check_ok set -gw window-size latest
+
 # --- flag options ---------------------------------------------------------
 #
 # focus-events is an on/off flag.  Setting with no value toggles it; explicit

--- a/regress/window-size-manual-or-smallest.sh
+++ b/regress/window-size-manual-or-smallest.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+# window-size manual-or-smallest uses the stored manual size unless an
+# attached client is smaller, in which case the smallest client wins.
+# Width and height are capped independently so a tall-and-narrow client
+# shrinks only the dimension that is actually smaller.
+#
+# Also covers: two clients at once, a live refresh-client -C, using the
+# creation size as the cap (no resize-window), and resize-window resetting
+# the option back to manual.
+
+PATH=/bin:/usr/bin
+TERM=screen
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+$TMUX kill-server 2>/dev/null
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"; $TMUX kill-server 2>/dev/null' 0 1 15
+
+fail()
+{
+	echo "$@"
+	exit 1
+}
+
+window_size()
+{
+	$TMUX display -t t -p '#{window_width}x#{window_height}'
+}
+
+manual_size()
+{
+	$TMUX display -t t -p '#{window_manual_width}x#{window_manual_height}'
+}
+
+# Wait until the window reports $1, or fail after a short poll.
+wait_size()
+{
+	want=$1
+	n=0
+	while [ $n -lt 30 ]; do
+		got=$(window_size 2>/dev/null) || got=
+		[ "$got" = "$want" ] && return 0
+		sleep 0.1
+		n=$((n + 1))
+	done
+	fail "expected $want, got $got"
+}
+
+# Keep a control client attached at a given size in the background.
+attach_sized()
+{
+	sx=$1
+	sy=$2
+	(echo "refresh-client -C ${sx},${sy}"; sleep 8) |
+		$TMUX -f/dev/null -C attach -t t >>$TMP 2>&1 &
+}
+
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+# Detached: stay at the manual size and expose it via formats.
+[ "$(window_size)" = "100x50" ] || fail "detached size $(window_size)"
+[ "$(manual_size)" = "100x50" ] || fail "manual format $(manual_size)"
+
+# A larger client must not grow the window past the manual size.
+attach_sized 120 60
+wait_size 100x50
+
+# A smaller client shrinks the window.
+attach_sized 40 10
+wait_size 40x10
+
+# Width and height are independent: a wide-but-short client only shrinks
+# height, a tall-but-narrow client only shrinks width.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+attach_sized 120 20
+wait_size 100x20
+
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+attach_sized 30 80
+wait_size 30x50
+
+# After the small client goes away, grow back to the manual size.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+attach_sized 40 10
+wait_size 40x10
+$TMUX detach-client -s t || exit 1
+wait_size 100x50
+
+# Two clients at once: smallest wins, still never above the manual cap.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+attach_sized 120 60
+wait_size 100x50
+attach_sized 40 10
+wait_size 40x10
+[ "$(window_size)" = "40x10" ] || fail "two clients $(window_size)"
+
+# Live refresh-client -C on an already-attached client.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+
+attach_sized 120 60
+wait_size 100x50
+client=
+n=0
+while [ $n -lt 30 ]; do
+	client=$($TMUX lsc -F '#{client_name}' 2>/dev/null | head -1) || client=
+	[ -n "$client" ] && break
+	sleep 0.1
+	n=$((n + 1))
+done
+[ -n "$client" ] || fail "no control client to refresh"
+$TMUX refresh-client -t "$client" -C 40,10 || exit 1
+wait_size 40x10
+
+# Creation size is the cap when resize-window was never used.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s bootstrap || exit 1
+$TMUX set -g window-size manual-or-smallest || exit 1
+$TMUX new -d -s t -x 80 -y 24 || exit 1
+$TMUX kill-session -t bootstrap || exit 1
+[ "$(window_size)" = "80x24" ] || fail "created size $(window_size)"
+[ "$(manual_size)" = "80x24" ] || fail "created manual $(manual_size)"
+attach_sized 40 10
+wait_size 40x10
+
+# resize-window switches the option back to manual; re-set to continue.
+$TMUX kill-server 2>/dev/null
+$TMUX -f/dev/null new -d -s t -x 100 -y 50 || exit 1
+$TMUX resizew -t t -x 100 -y 50 || exit 1
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+$TMUX resizew -t t -x 90 -y 40 || exit 1
+opt=$($TMUX show -wv -t t window-size)
+[ "$opt" = "manual" ] || fail "resizew left window-size=$opt"
+[ "$(window_size)" = "90x40" ] || fail "after resizew $(window_size)"
+$TMUX set -w -t t window-size manual-or-smallest || exit 1
+attach_sized 40 10
+wait_size 40x10
+
+exit 0

--- a/resize.c
+++ b/resize.c
@@ -139,12 +139,13 @@ clients_calculate_size(int type, int current, struct client *c,
 
 	/*
 	 * Start comparing with 0 for largest and UINT_MAX for smallest or
-	 * latest.
+	 * latest. Manual types start from the stored manual size so they
+	 * never grow past it; manual-or-smallest then mins with clients.
 	 */
 	if (type == WINDOW_SIZE_LARGEST) {
 		*sx = 0;
 		*sy = 0;
-	} else if (w != NULL && type == WINDOW_SIZE_MANUAL) {
+	} else if (w != NULL && WINDOW_SIZE_USES_MANUAL(type)) {
 		*sx = w->manual_sx;
 		*sy = w->manual_sy;
 		log_debug("%s: manual size %ux%u", __func__, *sx, *sy);
@@ -161,7 +162,7 @@ clients_calculate_size(int type, int current, struct client *c,
 	if (type == WINDOW_SIZE_LATEST && w != NULL)
 		n = clients_with_window(w);
 
-	/* Skip setting the size if manual */
+	/* Skip setting the size if manual (but not manual-or-smallest). */
 	if (type == WINDOW_SIZE_MANUAL)
 		goto skip;
 
@@ -254,19 +255,25 @@ skip:
 		log_debug("%s: no calculated size", __func__);
 
 	/* Return whether a suitable size was found. */
-	if (type == WINDOW_SIZE_MANUAL) {
+	switch (type) {
+	case WINDOW_SIZE_MANUAL:
 		log_debug("%s: type is manual", __func__);
 		return (w != NULL);
-	}
-	if (type == WINDOW_SIZE_LARGEST) {
+	case WINDOW_SIZE_MANUAL_OR_SMALLEST:
+		log_debug("%s: type is manual-or-smallest", __func__);
+		if (w != NULL)
+			return (1);
+		return (*sx != UINT_MAX && *sy != UINT_MAX);
+	case WINDOW_SIZE_LARGEST:
 		log_debug("%s: type is largest", __func__);
 		return (*sx != 0 && *sy != 0);
-	}
-	if (type == WINDOW_SIZE_LATEST)
+	case WINDOW_SIZE_LATEST:
 		log_debug("%s: type is latest", __func__);
-	else
+		return (*sx != UINT_MAX && *sy != UINT_MAX);
+	default:
 		log_debug("%s: type is smallest", __func__);
-	return (*sx != UINT_MAX && *sy != UINT_MAX);
+		return (*sx != UINT_MAX && *sy != UINT_MAX);
+	}
 }
 
 static int
@@ -370,9 +377,9 @@ recalculate_size(struct window *w, int now)
 	log_debug("%s: @%u is %ux%u", __func__, w->id, w->sx, w->sy);
 
 	/*
-	 * Type is manual, smallest, largest, latest. Current is the
-	 * aggressive-resize option (do not resize based on clients where the
-	 * window is not the current window).
+	 * Type is manual, manual-or-smallest, smallest, largest, latest.
+	 * Current is the aggressive-resize option (do not resize based on
+	 * clients where the window is not the current window).
 	 */
 	type = options_get_number(w->options, "window-size");
 	current = options_get_number(w->options, "aggressive-resize");
@@ -404,12 +411,12 @@ recalculate_size(struct window *w, int now)
 	}
 
 	/*
-	 * If the now flag is set or if the window is sized manually, change
-	 * the size immediately. Otherwise set the flag and it will be done
-	 * later.
+	 * If the now flag is set or if the window is sized from a manual
+	 * size, change the size immediately. Otherwise set the flag and it
+	 * will be done later.
 	 */
 	log_debug("%s: @%u new size %ux%u", __func__, w->id, sx, sy);
-	if (now || type == WINDOW_SIZE_MANUAL)
+	if (now || WINDOW_SIZE_USES_MANUAL(type))
 		resize_window(w, sx, sy, xpixel, ypixel);
 	else {
 		w->new_sx = sx;

--- a/tmux.1
+++ b/tmux.1
@@ -5249,7 +5249,11 @@ is used as a login shell.
 .It Ic default\-size Ar XxY
 Set the default size of new windows when the
 .Ic window\-size
-option is set to manual or when a session is created with
+option is set to
+.Ar manual
+or
+.Ar manual-or-smallest
+or when a session is created with
 .Ic new\-session
 .Fl d .
 The value is the width and height separated by an
@@ -6241,7 +6245,8 @@ see the
 section.
 .Pp
 .It Xo Ic window\-size
-.Ar largest | Ar smallest | Ar manual | Ar latest
+.Ar largest | Ar smallest | Ar manual | Ar latest |
+.Ar manual-or-smallest
 .Xc
 Configure how
 .Nm
@@ -6256,6 +6261,10 @@ If
 the size of a new window is set from the
 .Ic default\-size
 option and windows are resized automatically.
+If
+.Ar manual-or-smallest ,
+the window uses its manual size unless an attached client is smaller,
+in which case the smallest client is used.
 With
 .Ar latest ,
 .Nm

--- a/tmux.h
+++ b/tmux.h
@@ -1530,6 +1530,9 @@ TAILQ_HEAD(winlink_stack, winlink);
 #define WINDOW_SIZE_SMALLEST 1
 #define WINDOW_SIZE_MANUAL 2
 #define WINDOW_SIZE_LATEST 3
+#define WINDOW_SIZE_MANUAL_OR_SMALLEST 4
+#define WINDOW_SIZE_USES_MANUAL(t) \
+	((t) == WINDOW_SIZE_MANUAL || (t) == WINDOW_SIZE_MANUAL_OR_SMALLEST)
 
 /* Pane border status option. */
 #define PANE_STATUS_OFF 0


### PR DESCRIPTION
## Summary
- Add a `window-size manual-or-smallest` choice: keep the manual size unless an attached client is smaller.
- Width and height are capped independently.
- Documents the option and adds regress coverage.

Fixes #2671.

## Test plan
- [x] `TEST_TMUX=$(pwd)/tmux sh regress/window-size-manual-or-smallest.sh`
- [x] `TEST_TMUX=$(pwd)/tmux sh regress/options-values.sh`
- [x] Comment on #2671 / #4808 so this does not collide with other work