### PR TITLE
Prevent live pane output from overwriting menus

### DIFF
--- a/regress/menu-live-output.sh
+++ b/regress/menu-live-output.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+# check the actual terminal image while a pane writes underneath a menu.
+# an outer tmux captures the display of an attached inner tmux client.
+
+PATH=/bin:/usr/bin
+TERM=screen
+LC_ALL=C.UTF-8
+export TERM LC_ALL
+
+[ -z "$TEST_TMUX" ] && TEST_TMUX=$(readlink -f ../tmux)
+TMUX="$TEST_TMUX -LtestA$$ -f/dev/null"
+TMUX2="$TEST_TMUX -LtestB$$ -f/dev/null"
+TMP=$(mktemp -d)
+MENU_ROW=4
+
+cleanup() {
+	$TMUX kill-server 2>/dev/null
+	$TMUX2 kill-server 2>/dev/null
+	rm -rf "$TMP"
+}
+trap cleanup 0 1 15
+
+fail() {
+	echo "$*" >&2
+	exit 1
+}
+
+capture_menu() {
+	$TMUX capturep -p -S"$MENU_ROW" -E"$((MENU_ROW + 3))" >"$TMP/rows" || exit 1
+	cut -c7-19 "$TMP/rows" >"$1" || exit 1
+}
+
+check_update() {
+	printf '%b' "$2" >&3
+	printf '\033[1;1H\033[2K%s' "$1" >&3
+	sleep 1
+	$TMUX capturep -p >"$TMP/screen" || exit 1
+	grep -q "^$1$" "$TMP/screen" || fail "$1: pane stopped updating"
+	capture_menu "$TMP/actual"
+	cmp -s "$TMP/expected" "$TMP/actual" ||
+		fail "$1: pane output overwrote the menu"
+}
+
+mkfifo "$TMP/output" || exit 1
+$TMUX2 new -d -x40 -y14 "exec cat '$TMP/output'" || exit 1
+$TMUX2 set -g status off || exit 1
+$TMUX2 set -g window-size manual || exit 1
+$TMUX2 resizew -x40 -y14 || exit 1
+$TMUX2 set -as terminal-features ',screen:clipboard' || exit 1
+$TMUX2 set -g set-clipboard on || exit 1
+exec 3>"$TMP/output"
+
+$TMUX new -d -x40 -y14 "$TMUX2 attach" || exit 1
+$TMUX set -g status off || exit 1
+$TMUX set -g window-size manual || exit 1
+$TMUX resizew -x40 -y14 || exit 1
+$TMUX set -g set-clipboard on || exit 1
+sleep 1
+
+# simple borders keep the captured rectangle single-byte and portable.
+$TMUX2 display-menu -b simple -T live -C 0 -x6 -y8 \
+	alpha a "" beta b "" || exit 1
+sleep 1
+capture_menu "$TMP/expected"
+grep -q 'alpha' "$TMP/expected" || fail "menu did not appear"
+
+check_update text '\033[6;1Habcdefghijklmnopqrstuvwxyz0123456789'
+check_update clear-line '\033[6;1H\033[2K'
+check_update clear-screen '\033[2J'
+check_update scroll '\033[14;1Hone\r\ntwo\r\nthree\r\nfour\r\n'
+check_update insert-character '\033[6;1H\033[3@'
+check_update delete-character '\033[6;1H\033[3P'
+check_update insert-line '\033[5;1H\033[2L'
+check_update delete-line '\033[5;1H\033[2M'
+check_update wide-text '\033[6;6H\347\225\214\347\225\214\347\225\214'
+check_update insert-mode '\033[6;1H\033[4habc\033[4l'
+
+# a clipped client viewport must not fall back to drawing over the menu.
+$TMUX2 resizew -x60 -y14 || exit 1
+sleep 1
+check_update viewport '\033[6;1Habcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx'
+$TMUX2 resizew -x40 -y14 || exit 1
+
+# menu clipping uses window coordinates even with a status line above it.
+$TMUX2 set -g status on || exit 1
+$TMUX2 set -g status-position top || exit 1
+MENU_ROW=5
+sleep 1
+capture_menu "$TMP/expected"
+grep -q 'alpha' "$TMP/expected" || fail "menu missing with top status"
+check_update top-status '\033[6;1Habcdefghijklmnopqrstuvwxyz0123456789\033[2K'
+
+# nonvisual terminal output must still be delivered while the menu is open.
+printf '\033]52;c;bWVudS1jbGlwYm9hcmQ=\007' >&3
+sleep 1
+[ "$($TMUX show-buffer 2>/dev/null)" = menu-clipboard ] ||
+	fail "menu blocked the clipboard update"
+
+# closing the menu must reveal the latest contents of the pane beneath it.
+printf '\033[2J\033[6;7Hlatest content' >&3
+sleep 1
+$TMUX send Escape || exit 1
+sleep 1
+$TMUX capturep -p >"$TMP/screen" || exit 1
+grep -q 'latest content' "$TMP/screen" || fail "menu close left stale content"
+
+exit 0

--- a/screen-write.c
+++ b/screen-write.c
@@ -175,11 +175,12 @@ screen_write_set_client_cb(struct tty_ctx *ttyctx, struct client *c)
 	return (1);
 }
 
-/* Return 1 if there is a floating window pane overlapping this pane. */
+/* return 1 if a menu or floating pane overlaps this pane. */
 static int
 screen_write_pane_is_obscured(struct screen_write_ctx *ctx)
 {
 	struct window_pane	*wp = ctx->wp;
+	struct menu_data	*md;
 
 	if (ctx->wp == NULL)
 		return (0);
@@ -189,6 +190,16 @@ screen_write_pane_is_obscured(struct screen_write_ctx *ctx)
 		return (0);
 	}
 	ctx->flags |= SCREEN_WRITE_CHECKED_IF_OBSCURED;
+
+	md = wp->window->menu;
+	if (md != NULL &&
+	    (int)menu_x(md) < wp->xoff + (int)wp->sx &&
+	    (int)(menu_x(md) + menu_width(md)) > wp->xoff &&
+	    (int)menu_y(md) < wp->yoff + (int)wp->sy &&
+	    (int)(menu_y(md) + menu_height(md)) > wp->yoff) {
+		ctx->flags |= SCREEN_WRITE_OBSCURED;
+		return (1);
+	}
 
 	if (ctx->wp->xoff < 0 ||
 	    ctx->wp->yoff < 0 ||

--- a/tty.c
+++ b/tty.c
@@ -1433,6 +1433,12 @@ tty_draw_pane(struct tty *tty, const struct tty_ctx *ctx, u_int py)
 
 	log_debug("%s: %s %u", __func__, tty->client->name, py);
 
+	/* the scene must clip a whole-line fallback around the window menu. */
+	if (tty->client->session->curw->window->menu != NULL) {
+		ctx->redraw_cb(ctx);
+		return;
+	}
+
 	if (~ctx->flags & TTY_CTX_WINDOW_BIGGER) {
 		r = tty_check_overlay_range(tty, ctx->xoff, ctx->yoff + py, nx);
 		for (j = 0; j < r->used; j++) {
@@ -1690,6 +1696,7 @@ tty_cmd_insertcharacter(struct tty *tty, const struct tty_ctx *ctx)
 	    tty_fake_bce(tty, &ctx->defaults, ctx->bg) ||
 	    (!tty_term_has(tty->term, TTYC_ICH) &&
 	    !tty_term_has(tty->term, TTYC_ICH1)) ||
+	    c->session->curw->window->menu != NULL ||
 	    c->overlay_check != NULL) {
 		tty_draw_pane(tty, ctx, ctx->ocy);
 		return;

--- a/window-visible.c
+++ b/window-visible.c
@@ -53,6 +53,7 @@ window_visible_ranges(struct window_pane *base_wp, int px, int py, u_int width,
 {
 	struct window_pane		*wp;
 	struct window			*w;
+	struct menu_data			*md;
 	struct visible_range		*ri;
 	static struct visible_ranges	 sr = { NULL, 0, 0 };
 	int				 found_self, sb_w, sb_pos;
@@ -95,6 +96,34 @@ window_visible_ranges(struct window_pane *base_wp, int px, int py, u_int width,
 		r->used = 1;
 	}
 
+	/* exclude the menu, which is above every pane in the window. */
+	md = w->menu;
+	if (md != NULL && (u_int)py >= menu_y(md) &&
+	    (u_int)py - menu_y(md) < menu_height(md)) {
+		lb = menu_x(md);
+		rb = lb + menu_width(md);
+		for (i = 0; i < r->used; i++) {
+			ri = &r->ranges[i];
+			sx = ri->px;
+			ex = sx + ri->nx;
+			if (ri->nx == 0 || rb <= sx || lb >= ex)
+				continue;
+			if (lb <= sx) {
+				ri->px = rb < ex ? rb : ex;
+				ri->nx = ex - ri->px;
+			} else {
+				ri->nx = lb - sx;
+				if (rb < ex) {
+					server_client_ensure_ranges(r, r->used + 1);
+					memmove(&r->ranges[i + 2], &r->ranges[i + 1],
+					    (r->used - i - 1) * sizeof *r->ranges);
+					r->ranges[i + 1].px = rb;
+					r->ranges[i + 1].nx = ex - rb;
+					r->used++;
+				}
+			}
+		}
+	}
 
 	found_self = 0;
 	TAILQ_FOREACH_REVERSE(wp, &w->z_index, window_panes_zindex, zentry) {


### PR DESCRIPTION
Window menus are drawn above panes during scene redraws, but incremental pane output does not account for their position. Text updates, line clears, scrolling, and other terminal operations can overwrite an open menu.

This change excludes the menu rectangle from pane-visible ranges and treats overlapping menus as obstructions when choosing redraw paths. Whole-line fallbacks and insert-character operations use the scene renderer when a menu is present.

Pane contents continue updating underneath the menu, and uncovered areas remain live. `capture-pane` still returns the underlying pane contents without clipping or menu decorations.

### Validation

- Added a nested-client regression covering text updates, clears, scrolling, character and line edits, wide characters, insert mode, viewport clipping, top status positioning, clipboard delivery, and menu closure.
- Confirmed failures before the corresponding fixes and passing results afterward.
- Passed existing menu, popup, TTY drawing, synchronized-output, and input editing/scrolling regressions.
- Separately verified that capturing a background pane includes newly updated content beneath an open menu.
